### PR TITLE
Switch to 'push' trigger from 'pr/closed' trigger to get write token

### DIFF
--- a/.github/workflows/chart-publish.yml
+++ b/.github/workflows/chart-publish.yml
@@ -42,3 +42,4 @@ jobs:
           (cd deployment/helm && helm push mediator-*.tgz oci://$KO_DOCKER_REPO/helm)
         env:
           KO_DOCKER_REPO: "ghcr.io/stacklok/mediator"
+          KO_PUSH_IMAGE: "true"


### PR DESCRIPTION
Commits triggered by PRs are failing, while the scheduled actions succeed:

https://github.com/stacklok/mediator/actions/workflows/chart-publish.yml
