### PR TITLE
fix: do not use reserved chars for password

### DIFF
--- a/pkg/controlplane/handlers_auth.go
+++ b/pkg/controlplane/handlers_auth.go
@@ -35,7 +35,7 @@ import (
 
 type loginValidation struct {
 	Username string `db:"username" validate:"required"`
-	Password string `validate:"min=8,containsany=_.,:;?&"`
+	Password string `validate:"min=8,containsany=_.;?&"`
 }
 
 func generateToken(ctx context.Context, store db.Store, userId int32) (string, string, int64, int64, auth.UserClaims, error) {

--- a/pkg/controlplane/handlers_user.go
+++ b/pkg/controlplane/handlers_user.go
@@ -35,7 +35,7 @@ type createUserValidation struct {
 	RoleId   int32  `db:"role_id" validate:"required"`
 	Email    string `db:"email" validate:"omitempty,email"`
 	Username string `db:"username" validate:"required"`
-	Password string `validate:"omitempty,min=8,containsany=!@#?*"`
+	Password string `validate:"omitempty,min=8,containsany=.;?&"`
 }
 
 func stringToNullString(s *string) *sql.NullString {
@@ -339,8 +339,8 @@ func (s *Server) GetUserByEmail(ctx context.Context,
 }
 
 type updatePasswordValidation struct {
-	Password             string `validate:"min=8,containsany=_.,:;?&"`
-	PasswordConfirmation string `validate:"min=8,containsany=_.,:;?&"`
+	Password             string `validate:"min=8,containsany=_.;?&"`
+	PasswordConfirmation string `validate:"min=8,containsany=_.;?&"`
 }
 
 // UpdatePassword is a service for updating a user's password

--- a/pkg/controlplane/handlers_user_test.go
+++ b/pkg/controlplane/handlers_user_test.go
@@ -45,6 +45,7 @@ func TestCreateUserDBMock(t *testing.T) {
 	lastname := "Bar"
 	email := "test@stacklok.com"
 	password := util.RandomPassword(8, seed)
+
 	request := &pb.CreateUserRequest{
 		RoleId:    1,
 		Email:     &email,
@@ -57,9 +58,9 @@ func TestCreateUserDBMock(t *testing.T) {
 	expectedUser := db.User{
 		ID:                  1,
 		RoleID:              1,
-		Email:               sql.NullString{String: "test@stacklok.com", Valid: true},
+		Email:               sql.NullString{String: email, Valid: true},
 		Username:            "test",
-		Password:            "1234567@",
+		Password:            util.RandomPassword(8, seed),
 		FirstName:           sql.NullString{String: "Foo", Valid: true},
 		LastName:            sql.NullString{String: "Bar", Valid: true},
 		IsProtected:         false,
@@ -302,7 +303,7 @@ func TestDeleteUserDBMock(t *testing.T) {
 		RoleID:      1,
 		Email:       sql.NullString{String: "test@stacklok.com", Valid: true},
 		Username:    "test",
-		Password:    "1234567@",
+		Password:    util.RandomPassword(8, time.Now().UnixNano()),
 		FirstName:   sql.NullString{String: "Foo", Valid: true},
 		LastName:    sql.NullString{String: "Bar", Valid: true},
 		IsProtected: false,

--- a/pkg/util/random.go
+++ b/pkg/util/random.go
@@ -75,7 +75,7 @@ func RandomPassword(length int, seed int64) string {
 	upperChars := "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
 	lowerChars := "abcdefghijklmnopqrstuvwxyz"
 	numberChars := "0123456789"
-	specialChars := "_.,:;?&"
+	specialChars := "_.;?&"
 
 	r := NewRand(seed)
 


### PR DESCRIPTION
Modified the chars for pass generation and validation, tested against a set of special chars that do not need escaping.

Closes: #271