### PR TITLE
Only start postgres

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Note that the application requires a database to be running. This can be achieve
 using docker-compose:
 
 ```bash
-docker-compose up
+docker-compose up -d postgres
 ```
 
 Then run the application


### PR DESCRIPTION
In the README it states the need for a running database in the Get Hacking section. Add `postgres` so only the postgres service starts, we don't need the containerised mediator running too. 