### PR TITLE
Use `go.mod` to infer go version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,6 +10,6 @@ jobs:
         run: echo "GOVERSION=$(sed -n 's/^go \([0-9.]*\)/\1/p' go.mod)" >> $GITHUB_ENV
       - uses: actions/setup-go@v4 # v4.0.0
         with:
-          go-version: 1.20.0
+          go-version-file: 'go.mod'
       - name: build
         run: make build

--- a/.github/workflows/generation.yml
+++ b/.github/workflows/generation.yml
@@ -50,7 +50,6 @@ jobs:
   sqlc-generation:
     runs-on: ubuntu-latest
     env:
-      GO_VERSION: 1.20.0
       SQLC_VERSION: 1.18.0
 
     steps:
@@ -60,7 +59,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: 1.20.0
+          go-version-file: 'go.mod'
 
       - name: Install sqlc
         run: |

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -10,11 +10,11 @@ jobs:
     name: Go Lint
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v3
       - uses: actions/setup-go@v4
         with:
-          go-version: "1.20"
+          go-version-file: 'go.mod'
           cache: false
-      - uses: actions/checkout@v3
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:

--- a/.github/workflows/license-check.yml
+++ b/.github/workflows/license-check.yml
@@ -9,7 +9,7 @@ jobs:
 
       - uses: actions/setup-go@v4 # v4.0.0
         with:
-          go-version: 1.20.0
+          go-version-file: 'go.mod'
       - name: Install addlicense
         run: go install github.com/google/addlicense@v1.0.0
       - name: Check license headers

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: 1.20.0
+          go-version-file: 'go.mod'
 
       # Install gotestfmt on the VM running the action.
       - name: Set up gotestfmt


### PR DESCRIPTION
Instead of specifying the golang version on our CI workflows, let's just
let our `go.mod` dictate the version. This way changes to our supported
modules file will also update our CI behaviour.
