### PR TITLE
Add dockerfile as well as ko options

### DIFF
--- a/.github/workflows/image-build.yml
+++ b/.github/workflows/image-build.yml
@@ -15,3 +15,22 @@ jobs:
           ko build --platform=linux/amd64,linux/arm64 --push=${{ github.ref == 'refs/heads/main' }} ./cmd/server \
             --image-label=org.opencontainers.image.source=https://github.com/stacklok/mediator,org.opencontainers.image.title="Stacklok Mediator",org.opencontainers.image.licenses=Apache-2.0,org.opencontainers.image.vendor=Stacklok
 
+  docker-image:
+    name: Check docker image build
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Test build on x86
+        id: docker_build
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          file: Dockerfile
+          platforms: linux/amd64
+          push: false  # Only attempt to build, to verify the Dockerfile is working

--- a/Dockerfile
+++ b/Dockerfile
@@ -39,8 +39,9 @@ COPY --chown=65534:65534 --from=builder /app /app
 
 WORKDIR /app
 
-# Copy database directory. This is needed for the migration sub-command to work.
-COPY --chown=65534:65534 --from=builder /opt/app-root/src/database /app/database
+# Copy database directory and config. This is needed for the migration sub-command to work.
+ADD --chown=65534:65534 ./cmd/server/kodata/config.yaml /app
+ADD --chown=65534:65534 ./cmd/server/kodata/database/migrations /app/database/migrations
 
 COPY --from=builder /opt/app-root/src/mediator-server /usr/bin/mediator-server
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -16,19 +16,20 @@
 version: '3.2'
 services:
   mediator:
+    build: .
+    image: mediator:latest
+
     command: [
       "serve",
       "--grpc-host=0.0.0.0",
       "--http-host=0.0.0.0",
       "--db-host=postgres",
       "--config=/app/config.yaml"
-
       ]
     restart: always # keep the server running
     ports:
       - "8080:8080"
       - "8090:8090"
-    image: ko://github.com/stacklok/mediator/cmd/server
     volumes:
           - ./config.yaml:/app/config.yaml:z
           - ./.ssh:/app/.ssh:z
@@ -49,13 +50,15 @@ services:
 #      migrate:
 #        condition: service_completed_successfully
   migrate:
+    build: .
+    image: mediator:latest
+
     command: [
       "migrate",
       "up",
       "--yes",
       "--db-host=postgres",
       ]
-    image: ko://github.com/stacklok/mediator/cmd/server
     volumes:
           - ./config.yaml:/app/config.yaml:z
           - ./database/migrations:/app/database/migrations:z


### PR DESCRIPTION
Fixes #460

On Mac, I needed to remove the `:z` option from the volume mounts on Mac to avoid the following error:

```
Error: unable to start container XYZ: preparing container XYZ for attach: lsetxattr .../config.yaml: operation not supported
```