### PR TITLE
.gitignore: Ignore test coverage file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@
 # Generated files
 /bin/
 /vendor/
+coverage.out
 
 # IDE specific files
 .vscode/


### PR DESCRIPTION
Our `coverage` Makefile target uses the `coverage.out` file to persist
the test coverage data. We should ignore that in our `.gitignore`.
