### PR TITLE
Fix lint errors that snuck in during #615 -> #626

### DIFF
--- a/pkg/auth/oauth.go
+++ b/pkg/auth/oauth.go
@@ -31,15 +31,16 @@ import (
 	go_github "github.com/google/go-github/v53/github"
 	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
-	"github.com/stacklok/mediator/internal/util"
 	"golang.org/x/oauth2"
 	"golang.org/x/oauth2/github"
 	"golang.org/x/oauth2/google"
+
+	"github.com/stacklok/mediator/internal/util"
 )
 
 const (
-	Google = "google"
 	// Google OAuth2 provider
+	Google = "google"
 
 	// Github OAuth2 provider
 	Github = "github"


### PR DESCRIPTION
Since most of our presubmit actions are pulled in via workflow call, lint wasn't running when `package:write` permissions were conflicting with PR permissions.
