### PR TITLE
fix: make jwt negative test message more informative

### DIFF
--- a/pkg/auth/jwauth_test.go
+++ b/pkg/auth/jwauth_test.go
@@ -83,6 +83,6 @@ func TestVerifyToken(t *testing.T) {
 	if err == nil {
 		t.Error("Expected error with invalid key, but got nil")
 	} else {
-		t.Logf("Successfully validated token with invalid key: %v", err)
+		t.Logf("Successfully received error when using an invalid key: %v", err)
 	}
 }


### PR DESCRIPTION
The test for invalid key is a negative test, actually it should warn when an invalid signature is passed. But the log message is not clear and gives the user the sensation that tests are failing.

Add a more informative message to be clear that this test is correctly passing

Closes: #127