### PR TITLE
small refactor: Move files around for testability

### DIFF
--- a/internal/engine/eval/errors/errors.go
+++ b/internal/engine/eval/errors/errors.go
@@ -1,0 +1,31 @@
+// Copyright 2023 Stacklok, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.role/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// Package rule provides the CLI subcommand for managing rules
+
+// Package errors provides errors for the evaluator engine
+package errors
+
+import (
+	"errors"
+	"fmt"
+)
+
+// ErrEvaluationFailed is an error that occurs during evaluation of a rule.
+var ErrEvaluationFailed = errors.New("evaluation error")
+
+// NewErrEvaluationFailed creates a new evaluation error
+func NewErrEvaluationFailed(sfmt string, args ...any) error {
+	msg := fmt.Sprintf(sfmt, args...)
+	return fmt.Errorf("%w: %s", ErrEvaluationFailed, msg)
+}

--- a/internal/engine/eval/eval.go
+++ b/internal/engine/eval/eval.go
@@ -19,24 +19,15 @@ package eval
 
 import (
 	"context"
-	"errors"
 	"fmt"
 
+	"github.com/stacklok/mediator/internal/engine/eval/jq"
 	pb "github.com/stacklok/mediator/pkg/generated/protobuf/go/mediator/v1"
 )
 
 // Evaluator is the interface for a rule type evaluator
 type Evaluator interface {
 	Eval(ctx context.Context, policy map[string]any, obj any) error
-}
-
-// ErrEvaluationFailed is an error that occurs during evaluation of a rule.
-var ErrEvaluationFailed = errors.New("evaluation error")
-
-// NewErrEvaluationFailed creates a new evaluation error
-func NewErrEvaluationFailed(sfmt string, args ...any) error {
-	msg := fmt.Sprintf(sfmt, args...)
-	return fmt.Errorf("%w: %s", ErrEvaluationFailed, msg)
 }
 
 // NewRuleEvaluator creates a new rule data evaluator
@@ -53,7 +44,7 @@ func NewRuleEvaluator(rt *pb.RuleType) (Evaluator, error) {
 			return nil, fmt.Errorf("rule type engine missing rest configuration")
 		}
 
-		return NewJQEvaluator(ing.GetJq())
+		return jq.NewJQEvaluator(ing.GetJq())
 	default:
 		return nil, fmt.Errorf("unsupported rule type engine: %s", rt.Def.Eval.Type)
 	}

--- a/internal/engine/eval/jq/jq.go
+++ b/internal/engine/eval/jq/jq.go
@@ -13,7 +13,8 @@
 // limitations under the License.
 // Package rule provides the CLI subcommand for managing rules
 
