### PR TITLE
Migrate container to use scratch as a base and non-root user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,5 +26,33 @@ ADD ./ $APP_ROOT/src/
 
 RUN CGO_ENABLED=0 go build -trimpath -o mediator-server ./cmd/server
 
+# Create a "nobody" non-root user for the next image by crafting an /etc/passwd
+# file that the next image can copy in. This is necessary since the next image
+# is based on scratch, which doesn't have adduser, cat, echo, or even sh.
+RUN echo "nobody:x:65534:65534:Nobody:/:" > /etc_passwd
+
+RUN mkdir -p /app
+
+FROM scratch
+
+COPY --chown=65534:65534 --from=builder /app /app
+
+WORKDIR /app
+
+# Copy database directory. This is needed for the migration sub-command to work.
+COPY --chown=65534:65534 --from=builder /opt/app-root/src/database /app/database
+
+COPY --from=builder /opt/app-root/src/mediator-server /usr/bin/mediator-server
+
+# Copy the certs from the builder stage
+COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
+
+# Copy the /etc_passwd file we created in the builder stage into /etc/passwd in
+# the target stage. This creates a new non-root user as a security best
+# practice.
+COPY --from=builder /etc_passwd /etc/passwd
+
+USER nobody
+
 # Set the binary as the entrypoint of the container
-ENTRYPOINT ["/opt/app-root/src/mediator-server"]
+ENTRYPOINT ["/usr/bin/mediator-server"]

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -28,12 +28,10 @@ services:
       - "8080:8080"
       - "8090:8090"
     image: ghcr.io/stacklok/mediator:latest
-    volumes:
-      - ./config/config.yaml.example:/opt/apt-root/src/config.yaml
     networks:
       - app_net
     depends_on:
-      - migrate
+      - postgres
   migrate:
     build: .
     command: [
@@ -43,8 +41,6 @@ services:
       "--db-host=postgres",
       ]
     image: ghcr.io/stacklok/mediator:latest
-    volumes:
-      - ./config/config.yaml.example:/opt/apt-root/src/config.yaml
     networks:
       - app_net
     deploy:


### PR DESCRIPTION
To decrease the attack vector and follow hardened defaults, this changes
the base image to be `scratch` with a `nobody` user that's set up
in the container.

Since our defaults actually work out of the box, this also removes the
mounting of the config. We now only rely on the minimal the containers need.
