### PR TITLE
Attempt to fix helm publish

### DIFF
--- a/.github/workflows/chart-publish.yml
+++ b/.github/workflows/chart-publish.yml
@@ -21,6 +21,11 @@ jobs:
       contents: read
       packages: write
 
+    env:
+      KO_DOCKER_REPO: "ghcr.io/stacklok/mediator"
+      KO_PUSH_IMAGE: "true"
+
+
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -31,15 +36,18 @@ jobs:
         with:
           version: v3.12.2
 
+      - name: Build images and Helm Chart
+        run: |
+          make helm
+
       - name: Helm Login
         # ko can pick up tokens ambiently from the GitHub Actions environment, but
         # Helm needs explicit login
         run: |
           helm registry login ghcr.io --username ${{ github.repository_owner }} --password ${{ secrets.GITHUB_TOKEN }}
 
-      - run: |
-          make helm
-          (cd deployment/helm && helm push mediator-*.tgz oci://$KO_DOCKER_REPO/helm)
-        env:
-          KO_DOCKER_REPO: "ghcr.io/stacklok/mediator"
-          KO_PUSH_IMAGE: "true"
+      - name: Push Helm Chart
+        run: |
+          cd deployment/helm
+          helm push mediator-*.tgz oci://$KO_DOCKER_REPO/helm
+          


### PR DESCRIPTION
I think `helm registry login` is disrupting the environment created by `setup-ko`; move the `ko resolve` step to _before_ `helm registry login`.

Also adjust the `helm registry login` part to line up with https://trstringer.com/helm-charts-github-container-registry/, just in case it changes anything.