-package eval
+// Package jq provides the jq policy evaluator
+package jq
 
 import (
 	"context"
@@ -21,17 +22,18 @@ import (
 	"fmt"
 	"reflect"
 
+	evalerrors "github.com/stacklok/mediator/internal/engine/eval/errors"
 	"github.com/stacklok/mediator/internal/util"
 	pb "github.com/stacklok/mediator/pkg/generated/protobuf/go/mediator/v1"
 )
 
-// JQEvaluator is an Evaluator that uses the jq library to evaluate rules
-type JQEvaluator struct {
+// Evaluator is an Evaluator that uses the jq library to evaluate rules
+type Evaluator struct {
 	assertions []*pb.RuleType_Definition_Eval_JQComparison
 }
 
 // NewJQEvaluator creates a new JQ rule data evaluator
-func NewJQEvaluator(assertions []*pb.RuleType_Definition_Eval_JQComparison) (*JQEvaluator, error) {
+func NewJQEvaluator(assertions []*pb.RuleType_Definition_Eval_JQComparison) (*Evaluator, error) {
 	if len(assertions) == 0 {
 		return nil, fmt.Errorf("missing jq assertions")
 	}
@@ -55,13 +57,13 @@ func NewJQEvaluator(assertions []*pb.RuleType_Definition_Eval_JQComparison) (*JQ
 		}
 	}
 
-	return &JQEvaluator{
+	return &Evaluator{
 		assertions: assertions,
 	}, nil
 }
 
 // Eval calls the jq library to evaluate the rule
-func (jqe *JQEvaluator) Eval(ctx context.Context, pol map[string]any, obj any) error {
+func (jqe *Evaluator) Eval(ctx context.Context, pol map[string]any, obj any) error {
 	for idx := range jqe.assertions {
 		a := jqe.assertions[idx]
 		policyVal, err := util.JQGetValuesFromAccessor(ctx, a.Policy.Def, pol)
@@ -84,7 +86,7 @@ func (jqe *JQEvaluator) Eval(ctx context.Context, pol map[string]any, obj any) e
 				msg = fmt.Sprintf("%s\nassertion: %s", msg, string(marshalledAssertion))
 			}
 
-			return NewErrEvaluationFailed(msg)
+			return evalerrors.NewErrEvaluationFailed(msg)
 		}
 	}
 

--- a/internal/engine/eval/jq/jq_test.go
+++ b/internal/engine/eval/jq/jq_test.go
@@ -13,7 +13,7 @@
 // limitations under the License.
 // Package rule provides the CLI subcommand for managing rules
 
-package eval_test
+package jq_test
 
 import (
 	"context"
@@ -21,7 +21,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/stacklok/mediator/internal/engine/eval"
+	evalerrors "github.com/stacklok/mediator/internal/engine/eval/errors"
+	"github.com/stacklok/mediator/internal/engine/eval/jq"
 	pb "github.com/stacklok/mediator/pkg/generated/protobuf/go/mediator/v1"
 )
 
@@ -79,7 +80,7 @@ func TestNewJQEvaluatorValid(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			got, err := eval.NewJQEvaluator(tt.args.assertions)
+			got, err := jq.NewJQEvaluator(tt.args.assertions)
 			assert.NoError(t, err, "Got unexpected error")
 			assert.NotNil(t, got, "Got unexpected nil")
 		})
@@ -187,7 +188,7 @@ func TestNewJQEvaluatorInvalid(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			got, err := eval.NewJQEvaluator(tt.args.assertions)
+			got, err := jq.NewJQEvaluator(tt.args.assertions)
 			assert.Error(t, err, "expected error")
 			assert.Nil(t, got, "expected nil")
 		})
@@ -296,7 +297,7 @@ func TestValidJQEvals(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			jqe, err := eval.NewJQEvaluator(tt.assertions)
+			jqe, err := jq.NewJQEvaluator(tt.assertions)
 			assert.NoError(t, err, "Got unexpected error")
 			assert.NotNil(t, jqe, "Got unexpected nil")
 
@@ -451,12 +452,12 @@ func TestValidJQEvalsFailed(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			jqe, err := eval.NewJQEvaluator(tt.assertions)
+			jqe, err := jq.NewJQEvaluator(tt.assertions)
 			assert.NoError(t, err, "Got unexpected error")
 			assert.NotNil(t, jqe, "Got unexpected nil")
 
 			err = jqe.Eval(context.Background(), tt.args.pol, tt.args.obj)
-			assert.ErrorIs(t, err, eval.ErrEvaluationFailed, "Got unexpected error")
+			assert.ErrorIs(t, err, evalerrors.ErrEvaluationFailed, "Got unexpected error")
 		})
 	}
 }
@@ -523,13 +524,13 @@ func TestInvalidJQEvals(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			jqe, err := eval.NewJQEvaluator(tt.assertions)
+			jqe, err := jq.NewJQEvaluator(tt.assertions)
 			assert.NoError(t, err, "Got unexpected error")
 			assert.NotNil(t, jqe, "Got unexpected nil")
 
 			err = jqe.Eval(context.Background(), tt.args.pol, tt.args.obj)
 			assert.Error(t, err, "Got unexpected error")
-			assert.NotErrorIs(t, err, eval.ErrEvaluationFailed, "Got unexpected error")
+			assert.NotErrorIs(t, err, evalerrors.ErrEvaluationFailed, "Got unexpected error")
 		})
 	}
 }

