### PR TITLE
fix: solve problems with golangci-lint

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -18,4 +18,4 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:
-          version: latest
+          version: v1.52.2


### PR DESCRIPTION
Latest version came with problems with depguard:
https://github.com/OpenPeeDeeP/depguard/issues/46

Current solution for now is pinning golangci-lint version to do not use latest deps.

Fix is currently ongoing here:
https://github.com/golangci/golangci-lint/pull/3866

But anyway it's good idea to have a pinned version and do not consume from latest.