### PR TITLE
Make database migrate up idempotent

### DIFF
--- a/cmd/server/app/migrate_up.go
+++ b/cmd/server/app/migrate_up.go
@@ -17,6 +17,7 @@
 package app
 
 import (
+	"errors"
 	"fmt"
 	"os"
 
@@ -67,9 +68,12 @@ var upCmd = &cobra.Command{
 			os.Exit(1)
 		}
 		if err := m.Up(); err != nil {
-			fmt.Printf("Error while migrating database: %v\n", err)
-			os.Exit(1)
-
+			if !errors.Is(err, migrate.ErrNoChange) {
+				fmt.Printf("Error while migrating database: %v\n", err)
+				os.Exit(1)
+			} else {
+				fmt.Println("Database already up-to-date")
+			}
 		}
 		fmt.Println("Database migration completed successfully")
 	},


### PR DESCRIPTION
If there is no change in the database migration, we don't need to fail the
command. The reasoning behind this is that we could add the migration command
to the docker-compose file (or a kube manifest if we ever get one), and it could
simply run the migration with the safe assumption that it'll pass.

Note that the fact that it's idempotent doesn't mean it can be ran in parallel.
