### PR TITLE
Enable metrics by default

### DIFF
--- a/config/config.yaml.example
+++ b/config/config.yaml.example
@@ -36,7 +36,7 @@ tracing:
   #sample_ratio: 0.1
 
 metrics:
-  enabled: false
+  enabled: true
 
 database:
   dbhost: "localhost"

--- a/pkg/controlplane/server.go
+++ b/pkg/controlplane/server.go
@@ -203,7 +203,7 @@ func StartHTTPServer(address, grpcAddress string, store db.Store) {
 		}()
 	}
 
-	viper.SetDefault("metrics.enabled", false)
+	viper.SetDefault("metrics.enabled", true)
 	addMeter := viper.GetBool("metrics.enabled")
 
 	if addMeter {


### PR DESCRIPTION
As @evankanderson suggested, the default case of deployment should have some observability
baked in. This reflects our posture by enabling metrics by default.
