### PR TITLE
Fix `make bootstrap`, at least on my Mac

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,10 +44,8 @@ run-server: ## run the app
 
 bootstrap: ## install build deps
 	go generate -tags tools tools/tools.go
-	cd tools
-	go mod tidy
-	@go install github.com/grpc-ecosystem/grpc-gateway/v2/protoc-gen-grpc-gateway github.com/grpc-ecosystem/grpc-gateway/v2/protoc-gen-openapiv2 google.golang.org/protobuf/cmd/protoc-gen-go google.golang.org/grpc/cmd/protoc-gen-go-grpc
-	cd ..
+	# N.B. each line runs in a different subshell, so we don't need to undo the 'cd' here
+	cd tools && go mod tidy && go install github.com/grpc-ecosystem/grpc-gateway/v2/protoc-gen-grpc-gateway github.com/grpc-ecosystem/grpc-gateway/v2/protoc-gen-openapiv2 google.golang.org/protobuf/cmd/protoc-gen-go google.golang.org/grpc/cmd/protoc-gen-go-grpc
 
 test: clean ## display test coverage
 	go test -json -v ./... | gotestfmt

--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ It is currently in early development.
 - [Docker Compose](https://docs.docker.com/compose/install/) or..
 - [Podman Compose](https://github.com/containers/podman-compose#installation)
 
+Once you have these and have [cloned the repository](#clone-the-repository), you'll also need to [install the other tools](#install-tools) and make sure that `$HOME/go/bin` is in your `PATH`.
+
 ## Clone the repository
 
 ```bash


### PR DESCRIPTION
Per https://unix.stackexchange.com/questions/150786/why-current-directory-doesnt-change-in-makefile and a number of others, each new line of a Makefile is 
executed as a separate shell started by the `make` process.  So `cd foo` on its own line doesn't do anything.

Added a comment so people don't try to "simplify" the line.  :grin:
