### PR TITLE
rule type: Add `actions_permissions` rule

### DIFF
--- a/examples/github/policies/policy.yaml
+++ b/examples/github/policies/policy.yaml
@@ -23,6 +23,10 @@ repository:
           allow_force_pushes: false
           allow_deletions: false
           allow_fork_syncing: true
+      - type: actions_permissions
+        def:
+          enabled: true
+          allowed_actions: selected
 # build_environment:
 #   - rules:  # Not specifying a context takes the default context
 #       - type: no_org_wide_github_action_permissions

--- a/examples/github/rule-types/actions_permissions.yaml
+++ b/examples/github/rule-types/actions_permissions.yaml
@@ -1,0 +1,49 @@
+---
+# verifies permissions for github actions for a specific repository
+version: v1
+type: rule-type
+name: actions_permissions
+context:
+  provider: github
+  organization: ACME
+def:
+  # Defines the section of the pipeline the rule will appear in.
+  # This will affect the template that is used to render multiple parts
+  # of the rule.
+  in_entity: repository
+  # Defines the schema for writing a rule with this rule being checked
+  rule_schema:
+    properties:
+      enabled:
+        type: boolean
+        default: true
+      allowed_actions:
+        type: string
+        description: The permissions policy that controls the actions and reusable workflows that are allowed to run.
+        enum:
+          - "all"
+          - "local_only"
+          - "selected"
+  # Defines the configuration for both ingesting and evaluating the rule.
+  data_eval:
+    type: rest
+    rest:
+      # This is the path to the data source. Given that this will evaluate
+      # for each repository in the organization, we use a template that
+      # will be evaluated for each repository. The structure to use is the
+      # protobuf structure for the entity that is being evaluated.
+      endpoint: '/repos/{{.Entity.Owner}}/{{.Entity.Repository}}/actions/permissions'
+      # This is the method to use to retrieve the data. It should already default to JSON
+      parse: json
+    key-type: jq
+    data:
+      # This key is meant to denote where the info will be
+      # persisted in the aspect itself.
+      ".enabled":
+        # This denotes where the information will be retrieved from
+        # the data source.
+        type: jq
+        def: '.enabled'
+      ".allowed_actions":
+        type: jq
+        def: '.allowed_actions'


### PR DESCRIPTION
This rule verifies the GitHub Actions permissions settings. We may verify that
actions are enabled or disabled, and even limit the actions that are usable.
e.g. only allow local actions or only allow actions coming from the owner's organization.
