### PR TITLE
Increase timeout for syncing repositories

### DIFF
--- a/pkg/providers/github/github.go
+++ b/pkg/providers/github/github.go
@@ -19,10 +19,16 @@ import (
 	"context"
 	"net/http"
 	"net/url"
+	"time"
 
 	"github.com/google/go-github/v53/github"
 	"github.com/shurcooL/graphql"
 	"golang.org/x/oauth2"
+)
+
+const (
+	// ExpensiveRestCallTimeout is the timeout for expensive REST calls
+	ExpensiveRestCallTimeout = 15 * time.Second
 )
 
 // GitHubConfig is the struct that contains the configuration for the GitHub client


### PR DESCRIPTION
This increases the timeout for syncing repositories from gitHub into the database.

We were getting timeouts since this may be a fairly expensive operation, so a context
timeout was merited.

Closes: #787
