### PR TITLE
docker-compose: Point to the right database when migrating

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -39,6 +39,7 @@ services:
       "up",
       "--yes",
       "--db-host=postgres",
+      "--db-name=postgres",
       ]
     image: ghcr.io/stacklok/mediator:latest
     networks:


### PR DESCRIPTION
We were not specifying the correct database when running the migration
in docker-compose. This fixes that issue.
