### PR TITLE
ci: Increase golangci-lint timeout to 5 min

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,6 +1,7 @@
 run:
   go: "1.20"
   issues-exit-code: 1
+  timeout: 5m
 
 linters-settings:
   lll:


### PR DESCRIPTION
As the codebase grows, we're starting to hit timeouts more constantly. Let's increase it.
