### PR TITLE
Issue 239 rationalise some more error messages

### DIFF
--- a/cmd/cli/app/enroll/enroll_provider.go
+++ b/cmd/cli/app/enroll/enroll_provider.go
@@ -137,10 +137,7 @@ actions such as adding repositories.`,
 			Cli:      true,
 			Port:     int32(port),
 		})
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "Error getting authorization URL: %s\n", err)
-			os.Exit(1)
-		}
+		util.ExitNicelyOnError(err, "Error getting authorization URL")
 
 		fmt.Printf("Your browser will now be opened to: %s\n", resp.GetUrl())
 		fmt.Println("Please follow the instructions on the page to complete the OAuth flow.")

--- a/cmd/cli/app/group/group_create.go
+++ b/cmd/cli/app/group/group_create.go
@@ -72,11 +72,7 @@ a mediator control plane.`,
 			OrganizationId: organization,
 			IsProtected:    protectedPtr,
 		})
-
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "Error creating group: %s\n", err)
-			os.Exit(1)
-		}
+		util.ExitNicelyOnError(err, "Error creating group")
 
 		group, err := json.MarshalIndent(resp, "", "  ")
 		if err != nil {

--- a/cmd/cli/app/group/group_delete.go
+++ b/cmd/cli/app/group/group_delete.go
@@ -49,11 +49,8 @@ mediator control plane.`,
 		force := util.GetConfigValue("force", "force", cmd, false).(bool)
 
 		conn, err := util.GetGrpcConnection(cmd)
+		util.ExitNicelyOnError(err, "Error getting grpc connection")
 
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "Error getting grpc connection: %s\n", err)
-			os.Exit(1)
-		}
 		defer conn.Close()
 
 		client := pb.NewGroupServiceClient(conn)
@@ -65,11 +62,8 @@ mediator control plane.`,
 			Id:    id,
 			Force: forcePtr,
 		})
+		util.ExitNicelyOnError(err, "Error deleting group")
 
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "Error deleting group: %s\n", err)
-			os.Exit(1)
-		}
 		cmd.Println("Successfully deleted group with id:", id)
 	},
 }

--- a/cmd/cli/app/group/group_get.go
+++ b/cmd/cli/app/group/group_get.go
@@ -72,19 +72,22 @@ mediator control plane.`,
 		}
 
 		var groupRecord *pb.GroupRecord
+
 		// get by id
 		if id > 0 {
-			group, _ := client.GetGroupById(ctx, &pb.GetGroupByIdRequest{
+			group, err := client.GetGroupById(ctx, &pb.GetGroupByIdRequest{
 				GroupId: id,
 			})
+			util.ExitNicelyOnError(err, "Error getting group")
 			if group != nil {
 				groupRecord = group.Group
 			}
 		} else if name != "" {
 			// get by name
-			group, _ := client.GetGroupByName(ctx, &pb.GetGroupByNameRequest{
+			group, err := client.GetGroupByName(ctx, &pb.GetGroupByNameRequest{
 				Name: name,
 			})
+			util.ExitNicelyOnError(err, "Error getting group")
 			if group != nil {
 				groupRecord = group.Group
 			}

--- a/cmd/cli/app/group/group_list.go
+++ b/cmd/cli/app/group/group_list.go
@@ -73,10 +73,7 @@ a mediator control plane.`,
 			Limit:          limit,
 			Offset:         offset,
 		})
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "Error getting groups: %s\n", err)
-			os.Exit(1)
-		}
+		util.ExitNicelyOnError(err, "Error getting groups")
 
 		// print output in a table
 		if format == "" {

--- a/cmd/cli/app/org/org_create.go
+++ b/cmd/cli/app/org/org_create.go
@@ -72,11 +72,7 @@ within a mediator control plane.`,
 			Company:              company.(string),
 			CreateDefaultRecords: create.(bool),
 		})
-
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "Error creating organization: %s\n", err)
-			os.Exit(1)
-		}
+		util.ExitNicelyOnError(err, "Error creating organization")
 
 		org, err := json.MarshalIndent(resp, "", "  ")
 		if err != nil {

--- a/cmd/cli/app/org/org_delete.go
+++ b/cmd/cli/app/org/org_delete.go
@@ -49,11 +49,8 @@ mediator control plane.`,
 		force := util.GetConfigValue("force", "force", cmd, false).(bool)
 
 		conn, err := util.GetGrpcConnection(cmd)
+		util.ExitNicelyOnError(err, "Error getting grpc connection")
 
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "Error getting grpc connection: %s\n", err)
-			os.Exit(1)
-		}
 		defer conn.Close()
 
 		client := pb.NewOrganizationServiceClient(conn)
