### PR TITLE
Add example rule to check for secret push protection

### DIFF
--- a/examples/github/policies/policy.yaml
+++ b/examples/github/policies/policy.yaml
@@ -11,6 +11,9 @@ repository:
       - type: secret_scanning
         def:
           enabled: true
+      - type: secret_push_protection
+        def:
+          enabled: true
       - type: branch_protection
         params:
           branch: main

--- a/examples/github/rule-types/secret_push_protection.yaml
+++ b/examples/github/rule-types/secret_push_protection.yaml
@@ -1,0 +1,38 @@
+---
+version: v1
+type: rule-type
+name: secret_push_protection
+context:
+  provider: github
+  organization: ACME
+def:
+  # Defines the section of the pipeline the rule will appear in.
+  # This will affect the template that is used to render multiple parts
+  # of the rule.
+  in_entity: repository
+  # Defines the schema for writing a rule with this rule being checked
+  rule_schema:
+    properties:
+      enabled:
+        type: boolean
+        default: true
+  # Defines the configuration for both ingesting and evaluating the rule.
+  data_eval:
+    type: rest
+    rest:
+      # This is the path to the data source. Given that this will evaluate
+      # for each repository in the organization, we use a template that
+      # will be evaluated for each repository. The structure to use is the
+      # protobuf structure for the entity that is being evaluated.
+      endpoint: '/repos/{{.Entity.Owner}}/{{.Entity.Repository}}'
+      # This is the method to use to retrieve the data. It should already default to JSON
+      parse: json
+    key-type: jq
+    data:
+      # This key is meant to denote where the info will be
+      # persisted in the aspect itself.
+      ".enabled":
+        # This denotes where the information will be retrieved from
+        # the data source.
+        type: jq
+        def: '.security_and_analysis.secret_scanning_push_protection.status == "enabled"'


### PR DESCRIPTION
This setting ensures that folks don't push secrets to the code-base.
