### PR TITLE
Fixes slsa-release action

### DIFF
--- a/.github/workflows/slsa-go-releaser.yml
+++ b/.github/workflows/slsa-go-releaser.yml
@@ -51,9 +51,10 @@ jobs:
         arch:
           - amd64
           - arm64
-    uses: slsa-framework/slsa-github-generator/.github/workflows/builder_go_slsa3.yml@v1.9.0
+    uses: slsa-framework/slsa-github-generator/.github/workflows/builder_go_slsa3.yml@v1.8.0
+
     with:
-      go-version: 1.20
+      go-version: '1.20'
       private-repository: true
       # Optional: only needed if using ldflags.
       evaluated-envs: "COMMIT_DATE:${{needs.args.outputs.commit-date}}, COMMIT:${{needs.args.outputs.commit}}, VERSION:${{needs.args.outputs.version}}, TREE_STATE:${{needs.args.outputs.tree-state}}"

--- a/.slsa-goreleaser/darwin-amd64.yml
+++ b/.slsa-goreleaser/darwin-amd64.yml
@@ -20,11 +20,8 @@ goarch: amd64
 # Binary output name.
 # {{ .Os }} will be replaced by goos field in the config file.
 # {{ .Arch }} will be replaced by goarch field in the config file.
-builds:
-  - main: ./cmd/cli
-    binary: medic-{{ .Os }}-{{ .Arch }}
-  - main: ./cmd/server
-    binary: mediator-server-{{ .Os }}-{{ .Arch }}
+main: ./cmd/cli
+binary: medic-{{ .Os }}-{{ .Arch }}
 
 # (Optional) ldflags generated dynamically in the workflow, and set as the `evaluated-envs` input variables in the workflow.
 ldflags:

--- a/.slsa-goreleaser/darwin-arm64.yml
+++ b/.slsa-goreleaser/darwin-arm64.yml
@@ -20,11 +20,8 @@ goarch: arm64
 # Binary output name.
 # {{ .Os }} will be replaced by goos field in the config file.
 # {{ .Arch }} will be replaced by goarch field in the config file.
-builds:
-  - main: ./cmd/cli
-    binary: medic-{{ .Os }}-{{ .Arch }}
-  - main: ./cmd/server
-    binary: mediator-server-{{ .Os }}-{{ .Arch }}
+main: ./cmd/cli
+binary: medic-{{ .Os }}-{{ .Arch }}
 
 # (Optional) ldflags generated dynamically in the workflow, and set as the `evaluated-envs` input variables in the workflow.
 ldflags:

--- a/.slsa-goreleaser/linux-amd64.yml
+++ b/.slsa-goreleaser/linux-amd64.yml
@@ -20,11 +20,8 @@ goarch: amd64
 # Binary output name.
 # {{ .Os }} will be replaced by goos field in the config file.
 # {{ .Arch }} will be replaced by goarch field in the config file.
-builds:
-  - main: ./cmd/cli
-    binary: medic-{{ .Os }}-{{ .Arch }}
-  - main: ./cmd/server
-    binary: mediator-server-{{ .Os }}-{{ .Arch }}
+main: ./cmd/cli
+binary: medic-{{ .Os }}-{{ .Arch }}
 
 # (Optional) ldflags generated dynamically in the workflow, and set as the `evaluated-envs` input variables in the workflow.
 # ldflags:

--- a/.slsa-goreleaser/linux-arm64.yml
+++ b/.slsa-goreleaser/linux-arm64.yml
@@ -20,11 +20,8 @@ goarch: arm64
 # Binary output name.
 # {{ .Os }} will be replaced by goos field in the config file.
 # {{ .Arch }} will be replaced by goarch field in the config file.
-builds:
-  - main: ./cmd/cli
-    binary: medic-{{ .Os }}-{{ .Arch }}
-  - main: ./cmd/server
-    binary: mediator-server-{{ .Os }}-{{ .Arch }}
+main: ./cmd/cli
+binary: medic-{{ .Os }}-{{ .Arch }}
 
 # (Optional) ldflags generated dynamically in the workflow, and set as the `evaluated-envs` input variables in the workflow.
 ldflags:

--- a/.slsa-goreleaser/windows-amd64.yml
+++ b/.slsa-goreleaser/windows-amd64.yml
@@ -20,11 +20,8 @@ goarch: amd64
 # Binary output name.
 # {{ .Os }} will be replaced by goos field in the config file.
 # {{ .Arch }} will be replaced by goarch field in the config file.
-builds:
-  - main: ./cmd/cli
-    binary: medic-{{ .Os }}-{{ .Arch }}
-  - main: ./cmd/server
-    binary: mediator-server-{{ .Os }}-{{ .Arch }}
+main: ./cmd/cli
+binary: medic-{{ .Os }}-{{ .Arch }}
 
 # (Optional) ldflags generated dynamically in the workflow, and set as the `evaluated-envs` input variables in the workflow.
 ldflags:

--- a/.slsa-goreleaser/windows-arm64.yml
+++ b/.slsa-goreleaser/windows-arm64.yml
@@ -20,11 +20,8 @@ goarch: arm64
 # Binary output name.
 # {{ .Os }} will be replaced by goos field in the config file.
 # {{ .Arch }} will be replaced by goarch field in the config file.
-builds:
-  - main: ./cmd/cli
-    binary: medic-{{ .Os }}-{{ .Arch }}
-  - main: ./cmd/server
-    binary: mediator-server-{{ .Os }}-{{ .Arch }}
+main: ./cmd/cli
+binary: medic-{{ .Os }}-{{ .Arch }}
 
 
 # (Optional) ldflags generated dynamically in the workflow, and set as the `evaluated-envs` input variables in the workflow.


### PR DESCRIPTION
Tested this locally, changes are needing to limit to medic for now (which is fine as we release the server with helm)

I also needed to quote the go release as it was being read as go 1.2 (not 1.20).

I also had the wrong release number for the action (latest is 1.8.0)

Tested this within my fork and works for me.