@@ -66,10 +63,7 @@ mediator control plane.`,
 			Force: forcePtr,
 		})
 
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "Error deleting organization: %s\n", err)
-			os.Exit(1)
-		}
+		util.ExitNicelyOnError(err, "Error deleting organization")
 		cmd.Println("Successfully deleted organization with id:", id)
 	},
 }

--- a/cmd/cli/app/org/org_get.go
+++ b/cmd/cli/app/org/org_get.go
@@ -47,10 +47,7 @@ mediator control plane.`,
 	},
 	Run: func(cmd *cobra.Command, args []string) {
 		conn, err := util.GetGrpcConnection(cmd)
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "Error getting grpc connection: %s\n", err)
-			os.Exit(1)
-		}
+		util.ExitNicelyOnError(err, "Error getting grpc connection")
 		defer conn.Close()
 
 		client := pb.NewOrganizationServiceClient(conn)

--- a/cmd/cli/app/org/org_list.go
+++ b/cmd/cli/app/org/org_list.go
@@ -74,10 +74,7 @@ mediator control plane.`,
 			Limit:  limitPtr,
 			Offset: offsetPtr,
 		})
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "Error getting organizations: %s\n", err)
-			os.Exit(1)
-		}
+		util.ExitNicelyOnError(err, "Error getting organizations")
 
 		// print output in a table
 		if format == "" {

--- a/cmd/cli/app/role/role_create.go
+++ b/cmd/cli/app/role/role_create.go
@@ -77,11 +77,8 @@ within a mediator control plane.`,
 			IsAdmin:     adminPtr,
 			IsProtected: protectedPtr,
 		})
+		util.ExitNicelyOnError(err, "Error creating role")
 
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "Error creating role: %s\n", err)
-			os.Exit(1)
-		}
 		role, err := json.MarshalIndent(resp, "", "  ")
 		if err != nil {
 			cmd.Println("Created role: ", resp.Name)

--- a/cmd/cli/app/role/role_delete.go
+++ b/cmd/cli/app/role/role_delete.go
@@ -50,10 +50,7 @@ mediator control plane.`,
 
 		conn, err := util.GetGrpcConnection(cmd)
 
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "Error getting grpc connection: %s\n", err)
-			os.Exit(1)
-		}
+		util.ExitNicelyOnError(err, "Error getting grpc connection")
 		defer conn.Close()
 
 		client := pb.NewRoleServiceClient(conn)
@@ -66,10 +63,7 @@ mediator control plane.`,
 			Force: forcePtr,
 		})
 
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "Error deleting role: %s\n", err)
-			os.Exit(1)
-		}
+		util.ExitNicelyOnError(err, "Error deleting role")
 		cmd.Println("Successfully deleted role with id:", id)
 	},
 }

