### PR TITLE
Refactor error handling

### DIFF
--- a/cmd/cli/app/auth/auth_login.go
+++ b/cmd/cli/app/auth/auth_login.go
@@ -63,8 +63,8 @@ will be saved to $XDG_CONFIG_HOME/mediator/credentials.json`,
 		resp, err := client.LogIn(ctx, &pb.LogInRequest{Username: username, Password: password})
 		if err != nil {
 			ret := status.Convert(err)
-			ns := util.GetNiceStatus(ret.Code())
-			fmt.Fprintf(os.Stderr, "Error logging in: %s\n", ns)
+			fmt.Fprintf(os.Stderr, "Error logging in: Code: %d\nName: %s\nDetails: %s\n", ret.Code(), ret.Code().String(), ret.Message())
+
 			os.Exit(int(ret.Code()))
 		}
 


### PR DESCRIPTION
The start of a cleanup to make it easier to pass useful error messages to clients.

For this phase, I created a GRPC interceptor specifically for statuses.

I also removed the client-side status normalization in `medctl auth login`, to make it easier to see the server-side behavior, and because we don't want to rely on client-side sanitization.  I also noticed the `logging_interceptor.go` was previously implementing this functionality, so I removed it to the `SanitizingInterceptor`, and put that in at the outermost processor.
