### PR TITLE
config: Move most things to a central configuration place

### DIFF
--- a/cmd/server/app/root.go
+++ b/cmd/server/app/root.go
@@ -22,7 +22,8 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
-	"github.com/stacklok/mediator/pkg/db"
+
+	"github.com/stacklok/mediator/internal/config"
 	"github.com/stacklok/mediator/pkg/util"
 )
 
@@ -46,12 +47,14 @@ func Execute() {
 func init() {
 	cobra.OnInitialize(initConfig)
 	RootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is $PWD/config.yaml)")
-	if err := db.RegisterFlags(viper.GetViper(), RootCmd.PersistentFlags()); err != nil {
+	if err := config.RegisterDatabaseFlags(viper.GetViper(), RootCmd.PersistentFlags()); err != nil {
 		log.Fatal(err)
 	}
 }
 
 func initConfig() {
+	config.SetViperDefaults(viper.GetViper())
+
 	if cfgFile != "" {
 		viper.SetConfigFile(cfgFile)
 	} else {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -19,16 +19,17 @@ package config
 
 import (
 	"github.com/spf13/viper"
-
-	"github.com/stacklok/mediator/pkg/controlplane"
-	"github.com/stacklok/mediator/pkg/db"
 )
 
 // Config is the top-level configuration structure.
 type Config struct {
-	HTTPServer controlplane.HTTPServerConfig `mapstructure:"http_server"`
-	GRPCServer controlplane.GRPCServerConfig `mapstructure:"grpc_server"`
-	Database   db.Config                     `mapstructure:"database"`
+	HTTPServer    HTTPServerConfig `mapstructure:"http_server"`
+	GRPCServer    GRPCServerConfig `mapstructure:"grpc_server"`
+	LoggingConfig LoggingConfig    `mapstructure:"logging"`
+	Tracing       TracingConfig    `mapstructure:"tracing"`
+	Metrics       MetricsConfig    `mapstructure:"metrics"`
+	Database      DatabaseConfig   `mapstructure:"database"`
+	Salt          CryptoConfig     `mapstructure:"salt"`
 }
 
 // ReadConfigFromViper reads the configuration from the given Viper instance.
@@ -39,4 +40,13 @@ func ReadConfigFromViper(v *viper.Viper) (*Config, error) {
 		return nil, err
 	}
 	return &cfg, nil
+}
+
+// SetViperDefaults sets the default values for the configuration to be picked
+// up by viper
+func SetViperDefaults(v *viper.Viper) {
+	SetLoggingViperDefaults(v)
+	SetTracingViperDefaults(v)
+	SetMetricsViperDefaults(v)
+	SetCryptoViperDefaults(v)
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -24,7 +24,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/stacklok/mediator/internal/config"
-	"github.com/stacklok/mediator/pkg/controlplane"
 )
 
 func TestReadValidConfig(t *testing.T) {
@@ -68,8 +67,8 @@ grpc_server:
 	v := viper.New()
 	flags := pflag.NewFlagSet("test", pflag.ContinueOnError)
 
-	require.NoError(t, controlplane.RegisterHTTPServerFlags(v, flags), "Unexpected error")
-	require.NoError(t, controlplane.RegisterGRPCServerFlags(v, flags), "Unexpected error")
+	require.NoError(t, config.RegisterHTTPServerFlags(v, flags), "Unexpected error")
+	require.NoError(t, config.RegisterGRPCServerFlags(v, flags), "Unexpected error")
 
 	v.SetConfigType("yaml")
 	require.NoError(t, v.ReadConfig(cfgbuf), "Unexpected error")
@@ -100,8 +99,8 @@ grpc_server:
 	v := viper.New()
 	flags := pflag.NewFlagSet("test", pflag.ContinueOnError)
 
-	require.NoError(t, controlplane.RegisterHTTPServerFlags(v, flags), "Unexpected error")
-	require.NoError(t, controlplane.RegisterGRPCServerFlags(v, flags), "Unexpected error")
+	require.NoError(t, config.RegisterHTTPServerFlags(v, flags), "Unexpected error")
+	require.NoError(t, config.RegisterGRPCServerFlags(v, flags), "Unexpected error")
 
 	require.NoError(t, flags.Parse([]string{"--http-host=foo", "--http-port=1234", "--grpc-host=bar", "--grpc-port=5678"}))
 

--- a/internal/config/crypto.go
+++ b/internal/config/crypto.go
@@ -1,0 +1,59 @@
+//
+// Copyright 2023 Stacklok, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+import (
+	"github.com/spf13/viper"
+)
+
+const (
+	saltMemory     = 64 * 1024
+	saltIterations = 3
+	saltParameters = 2
+	saltLength     = 16
+	saltKeyLength  = 32
+)
+
+// CryptoConfig is the configuration for the crypto package
+type CryptoConfig struct {
+	Memory      uint32 `mapstructure:"memory"`
+	Iterations  uint32 `mapstructure:"iterations"`
+	Parallelism uint   `mapstructure:"parallelism"`
+	SaltLength  uint32 `mapstructure:"salt_length"`
+	KeyLength   uint32 `mapstructure:"key_length"`
+}
+
+// SetCryptoViperDefaults sets the default values for the crypto configuration
+// to be picked up by viper
+func SetCryptoViperDefaults(v *viper.Viper) {
+	// set default values when not set
+	v.SetDefault("salt.memory", saltMemory)
+	v.SetDefault("salt.iterations", saltIterations)
+	v.SetDefault("salt.parallelism", saltParameters)
+	v.SetDefault("salt.salt_length", saltLength)
+	v.SetDefault("salt.key_length", saltKeyLength)
+}
+
+// GetCryptoConfigWithDefaults returns a CryptoConfig with default values
+func GetCryptoConfigWithDefaults() CryptoConfig {
+	return CryptoConfig{
+		Memory:      saltMemory,
+		Iterations:  saltIterations,
+		Parallelism: saltParameters,
+		SaltLength:  saltLength,
+		KeyLength:   saltKeyLength,
+	}
+}

--- a/internal/config/db.go
+++ b/internal/config/db.go
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package db
+package config
 
 import (
 	"database/sql"
@@ -26,8 +26,8 @@ import (
 	"github.com/stacklok/mediator/pkg/util"
 )
 
-// Config is the configuration for the database
-type Config struct {
+// DatabaseConfig is the configuration for the database
+type DatabaseConfig struct {
 	Host          string `mapstructure:"dbhost"`
 	Port          int    `mapstructure:"dbport"`
 	User          string `mapstructure:"dbuser"`
@@ -38,13 +38,13 @@ type Config struct {
 }
 
 // GetDBURI returns the database URI
-func (c *Config) GetDBURI() string {
+func (c *DatabaseConfig) GetDBURI() string {
 	return fmt.Sprintf("postgres://%s:%s@%s:%d/%s?sslmode=%s",
 		c.User, c.Password, c.Host, c.Port, c.Name, c.SSLMode)
 }
 
 // GetDBConnection returns a connection to the database
-func (c *Config) GetDBConnection() (*sql.DB, string, error) {
+func (c *DatabaseConfig) GetDBConnection() (*sql.DB, string, error) {
 	conn, err := sql.Open("postgres", c.GetDBURI())
 	if err != nil {
 		return nil, "", err
@@ -61,8 +61,8 @@ func (c *Config) GetDBConnection() (*sql.DB, string, error) {
 	return conn, c.GetDBURI(), err
 }
 
-// RegisterFlags registers the flags for the database configuration
-func RegisterFlags(v *viper.Viper, flags *pflag.FlagSet) error {
+// RegisterDatabaseFlags registers the flags for the database configuration
+func RegisterDatabaseFlags(v *viper.Viper, flags *pflag.FlagSet) error {
 	err := util.BindConfigFlagWithShort(
 		v, flags, "database.dbhost", "db-host", "H", "localhost", "Database host", flags.StringP)
 	if err != nil {

--- a/internal/config/logging.go
+++ b/internal/config/logging.go
@@ -1,0 +1,33 @@
+//
+// Copyright 2023 Stacklok, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+import "github.com/spf13/viper"
+
+// LoggingConfig is the configuration for the logging package
+type LoggingConfig struct {
+	Level   string `mapstructure:"level"`
+	Format  string `mapstructure:"format"`
+	LogFile string `mapstructure:"logFile"`
+}
+
+// SetLoggingViperDefaults sets the default values for the logging configuration
+// to be picked up by viper
+func SetLoggingViperDefaults(v *viper.Viper) {
+	v.SetDefault("logging.level", "debug")
+	v.SetDefault("logging.format", "json")
+	v.SetDefault("logging.logFile", "")
+}

--- a/internal/config/metrics.go
+++ b/internal/config/metrics.go
@@ -1,0 +1,29 @@
+//
+// Copyright 2023 Stacklok, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+import "github.com/spf13/viper"
+
+// MetricsConfig is the configuration for the metrics
+type MetricsConfig struct {
+	Enabled bool `mapstructure:"enabled"`
+}
+
+// SetMetricsViperDefaults sets the default values for the metrics configuration
+// to be picked up by viper
+func SetMetricsViperDefaults(v *viper.Viper) {
+	v.SetDefault("metrics.enabled", true)
+}

--- a/internal/config/server.go
+++ b/internal/config/server.go
@@ -1,10 +1,11 @@
+//
 // Copyright 2023 Stacklok, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//	http://www.apache.org/licenses/LICENSE-2.0
+//     http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -12,9 +13,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package controlplane
+package config
 
 import (
+	"fmt"
+
 	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
 
@@ -29,12 +32,22 @@ type HTTPServerConfig struct {
 	Port int `mapstructure:"port"`
 }
 
+// GetAddress returns the address to bind to
+func (s *HTTPServerConfig) GetAddress() string {
+	return fmt.Sprintf("%s:%d", s.Host, s.Port)
+}
+
 // GRPCServerConfig is the configuration for the gRPC server
 type GRPCServerConfig struct {
 	// Host is the host to bind to
 	Host string `mapstructure:"host"`
 	// Port is the port to bind to
 	Port int `mapstructure:"port"`
+}
+
+// GetAddress returns the address to bind to
+func (s *GRPCServerConfig) GetAddress() string {
+	return fmt.Sprintf("%s:%d", s.Host, s.Port)
 }
 
 // RegisterHTTPServerFlags registers the flags for the HTTP server

--- a/internal/config/tracing.go
+++ b/internal/config/tracing.go
@@ -1,0 +1,33 @@
+//
+// Copyright 2023 Stacklok, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+import "github.com/spf13/viper"
+
+// TracingConfig is the configuration for our tracing capabilities
+type TracingConfig struct {
+	Enabled bool `mapstructure:"enabled"`
+	// for the demonstration, we use AlwaysSmaple sampler to take all spans.
+	// do not use this option in production.
+	SampleRatio float64 `mapstructure:"sample_ratio"`
+}
+
+// SetTracingViperDefaults sets the default values for the tracing configuration
+// to be picked up by viper
+func SetTracingViperDefaults(v *viper.Viper) {
+	v.SetDefault("tracing.enabled", false)
+	v.SetDefault("tracing.sample_ratio", 0.1)
+}

--- a/pkg/controlplane/handlers_groups_test.go
+++ b/pkg/controlplane/handlers_groups_test.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/golang/mock/gomock"
 
+	"github.com/stacklok/mediator/internal/config"
 	"github.com/stacklok/mediator/pkg/auth"
 	"github.com/stacklok/mediator/pkg/db"
 	"github.com/stretchr/testify/assert"
@@ -175,7 +176,7 @@ func TestCreateGroup_gRPC(t *testing.T) {
 			mockStore := mockdb.NewMockStore(ctrl)
 			tc.buildStubs(mockStore)
 
-			server := NewServer(mockStore)
+			server := NewServer(mockStore, &config.Config{})
 
 			resp, err := server.CreateGroup(ctx, tc.req)
 			tc.checkResponse(t, resp, err)
@@ -294,7 +295,7 @@ func TestDeleteGroup_gRPC(t *testing.T) {
 			mockStore := mockdb.NewMockStore(ctrl)
 			tc.buildStubs(mockStore)
 
-			server := NewServer(mockStore)
+			server := NewServer(mockStore, &config.Config{})
 
 			resp, err := server.DeleteGroup(ctx, tc.req)
 			tc.checkResponse(t, resp, err)
@@ -439,7 +440,7 @@ func TestGetGroups_gRPC(t *testing.T) {
 			mockStore := mockdb.NewMockStore(ctrl)
 			tc.buildStubs(mockStore)
 
-			server := NewServer(mockStore)
+			server := NewServer(mockStore, &config.Config{})
 
 			resp, err := server.GetGroups(ctx, tc.req)
 			tc.checkResponse(t, resp, err)
@@ -604,7 +605,7 @@ func TestGetGroup_gRPC(t *testing.T) {
 			mockStore := mockdb.NewMockStore(ctrl)
 			tc.buildStubs(mockStore)
 
-			server := NewServer(mockStore)
+			server := NewServer(mockStore, &config.Config{})
 
 			resp, err := server.GetGroupById(ctx, tc.req)
 			tc.checkResponse(t, resp, err)

--- a/pkg/controlplane/handlers_oauth_test.go
+++ b/pkg/controlplane/handlers_oauth_test.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/golang/mock/gomock"
 	mockdb "github.com/stacklok/mediator/database/mock"
+	"github.com/stacklok/mediator/internal/config"
 	"github.com/stacklok/mediator/pkg/auth"
 	"github.com/stacklok/mediator/pkg/db"
 	pb "github.com/stacklok/mediator/pkg/generated/protobuf/go/mediator/v1"
@@ -33,43 +34,43 @@ import (
 func TestNewOAuthConfig(t *testing.T) {
 
 	// Test with CLI set
-	config, err := auth.NewOAuthConfig("google", true)
+	cfg, err := auth.NewOAuthConfig("google", true)
 	if err != nil {
 		t.Errorf("Error in newOAuthConfig: %v", err)
 	}
 
-	if config.Endpoint != google.Endpoint {
-		t.Errorf("Unexpected endpoint: %v", config.Endpoint)
+	if cfg.Endpoint != google.Endpoint {
+		t.Errorf("Unexpected endpoint: %v", cfg.Endpoint)
 	}
 
 	// Test with CLI set
-	config, err = auth.NewOAuthConfig("github", true)
+	cfg, err = auth.NewOAuthConfig("github", true)
 	if err != nil {
 		t.Errorf("Error in newOAuthConfig: %v", err)
 	}
 
-	if config.Endpoint != github.Endpoint {
-		t.Errorf("Unexpected endpoint: %v", config.Endpoint)
+	if cfg.Endpoint != github.Endpoint {
+		t.Errorf("Unexpected endpoint: %v", cfg.Endpoint)
 	}
 
 	// Test with CLI set
-	config, err = auth.NewOAuthConfig("google", false)
+	cfg, err = auth.NewOAuthConfig("google", false)
 	if err != nil {
 		t.Errorf("Error in newOAuthConfig: %v", err)
 	}
 
-	if config.Endpoint != google.Endpoint {
-		t.Errorf("Unexpected endpoint: %v", config.Endpoint)
+	if cfg.Endpoint != google.Endpoint {
+		t.Errorf("Unexpected endpoint: %v", cfg.Endpoint)
 	}
 
 	// Test with CLI set
-	config, err = auth.NewOAuthConfig("github", false)
+	cfg, err = auth.NewOAuthConfig("github", false)
 	if err != nil {
 		t.Errorf("Error in newOAuthConfig: %v", err)
 	}
 
-	if config.Endpoint != github.Endpoint {
-		t.Errorf("Unexpected endpoint: %v", config.Endpoint)
+	if cfg.Endpoint != github.Endpoint {
+		t.Errorf("Unexpected endpoint: %v", cfg.Endpoint)
 	}
 
 	_, err = auth.NewOAuthConfig("invalid", true)
@@ -165,7 +166,7 @@ func TestRevokeOauthTokens_gRPC(t *testing.T) {
 	mockStore := mockdb.NewMockStore(ctrl)
 	mockStore.EXPECT().GetAccessTokenByProvider(gomock.Any(), gomock.Any())
 
-	server := NewServer(mockStore)
+	server := NewServer(mockStore, &config.Config{})
 
 	res, err := server.RevokeOauthTokens(ctx, &pb.RevokeOauthTokensRequest{Provider: auth.Github})
 
@@ -188,7 +189,7 @@ func RevokeOauthGroupToken_gRPC(t *testing.T) {
 	mockStore := mockdb.NewMockStore(ctrl)
 	mockStore.EXPECT().GetAccessTokenByGroupID(gomock.Any(), gomock.Any())
 
-	server := NewServer(mockStore)
+	server := NewServer(mockStore, &config.Config{})
 
 	res, err := server.RevokeOauthGroupToken(ctx, &pb.RevokeOauthGroupTokenRequest{Provider: auth.Github, GroupId: 1})
 

--- a/pkg/controlplane/handlers_organization_test.go
+++ b/pkg/controlplane/handlers_organization_test.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/golang/mock/gomock"
 
+	"github.com/stacklok/mediator/internal/config"
 	"github.com/stacklok/mediator/pkg/auth"
 	"github.com/stacklok/mediator/pkg/db"
 	"github.com/stretchr/testify/assert"
@@ -187,7 +188,7 @@ func TestCreateOrganization_gRPC(t *testing.T) {
 			mockStore := mockdb.NewMockStore(ctrl)
 			tc.buildStubs(mockStore)
 
-			server := NewServer(mockStore)
+			server := NewServer(mockStore, &config.Config{})
 
 			resp, err := server.CreateOrganization(ctx, tc.req)
 			tc.checkResponse(t, resp, err)
@@ -328,7 +329,7 @@ func TestGetOrganizations_gRPC(t *testing.T) {
 			mockStore := mockdb.NewMockStore(ctrl)
 			tc.buildStubs(mockStore)
 
-			server := NewServer(mockStore)
+			server := NewServer(mockStore, &config.Config{})
 
 			resp, err := server.GetOrganizations(ctx, tc.req)
 			tc.checkResponse(t, resp, err)
@@ -496,7 +497,7 @@ func TestGetOrganization_gRPC(t *testing.T) {
 			mockStore := mockdb.NewMockStore(ctrl)
 			tc.buildStubs(mockStore)
 
-			server := NewServer(mockStore)
+			server := NewServer(mockStore, &config.Config{})
 
 			resp, err := server.GetOrganization(ctx, tc.req)
 			tc.checkResponse(t, resp, err)
@@ -663,7 +664,7 @@ func TestGetOrganizationByName_gRPC(t *testing.T) {
 			mockStore := mockdb.NewMockStore(ctrl)
 			tc.buildStubs(mockStore)
 
-			server := NewServer(mockStore)
+			server := NewServer(mockStore, &config.Config{})
 
 			resp, err := server.GetOrganizationByName(ctx, tc.req)
 			tc.checkResponse(t, resp, err)
@@ -779,7 +780,7 @@ func TestDeleteOrganization_gRPC(t *testing.T) {
 			mockStore := mockdb.NewMockStore(ctrl)
 			tc.buildStubs(mockStore)
 
-			server := NewServer(mockStore)
+			server := NewServer(mockStore, &config.Config{})
 
 			resp, err := server.DeleteOrganization(ctx, tc.req)
 			tc.checkResponse(t, resp, err)

--- a/pkg/controlplane/handlers_policy_test.go
+++ b/pkg/controlplane/handlers_policy_test.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/golang/mock/gomock"
 
+	"github.com/stacklok/mediator/internal/config"
 	"github.com/stacklok/mediator/pkg/auth"
 	"github.com/stacklok/mediator/pkg/db"
 	"github.com/stretchr/testify/assert"
@@ -161,7 +162,7 @@ func TestCreatePolicy_gRPC(t *testing.T) {
 			mockStore := mockdb.NewMockStore(ctrl)
 			tc.buildStubs(mockStore)
 
-			server := NewServer(mockStore)
+			server := NewServer(mockStore, &config.Config{})
 
 			resp, err := server.CreatePolicy(ctx, tc.req)
 			tc.checkResponse(t, resp, err)
@@ -262,7 +263,7 @@ func TestDeletePolicy_gRPC(t *testing.T) {
 			mockStore := mockdb.NewMockStore(ctrl)
 			tc.buildStubs(mockStore)
 
-			server := NewServer(mockStore)
+			server := NewServer(mockStore, &config.Config{})
 
 			resp, err := server.DeletePolicy(ctx, tc.req)
 			tc.checkResponse(t, resp, err)
@@ -388,7 +389,7 @@ func TestGetPolicies_gRPC(t *testing.T) {
 			mockStore := mockdb.NewMockStore(ctrl)
 			tc.buildStubs(mockStore)
 
-			server := NewServer(mockStore)
+			server := NewServer(mockStore, &config.Config{})
 
 			resp, err := server.GetPolicies(ctx, tc.req)
 			tc.checkResponse(t, resp, err)

--- a/pkg/controlplane/handlers_role_test.go
+++ b/pkg/controlplane/handlers_role_test.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/golang/mock/gomock"
 
+	"github.com/stacklok/mediator/internal/config"
 	"github.com/stacklok/mediator/pkg/auth"
 	"github.com/stacklok/mediator/pkg/db"
 	"github.com/stretchr/testify/assert"
@@ -189,7 +190,7 @@ func TestCreateRole_gRPC(t *testing.T) {
 			mockStore := mockdb.NewMockStore(ctrl)
 			tc.buildStubs(mockStore)
 
-			server := NewServer(mockStore)
+			server := NewServer(mockStore, &config.Config{})
 
 			resp, err := server.CreateRoleByGroup(ctx, tc.req)
 			tc.checkResponse(t, resp, err)
@@ -296,7 +297,7 @@ func TestDeleteRole_gRPC(t *testing.T) {
 			mockStore := mockdb.NewMockStore(ctrl)
 			tc.buildStubs(mockStore)
 
-			server := NewServer(mockStore)
+			server := NewServer(mockStore, &config.Config{})
 
 			resp, err := server.DeleteRole(ctx, tc.req)
 			tc.checkResponse(t, resp, err)
@@ -441,7 +442,7 @@ func TestGetRoles_gRPC(t *testing.T) {
 			mockStore := mockdb.NewMockStore(ctrl)
 			tc.buildStubs(mockStore)
 
-			server := NewServer(mockStore)
+			server := NewServer(mockStore, &config.Config{})
 
 			resp, err := server.GetRoles(ctx, tc.req)
 			tc.checkResponse(t, resp, err)
@@ -595,7 +596,7 @@ func TestGetRole_gRPC(t *testing.T) {
 			mockStore := mockdb.NewMockStore(ctrl)
 			tc.buildStubs(mockStore)
 
-			server := NewServer(mockStore)
+			server := NewServer(mockStore, &config.Config{})
 
 			resp, err := server.GetRoleById(ctx, tc.req)
 			tc.checkResponse(t, resp, err)

--- a/pkg/controlplane/handlers_user.go
+++ b/pkg/controlplane/handlers_user.go
@@ -89,7 +89,7 @@ func (s *Server) CreateUser(ctx context.Context,
 	}
 
 	// hash the password for storing in the database
-	pHash, err := mcrypto.GeneratePasswordHash(*in.Password)
+	pHash, err := mcrypto.GeneratePasswordHash(*in.Password, &s.cfg.Salt)
 	if err != nil {
 		return nil, err
 	}
@@ -584,7 +584,7 @@ func (s *Server) UpdatePassword(ctx context.Context, in *pb.UpdatePasswordReques
 	}
 
 	// hash the password for storing in the database
-	pHash, err := mcrypto.GeneratePasswordHash(in.Password)
+	pHash, err := mcrypto.GeneratePasswordHash(in.Password, &s.cfg.Salt)
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "failed to generate password hash: %s", err)
 	}

--- a/pkg/controlplane/handlers_user_test.go
+++ b/pkg/controlplane/handlers_user_test.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/golang/mock/gomock"
 
+	"github.com/stacklok/mediator/internal/config"
 	"github.com/stacklok/mediator/pkg/auth"
 	"github.com/stacklok/mediator/pkg/db"
 	"github.com/stacklok/mediator/pkg/util"
@@ -89,6 +90,9 @@ func TestCreateUserDBMock(t *testing.T) {
 
 	server := &Server{
 		store: mockStore,
+		cfg: &config.Config{
+			Salt: config.GetCryptoConfigWithDefaults(),
+		},
 	}
 
 	response, err := server.CreateUser(ctx, request)
@@ -194,8 +198,9 @@ func TestCreateUser_gRPC(t *testing.T) {
 
 			mockStore := mockdb.NewMockStore(ctrl)
 			tc.buildStubs(mockStore)
-
-			server := NewServer(mockStore)
+			server := NewServer(mockStore, &config.Config{
+				Salt: config.GetCryptoConfigWithDefaults(),
+			})
 
 			resp, err := server.CreateUser(ctx, tc.req)
 			tc.checkResponse(t, resp, err)
@@ -228,6 +233,9 @@ func TestUpdatePasswordDBMock(t *testing.T) {
 
 	server := &Server{
 		store: mockStore,
+		cfg: &config.Config{
+			Salt: config.GetCryptoConfigWithDefaults(),
+		},
 	}
 
 	response, err := server.UpdatePassword(ctx, request)
@@ -298,7 +306,9 @@ func TestUpdatePassword_gRPC(t *testing.T) {
 			mockStore := mockdb.NewMockStore(ctrl)
 			tc.buildStubs(mockStore)
 
-			server := NewServer(mockStore)
+			server := NewServer(mockStore, &config.Config{
+				Salt: config.GetCryptoConfigWithDefaults(),
+			})
 
 			resp, err := server.UpdatePassword(ctx, tc.req)
 			tc.checkResponse(t, resp, err)
@@ -329,6 +339,9 @@ func TestUpdateProfileDBMock(t *testing.T) {
 
 	server := &Server{
 		store: mockStore,
+		cfg: &config.Config{
+			Salt: config.GetCryptoConfigWithDefaults(),
+		},
 	}
 
 	response, err := server.store.UpdateUser(ctx, db.UpdateUserParams{ID: 1, Email: sql.NullString{String: email, Valid: true},
@@ -401,7 +414,9 @@ func TestUpdateProfile_gRPC(t *testing.T) {
 			mockStore := mockdb.NewMockStore(ctrl)
 			tc.buildStubs(mockStore)
 
-			server := NewServer(mockStore)
+			server := NewServer(mockStore, &config.Config{
+				Salt: config.GetCryptoConfigWithDefaults(),
+			})
 
 			resp, err := server.UpdateProfile(ctx, tc.req)
 			tc.checkResponse(t, resp, err)
@@ -447,6 +462,9 @@ func TestDeleteUserDBMock(t *testing.T) {
 
 	server := &Server{
 		store: mockStore,
+		cfg: &config.Config{
+			Salt: config.GetCryptoConfigWithDefaults(),
+		},
 	}
 
 	response, err := server.DeleteUser(ctx, request)
@@ -520,7 +538,9 @@ func TestDeleteUser_gRPC(t *testing.T) {
 			mockStore := mockdb.NewMockStore(ctrl)
 			tc.buildStubs(mockStore)
 
-			server := NewServer(mockStore)
+			server := NewServer(mockStore, &config.Config{
+				Salt: config.GetCryptoConfigWithDefaults(),
+			})
 
 			resp, err := server.DeleteUser(ctx, tc.req)
 			tc.checkResponse(t, resp, err)
@@ -567,6 +587,9 @@ func TestGetUsersDBMock(t *testing.T) {
 
 	server := &Server{
 		store: mockStore,
+		cfg: &config.Config{
+			Salt: config.GetCryptoConfigWithDefaults(),
+		},
 	}
 
 	response, err := server.GetUsers(ctx, request)
@@ -671,7 +694,9 @@ func TestGetUsers_gRPC(t *testing.T) {
 			mockStore := mockdb.NewMockStore(ctrl)
 			tc.buildStubs(mockStore)
 
-			server := NewServer(mockStore)
+			server := NewServer(mockStore, &config.Config{
+				Salt: config.GetCryptoConfigWithDefaults(),
+			})
 
 			resp, err := server.GetUsers(ctx, tc.req)
 			tc.checkResponse(t, resp, err)
@@ -710,6 +735,9 @@ func TestGetUserDBMock(t *testing.T) {
 
 	server := &Server{
 		store: mockStore,
+		cfg: &config.Config{
+			Salt: config.GetCryptoConfigWithDefaults(),
+		},
 	}
 
 	response, err := server.GetUserById(ctx, request)
@@ -748,6 +776,9 @@ func TestGetNonExistingUserDBMock(t *testing.T) {
 
 	server := &Server{
 		store: mockStore,
+		cfg: &config.Config{
+			Salt: config.GetCryptoConfigWithDefaults(),
+		},
 	}
 
 	response, err := server.GetUserById(ctx, request)
@@ -834,7 +865,9 @@ func TestGetUser_gRPC(t *testing.T) {
 			mockStore := mockdb.NewMockStore(ctrl)
 			tc.buildStubs(mockStore)
 
-			server := NewServer(mockStore)
+			server := NewServer(mockStore, &config.Config{
+				Salt: config.GetCryptoConfigWithDefaults(),
+			})
 
 			resp, err := server.GetUserById(ctx, tc.req)
 			tc.checkResponse(t, resp, err)


### PR DESCRIPTION
This moves everything configuration related into the `internal/config` package.

This allows us to easily track where settings come from and where their defaults
come from as well.

Originally, each package would be in charge of creating their own configuration and
exporing that, but that lead to circular dependencies which got tricky to handle.

This approach instead gives us more predictability which will hopefully lead
to a better developer experience.

Alongside this work, there was an effort done to make the `Server` adopt the configuration
structure more thoroughly.
