### PR TITLE
cleanup: Remove duplicated import

### DIFF
--- a/pkg/controlplane/server.go
+++ b/pkg/controlplane/server.go
@@ -24,7 +24,7 @@ import (
 	"time"
 
 	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
-	_ "github.com/lib/pq" // nolint
+	_ "github.com/lib/pq" // This is required for the postgres driver
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc"
 	"go.opentelemetry.io/otel"
@@ -39,8 +39,6 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/reflection"
-
-	_ "github.com/lib/pq" // nolint
 
 	"github.com/stacklok/mediator/internal/config"
 	"github.com/stacklok/mediator/internal/events"


### PR DESCRIPTION
The `github.com/lib/pq` library was being imported twice, this removes a duplicated import.
