### PR TITLE
Update golang version in golangci-lint config

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,5 +1,5 @@
 run:
-  go: "1.19"
+  go: "1.20"
   issues-exit-code: 1
 
 linters-settings:


### PR DESCRIPTION
We're using golang 1.20 in our CI and go.mod. So let's reflect that in the linter too.
