### PR TITLE
util: Use dedicated test package for unit tests

### DIFF
--- a/internal/util/helpers_test.go
+++ b/internal/util/helpers_test.go
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package util
+package util_test
 
 import (
 	"strconv"
@@ -22,6 +22,8 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/stacklok/mediator/internal/util"
 )
 
 func TestGetConfigValue(t *testing.T) {
@@ -96,7 +98,7 @@ func TestGetConfigValue(t *testing.T) {
 				}
 			}
 
-			result := GetConfigValue(tc.key, tc.flagName, cmd, tc.defaultValue)
+			result := util.GetConfigValue(tc.key, tc.flagName, cmd, tc.defaultValue)
 			assert.Equal(t, tc.expected, result)
 		})
 	}

--- a/internal/util/random_test.go
+++ b/internal/util/random_test.go
@@ -19,12 +19,14 @@
 // It does make a good example of how to use the generated client code
 // for others to use as a reference.
 
-package util
+package util_test
 
 import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+
+	"github.com/stacklok/mediator/internal/util"
 )
 
 func TestRandomInt(t *testing.T) {
@@ -33,7 +35,7 @@ func TestRandomInt(t *testing.T) {
 	min := int64(1)
 	max := int64(10)
 	seed := int64(12345)
-	randomInt := RandomInt(min, max, seed)
+	randomInt := util.RandomInt(min, max, seed)
 	require.GreaterOrEqual(t, randomInt, min)
 	require.LessOrEqual(t, randomInt, max)
 }
@@ -41,7 +43,7 @@ func TestRandomInt(t *testing.T) {
 func TestRandomString(t *testing.T) {
 	t.Parallel()
 	seed := int64(12345)
-	randomString := RandomString(10, seed)
+	randomString := util.RandomString(10, seed)
 	require.NotEmpty(t, randomString)
 	require.Len(t, randomString, 10)
 }
@@ -50,7 +52,7 @@ func TestRandomEmail(t *testing.T) {
 	t.Parallel()
 
 	seed := int64(12345)
-	email := RandomEmail(seed)
+	email := util.RandomEmail(seed)
 	require.NotEmpty(t, email)
 	require.Contains(t, email, "@")
 	require.Contains(t, email, ".")
@@ -61,7 +63,7 @@ func TestRandomName(t *testing.T) {
 	t.Parallel()
 
 	seed := int64(12345)
-	name := RandomName(seed)
+	name := util.RandomName(seed)
 	require.NotEmpty(t, name)
 	require.Len(t, name, 10)
 }

--- a/internal/util/statuses_test.go
+++ b/internal/util/statuses_test.go
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package util
+package util_test
 
 import (
 	"fmt"
@@ -21,12 +21,14 @@ import (
 
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc/codes"
+
+	"github.com/stacklok/mediator/internal/util"
 )
 
 func TestNiceStatusCreation(t *testing.T) {
 	t.Parallel()
 
-	s := GetNiceStatus(codes.OK)
+	s := util.GetNiceStatus(codes.OK)
 	require.Equal(t, codes.OK, s.Code)
 	require.Equal(t, "OK", s.Name)
 	require.Equal(t, "OK", s.Description)


### PR DESCRIPTION
This uses a dedicated test package as opposed to including tests as part
of the same `util` package.

The idea with this pattern is that it allows us to test how a regular
test implementation would actually use the functions. It also, deters
us from testing specifics within the implementations which is not ideal.
