### PR TITLE
cli: Use viper.GetInt32("group-id") directly for group-id instead of util.GetConfigValue

### DIFF
--- a/cmd/cli/app/provider/provider_enroll.go
+++ b/cmd/cli/app/provider/provider_enroll.go
@@ -127,7 +127,7 @@ actions such as adding repositories.`,
 			fmt.Fprintf(os.Stderr, "Only %s is supported at this time\n", ghclient.Github)
 			os.Exit(1)
 		}
-		group := util.GetConfigValue("group-id", "group-id", cmd, int32(0)).(int32)
+		group := viper.GetInt32("group-id")
 		pat := util.GetConfigValue("token", "token", cmd, "").(string)
 		owner := util.GetConfigValue("owner", "owner", cmd, "").(string)
 


### PR DESCRIPTION
This is a follow-up to PR #732 which uncovered a subtle bug in how we retrieve
defaults for command line flags. This is really not easily visible when
reading the code, but can cause panics and makes the default value passed to
GetConfigValue useless as it can never be returned.

We were using util.GetConfigValue to get the group-id and relied on the return
value being `int(32)`, but because we're retrieving a command line flag that
already had a default defined when setting the flag, the default passed to
util.GetConfigValue would never be used in fact.

This is because `util.GetConfigValue` first calls `viper.Get(key)`, attempting
to get the configuration file key. If the `key` is the same as the command
line flag and the command line flag has a default defined, as it's the case
for `group-id`, `viper.Get` returns the default for that command line flag.

But, for any numerical types, `viper.Get` would have returned the default
value, typed as an `int`:
```
case int32, int16, int8, int:
    return cast.ToInt(val)
```
which would then trip up the explicit type cast to `int32` we had after
calling `util.GetConfigValue`. This would cause panic.

Because we're really only interested in the command line flag in this
case, let's not use `util.GetConfigValue` and confuse us with type cases
back, but just straight use `viper.GetInt32`.

In general, `util.GetConfigValue` should be used to retrieve config
values optionally overriden by command line flags, but for values that
are only defined with command line flags, especially numerical.

In addition, it is odd to have the default defined both when declaring
the flag and when retrieving the value.
