### PR TITLE
ci: Add linter for docker-compose

### DIFF
--- a/.github/workflows/docker-compose-lint.yml
+++ b/.github/workflows/docker-compose-lint.yml
@@ -14,12 +14,5 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Fetch docker-compose schema
-        run: |
-          curl -sSL https://raw.githubusercontent.com/compose-spec/compose-spec/master/schema/compose-spec.json -o compose-spec.json
-      - name: Lint docker-compose.yml
-        uses: thiagodnf/yaml-schema-checker@v0.0.10
-        with:
-          jsonSchemaFile: compose-spec.json
-          yamlFiles: |
-            docker-compose.yaml
+      - name: Lint docker-compose.yaml
+        run: docker-compose config --quiet


### PR DESCRIPTION
This uses `docker-compose config` to lint the file.
