### PR TITLE
feat: allow to create users that do not belong to any org

### DIFF
--- a/cmd/cli/app/user/user_create.go
+++ b/cmd/cli/app/user/user_create.go
@@ -128,8 +128,9 @@ within a mediator control plane.`,
 			}
 
 			clientr := pb.NewRoleServiceClient(conn)
+			isAdmin := true
 			respr, err := clientr.CreateRole(ctx, &pb.CreateRoleRequest{GroupId: respg.GroupId,
-				Name: username.(string) + "-role"})
+				Name: username.(string) + "-role", IsAdmin: &isAdmin})
 
 			if err != nil {
 				fmt.Fprintf(os.Stderr, "Error creating role: %s\n", err)


### PR DESCRIPTION
Allow to do it by avoiding the "role-id" flag. In this case a question will arise asking the user if the desire is to create a self enrolled user.

Closes: #237