### PR TITLE
Ignore errors on `proto-breaking-changes` test

### DIFF
--- a/.github/workflows/generation.yml
+++ b/.github/workflows/generation.yml
@@ -36,6 +36,8 @@ jobs:
 
   proto-breaking-changes:
     runs-on: ubuntu-latest
+    # TODO(JAORMX): remove this once we declare our protobuf to be stable.
+    continue-on-error: true
     steps:
       - uses: actions/checkout@v3
       - uses: bufbuild/buf-setup-action@v1


### PR DESCRIPTION
This test is not so relevant as of now. We should re-enable it once we
release a beta version of mediator.
