### PR TITLE
fix: do not use deprecated packages

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -61,6 +61,7 @@ linters:
     - ineffassign
     - promlinter
     - revive
+    - staticcheck
     - unused
 
 issues:

--- a/cmd/cli/app/apply/apply.go
+++ b/cmd/cli/app/apply/apply.go
@@ -19,7 +19,7 @@ package apply
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -82,14 +82,14 @@ var ApplyCmd = &cobra.Command{
 		var err error
 
 		if f == "-" {
-			data, err = ioutil.ReadAll(os.Stdin)
+			data, err = io.ReadAll(os.Stdin)
 			if err != nil {
 				fmt.Fprintf(os.Stderr, "Error reading from stdin: %s\n", err)
 				os.Exit(1)
 			}
 		} else {
 			f = filepath.Clean(f)
-			data, err = ioutil.ReadFile(f)
+			data, err = os.ReadFile(f)
 			if err != nil {
 				fmt.Fprintf(os.Stderr, "Error reading file %s: %s\n", f, err)
 				os.Exit(1)

--- a/cmd/cli/app/user/user_delete.go
+++ b/cmd/cli/app/user/user_delete.go
@@ -49,12 +49,11 @@ mediator control plane.`,
 		force := util.GetConfigValue("force", "force", cmd, false).(bool)
 
 		conn, err := util.GetGrpcConnection(cmd)
-		defer conn.Close()
-
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Error getting grpc connection: %s\n", err)
 			os.Exit(1)
 		}
+		defer conn.Close()
 
 		client := pb.NewUserServiceClient(conn)
 		ctx, cancel := context.WithTimeout(context.Background(), time.Second)

--- a/pkg/controlplane/handlers_auth.go
+++ b/pkg/controlplane/handlers_auth.go
@@ -18,7 +18,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 
 	"github.com/go-playground/validator/v10"
@@ -64,7 +64,7 @@ func (s *Server) LogIn(ctx context.Context, in *pb.LogInRequest) (*pb.LogInRespo
 	}
 
 	privateKeyPath = filepath.Clean(privateKeyPath)
-	keyBytes, err := ioutil.ReadFile(privateKeyPath)
+	keyBytes, err := os.ReadFile(privateKeyPath)
 	if err != nil {
 		return &pb.LogInResponse{Status: "Failed to read private key"}, nil
 	}
@@ -75,7 +75,7 @@ func (s *Server) LogIn(ctx context.Context, in *pb.LogInRequest) (*pb.LogInRespo
 	}
 
 	refreshPrivateKeyPath = filepath.Clean(refreshPrivateKeyPath)
-	refreshKeyBytes, err := ioutil.ReadFile(refreshPrivateKeyPath)
+	refreshKeyBytes, err := os.ReadFile(refreshPrivateKeyPath)
 	if err != nil {
 		return &pb.LogInResponse{Status: "Failed to read private key"}, nil
 	}

--- a/pkg/controlplane/handlers_authz.go
+++ b/pkg/controlplane/handlers_authz.go
@@ -17,7 +17,7 @@ package controlplane
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"reflect"
 
@@ -41,7 +41,7 @@ func parseToken(token string) (auth.UserClaims, error) {
 	if publicKeyPath == "" {
 		return claims, fmt.Errorf("could not read public key")
 	}
-	pubKeyData, err := ioutil.ReadFile(filepath.Clean(publicKeyPath))
+	pubKeyData, err := os.ReadFile(filepath.Clean(publicKeyPath))
 	if err != nil {
 		return claims, fmt.Errorf("failed to read public key file")
 	}


### PR DESCRIPTION
Removed the usage of ioutils as it has been deprecated. Also include staticcheck on the linters, because it validates deprecation. Fix additional lint errors.

Closes: #240