### PR TITLE
fix: do not fail if creds file do not exist

### DIFF
--- a/pkg/util/helpers.go
+++ b/pkg/util/helpers.go
@@ -138,16 +138,16 @@ func GetGrpcConnection(cmd *cobra.Command) (*grpc.ClientConn, error) {
 	grpc_port := GetConfigValue("grpc_server.port", "grpc-port", cmd, 0).(int)
 	address := fmt.Sprintf("%s:%d", grpc_host, grpc_port)
 
-	// read the credentials
+	// read credentials
+	token := ""
 	creds, err := LoadCredentials()
-	if err != nil {
-		return nil, fmt.Errorf("error loading credentials: %v", err)
+	if err == nil {
+		token = creds.AccessToken
 	}
 
 	// generate credentials
-
 	conn, err := grpc.Dial(address, grpc.WithTransportCredentials(insecure.NewCredentials()),
-		grpc.WithPerRPCCredentials(JWTTokenCredentials(creds.AccessToken)))
+		grpc.WithPerRPCCredentials(JWTTokenCredentials(token)))
 	if err != nil {
 		return nil, fmt.Errorf("error connecting to gRPC server: %v", err)
 	}


### PR DESCRIPTION
Instead, just pass a blank token. It will allow requests that do not need creds to still work (login, check health, etc...) While request that need auth will fail anyway because the token will be invalid

Closes: #246