### PR TITLE
fix: fix license check for schemas

### DIFF
--- a/.github/workflows/license-check.yml
+++ b/.github/workflows/license-check.yml
@@ -15,5 +15,5 @@ jobs:
       - name: Check license headers
         run: |
           set -e
-          addlicense -ignore **/pkg/generated/* -ignore **/pkg/db/* -ignore **/database/query/* -ignore **/docs/docs/* -ignore ./docs/src/* -ignore ./docs/static/* -ignore **/pkg/controlplane/policy_types/*  -l apache -c 'Stacklok, Inc' -v * 
+          addlicense -l apache -c 'Stacklok, Inc' -v -ignore "pkg/generated/*" -ignore "**/database/query/**" -ignore "pkg/db/*" -ignore "docs/docs/**" -ignore "docs/src/**" -ignore "docs/static/**" -ignore "pkg/controlplane/policy_types/**" -ignore "docs/build/**" *
           git diff --exit-code


### PR DESCRIPTION
Modify addlicense to include the schemas directory, and to work locally in  osx.