### PR TITLE
`policy_status list`: return when JSON has been printed out

### DIFF
--- a/cmd/cli/app/policy_status/policy_status_list.go
+++ b/cmd/cli/app/policy_status/policy_status_list.go
@@ -107,6 +107,8 @@ mediator control plane for an specific provider/group or policy id.`,
 					return fmt.Errorf("error marshalling json: %w", err)
 				}
 			}
+
+			return nil
 		}
 
 		enc := yaml.NewEncoder(os.Stdout)


### PR DESCRIPTION
A `return nil` was missing, which made the sub-command output both
JSON and YAML. This fixes that.

Closes: #570
