### PR TITLE
config: Move database configs to use centralized struct

### DIFF
--- a/cmd/server/app/migrate.go
+++ b/cmd/server/app/migrate.go
@@ -16,10 +16,7 @@
 package app
 
 import (
-	"log"
-
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
 )
 
 // migrateCmd represents the migrate command
@@ -35,13 +32,4 @@ var migrateCmd = &cobra.Command{
 func init() {
 	RootCmd.AddCommand(migrateCmd)
 	migrateCmd.PersistentFlags().BoolP("yes", "y", false, "Answer yes to all questions")
-	migrateCmd.PersistentFlags().StringP("db-host", "H", "localhost", "Database host")
-	migrateCmd.PersistentFlags().Int("db-port", 5432, "Database port")
-	migrateCmd.PersistentFlags().StringP("db-user", "u", "postgres", "Database user")
-	migrateCmd.PersistentFlags().StringP("db-pass", "P", "postgres", "Database password")
-	migrateCmd.PersistentFlags().StringP("db-name", "d", "postgres", "Database name")
-	migrateCmd.PersistentFlags().StringP("sslmode", "s", "disable", "Database sslmode")
-	if err := viper.BindPFlags(migrateCmd.PersistentFlags()); err != nil {
-		log.Fatal(err)
-	}
 }

--- a/cmd/server/app/root.go
+++ b/cmd/server/app/root.go
@@ -18,9 +18,11 @@ package app
 
 import (
 	"fmt"
+	"log"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
+	"github.com/stacklok/mediator/pkg/db"
 	"github.com/stacklok/mediator/pkg/util"
 )
 
@@ -44,6 +46,9 @@ func Execute() {
 func init() {
 	cobra.OnInitialize(initConfig)
 	RootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is $PWD/config.yaml)")
+	if err := db.RegisterFlags(viper.GetViper(), RootCmd.PersistentFlags()); err != nil {
+		log.Fatal(err)
+	}
 }
 
 func initConfig() {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -18,16 +18,17 @@
 package config
 
 import (
-	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
 
 	"github.com/stacklok/mediator/pkg/controlplane"
+	"github.com/stacklok/mediator/pkg/db"
 )
 
 // Config is the top-level configuration structure.
 type Config struct {
 	HTTPServer controlplane.HTTPServerConfig `mapstructure:"http_server"`
 	GRPCServer controlplane.GRPCServerConfig `mapstructure:"grpc_server"`
+	Database   db.Config                     `mapstructure:"database"`
 }
 
 // ReadConfigFromViper reads the configuration from the given Viper instance.
@@ -38,13 +39,4 @@ func ReadConfigFromViper(v *viper.Viper) (*Config, error) {
 		return nil, err
 	}
 	return &cfg, nil
-}
-
-// RegisterFlags registers all flags for the given Viper instance.
-func RegisterFlags(v *viper.Viper, flags *pflag.FlagSet) error {
-	if err := controlplane.RegisterHTTPServerFlags(v, flags); err != nil {
-		return err
-	}
-
-	return controlplane.RegisterGRPCServerFlags(v, flags)
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/stacklok/mediator/internal/config"
+	"github.com/stacklok/mediator/pkg/controlplane"
 )
 
 func TestReadValidConfig(t *testing.T) {
@@ -41,9 +42,6 @@ grpc_server:
 	cfgbuf := bytes.NewBufferString(cfgstr)
 
 	v := viper.New()
-	flags := pflag.NewFlagSet("test", pflag.ContinueOnError)
-
-	require.NoError(t, config.RegisterFlags(v, flags), "Unexpected error")
 
 	v.SetConfigType("yaml")
 	require.NoError(t, v.ReadConfig(cfgbuf), "Unexpected error")
@@ -70,7 +68,8 @@ grpc_server:
 	v := viper.New()
 	flags := pflag.NewFlagSet("test", pflag.ContinueOnError)
 
-	require.NoError(t, config.RegisterFlags(v, flags), "Unexpected error")
+	require.NoError(t, controlplane.RegisterHTTPServerFlags(v, flags), "Unexpected error")
+	require.NoError(t, controlplane.RegisterGRPCServerFlags(v, flags), "Unexpected error")
 
 	v.SetConfigType("yaml")
 	require.NoError(t, v.ReadConfig(cfgbuf), "Unexpected error")
@@ -101,7 +100,8 @@ grpc_server:
 	v := viper.New()
 	flags := pflag.NewFlagSet("test", pflag.ContinueOnError)
 
-	require.NoError(t, config.RegisterFlags(v, flags), "Unexpected error")
+	require.NoError(t, controlplane.RegisterHTTPServerFlags(v, flags), "Unexpected error")
+	require.NoError(t, controlplane.RegisterGRPCServerFlags(v, flags), "Unexpected error")
 
 	require.NoError(t, flags.Parse([]string{"--http-host=foo", "--http-port=1234", "--grpc-host=bar", "--grpc-port=5678"}))
 

--- a/pkg/db/config.go
+++ b/pkg/db/config.go
@@ -1,0 +1,98 @@
+//
+// Copyright 2023 Stacklok, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package db
+
+import (
+	"database/sql"
+	"fmt"
+	"log"
+
+	"github.com/spf13/pflag"
+	"github.com/spf13/viper"
+
+	"github.com/stacklok/mediator/pkg/util"
+)
+
+// Config is the configuration for the database
+type Config struct {
+	Host          string `mapstructure:"dbhost"`
+	Port          int    `mapstructure:"dbport"`
+	User          string `mapstructure:"dbuser"`
+	Password      string `mapstructure:"dbpass"`
+	Name          string `mapstructure:"dbname"`
+	SSLMode       string `mapstructure:"sslmode"`
+	EncryptionKey string `mapstructure:"encryption_key"`
+}
+
+// GetDBURI returns the database URI
+func (c *Config) GetDBURI() string {
+	return fmt.Sprintf("postgres://%s:%s@%s:%d/%s?sslmode=%s",
+		c.User, c.Password, c.Host, c.Port, c.Name, c.SSLMode)
+}
+
+// GetDBConnection returns a connection to the database
+func (c *Config) GetDBConnection() (*sql.DB, string, error) {
+	conn, err := sql.Open("postgres", c.GetDBURI())
+	if err != nil {
+		return nil, "", err
+	}
+
+	// Ensure we actually connected to the database, per Go docs
+	if err := conn.Ping(); err != nil {
+		//nolint:gosec // Not much we can do about an error here.
+		conn.Close()
+		return nil, "", err
+	}
+
+	log.Println("Connected to DB")
+	return conn, c.GetDBURI(), err
+}
+
+// RegisterFlags registers the flags for the database configuration
+func RegisterFlags(v *viper.Viper, flags *pflag.FlagSet) error {
+	err := util.BindConfigFlagWithShort(
+		v, flags, "database.dbhost", "db-host", "H", "localhost", "Database host", flags.StringP)
+	if err != nil {
+		return err
+	}
+
+	err = util.BindConfigFlag(
+		v, flags, "database.dbport", "db-port", 5432, "Database port", flags.Int)
+	if err != nil {
+		return err
+	}
+
+	err = util.BindConfigFlagWithShort(
+		v, flags, "database.dbuser", "db-user", "u", "postgres", "Database user", flags.StringP)
+	if err != nil {
+		return err
+	}
+
+	err = util.BindConfigFlagWithShort(
+		v, flags, "database.dbpass", "db-pass", "P", "postgres", "Database password", flags.StringP)
+	if err != nil {
+		return err
+	}
+
+	err = util.BindConfigFlagWithShort(
+		v, flags, "database.dbname", "db-name", "d", "mediator", "Database name", flags.StringP)
+	if err != nil {
+		return err
+	}
+
+	return util.BindConfigFlagWithShort(
+		v, flags, "database.sslmode", "db-sslmode", "s", "disable", "Database sslmode", flags.StringP)
+}

--- a/pkg/util/configutils.go
+++ b/pkg/util/configutils.go
@@ -24,6 +24,9 @@ import (
 // FlagInst is a function that creates a flag and returns a pointer to the value
 type FlagInst[V any] func(name string, value V, usage string) *V
 
+// FlagInstShort is a function that creates a flag and returns a pointer to the value
+type FlagInstShort[V any] func(name, shorthand string, value V, usage string) *V
+
 // BindConfigFlag is a helper function that binds a configuration value to a flag.
 //
 // Parameters:
@@ -44,6 +47,41 @@ func BindConfigFlag[V any](
 	binder FlagInst[V],
 ) error {
 	binder(cmdLineArg, defaultValue, help)
+	return doViperBind[V](v, flags, viperPath, cmdLineArg, defaultValue)
+}
+
+// BindConfigFlagWithShort is a helper function that binds a configuration value to a flag.
+//
+// Parameters:
+// - v: The viper.Viper object used to retrieve the configuration value.
+// - flags: The pflag.FlagSet object used to retrieve the flag value.
+// - viperPath: The path used to retrieve the configuration value from Viper.
+// - cmdLineArg: The flag name used to check if the flag has been set and to retrieve its value.
+// - short: The short name for the flag.
+// - help: The help text for the flag.
+// - defaultValue: A default value used to determine the type of the flag (string, int, etc.).
+// - binder: A function that creates a flag and returns a pointer to the value.
+func BindConfigFlagWithShort[V any](
+	v *viper.Viper,
+	flags *pflag.FlagSet,
+	viperPath string,
+	cmdLineArg string,
+	short string,
+	defaultValue V,
+	help string,
+	binder FlagInstShort[V],
+) error {
+	binder(cmdLineArg, short, defaultValue, help)
+	return doViperBind[V](v, flags, viperPath, cmdLineArg, defaultValue)
+}
+
+func doViperBind[V any](
+	v *viper.Viper,
+	flags *pflag.FlagSet,
+	viperPath string,
+	cmdLineArg string,
+	defaultValue V,
+) error {
 	v.SetDefault(viperPath, defaultValue)
 	if err := v.BindPFlag(viperPath, flags.Lookup(cmdLineArg)); err != nil {
 		return fmt.Errorf("failed to bind flag %s to viper path %s: %w", cmdLineArg, viperPath, err)

--- a/pkg/util/helpers.go
+++ b/pkg/util/helpers.go
@@ -24,14 +24,11 @@ package util
 
 import (
 	"context"
-	"database/sql"
 	"encoding/json"
 	"fmt"
-	"log"
 	"net"
 	"os"
 	"path/filepath"
-	"strconv"
 	"time"
 
 	_ "github.com/lib/pq" // nolint
@@ -72,33 +69,6 @@ func GetConfigValue(key string, flagName string, cmd *cobra.Command, defaultValu
 		return value
 	}
 	return defaultValue
-}
-
-// GetDbConnectionFromConfig is a helper to get a database connection and connection string from a viper config
-func GetDbConnectionFromConfig(cmd *cobra.Command) (*sql.DB, string, error) {
-	// Database configuration
-	dbhost := GetConfigValue("database.dbhost", "db-host", cmd, "localhost").(string)
-	dbport := GetConfigValue("database.dbport", "db-port", cmd, 5432).(int)
-	dbuser := GetConfigValue("database.dbuser", "db-user", cmd, "postgres").(string)
-	dbpass := GetConfigValue("database.dbpass", "db-pass", cmd, "postgres").(string)
-	dbname := GetConfigValue("database.dbname", "db-name", cmd, "mediator").(string)
-	dbsslmode := GetConfigValue("database.sslmode", "db-sslmode", cmd, "disable").(string)
-
-	dbConn := fmt.Sprintf("postgres://%s:%s@%s:%s/%s?sslmode=%s", dbuser, dbpass, dbhost, strconv.Itoa(dbport), dbname, dbsslmode)
-	conn, err := sql.Open("postgres", dbConn)
-	if err != nil {
-		return nil, "", err
-	}
-
-	// Ensure we actually connected to the database, per Go docs
-	if err := conn.Ping(); err != nil {
-		//nolint:gosec // Not much we can do about an error here.
-		conn.Close()
-		return nil, "", err
-	}
-
-	log.Println("Connected to DB")
-	return conn, dbConn, err
 }
 
 // Credentials is a struct to hold the access and refresh tokens


### PR DESCRIPTION
This uses the central struct pattern to define the database configurations.

If we only need some of the flags for a certain sub-command, we may use the database
configs directly.
