### PR TITLE
ci: Remove proto-breaking changes check

### DIFF
--- a/.github/workflows/generation.yml
+++ b/.github/workflows/generation.yml
@@ -34,18 +34,17 @@ jobs:
       # Lint your Protobuf sources
       - uses: bufbuild/buf-lint-action@v1
 
-  proto-breaking-changes:
-    runs-on: ubuntu-latest
-    # TODO(JAORMX): remove this once we declare our protobuf to be stable.
-    continue-on-error: true
-    steps:
-      - uses: actions/checkout@v3
-      - uses: bufbuild/buf-setup-action@v1
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-      - uses: bufbuild/buf-breaking-action@v1
-        with:
-          against: "https://github.com/stacklok/mediator.git#branch=main"
+  # TODO(jaosorior): Re-enable this once we have a stable API.
+  # proto-breaking-changes:
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - uses: actions/checkout@v3
+  #     - uses: bufbuild/buf-setup-action@v1
+  #       with:
+  #         github_token: ${{ secrets.GITHUB_TOKEN }}
+  #     - uses: bufbuild/buf-breaking-action@v1
+  #       with:
+  #         against: "https://github.com/stacklok/mediator.git#branch=main"
 
   sqlc-generation:
     runs-on: ubuntu-latest


### PR DESCRIPTION
We had tried to continue on error but this is not cutting it as changes are
still appearing as red. We are not in a stage where we have a stable API, so
let's not do these types of checks just yet. Instead, let's defer checking this
until we declar the API stable.
