### PR TITLE
cli: Use the correct datatype for group-id in the enroll command

### DIFF
--- a/cmd/cli/app/provider/provider_enroll.go
+++ b/cmd/cli/app/provider/provider_enroll.go
@@ -127,7 +127,7 @@ actions such as adding repositories.`,
 			fmt.Fprintf(os.Stderr, "Only %s is supported at this time\n", ghclient.Github)
 			os.Exit(1)
 		}
-		group := util.GetConfigValue("group-id", "group-id", cmd, 0).(int)
+		group := util.GetConfigValue("group-id", "group-id", cmd, int32(0)).(int32)
 		pat := util.GetConfigValue("token", "token", cmd, "").(string)
 		owner := util.GetConfigValue("owner", "owner", cmd, "").(string)
 


### PR DESCRIPTION
We used int as the datatype passed when extracting the rules which meant
that the group-id was always assigned the zero value for the int type
which is 0.

Fixes: #721
