### PR TITLE
docker-compose: restart migration on failure

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -47,6 +47,12 @@ services:
       - ./config/config.yaml.example:/opt/apt-root/src/config.yaml
     networks:
       - app_net
+    deploy:
+      restart_policy:
+        condition: on-failure
+        delay: 5s
+        max_attempts: 3
+        window: 120s
     depends_on:
       postgres:
         condition: service_healthy


### PR DESCRIPTION
There is a scenario where the postgres container might show up as ready
at a similar time when the migration starts running. In this case, the
migration will fail.

This ensures the migration container is re-run.
