### PR TITLE
Fix sample config to use `nonce_period`

### DIFF
--- a/config/config.yaml.example
+++ b/config/config.yaml.example
@@ -54,7 +54,7 @@ auth:
   refresh_token_public_key: "./.ssh/refresh_token_rsa.pub"
   token_expiry: 3600
   refresh_expiry: 86400
-  nonce: 3600
+  nonce_period: 3600
   session_key: "12345678901234567890123456789012"
 
 # Password Salting, these values are using argon2id


### PR DESCRIPTION
We had just `nonce` which is not the correct configuration. Without this
the provider enrollment registration fails.
