### PR TITLE
CI: Add CI test to verify that sqlc has been run

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -41,3 +41,5 @@ jobs:
     uses: ./.github/workflows/test.yml
   image-build:
     uses: ./.github/workflows/image-build.yml
+  tools:
+    uses: ./.github/workflows/tools.yml

--- a/.github/workflows/tools.yml
+++ b/.github/workflows/tools.yml
@@ -1,0 +1,41 @@
+---
+# This workflow is meant to verify that our helper tooling works as expected.
+name: tools
+on:
+  workflow_call:
+permissions:
+  contents: read
+jobs:
+  sqlc:
+    name: sqlc
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: mediator
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 5432:5432
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: actions/setup-go@v4
+        with:
+          go-version-file: 'go.mod'
+          cache: false
+
+      - name: Run make bootstrap
+        run: make bootstrap
+
+      - name: Run make sqlc
+        run: make sqlc
+    
+      - name: Fail if sqlc is not up to date
+        run: git diff --exit-code


### PR DESCRIPTION
This sets up a simple CI job that runs sqlc and verifies that it's been
run recently and it works as expected.

The idea is that we shouldn't accept PRs that haven't had sqlc auto-generate
the SQL queries. This also helps us verify that new changes to sqlc don't
break the code generation.
