### PR TITLE
Don't print stacktrace in base64

### DIFF
--- a/internal/logger/logging_interceptor.go
+++ b/internal/logger/logging_interceptor.go
@@ -112,7 +112,7 @@ func LogErrorCall(ctx context.Context, logger *zerolog.Event, method string, t t
 			"http.body":            jsonText,
 			"http.duration":        time.Since(t).String(),
 			"exception.message":    err.Error(),
-			"exception.stacktrace": debug.Stack(),
+			"exception.stacktrace": string(debug.Stack()),
 		})
 	}
 


### PR DESCRIPTION
We were logging a base64-encoded stacktrace. This is not great for operations
and usability.

This instead prints the raw stacktrace which is a lot easier to read and debug.
