### PR TITLE
feat: use rs256 for token generation

### DIFF
--- a/config/config.yaml.example
+++ b/config/config.yaml.example
@@ -52,7 +52,10 @@ database:
 
 # Crypto (these should be ultimately stored in a secure vault)
 auth:
-  jwt_key: "secret"
+  access_token_private_key: "$HOME/.ssh/access_token_rsa"
+  access_token_public_key: "$HOME/.ssh/acces_token_rsa.pub"
+  refresh_token_private_key: "$HOME/.ssh/refresh_token_rsa"
+  refresh_token_public_key: "$HOME/.ssh/refresh_token_rsa.pub"
   token_expiry: 3600
   refresh_expiry: 86400
 

--- a/pkg/util/random.go
+++ b/pkg/util/random.go
@@ -22,6 +22,10 @@
 package util
 
 import (
+	crand "crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/pem"
 	"math/rand"
 )
 
@@ -104,4 +108,27 @@ func fillPasswordChars(r *rand.Rand, password []byte, charset string, count int)
 
 func getRandomChar(r *rand.Rand, charset string) byte {
 	return charset[r.Intn(len(charset))]
+}
+
+// RandomKeypair returns a random RSA keypair
+func RandomKeypair(length int) ([]byte, []byte) {
+	privateKey, err := rsa.GenerateKey(crand.Reader, length)
+	if err != nil {
+		return nil, nil
+	}
+	publicKey := &privateKey.PublicKey
+
+	privateKeyPEM := &pem.Block{
+		Type:  "RSA PRIVATE KEY",
+		Bytes: x509.MarshalPKCS1PrivateKey(privateKey),
+	}
+	publicKeyPEM := &pem.Block{
+		Type:  "RSA PUBLIC KEY",
+		Bytes: x509.MarshalPKCS1PublicKey(publicKey),
+	}
+	// Encode the PEM block to a string
+	privateKeyString := pem.EncodeToMemory(privateKeyPEM)
+	publicKeyString := pem.EncodeToMemory(publicKeyPEM)
+
+	return privateKeyString, publicKeyString
 }


### PR DESCRIPTION
Modify the generation and verification of token, using rs256 method. Also include generation date for token, and username.
Modify tests to properly use keys.

Closes: #228