### PR TITLE
policy: Do initial policy run when it's created

### DIFF
--- a/database/mock/store.go
+++ b/database/mock/store.go
@@ -1131,6 +1131,21 @@ func (mr *MockStoreMockRecorder) ListPoliciesByGroupID(arg0, arg1 interface{}) *
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListPoliciesByGroupID", reflect.TypeOf((*MockStore)(nil).ListPoliciesByGroupID), arg0, arg1)
 }
 
+// ListRegisteredRepositoriesByGroupIDAndProvider mocks base method.
+func (m *MockStore) ListRegisteredRepositoriesByGroupIDAndProvider(arg0 context.Context, arg1 db.ListRegisteredRepositoriesByGroupIDAndProviderParams) ([]db.Repository, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListRegisteredRepositoriesByGroupIDAndProvider", arg0, arg1)
+	ret0, _ := ret[0].([]db.Repository)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListRegisteredRepositoriesByGroupIDAndProvider indicates an expected call of ListRegisteredRepositoriesByGroupIDAndProvider.
+func (mr *MockStoreMockRecorder) ListRegisteredRepositoriesByGroupIDAndProvider(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListRegisteredRepositoriesByGroupIDAndProvider", reflect.TypeOf((*MockStore)(nil).ListRegisteredRepositoriesByGroupIDAndProvider), arg0, arg1)
+}
+
 // ListRepositoriesByGroupID mocks base method.
 func (m *MockStore) ListRepositoriesByGroupID(arg0 context.Context, arg1 db.ListRepositoriesByGroupIDParams) ([]db.Repository, error) {
 	m.ctrl.T.Helper()

--- a/database/query/repositories.sql
+++ b/database/query/repositories.sql
@@ -30,6 +30,11 @@ ORDER BY id
 LIMIT $3
 OFFSET $4;
 
+-- name: ListRegisteredRepositoriesByGroupIDAndProvider :many
+SELECT * FROM repositories
+WHERE provider = $1 AND group_id = $2 AND webhook_id IS NOT NULL
+ORDER BY id;
+
 -- name: ListRepositoriesByOwner :many
 SELECT * FROM repositories
 WHERE provider = $1 AND repo_owner = $2

--- a/pkg/db/querier.go
+++ b/pkg/db/querier.go
@@ -82,6 +82,7 @@ type Querier interface {
 	ListGroupsByOrganizationID(ctx context.Context, organizationID int32) ([]Group, error)
 	ListOrganizations(ctx context.Context, arg ListOrganizationsParams) ([]Organization, error)
 	ListPoliciesByGroupID(ctx context.Context, groupID int32) ([]ListPoliciesByGroupIDRow, error)
+	ListRegisteredRepositoriesByGroupIDAndProvider(ctx context.Context, arg ListRegisteredRepositoriesByGroupIDAndProviderParams) ([]Repository, error)
 	ListRepositoriesByGroupID(ctx context.Context, arg ListRepositoriesByGroupIDParams) ([]Repository, error)
 	ListRepositoriesByOwner(ctx context.Context, arg ListRepositoriesByOwnerParams) ([]Repository, error)
 	ListRoles(ctx context.Context, arg ListRolesParams) ([]Role, error)


### PR DESCRIPTION
When a policy is created this triggers an initialization event which
gets picked up by the executor. The executor in turn will list all
repositories in the group and evaluate the policy on them.

This ensures that we have an initial status that's relevant and that
we may use.

Closes: #561