### PR TITLE
engine: Handle skipped rules and silent skips

### DIFF
--- a/internal/engine/errors/errors.go
+++ b/internal/engine/errors/errors.go
@@ -29,3 +29,21 @@ func NewErrEvaluationFailed(sfmt string, args ...any) error {
 	msg := fmt.Sprintf(sfmt, args...)
 	return fmt.Errorf("%w: %s", ErrEvaluationFailed, msg)
 }
+
+// ErrEvaluationSkipped specifies that the rule was evaluated but skipped.
+var ErrEvaluationSkipped = errors.New("evaluation skipped")
+
+// NewErrEvaluationSkipped creates a new evaluation error
+func NewErrEvaluationSkipped(sfmt string, args ...any) error {
+	msg := fmt.Sprintf(sfmt, args...)
+	return fmt.Errorf("%w: %s", ErrEvaluationSkipped, msg)
+}
+
+// ErrEvaluationSkipSilently specifies that the rule was evaluated but skipped silently.
+var ErrEvaluationSkipSilently = errors.New("evaluation skipped silently")
+
+// NewErrEvaluationSkipSilently creates a new evaluation error
+func NewErrEvaluationSkipSilently(sfmt string, args ...any) error {
+	msg := fmt.Sprintf(sfmt, args...)
+	return fmt.Errorf("%w: %s", ErrEvaluationSkipSilently, msg)
+}

--- a/internal/engine/eval/jq/jq.go
+++ b/internal/engine/eval/jq/jq.go
@@ -22,7 +22,7 @@ import (
 	"fmt"
 	"reflect"
 
-	evalerrors "github.com/stacklok/mediator/internal/engine/eval/errors"
+	evalerrors "github.com/stacklok/mediator/internal/engine/errors"
 	"github.com/stacklok/mediator/internal/util"
 	pb "github.com/stacklok/mediator/pkg/generated/protobuf/go/mediator/v1"
 )

--- a/internal/engine/eval/jq/jq_test.go
+++ b/internal/engine/eval/jq/jq_test.go
@@ -21,7 +21,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	evalerrors "github.com/stacklok/mediator/internal/engine/eval/errors"
+	evalerrors "github.com/stacklok/mediator/internal/engine/errors"
 	"github.com/stacklok/mediator/internal/engine/eval/jq"
 	pb "github.com/stacklok/mediator/pkg/generated/protobuf/go/mediator/v1"
 )


### PR DESCRIPTION
This adds the needed functionality to skip rules from either an ingestor or an
evaluator, as well as silently skip rule evaluation for an event that
doesn't match certain criteria. The main use-case is artifacts that may
trigger a policy run for artifacts that are not relevant to a policy.
