### PR TITLE
Fix migratedown and bootstrap

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,12 +47,12 @@ bootstrap: ## install build deps
 	# N.B. each line runs in a different subshell, so we don't need to undo the 'cd' here
 	cd tools && go mod tidy && go install github.com/grpc-ecosystem/grpc-gateway/v2/protoc-gen-grpc-gateway github.com/grpc-ecosystem/grpc-gateway/v2/protoc-gen-openapiv2 google.golang.org/protobuf/cmd/protoc-gen-go google.golang.org/grpc/cmd/protoc-gen-go-grpc
 	# Create a config.yaml if it doesn't exist
-	cp -n config/config.yaml.example ./config.yaml
+	cp -n config/config.yaml.example ./config.yaml || echo "config.yaml already exists, not overwriting"
 	# Create keys:
-	mkdir .ssh
+	mkdir -p .ssh
 	# No passphrase (-N), don't overwrite existing keys ("n" to prompt)
-	echo n | ssh-keygen -t rsa -b 2048 -N "" -m PEM -f .ssh/access_token_rsa
-	echo n | ssh-keygen -t rsa -b 2048 -N "" -m PEM -f .ssh/refresh_token_rsa
+	echo n | ssh-keygen -t rsa -b 2048 -N "" -m PEM -f .ssh/access_token_rsa || true
+	echo n | ssh-keygen -t rsa -b 2048 -N "" -m PEM -f .ssh/refresh_token_rsa || true
 
 test: clean ## display test coverage
 	go test -json -v ./... | gotestfmt

--- a/database/migrations/000001_init.down.sql
+++ b/database/migrations/000001_init.down.sql
@@ -13,7 +13,12 @@
 -- limitations under the License.
 
 
-DROP TABLE IF EXISTS organizations;
-DROP TABLE IF EXISTS groups;
-DROP TABLE IF EXISTS roles;
+DROP TABLE IF EXISTS session_store;
+DROP TABLE IF EXISTS repositories;
+DROP TABLE IF EXISTS provider_access_tokens;
+DROP TABLE IF EXISTS user_roles;
+DROP TABLE IF EXISTS user_groups;
 DROP TABLE IF EXISTS users;
+DROP TABLE IF EXISTS roles;
+DROP TABLE IF EXISTS groups;
+DROP TABLE IF EXISTS organizations;


### PR DESCRIPTION
A little bit of cleanup.  I wanted to refresh my schema and tried running `migratedown`, but that failed.  Then I tried re-`make bootstrap`ping, and that failed too.

I was trying to use the `github.com/golang-migrate/migrate/v4/cmd/migrate` CLI instead of needing `migratedown`, but I discovered that target by default doesn't build with any database drivers (you need to use tags to build it with database drivers), so I backed off that plan for the moment.  The `migrate` command includes the ability to recover (force) the database version if needed, but I ended up dropping my database rather than recovering it.
