### PR TITLE
rego: Introduce `file.ls` which allows us to list files

### DIFF
--- a/examples/github/repository.yaml
+++ b/examples/github/repository.yaml
@@ -3,6 +3,7 @@ owner: JAORMX
 repository: auditevent
 repoId: 605597568
 HookUrl:
+clone_url: "https://github.com/JAORMX/auditevent.git"
 CreatedAt: 2021-03-19T16:00:00Z
 UpdatedAt: 2021-03-19T16:00:00Z
 Registered: true

--- a/examples/github/rule-types/codeql_enabled.yaml
+++ b/examples/github/rule-types/codeql_enabled.yaml
@@ -37,9 +37,17 @@ def:
         default allow := false
 
         allow {
-            some i
-            workflowstr := file.read("./.github/workflows/codeql.yml")
+            # List all workflows
+            workflows := file.ls("./.github/workflows")
+
+            # Read all workflows
+            some w
+            workflowstr := file.read(workflows[w])
+
             workflow := yaml.unmarshal(workflowstr)
+
+            # Ensure a workflow contains the codel-ql action
+            some i
             steps := workflow.jobs.analyze.steps[i]
-            contains(steps.uses, "github/codeql-action/analyze@")
+            startswith(steps.uses, "github/codeql-action/analyze@")
         }

--- a/internal/engine/eval/rego/lib.go
+++ b/internal/engine/eval/rego/lib.go
@@ -22,6 +22,7 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/go-git/go-billy/v5"
 	"github.com/open-policy-agent/opa/ast"
 	"github.com/open-policy-agent/opa/rego"
 	"github.com/open-policy-agent/opa/types"
@@ -31,6 +32,7 @@ import (
 
 var mediatorRegoLib = []func(res *engif.Result) func(*rego.Rego){
 	FileExists,
+	FileLs,
 	FileRead,
 }
 
@@ -120,4 +122,112 @@ func FileRead(res *engif.Result) func(*rego.Rego) {
 			return ast.NewTerm(allstr), nil
 		},
 	)
+}
+
+// FileLs is a rego function that lists the files in a directory
+// in the filesystem being evaluated (which comes from the ingester).
+// It takes one argument, the path to the directory to list. It's exposed
+// as `file.ls`.
+// If the file is a file, it returns the file itself.
+// If the file is a directory, it returns the files in the directory.
+// If the file is a symlink, it follows the symlink and returns the files
+// in the target.
+func FileLs(res *engif.Result) func(*rego.Rego) {
+	return rego.Function1(
+		&rego.Function{
+			Name: "file.ls",
+			Decl: types.NewFunction(types.Args(types.S), types.A),
+		},
+		func(bctx rego.BuiltinContext, op1 *ast.Term) (*ast.Term, error) {
+			var path string
+			if err := ast.As(op1.Value, &path); err != nil {
+				return nil, err
+			}
+
+			if res.Fs == nil {
+				return nil, fmt.Errorf("cannot walk file without a filesystem")
+			}
+
+			fs := res.Fs
+
+			// Check file information and return a list of files
+			// and directories
+			finfo, err := fs.Lstat(path)
+			if err != nil {
+				return fileLsHandleError(err)
+			}
+
+			// If the file is a file return the file itself
+			if finfo.Mode().IsRegular() {
+				return fileLsHandleFile(path)
+			}
+
+			// If the file is a directory return the files in the directory
+			if finfo.Mode().IsDir() {
+				return fileLsHandleDir(path, fs)
+			}
+
+			// If the file is a symlink, follow it
+			if finfo.Mode()&os.ModeSymlink != 0 {
+				// Get the target of the symlink
+				target, err := fs.Readlink(path)
+				if err != nil {
+					return nil, err
+				}
+
+				// Get the file information of the target
+				// NOTE: This overwrites the previous finfo
+				finfo, err = fs.Lstat(target)
+				if err != nil {
+					return fileLsHandleError(err)
+				}
+
+				// If the target is a file return the file itself
+				if finfo.Mode().IsRegular() {
+					return fileLsHandleFile(target)
+				}
+
+				// If the target is a directory return the files in the directory
+				if finfo.Mode().IsDir() {
+					return fileLsHandleDir(target, fs)
+				}
+			}
+
+			return nil, fmt.Errorf("cannot handle file type %s", finfo.Mode())
+		},
+	)
+}
+
+func fileLsHandleError(err error) (*ast.Term, error) {
+	// If the file does not exist return null
+	if errors.Is(err, os.ErrNotExist) {
+		return ast.NullTerm(), nil
+	}
+	return nil, err
+}
+
+func fileLsHandleFile(path string) (*ast.Term, error) {
+	return ast.NewTerm(
+		ast.NewArray(
+			ast.NewTerm(ast.String(path)),
+		),
+	), nil
+}
+
+func fileLsHandleDir(path string, fs billy.Filesystem) (*ast.Term, error) {
+	// Get the files in the directory
+	paths, err := fs.ReadDir(path)
+	if err != nil {
+		return nil, err
+	}
+
+	// Create a list of files
+	var files []*ast.Term
+	for _, p := range paths {
+		fpath := filepath.Join(path, p.Name())
+		files = append(files, ast.NewTerm(ast.String(fpath)))
+	}
+
+	return ast.NewTerm(
+		ast.NewArray(files...)), nil
 }


### PR DESCRIPTION
The idea is that we can traverse the filesystem cloned by git, and, in-turn,
evaluate all traversed files. This allows us to write policies such as:

	I want to verify that there is a workflow that runs code QL

We should be able to extrapolate from here and write more complex rules that
very that all files conform to something specific.
