### PR TITLE
Use a generic version of JQ accessor, called JQGetTypedFromAccessor to parse GitHub payload

### DIFF
--- a/internal/engine/ingester/builtin/builtin.go
+++ b/internal/engine/ingester/builtin/builtin.go
@@ -19,6 +19,7 @@ package builtin
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log"
 	"reflect"
@@ -117,8 +118,8 @@ func entityMatchesParams(ctx context.Context, ent protoreflect.ProtoMessage, par
 		if !strings.HasPrefix(key, ".") {
 			key = "." + key
 		}
-		expectedVal, err := util.JQGetValuesFromAccessor(ctx, key, jsonData)
-		if err != nil {
+		expectedVal, err := util.JQReadFrom[any](ctx, key, jsonData)
+		if err != nil && !errors.Is(err, util.ErrNoValueFound) {
 			return false, fmt.Errorf("cannot get values from data accessor: %w", err)
 		}
 		if !reflect.DeepEqual(expectedVal, val) {


### PR DESCRIPTION
Addresses a comment brought up during an earlier review that the way we
parse the github payload is unsafe - in case the JQ accessor wouldn't
return anything, the value returned would have been `nil` (the default
value of `any`) which would panic on type assertion. Similarly, if the
assertion failed due to github changing its API.

Because these attributes are all required by the layer calling
`JQGetTypedFromAccessor`, I opted to return an error in case the
accessor doesn't find a value which would be propagated to the caller
and handled appropriately.

Other parts of the mediator where `nil` can be handled more gracefully
(e.g. because it is just passed to `reflect.DeepEqual`) still use the
old function `JQGetTypedFromAccessor` which returns `any`

Fixes: #785
