### PR TITLE
Allow storing GitHub App secrets as files / use of K8s secrets

### DIFF
--- a/cmd/server/app/root.go
+++ b/cmd/server/app/root.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/stacklok/mediator/internal/config"
 	"github.com/stacklok/mediator/internal/util"
+	"github.com/stacklok/mediator/pkg/auth"
 )
 
 var (
@@ -48,6 +49,9 @@ func init() {
 	cobra.OnInitialize(initConfig)
 	RootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is $PWD/config.yaml)")
 	if err := config.RegisterDatabaseFlags(viper.GetViper(), RootCmd.PersistentFlags()); err != nil {
+		log.Fatal(err)
+	}
+	if err := auth.RegisterOAuthFlags(viper.GetViper(), RootCmd.PersistentFlags()); err != nil {
 		log.Fatal(err)
 	}
 }

--- a/deployment/helm/templates/deployment.yaml
+++ b/deployment/helm/templates/deployment.yaml
@@ -52,6 +52,8 @@ spec:
           - "--config=/config/config.yaml"
           - "--grpc-host=0.0.0.0"
           - "--http-host=0.0.0.0"
+          - "--github-client-id-file=/secrets/app/client_id"
+          - "--github-client-secret-file=/secrets/app/client_secret"
           env:
           - name: "AUTH.ACCESS_TOKEN_PRIVATE_KEY"
             value: "/secrets/auth/access_token_rsa"
@@ -61,10 +63,6 @@ spec:
             value: "/secrets/auth/refresh_token_rsa"
           - name: "AUTH.REFRESH_TOKEN_PUBLIC_KEY"
             value: "/secrets/auth/refresh_token_rsa.pub"
-          - name: "GITHUB.CLIENT_ID_FILE"
-            value: "/secrets/app/client_id"
-          - name: "GITHUB.CLIENT_SECRET_FILE"
-            value: "/secrets/app/client_secret"
           
           # ko will always specify a digest, so we don't need to worry about
           # CRI image caching

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -25,6 +25,10 @@ services:
       "--http-host=0.0.0.0",
       "--db-host=postgres",
       "--config=/app/config.yaml",
+      # If you don't want to store your GitHub client ID and secret in the main
+      # config file, point to them here:
+      # "--github-client-id-file=/secrets/github_client_id",
+      # "--github-client-secret-file=/secrets/github_client_secret",
       ]
     restart: always # keep the server running
     ports:
@@ -44,10 +48,6 @@ services:
       - AUTH.ACCESS_TOKEN_PUBLIC_KEY=/app/.ssh/access_token_rsa.pub
       - AUTH.REFRESH_TOKEN_PRIVATE_KEY=/app/.ssh/refresh_token_rsa
       - AUTH.REFRESH_TOKEN_PUBLIC_KEY=/app/.ssh/refresh_token_rsa.pub
-      # If you don't want to store your GitHub client ID and secret in the main
-      # config file, point to them here:
-      # - GITHUB.CLIENT_ID_FILE=/secrets/github_client_id
-      # - GITHUB.CLIENT_SECRET_FILE=/secrets/github_client_secret
     networks:
       - app_net
     depends_on:

--- a/pkg/auth/oauth.go
+++ b/pkg/auth/oauth.go
@@ -29,17 +29,24 @@ import (
 	"path/filepath"
 
 	go_github "github.com/google/go-github/v53/github"
+	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
+	"github.com/stacklok/mediator/internal/util"
 	"golang.org/x/oauth2"
 	"golang.org/x/oauth2/github"
 	"golang.org/x/oauth2/google"
 )
 
-// Google OAuth2 provider
-const Google = "google"
+const (
+	Google = "google"
+	// Google OAuth2 provider
 
-// Github OAuth2 provider
-const Github = "github"
+	// Github OAuth2 provider
+	Github = "github"
+)
+
+// TODO:
+var knownProviders = []string{Google, Github}
 
 // NewOAuthConfig creates a new OAuth2 config for the given provider
 // and whether the client is a CLI or web client
@@ -90,8 +97,9 @@ func NewOAuthConfig(provider string, cli bool) (*oauth2.Config, error) {
 // readFileOrConfig prefers reading from configKey_file (for Kubernetes distribution
 // of secrets), but falls back to a viper string value if the file is not present.
 func readFileOrConfig(configKey string) (string, error) {
-	if viper.IsSet(configKey + "_file") {
-		filename := viper.GetString(configKey + "_file")
+	fileKey := configKey + "_file"
+	if viper.IsSet(fileKey) && viper.GetString(fileKey) != "" {
+		filename := viper.GetString(fileKey)
 		// filepath.Clean avoids a gosec warning on reading a file by name
 		data, err := os.ReadFile(filepath.Clean(filename))
 		if err != nil {
@@ -151,4 +159,28 @@ func ValidateProviderToken(_ context.Context, provider string, token string) err
 		return nil
 	}
 	return fmt.Errorf("invalid provider: %s", provider)
+}
+
+// RegisterOAuthFlags registers client ID and secret file flags for all known
+// providers.  This is pretty tied into the internal of the auth module, so it
+// lives here, but it would be nice if we have a consistent registration
+// pattern (database flags are registered in the config module).
+func RegisterOAuthFlags(v *viper.Viper, flags *pflag.FlagSet) error {
+	for _, provider := range knownProviders {
+		idFileKey := fmt.Sprintf("%s.client_id_file", provider)
+		idFileFlag := fmt.Sprintf("%s-client-id-file", provider)
+		idFileDesc := fmt.Sprintf("File containing %s client ID", provider)
+		secretFileKey := fmt.Sprintf("%s.client_secret_file", provider)
+		secretFileFlag := fmt.Sprintf("%s-client-secret-file", provider)
+		secretFileDesc := fmt.Sprintf("File containing %s client secret", provider)
+		if err := util.BindConfigFlag(
+			v, flags, idFileKey, idFileFlag, "", idFileDesc, flags.String); err != nil {
+			return err
+		}
+		if err := util.BindConfigFlag(
+			v, flags, secretFileKey, secretFileFlag, "", secretFileDesc, flags.String); err != nil {
+			return err
+		}
+	}
+	return nil
 }


### PR DESCRIPTION
Currently, you can only store your GitHub app information (client ID and client secrets) in the config, which makes the entire config sensitive.  This adds _file tokens which can be used to extract the sensitive data into separate files.  (I didn't do something more comprehensive yet, but could see adding flags for these like we have for the database.)
