### PR TITLE
Change entrypoint to just the main binary

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,4 +27,4 @@ ADD ./ $APP_ROOT/src/
 RUN CGO_ENABLED=0 go build -trimpath -o mediator-server ./cmd/server
 
 # Set the binary as the entrypoint of the container
-ENTRYPOINT ["/opt/app-root/src/mediator-server", "serve"]
+ENTRYPOINT ["/opt/app-root/src/mediator-server"]


### PR DESCRIPTION
By changing the entrypoint to simply be the binary, we may easily create workload
definitions for our containers without having to change the entrypoint. e.g. for
the `migrate` sub-command. This will come in handy as we expand to other services
such as dedicated message brokers/ingestors.
