### PR TITLE
Allow private repo entries in rekor

### DIFF
--- a/.github/workflows/slsa-go-releaser.yml
+++ b/.github/workflows/slsa-go-releaser.yml
@@ -54,6 +54,7 @@ jobs:
     uses: slsa-framework/slsa-github-generator/.github/workflows/builder_go_slsa3.yml@v1.9.0
     with:
       go-version: 1.20
+      private-repository: true
       # Optional: only needed if using ldflags.
       evaluated-envs: "COMMIT_DATE:${{needs.args.outputs.commit-date}}, COMMIT:${{needs.args.outputs.commit}}, VERSION:${{needs.args.outputs.version}}, TREE_STATE:${{needs.args.outputs.tree-state}}"
       config-file: slsa/goreleaser-${{matrix.os}}-${{matrix.arch}}.yml


### PR DESCRIPTION
FYI: https://github.com/slsa-framework/slsa-github-generator/blob/main/internal/builders/generic/README.md#private-repositories

I chatted this over with folks are we are ok with the name "stacklok/mediator" being in a public rekor log

Its highly unlikely someone would search for this, and if they did find it and take to twitter, well its free promo and hype for us.