### PR TITLE
fix: map config and keys in docker compose

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -22,12 +22,16 @@ services:
       "--grpc-host=0.0.0.0",
       "--http-host=0.0.0.0",
       "--db-host=postgres",
+      "--config=/app/config.yaml"
       ]
     restart: always # keep the server running
     ports:
       - "8080:8080"
       - "8090:8090"
     image: ghcr.io/stacklok/mediator:latest
+    volumes:
+          - ./config.yaml:/app/config.yaml
+          - .ssh:/app/.ssh
     networks:
       - app_net
     depends_on:


### PR DESCRIPTION
In order to make it work via containers, we need to map the right config.yaml file, and the ssh keys used for generating tokens.