--- a/cmd/cli/app/role/role_get.go
+++ b/cmd/cli/app/role/role_get.go
@@ -47,10 +47,7 @@ mediator control plane.`,
 	},
 	Run: func(cmd *cobra.Command, args []string) {
 		conn, err := util.GetGrpcConnection(cmd)
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "Error getting grpc connection: %s\n", err)
-			os.Exit(1)
-		}
+		util.ExitNicelyOnError(err, "Error getting grpc connection")
 		defer conn.Close()
 
 		client := pb.NewRoleServiceClient(conn)

--- a/cmd/cli/app/role/role_list.go
+++ b/cmd/cli/app/role/role_list.go
@@ -76,10 +76,7 @@ mediator control plane for an specific group.`,
 			Limit:   limitPtr,
 			Offset:  offsetPtr,
 		})
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "Error getting roles: %s\n", err)
-			os.Exit(1)
-		}
+		util.ExitNicelyOnError(err, "Error getting roles")
 
 		// print output in a table
 		if format == "" {

--- a/cmd/cli/app/user/user_delete.go
+++ b/cmd/cli/app/user/user_delete.go
@@ -49,10 +49,8 @@ mediator control plane.`,
 		force := util.GetConfigValue("force", "force", cmd, false).(bool)
 
 		conn, err := util.GetGrpcConnection(cmd)
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "Error getting grpc connection: %s\n", err)
-			os.Exit(1)
-		}
+		util.ExitNicelyOnError(err, "Error getting grpc connection")
+
 		defer conn.Close()
 
 		client := pb.NewUserServiceClient(conn)
@@ -65,10 +63,7 @@ mediator control plane.`,
 			Force: forcePtr,
 		})
 
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "Error deleting user: %s\n", err)
-			os.Exit(1)
-		}
+		util.ExitNicelyOnError(err, "Error deleting user")
 		cmd.Println("Successfully deleted user with id:", id)
 	},
 }

--- a/cmd/cli/app/user/user_get.go
+++ b/cmd/cli/app/user/user_get.go
@@ -80,10 +80,7 @@ mediator control plane.`,
 
 	Run: func(cmd *cobra.Command, args []string) {
 		conn, err := util.GetGrpcConnection(cmd)
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "Error getting grpc connection: %s\n", err)
-			os.Exit(1)
-		}
+		util.ExitNicelyOnError(err, "Error getting grpc connection")
 		defer conn.Close()
 
 		client := pb.NewUserServiceClient(conn)

--- a/cmd/cli/app/user/user_list.go
+++ b/cmd/cli/app/user/user_list.go
@@ -77,10 +77,7 @@ mediator control plane for an specific role.`,
 			Limit:  limitPtr,
 			Offset: offsetPtr,
 		})
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "Error getting users: %s\n", err)
-			os.Exit(1)
-		}
+		util.ExitNicelyOnError(err, "Error getting users")
 
 		// print output in a table
 		if format == "" {

--- a/pkg/util/statuses.go
+++ b/pkg/util/statuses.go
@@ -24,8 +24,11 @@ package util
 
 import (
 	"fmt"
+	"os"
+	"strings"
 
 	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 // NiceStatus A wrapper around a status to give a better description.
@@ -141,4 +144,19 @@ authentication credentials for the operation.`
 func (s *NiceStatus) String() string {
 	ret := fmt.Sprintf("Code: %d\nName: %s\nDescription: %s\nDetails: %s", s.Code, s.Name, s.Description, s.Details)
 	return ret
+}
+
+// ExitNicelyOnError print a message and exit with the right code
+func ExitNicelyOnError(err error, message string) {
+	if err != nil {
+		ret := status.Convert(err)
+		ns := GetNiceStatus(ret.Code())
+		es := fmt.Sprintf("%s", err)
+		if len(es) > 0 && !strings.Contains(es, "rpc error:") {
+			fmt.Fprintf(os.Stderr, "%s: %s\n", message, es)
+		} else {
+			fmt.Fprintf(os.Stderr, "%s: %s\n", message, ns)
+		}
+		os.Exit(int(ret.Code()))
+	}
 }


### PR DESCRIPTION
This is another small chunk of error rationalisation.

I have done most of the client side (not checked all of it in because of conflicts). The client changes should act pretty much as before even without the server changes. 

The only part of the server so far is handlers_groups.go. This shows the general pattern of returning status errors
```
return nil, fmt.Errorf("failed to get group by name: %w", err)
```
goes to
```
return nil, status.Errorf(codes.NotFound, "failed to get group by name: %s", err)
```
Where the text will be logged but the message the user sees is purely based on the code.

There is lots more to do, but this is a start. Please feel free to merge.

