### PR TITLE
rtest: Use right golang structure to parse repository

### DIFF
--- a/cmd/cli/app/rule_type/rtest.go
+++ b/cmd/cli/app/rule_type/rtest.go
@@ -192,7 +192,7 @@ func readEntityFromFile(fpath string, entType string) (any, error) {
 
 	switch entType {
 	case "repository":
-		out = &pb.GetRepositoryByIdResponse{}
+		out = &pb.RepositoryResult{}
 	default:
 		return nil, fmt.Errorf("unknown entity type: %s", entType)
 	}


### PR DESCRIPTION
With some recent changes, we were using the wrong structure.