--- a/internal/engine/executor.go
+++ b/internal/engine/executor.go
@@ -27,7 +27,7 @@ import (
 	"github.com/go-playground/validator/v10"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
-	"github.com/stacklok/mediator/internal/engine/eval"
+	evalerrors "github.com/stacklok/mediator/internal/engine/eval/errors"
 	"github.com/stacklok/mediator/internal/events"
 	"github.com/stacklok/mediator/internal/util"
 	"github.com/stacklok/mediator/pkg/crypto"
@@ -608,7 +608,7 @@ func parseRepoID(repoID any) (int32, error) {
 }
 
 func errorAsEvalStatus(err error) db.EvalStatusTypes {
-	if errors.Is(err, eval.ErrEvaluationFailed) {
+	if errors.Is(err, evalerrors.ErrEvaluationFailed) {
 		return db.EvalStatusTypesFailure
 	} else if err != nil {
 		return db.EvalStatusTypesError

--- a/internal/engine/ingester/builtin/builtin.go
+++ b/internal/engine/ingester/builtin/builtin.go
@@ -13,7 +13,8 @@
 // limitations under the License.
 // Package rule provides the CLI subcommand for managing rules
 
-package ingester
+// Package builtin provides the builtin ingestion engine
+package builtin
 
 import (
 	"context"
@@ -28,6 +29,11 @@ import (
 	"github.com/stacklok/mediator/internal/util"
 	pb "github.com/stacklok/mediator/pkg/generated/protobuf/go/mediator/v1"
 	"github.com/stacklok/mediator/pkg/rule_methods"
+)
+
+const (
+	// BuiltinRuleDataIngestType is the type of the builtin rule data ingest engine
+	BuiltinRuleDataIngestType = "builtin"
 )
 
 // BuiltinRuleDataIngest is the engine for a rule type that uses builtin methods

--- a/internal/engine/ingester/ingester.go
+++ b/internal/engine/ingester/ingester.go
@@ -23,6 +23,8 @@ import (
 
 	"google.golang.org/protobuf/reflect/protoreflect"
 
+	"github.com/stacklok/mediator/internal/engine/ingester/builtin"
+	"github.com/stacklok/mediator/internal/engine/ingester/rest"
 	pb "github.com/stacklok/mediator/pkg/generated/protobuf/go/mediator/v1"
 	ghclient "github.com/stacklok/mediator/pkg/providers/github"
 )
@@ -36,20 +38,19 @@ type Ingester interface {
 // type definition.
 func NewRuleDataIngest(rt *pb.RuleType, cli ghclient.RestAPI, access_token string) (Ingester, error) {
 	ing := rt.Def.GetIngest()
-	// TODO: make this more generic and/or use constants
 	switch rt.Def.Ingest.Type {
-	case "rest":
+	case rest.RestRuleDataIngestType:
 		if rt.Def.Ingest.GetRest() == nil {
 			return nil, fmt.Errorf("rule type engine missing rest configuration")
 		}
 
-		return NewRestRuleDataIngest(ing.GetRest(), cli)
+		return rest.NewRestRuleDataIngest(ing.GetRest(), cli)
 
-	case "builtin":
+	case builtin.BuiltinRuleDataIngestType:
 		if rt.Def.Ingest.GetBuiltin() == nil {
 			return nil, fmt.Errorf("rule type engine missing internal configuration")
 		}
-		return NewBuiltinRuleDataIngest(ing.GetBuiltin(), access_token)
+		return builtin.NewBuiltinRuleDataIngest(ing.GetBuiltin(), access_token)
 	default:
 		return nil, fmt.Errorf("unsupported rule type engine: %s", rt.Def.Ingest.Type)
 	}

--- a/internal/engine/ingester/ingester_test.go
+++ b/internal/engine/ingester/ingester_test.go
@@ -1,0 +1,126 @@
+// Copyright 2023 Stacklok, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.role/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// Package rule provides the CLI subcommand for managing rules
+
+// Package ingester provides necessary interfaces and implementations for ingesting
+// data for rules.
+package ingester
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/stacklok/mediator/internal/engine/ingester/builtin"
+	"github.com/stacklok/mediator/internal/engine/ingester/rest"
+	pb "github.com/stacklok/mediator/pkg/generated/protobuf/go/mediator/v1"
+)
+
+func TestNewRuleDataIngest(t *testing.T) {
+	t.Parallel()
+
+	type args struct {
+		rt           *pb.RuleType
+		access_token string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		wantErr bool
+	}{
+		{
+			name: "rest",
+			args: args{
+				rt: &pb.RuleType{
+					Def: &pb.RuleType_Definition{
+						Ingest: &pb.RuleType_Definition_Ingest{
+							Type: rest.RestRuleDataIngestType,
+							Rest: &pb.RestType{
+								Endpoint: "https://api.github.com/repos/Foo/Bar",
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "rest missing",
+			args: args{
+				rt: &pb.RuleType{
+					Def: &pb.RuleType_Definition{
+						Ingest: &pb.RuleType_Definition_Ingest{
+							Type: rest.RestRuleDataIngestType,
+						},
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "builtin",
+			args: args{
+				rt: &pb.RuleType{
+					Def: &pb.RuleType_Definition{
+						Ingest: &pb.RuleType_Definition_Ingest{
+							Type:    builtin.BuiltinRuleDataIngestType,
+							Builtin: &pb.BuiltinType{},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "builtin missing",
+			args: args{
+				rt: &pb.RuleType{
+					Def: &pb.RuleType_Definition{
+						Ingest: &pb.RuleType_Definition_Ingest{
+							Type: builtin.BuiltinRuleDataIngestType,
+						},
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "unsupported",
+			args: args{
+				rt: &pb.RuleType{
+					Def: &pb.RuleType_Definition{
+						Ingest: &pb.RuleType_Definition_Ingest{
+							Type: "unsupported",
+						},
+					},
+				},
+			},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := NewRuleDataIngest(tt.args.rt, nil, tt.args.access_token)
+			if tt.wantErr {
+				require.Error(t, err, "Expected error")
+				require.Nil(t, got, "Expected nil")
+				return
+			}
+
+			require.NoError(t, err, "Unexpected error")
+			require.NotNil(t, got, "Expected non-nil")
+		})
+	}
+}

--- a/internal/engine/ingester/rest/rest_test.go
+++ b/internal/engine/ingester/rest/rest_test.go
@@ -1,0 +1,85 @@
+// Copyright 2023 Stacklok, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.role/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// Package rule provides the CLI subcommand for managing rules
+
+package rest
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	pb "github.com/stacklok/mediator/pkg/generated/protobuf/go/mediator/v1"
+	ghclient "github.com/stacklok/mediator/pkg/providers/github"
+)
+
+func TestNewRestRuleDataIngest(t *testing.T) {
+	t.Parallel()
+
+	type args struct {
+		restCfg *pb.RestType
+		cli     ghclient.RestAPI
+	}
+	tests := []struct {
+		name    string
+		args    args
+		wantErr bool
+	}{
+		{
+			name: "valid rest",
+			args: args{
+				restCfg: &pb.RestType{
+					Endpoint: "https://api.github.com/repos/Foo/Bar",
+				},
+				cli: nil,
+			},
+			wantErr: false,
+		},
+		{
+			name: "invalid template",
+			args: args{
+				restCfg: &pb.RestType{
+					Endpoint: "{{",
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "empty endpoint",
+			args: args{
+				restCfg: &pb.RestType{
+					Endpoint: "",
+				},
+			},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		tt := tt
+
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := NewRestRuleDataIngest(tt.args.restCfg, tt.args.cli)
+			if tt.wantErr {
+				require.Error(t, err, "expected error")
+				require.Nil(t, got, "expected nil")
+				return
+			}
+
+			require.NoError(t, err, "unexpected error")
+			require.NotNil(t, got, "expected non-nil")
+		})
+	}
+}


### PR DESCRIPTION
This moves the evaluation and ingester engines to their own packages.

This makes these packages more self-contained and easier to test.
