### PR TITLE
docker-compose: Explicitly specify user to run

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -56,6 +56,7 @@ services:
       container_name: postgres_container
       image: postgres:14-alpine
       restart: always
+      user: postgres
       environment:
         POSTGRES_USER: postgres
         POSTGRES_PASSWORD: postgres


### PR DESCRIPTION
We were not specifying the user to run the db container with and this
was resulting in very annoying warnings. By specifying the user directly
we are no longer running the container as root and using the dedicated
postgres user instead.
