### PR TITLE
fix: do not bind flags on init, but on pre-run

### DIFF
--- a/cmd/cli/app/auth/auth.go
+++ b/cmd/cli/app/auth/auth.go
@@ -22,13 +22,9 @@
 package auth
 
 import (
-	"fmt"
-	"os"
-
 	"github.com/stacklok/mediator/cmd/cli/app"
 
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
 )
 
 // AuthCmd represents the account command
@@ -44,8 +40,4 @@ authorization to existing accounts within a mediator control plane.`,
 
 func init() {
 	app.RootCmd.AddCommand(AuthCmd)
-	if err := viper.BindPFlags(AuthCmd.PersistentFlags()); err != nil {
-		fmt.Fprintf(os.Stderr, "Error binding flags: %s\n", err)
-	}
-
 }

--- a/cmd/cli/app/auth/auth_create.go
+++ b/cmd/cli/app/auth/auth_create.go
@@ -135,6 +135,11 @@ var auth_createCmd = &cobra.Command{
 an OAuth2 login with a provider, then pass in the --provider flag alongside
 --oauth2, e.g. --oauth2 --provider=github. This will then initiate the OAuth2 flow
 and allow mediator to access user account details via the provider / iDP.`,
+	PreRun: func(cmd *cobra.Command, args []string) {
+		if err := viper.BindPFlags(cmd.Flags()); err != nil {
+			fmt.Fprintf(os.Stderr, "Error binding flags: %s\n", err)
+		}
+	},
 	Run: func(cmd *cobra.Command, args []string) {
 
 		grpc_host := util.GetConfigValue("grpc_server.host", "grpc-host", cmd, "").(string)
@@ -176,7 +181,4 @@ func init() {
 	auth_createCmd.Flags().BoolP("active", "a", true, "Is the account active")
 	auth_createCmd.Flags().StringP("provider", "r", "", "OAuth2 provider to use (e.g. google, github)")
 
-	if err := viper.BindPFlags(auth_createCmd.Flags()); err != nil {
-		fmt.Fprintf(os.Stderr, "Error binding flags: %s\n", err)
-	}
 }

--- a/cmd/cli/app/auth/auth_delete.go
+++ b/cmd/cli/app/auth/auth_delete.go
@@ -22,7 +22,8 @@
 package auth
 
 import (
-	"log"
+	"fmt"
+	"os"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -48,6 +49,11 @@ user data. This is not reversible. This includes any repositories owned by the
 user, and any data associated with those repositories.
 
 medctl auth delete --user-id=1234 --force`,
+	PreRun: func(cmd *cobra.Command, args []string) {
+		if err := viper.BindPFlags(cmd.Flags()); err != nil {
+			fmt.Fprintf(os.Stderr, "Error binding flags: %s\n", err)
+		}
+	},
 	Run: func(cmd *cobra.Command, args []string) {
 		cmd.Println("auth delete called")
 	},
@@ -57,7 +63,4 @@ func init() {
 	AuthCmd.AddCommand(auth_deluserCmd)
 	auth_deluserCmd.Flags().Int64("user-id", 0, "The user-id of the user to delete")
 	auth_deluserCmd.Flags().Bool("force", false, "Force deletion of user without confirmation")
-	if err := viper.BindPFlags(auth_deluserCmd.Flags()); err != nil {
-		log.Fatal(err)
-	}
 }

--- a/cmd/cli/app/auth/auth_list.go
+++ b/cmd/cli/app/auth/auth_list.go
@@ -34,6 +34,11 @@ var auth_listCmd = &cobra.Command{
 	Use:   "list",
 	Short: "List all auth accounts and tokens",
 	Long:  `List all accounts and tokens for active or expired mediator sessions.`,
+	PreRun: func(cmd *cobra.Command, args []string) {
+		if err := viper.BindPFlags(cmd.Flags()); err != nil {
+			fmt.Fprintf(os.Stderr, "Error binding flags: %s\n", err)
+		}
+	},
 	Run: func(cmd *cobra.Command, args []string) {
 		cmd.Println("auth list called")
 	},
@@ -41,7 +46,4 @@ var auth_listCmd = &cobra.Command{
 
 func init() {
 	AuthCmd.AddCommand(auth_listCmd)
-	if err := viper.BindPFlags(auth_listCmd.Flags()); err != nil {
-		fmt.Fprintf(os.Stderr, "Error binding flags: %s\n", err)
-	}
 }

--- a/cmd/cli/app/auth/auth_login.go
+++ b/cmd/cli/app/auth/auth_login.go
@@ -122,6 +122,11 @@ var auth_loginCmd = &cobra.Command{
 	Short: "Login to a mediator control plane.",
 	Long: `Login to a mediator control plane. Upon successful login, credentials
 will be saved to $XDG_CONFIG_HOME/mediator/credentials.json`,
+	PreRun: func(cmd *cobra.Command, args []string) {
+		if err := viper.BindPFlags(cmd.Flags()); err != nil {
+			fmt.Fprintf(os.Stderr, "Error binding flags: %s\n", err)
+		}
+	},
 	Run: func(cmd *cobra.Command, args []string) {
 		grpc_host := util.GetConfigValue("grpc_server.host", "grpc-host", cmd, "").(string)
 		grpc_port := util.GetConfigValue("grpc_server.port", "grpc-port", cmd, 0).(int)
@@ -152,7 +157,4 @@ func init() {
 	auth_loginCmd.Flags().StringP("username", "u", "", "Username to use for authentication")
 	auth_loginCmd.Flags().StringP("password", "p", "", "Password to use for authentication")
 	auth_loginCmd.Flags().String("provider", "", "The OAuth2 provider to use for login")
-	if err := viper.BindPFlags(auth_loginCmd.Flags()); err != nil {
-		fmt.Fprintf(os.Stderr, "Error binding flags: %s\n", err)
-	}
 }

--- a/cmd/cli/app/auth/auth_revoke.go
+++ b/cmd/cli/app/auth/auth_revoke.go
@@ -39,6 +39,11 @@ If no --user-id flag is passed, it will revoke the token for the current logged 
 user. If a --user-id flag is passed, it will revoke the token for the specified user, 
 but only if the current user has sufficient privileges.
 `,
+	PreRun: func(cmd *cobra.Command, args []string) {
+		if err := viper.BindPFlags(cmd.Flags()); err != nil {
+			fmt.Fprintf(os.Stderr, "Error binding flags: %s\n", err)
+		}
+	},
 	Run: func(cmd *cobra.Command, args []string) {
 		cmd.Println("auth revoke called")
 	},
@@ -46,7 +51,4 @@ but only if the current user has sufficient privileges.
 
 func init() {
 	AuthCmd.AddCommand(auth_revokeCmd)
-	if err := viper.BindPFlags(auth_revokeCmd.Flags()); err != nil {
-		fmt.Fprintf(os.Stderr, "Error binding flags: %s\n", err)
-	}
 }

--- a/cmd/cli/app/group/group.go
+++ b/cmd/cli/app/group/group.go
@@ -23,13 +23,9 @@
 package group
 
 import (
-	"fmt"
-	"os"
-
 	"github.com/stacklok/mediator/cmd/cli/app"
 
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
 )
 
 // GroupCmd is the root command for the group subcommands
@@ -45,8 +41,4 @@ mediator control plane.`,
 
 func init() {
 	app.RootCmd.AddCommand(GroupCmd)
-	if err := viper.BindPFlags(GroupCmd.PersistentFlags()); err != nil {
-		fmt.Fprintf(os.Stderr, "Error binding flags: %s\n", err)
-	}
-
 }

--- a/cmd/cli/app/group/group_create.go
+++ b/cmd/cli/app/group/group_create.go
@@ -39,6 +39,11 @@ var group_createCmd = &cobra.Command{
 	Short: "Create a group within a mediator control plane",
 	Long: `The medctl group create subcommand lets you create new groups within
 a mediator control plane.`,
+	PreRun: func(cmd *cobra.Command, args []string) {
+		if err := viper.BindPFlags(cmd.Flags()); err != nil {
+			fmt.Fprintf(os.Stderr, "Error binding flags: %s\n", err)
+		}
+	},
 	Run: func(cmd *cobra.Command, args []string) {
 
 		name := util.GetConfigValue("name", "name", cmd, "")
@@ -91,9 +96,5 @@ func init() {
 	}
 	if err := group_createCmd.MarkFlagRequired("org-id"); err != nil {
 		fmt.Fprintf(os.Stderr, "Error marking flag as required: %s\n", err)
-	}
-
-	if err := viper.BindPFlags(group_createCmd.Flags()); err != nil {
-		fmt.Fprintf(os.Stderr, "Error binding flags: %s\n", err)
 	}
 }

--- a/cmd/cli/app/group/group_delete.go
+++ b/cmd/cli/app/group/group_delete.go
@@ -24,7 +24,6 @@ package group
 import (
 	"context"
 	"fmt"
-	"log"
 	"os"
 	"time"
 
@@ -39,6 +38,11 @@ var group_deleteCmd = &cobra.Command{
 	Short: "delete a group within a mediator controlplane",
 	Long: `The medctl group delete subcommand lets you delete groups within a
 mediator control plane.`,
+	PreRun: func(cmd *cobra.Command, args []string) {
+		if err := viper.BindPFlags(cmd.Flags()); err != nil {
+			fmt.Fprintf(os.Stderr, "Error binding flags: %s\n", err)
+		}
+	},
 	Run: func(cmd *cobra.Command, args []string) {
 		// delete the group via GRPC
 		id := util.GetConfigValue("group-id", "group-id", cmd, int32(0)).(int32)
@@ -79,9 +83,5 @@ func init() {
 	if err := group_deleteCmd.MarkFlagRequired("group-id"); err != nil {
 		fmt.Fprintf(os.Stderr, "Error marking flag as required: %s\n", err)
 		os.Exit(1)
-	}
-
-	if err := viper.BindPFlags(group_deleteCmd.Flags()); err != nil {
-		log.Fatal(err)
 	}
 }

--- a/cmd/cli/app/group/group_list.go
+++ b/cmd/cli/app/group/group_list.go
@@ -39,6 +39,11 @@ var group_listCmd = &cobra.Command{
 	Short: "medctl group list",
 	Long: `The medctl group list subcommand lets you list groups within
 a mediator control plane.`,
+	PreRun: func(cmd *cobra.Command, args []string) {
+		if err := viper.BindPFlags(cmd.Flags()); err != nil {
+			fmt.Fprintf(os.Stderr, "Error binding flags: %s\n", err)
+		}
+	},
 	Run: func(cmd *cobra.Command, args []string) {
 
 		conn, err := util.GetGrpcConnection(cmd)
@@ -109,7 +114,4 @@ func init() {
 	group_listCmd.Flags().Int("org-id", 0, "Organisation ID")
 	group_listCmd.Flags().Int("limit", 10, "Limit number of results")
 	group_listCmd.Flags().Int("offset", 0, "Offset number of results")
-	if err := viper.BindPFlags(group_listCmd.Flags()); err != nil {
-		fmt.Fprintf(os.Stderr, "Error binding flags: %s\n", err)
-	}
 }

--- a/cmd/cli/app/org/org.go
+++ b/cmd/cli/app/org/org.go
@@ -23,13 +23,9 @@
 package org
 
 import (
-	"fmt"
-	"os"
-
 	"github.com/stacklok/mediator/cmd/cli/app"
 
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
 )
 
 // OrgCmd is the root command for the org subcommands
@@ -45,7 +41,4 @@ control plane.`,
 
 func init() {
 	app.RootCmd.AddCommand(OrgCmd)
-	if err := viper.BindPFlags(OrgCmd.PersistentFlags()); err != nil {
-		fmt.Fprintf(os.Stderr, "Error binding flags: %s\n", err)
-	}
 }

--- a/cmd/cli/app/org/org_create.go
+++ b/cmd/cli/app/org/org_create.go
@@ -38,6 +38,11 @@ var org_createCmd = &cobra.Command{
 	Short: "Create an organization within a mediator control plane",
 	Long: `The medctl org create subcommand lets you create new organizations
 within a mediator control plane.`,
+	PreRun: func(cmd *cobra.Command, args []string) {
+		if err := viper.BindPFlags(cmd.Flags()); err != nil {
+			fmt.Fprintf(os.Stderr, "Error binding flags: %s\n", err)
+		}
+	},
 	Run: func(cmd *cobra.Command, args []string) {
 		// create the organisation via GRPC
 		name := util.GetConfigValue("name", "name", cmd, "")
@@ -76,9 +81,6 @@ func init() {
 		fmt.Fprintf(os.Stderr, "Error binding flags: %s\n", err)
 	}
 	if err := org_createCmd.MarkFlagRequired("company"); err != nil {
-		fmt.Fprintf(os.Stderr, "Error binding flags: %s\n", err)
-	}
-	if err := viper.BindPFlags(org_createCmd.Flags()); err != nil {
 		fmt.Fprintf(os.Stderr, "Error binding flags: %s\n", err)
 	}
 }

--- a/cmd/cli/app/org/org_delete.go
+++ b/cmd/cli/app/org/org_delete.go
@@ -24,7 +24,6 @@ package org
 import (
 	"context"
 	"fmt"
-	"log"
 	"os"
 	"time"
 
@@ -39,6 +38,11 @@ var org_deleteCmd = &cobra.Command{
 	Short: "delete a organisation within a mediator controlplane",
 	Long: `The medctl org delete subcommand lets you delete organisations within a
 mediator control plane.`,
+	PreRun: func(cmd *cobra.Command, args []string) {
+		if err := viper.BindPFlags(cmd.Flags()); err != nil {
+			fmt.Fprintf(os.Stderr, "Error binding flags: %s\n", err)
+		}
+	},
 	Run: func(cmd *cobra.Command, args []string) {
 		// delete the org via GRPC
 		id := util.GetConfigValue("org-id", "org-id", cmd, int32(0)).(int32)
@@ -78,9 +82,5 @@ func init() {
 	if err := org_deleteCmd.MarkFlagRequired("org-id"); err != nil {
 		fmt.Fprintf(os.Stderr, "Error marking flag as required: %s\n", err)
 		os.Exit(1)
-	}
-
-	if err := viper.BindPFlags(org_deleteCmd.Flags()); err != nil {
-		log.Fatal(err)
 	}
 }

--- a/cmd/cli/app/org/org_get.go
+++ b/cmd/cli/app/org/org_get.go
@@ -40,6 +40,11 @@ var org_getCmd = &cobra.Command{
 	Short: "Get details for an organization within a mediator control plane",
 	Long: `The medctl org get subcommand lets you retrieve details for an organization within a
 mediator control plane.`,
+	PreRun: func(cmd *cobra.Command, args []string) {
+		if err := viper.BindPFlags(cmd.Flags()); err != nil {
+			fmt.Fprintf(os.Stderr, "Error binding flags: %s\n", err)
+		}
+	},
 	Run: func(cmd *cobra.Command, args []string) {
 		conn, err := util.GetGrpcConnection(cmd)
 		if err != nil {
@@ -103,8 +108,4 @@ func init() {
 	OrgCmd.AddCommand(org_getCmd)
 	org_getCmd.Flags().Int32P("id", "i", -1, "ID for the organisation to query")
 	org_getCmd.Flags().StringP("name", "n", "", "Name for the organisation to query")
-
-	if err := viper.BindPFlags(org_getCmd.Flags()); err != nil {
-		fmt.Fprintf(os.Stderr, "Error binding flags: %s\n", err)
-	}
 }

--- a/cmd/cli/app/org/org_list.go
+++ b/cmd/cli/app/org/org_list.go
@@ -42,6 +42,11 @@ var org_listCmd = &cobra.Command{
 	Short: "List organizations within a mediator control plane",
 	Long: `The medctl org list subcommand lets you list organizations within a
 mediator control plane.`,
+	PreRun: func(cmd *cobra.Command, args []string) {
+		if err := viper.BindPFlags(cmd.Flags()); err != nil {
+			fmt.Fprintf(os.Stderr, "Error binding flags: %s\n", err)
+		}
+	},
 	Run: func(cmd *cobra.Command, args []string) {
 		conn, err := util.GetGrpcConnection(cmd)
 		if err != nil {
@@ -114,8 +119,4 @@ func init() {
 	org_listCmd.Flags().StringP("output", "o", "", "Output format (json or yaml)")
 	org_listCmd.Flags().Int32P("limit", "l", -1, "Limit the number of results returned")
 	org_listCmd.Flags().Int32P("offset", "f", 0, "Offset the results returned")
-
-	if err := viper.BindPFlags(org_listCmd.Flags()); err != nil {
-		fmt.Fprintf(os.Stderr, "Error binding flags: %s\n", err)
-	}
 }

--- a/cmd/cli/app/role/role.go
+++ b/cmd/cli/app/role/role.go
@@ -17,13 +17,9 @@
 package role
 
 import (
-	"fmt"
-	"os"
-
 	"github.com/stacklok/mediator/cmd/cli/app"
 
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
 )
 
 // RoleCmd is the root command for the role subcommands
@@ -39,7 +35,4 @@ a mediator controlplane.`,
 
 func init() {
 	app.RootCmd.AddCommand(RoleCmd)
-	if err := viper.BindPFlags(RoleCmd.PersistentFlags()); err != nil {
-		fmt.Fprintf(os.Stderr, "Error binding flags: %s\n", err)
-	}
 }

--- a/cmd/cli/app/role/role_create.go
+++ b/cmd/cli/app/role/role_create.go
@@ -39,6 +39,11 @@ var role_createCmd = &cobra.Command{
 	Short: "Create a role within a mediator control plane",
 	Long: `The medctl role create subcommand lets you create new roles for a group
 within a mediator control plane.`,
+	PreRun: func(cmd *cobra.Command, args []string) {
+		if err := viper.BindPFlags(cmd.Flags()); err != nil {
+			fmt.Fprintf(os.Stderr, "Error binding flags: %s\n", err)
+		}
+	},
 	Run: func(cmd *cobra.Command, args []string) {
 		// create the role via GRPC
 		group := util.GetConfigValue("group-id", "group-id", cmd, int32(0)).(int32)
@@ -47,6 +52,10 @@ within a mediator control plane.`,
 		isProtected := util.GetConfigValue("is_protected", "is_protected", cmd, false).(bool)
 
 		conn, err := util.GetGrpcConnection(cmd)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error getting grpc connection: %s\n", err)
+			os.Exit(1)
+		}
 		defer conn.Close()
 
 		if err != nil {
@@ -94,10 +103,6 @@ func init() {
 	}
 	if err := role_createCmd.MarkFlagRequired("group-id"); err != nil {
 		fmt.Fprintf(os.Stderr, "Error marking flag as required: %s\n", err)
-		os.Exit(1)
-	}
-	if err := viper.BindPFlags(role_createCmd.Flags()); err != nil {
-		fmt.Fprintf(os.Stderr, "Error binding flags: %s\n", err)
 		os.Exit(1)
 	}
 }

--- a/cmd/cli/app/role/role_delete.go
+++ b/cmd/cli/app/role/role_delete.go
@@ -24,7 +24,6 @@ package role
 import (
 	"context"
 	"fmt"
-	"log"
 	"os"
 	"time"
 
@@ -39,6 +38,11 @@ var role_deleteCmd = &cobra.Command{
 	Short: "delete a role within a mediator controlplane",
 	Long: `The medctl role delete subcommand lets you delete roles within a
 mediator control plane.`,
+	PreRun: func(cmd *cobra.Command, args []string) {
+		if err := viper.BindPFlags(cmd.Flags()); err != nil {
+			fmt.Fprintf(os.Stderr, "Error binding flags: %s\n", err)
+		}
+	},
 	Run: func(cmd *cobra.Command, args []string) {
 		// delete the role via GRPC
 		id := util.GetConfigValue("role-id", "role-id", cmd, int32(0)).(int32)
@@ -79,9 +83,5 @@ func init() {
 	if err := role_deleteCmd.MarkFlagRequired("role-id"); err != nil {
 		fmt.Fprintf(os.Stderr, "Error marking flag as required: %s\n", err)
 		os.Exit(1)
-	}
-
-	if err := viper.BindPFlags(role_deleteCmd.Flags()); err != nil {
-		log.Fatal(err)
 	}
 }

--- a/cmd/cli/app/user/user.go
+++ b/cmd/cli/app/user/user.go
@@ -17,13 +17,9 @@
 package user
 
 import (
-	"fmt"
-	"os"
-
 	"github.com/stacklok/mediator/cmd/cli/app"
 
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
 )
 
 // UserCmd is the root command for the user subcommands.
@@ -39,7 +35,4 @@ a mediator controlplane.`,
 
 func init() {
 	app.RootCmd.AddCommand(UserCmd)
-	if err := viper.BindPFlags(UserCmd.PersistentFlags()); err != nil {
-		fmt.Fprintf(os.Stderr, "Error binding flags: %s\n", err)
-	}
 }

--- a/cmd/cli/app/user/user_create.go
+++ b/cmd/cli/app/user/user_create.go
@@ -39,6 +39,11 @@ var user_createCmd = &cobra.Command{
 	Short: "Create a user within a mediator control plane",
 	Long: `The medctl user create subcommand lets you create new users for a role
 within a mediator control plane.`,
+	PreRun: func(cmd *cobra.Command, args []string) {
+		if err := viper.BindPFlags(cmd.Flags()); err != nil {
+			fmt.Fprintf(os.Stderr, "Error binding flags: %s\n", err)
+		}
+	},
 	Run: func(cmd *cobra.Command, args []string) {
 		// create the user via GRPC
 		role := util.GetConfigValue("role-id", "role-id", cmd, int32(0)).(int32)
@@ -111,11 +116,6 @@ func init() {
 	}
 	if err := user_createCmd.MarkFlagRequired("role-id"); err != nil {
 		fmt.Fprintf(os.Stderr, "Error marking flag as required: %s\n", err)
-		os.Exit(1)
-	}
-
-	if err := viper.BindPFlags(user_createCmd.Flags()); err != nil {
-		fmt.Fprintf(os.Stderr, "Error binding flags: %s\n", err)
 		os.Exit(1)
 	}
 }

--- a/cmd/cli/app/user/user_delete.go
+++ b/cmd/cli/app/user/user_delete.go
@@ -24,7 +24,6 @@ package user
 import (
 	"context"
 	"fmt"
-	"log"
 	"os"
 	"time"
 
@@ -39,6 +38,11 @@ var user_deleteCmd = &cobra.Command{
 	Short: "delete a user within a mediator controlplane",
 	Long: `The medctl user delete subcommand lets you delete users within a
 mediator control plane.`,
+	PreRun: func(cmd *cobra.Command, args []string) {
+		if err := viper.BindPFlags(cmd.Flags()); err != nil {
+			fmt.Fprintf(os.Stderr, "Error binding flags: %s\n", err)
+		}
+	},
 	Run: func(cmd *cobra.Command, args []string) {
 		// delete the user via GRPC
 		id := util.GetConfigValue("user-id", "user-id", cmd, int32(0)).(int32)
@@ -79,9 +83,5 @@ func init() {
 	if err := user_deleteCmd.MarkFlagRequired("user-id"); err != nil {
 		fmt.Fprintf(os.Stderr, "Error marking flag as required: %s\n", err)
 		os.Exit(1)
-	}
-
-	if err := viper.BindPFlags(user_deleteCmd.Flags()); err != nil {
-		log.Fatal(err)
 	}
 }


### PR DESCRIPTION
Binding flags on init causes to incorrectly bind all flags of all commands, actually causing inconsistencies when flags are duplicated.

Closes: #207