### PR TITLE
fix: random charts in password generation need to match validation rules

### DIFF
--- a/pkg/util/random.go
+++ b/pkg/util/random.go
@@ -63,7 +63,7 @@ func RandomPassword(length int, seed int64) string {
 	upperChars := "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
 	lowerChars := "abcdefghijklmnopqrstuvwxyz"
 	numberChars := "0123456789"
-	specialChars := "!@#$"
+	specialChars := "!@#?*"
 
 	r := NewRand(seed)
 


### PR DESCRIPTION
The random chars for pass generation was missing one special char, so it was generating passwords that were not passing validation