### PR TITLE
Keep short, pretty names when building

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,9 +62,9 @@ run-server: ## run the app
 DOCKERARCH := $(shell uname -m | sed 's/x86_64/amd64/' | sed 's/aarch64/arm64/')
 
 run-docker:  ## run the app under docker.
-    # podman (at least) doesn't seem to like multi-arch images, and sometimes picks the wrong one (e.g. amd64 on arm64)
-    # ko resolve will fill in the image: field in the compose file, but it adds a yaml document separator
-	ko resolve --platform linux/$(DOCKERARCH) -f docker-compose.yaml | sed 's/^--*$$//' > .resolved-compose.yaml
+	# podman (at least) doesn't seem to like multi-arch images, and sometimes picks the wrong one (e.g. amd64 on arm64)
+	# ko resolve will fill in the image: field in the compose file, but it adds a yaml document separator
+	ko resolve --base-import-paths --platform linux/$(DOCKERARCH) -f docker-compose.yaml | sed 's/^--*$$//' > .resolved-compose.yaml
 	# MacOS can't tolerate the ":z" flag, Linux needs it.  https://github.com/containers/podman-compose/issues/509
 ifeq ($(OS),Darwin)
 	sed -i '' 's/:z$$//' .resolved-compose.yaml


### PR DESCRIPTION
This produces a more predictable image name (requested by @JAORMX), and it seems unlikely that we're using the problematic registries [mentioned in the documentation](https://ko.build/configuration/#naming-images).