### PR TITLE
engine: Make `ErrEvaluationSkipSilently` not so silent

### DIFF
--- a/internal/engine/executor.go
+++ b/internal/engine/executor.go
@@ -826,6 +826,8 @@ func (e *Executor) createOrUpdateEvalStatus(
 	}
 
 	if errors.Is(params.evalErr, evalerrors.ErrEvaluationSkipSilently) {
+		log.Printf("silent skip of rule %d for policy %d for entity %s in repo %d",
+			params.ruleTypeID, params.policyID, params.ruleTypeEntity, params.repoID)
 		return nil
 	}
 


### PR DESCRIPTION
While we don't want to surface this error up to the user, we do want to know that it happened. So this that the exception happened so we have some visibility.
