### PR TITLE
fix: enable os.stdout in multiwriter for logs

### DIFF
--- a/internal/logger/logging_interceptor.go
+++ b/internal/logger/logging_interceptor.go
@@ -178,7 +178,7 @@ func Interceptor(logLevel string, logFormat string, logFile string) grpc.UnarySe
 		if logToFile {
 			var multi zerolog.LevelWriter
 			if logFormat == Text {
-				multi = zerolog.MultiLevelWriter(consoleWriter, file)
+				multi = zerolog.MultiLevelWriter(consoleWriter, os.Stdout, file)
 			} else {
 				multi = zerolog.MultiLevelWriter(os.Stdout, file)
 			}


### PR DESCRIPTION
The os.stdout was not enabled on logger when console mode was active, causing that the fmt debug messages were not printed. Enabled os.stdout as part of multiwriter as well

Closes: #176