### PR TITLE
Fix "Build Helm chart" action

### DIFF
--- a/.github/workflows/chart-publish.yml
+++ b/.github/workflows/chart-publish.yml
@@ -22,8 +22,7 @@ jobs:
       packages: write
 
     env:
-      KO_DOCKER_REPO: "ghcr.io/stacklok/mediator"
-      KO_PUSH_IMAGE: "true"
+      BASE_REPO: "ghcr.io/stacklok/mediator"
 
 
     steps:
@@ -38,16 +37,18 @@ jobs:
 
       - name: Build images and Helm Chart
         run: |
-          make helm
+          KO_DOCKER_REPO=$BASE_REPO make helm
+        env:
+          KO_PUSH_IMAGE: "true"
 
       - name: Helm Login
         # ko can pick up tokens ambiently from the GitHub Actions environment, but
         # Helm needs explicit login
         run: |
-          helm registry login ghcr.io --username ${{ github.repository_owner }} --password ${{ secrets.GITHUB_TOKEN }}
+          helm registry login $BASE_REPO --username ${{ github.repository_owner }} --password ${{ secrets.GITHUB_TOKEN }}
 
       - name: Push Helm Chart
         run: |
           cd deployment/helm
-          helm push mediator-*.tgz oci://$KO_DOCKER_REPO/helm
-          
+          helm push mediator-*.tgz oci://$BASE_REPO/helm
+


### PR DESCRIPTION
It turns out that setting `KO_DOCKER_REPO` in the `setup-ko` action causes `setup-ko` not to log in to `ghcr.io`, and assume you set it up yourself.  Also, it was sort of weird to use the `KO_DOCKER_REPO` var for commands that weren't related to `ko`.

The other BIG fix here is adjusting https://github.com/orgs/stacklok/packages/container/mediator%2Fhelm%2Fmediator/settings and https://github.com/orgs/stacklok/packages/container/mediator%2Fserver/settings to allow the `mediator` repo "Admin" access.  (I could have used "Write", but I have a dream that we might automatically clean up old container images if we're publishing 5x / day or more...)
