### PR TITLE
Use `IS NOT DISTINCT FROM` for comparing rule eval status on upsert

### DIFF
--- a/database/query/policy_status.sql
+++ b/database/query/policy_status.sql
@@ -31,7 +31,7 @@ ON CONFLICT(policy_id, repository_id, COALESCE(artifact_id, 0), entity, rule_typ
     last_updated = NOW()
 WHERE rule_evaluation_status.policy_id = $1
   AND rule_evaluation_status.repository_id = $2
-  AND rule_evaluation_status.artifact_id = $3
+  AND rule_evaluation_status.artifact_id IS NOT DISTINCT FROM $3
   AND rule_evaluation_status.rule_type_id = $4
   AND rule_evaluation_status.entity = $5;
 

--- a/pkg/db/policy_status.sql.go
+++ b/pkg/db/policy_status.sql.go
@@ -216,7 +216,7 @@ ON CONFLICT(policy_id, repository_id, COALESCE(artifact_id, 0), entity, rule_typ
     last_updated = NOW()
 WHERE rule_evaluation_status.policy_id = $1
   AND rule_evaluation_status.repository_id = $2
-  AND rule_evaluation_status.artifact_id = $3
+  AND rule_evaluation_status.artifact_id IS NOT DISTINCT FROM $3
   AND rule_evaluation_status.rule_type_id = $4
   AND rule_evaluation_status.entity = $5
 `


### PR DESCRIPTION
This fixes the upsert by using the `IS NOT DISTINCT FROM` postgres construct
when evaluating the conflict in the upsert call.

Closes: #798
Co-Authored-By: Jakub Hrozek <jakub@stacklok.com>
