### PR TITLE
fix: use consistent sql.ErrNoRow error comparision

### DIFF
--- a/internal/gh/queries/sync_repo_db.go
+++ b/internal/gh/queries/sync_repo_db.go
@@ -18,6 +18,7 @@ package queries
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
 
 	"github.com/stacklok/mediator/pkg/db"
@@ -62,7 +63,7 @@ func SyncRepositoriesWithDB(ctx context.Context,
 		existingRepo, err := store.GetRepositoryByRepoID(ctx,
 			db.GetRepositoryByRepoIDParams{Provider: provider, RepoID: int32(*repo.ID)})
 		if err != nil {
-			if err == sql.ErrNoRows {
+			if errors.Is(err, sql.ErrNoRows) {
 				// The repository doesn't exist in our DB, let's create it
 				_, err = store.CreateRepository(ctx, db.CreateRepositoryParams{
 					Provider:  provider,

--- a/pkg/controlplane/handlers_artifacts.go
+++ b/pkg/controlplane/handlers_artifacts.go
@@ -17,6 +17,7 @@ package controlplane
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"strings"
 
 	"google.golang.org/grpc/codes"
@@ -54,7 +55,7 @@ func (s *Server) ListArtifacts(ctx context.Context, in *pb.ListArtifactsRequest)
 	repositories, err := s.store.ListRegisteredRepositoriesByGroupIDAndProvider(ctx,
 		db.ListRegisteredRepositoriesByGroupIDAndProviderParams{Provider: in.Provider, GroupID: in.GroupId})
 	if err != nil {
-		if err == sql.ErrNoRows {
+		if errors.Is(err, sql.ErrNoRows) {
 			return nil, status.Errorf(codes.NotFound, "repositories not found")
 		}
 		return nil, status.Errorf(codes.Unknown, "failed to get repositories: %s", err)
@@ -97,7 +98,7 @@ func (s *Server) GetArtifactById(ctx context.Context, in *pb.GetArtifactByIdRequ
 	// retrieve artifact details
 	artifact, err := s.store.GetArtifactByID(ctx, in.Id)
 	if err != nil {
-		if err == sql.ErrNoRows {
+		if errors.Is(err, sql.ErrNoRows) {
 			return nil, status.Errorf(codes.NotFound, "artifact not found")
 		}
 		return nil, status.Errorf(codes.Unknown, "failed to get artifact: %s", err)

--- a/pkg/controlplane/handlers_auth.go
+++ b/pkg/controlplane/handlers_auth.go
@@ -17,6 +17,7 @@ package controlplane
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -97,7 +98,7 @@ func (s *Server) LogIn(ctx context.Context, in *pb.LogInRequest) (*pb.LogInRespo
 
 	user, err := s.store.GetUserByUserName(ctx, in.Username)
 	if err != nil {
-		if err == sql.ErrNoRows {
+		if errors.Is(err, sql.ErrNoRows) {
 			return &pb.LogInResponse{}, status.Error(codes.NotFound, "User and password not found")
 		}
 		return nil, err

--- a/pkg/controlplane/handlers_groups.go
+++ b/pkg/controlplane/handlers_groups.go
@@ -17,6 +17,7 @@ package controlplane
 import (
 	"context"
 	"database/sql"
+	"errors"
 
 	"github.com/go-playground/validator/v10"
 	"google.golang.org/grpc/codes"
@@ -134,7 +135,7 @@ func (s *Server) GetGroupById(ctx context.Context, req *pb.GetGroupByIdRequest) 
 
 	grp, err := s.store.GetGroupByID(ctx, req.GroupId)
 	if err != nil {
-		if err == sql.ErrNoRows {
+		if errors.Is(err, sql.ErrNoRows) {
 			return nil, status.Error(codes.NotFound, "group not found")
 		}
 		return nil, status.Errorf(codes.Internal, "failed to get group by id: %s", err)
@@ -261,7 +262,7 @@ func (s *Server) DeleteGroup(ctx context.Context,
 	// first check if the group exists and is not protected
 	group, err := s.store.GetGroupByID(ctx, in.Id)
 	if err != nil {
-		if err == sql.ErrNoRows {
+		if errors.Is(err, sql.ErrNoRows) {
 			return nil, status.Errorf(codes.NotFound, "group not found")
 		}
 		return nil, status.Errorf(codes.Internal, "failed to get group by id: %s", err)

--- a/pkg/controlplane/handlers_oauth.go
+++ b/pkg/controlplane/handlers_oauth.go
@@ -445,7 +445,7 @@ func (s *Server) VerifyProviderTokenFrom(ctx context.Context,
 	_, err := s.store.GetAccessTokenSinceDate(ctx,
 		db.GetAccessTokenSinceDateParams{Provider: in.Provider, GroupID: in.GroupId, CreatedAt: in.Timestamp.AsTime()})
 	if err != nil {
-		if err == sql.ErrNoRows {
+		if errors.Is(err, sql.ErrNoRows) {
 			return &pb.VerifyProviderTokenFromResponse{Status: "KO"}, nil
 		}
 		return nil, status.Errorf(codes.Internal, "error getting access token: %v", err)

--- a/pkg/controlplane/handlers_organization.go
+++ b/pkg/controlplane/handlers_organization.go
@@ -17,6 +17,7 @@ package controlplane
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
 	"time"
 
@@ -283,7 +284,7 @@ func (s *Server) GetOrganization(ctx context.Context,
 
 	org, err := s.store.GetOrganization(ctx, in.OrganizationId)
 	if err != nil {
-		if err == sql.ErrNoRows {
+		if errors.Is(err, sql.ErrNoRows) {
 			return nil, status.Error(codes.NotFound, "organization not found")
 		}
 		return nil, status.Errorf(codes.Internal, "failed to get organization: %s", err)
@@ -318,7 +319,7 @@ func (s *Server) GetOrganizationByName(ctx context.Context,
 
 	org, err := s.store.GetOrganizationByName(ctx, in.Name)
 	if err != nil {
-		if err == sql.ErrNoRows {
+		if errors.Is(err, sql.ErrNoRows) {
 			return nil, status.Error(codes.NotFound, "organization not found")
 		}
 		return nil, status.Errorf(codes.Internal, "failed to get organization: %s", err)
@@ -364,7 +365,7 @@ func (s *Server) DeleteOrganization(ctx context.Context,
 
 	_, err = s.store.GetOrganization(ctx, in.Id)
 	if err != nil {
-		if err == sql.ErrNoRows {
+		if errors.Is(err, sql.ErrNoRows) {
 			return nil, status.Error(codes.NotFound, "organization not found")
 		}
 		return nil, status.Errorf(codes.Internal, "failed to get organization: %s", err)

--- a/pkg/controlplane/handlers_policy.go
+++ b/pkg/controlplane/handlers_policy.go
@@ -113,7 +113,7 @@ func (s *Server) CreatePolicy(ctx context.Context,
 	_, err = s.store.GetAccessTokenByGroupID(ctx,
 		db.GetAccessTokenByGroupIDParams{Provider: entityCtx.GetProvider(), GroupID: entityCtx.Group.GetID()})
 	if err != nil {
-		if err == sql.ErrNoRows {
+		if errors.Is(err, sql.ErrNoRows) {
 			return nil, status.Errorf(codes.FailedPrecondition, "provider %s is not enrolled", entityCtx.GetProvider())
 		}
 		return nil, status.Errorf(codes.Unknown, "failed to get access token: %s", err)
@@ -277,7 +277,7 @@ func (s *Server) DeletePolicy(ctx context.Context,
 
 	_, err = s.store.GetPolicyByID(ctx, in.Id)
 	if err != nil {
-		if err == sql.ErrNoRows {
+		if errors.Is(err, sql.ErrNoRows) {
 			return nil, status.Error(codes.NotFound, "policy not found")
 		}
 		return nil, status.Errorf(codes.Internal, "failed to get policy: %s", err)

--- a/pkg/controlplane/handlers_repositories.go
+++ b/pkg/controlplane/handlers_repositories.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"database/sql"
 	"encoding/json"
+	"errors"
 	"log"
 	"strings"
 
@@ -262,7 +263,7 @@ func (s *Server) GetRepositoryById(ctx context.Context,
 	}
 	// read the repository
 	repo, err := s.store.GetRepositoryByID(ctx, in.RepositoryId)
-	if err == sql.ErrNoRows {
+	if errors.Is(err, sql.ErrNoRows) {
 		return nil, status.Errorf(codes.NotFound, "repository not found")
 	} else if err != nil {
 		return nil, status.Errorf(codes.Internal, "cannot read repository: %v", err)
@@ -312,7 +313,7 @@ func (s *Server) GetRepositoryByName(ctx context.Context,
 	repo, err := s.store.GetRepositoryByRepoName(ctx,
 		db.GetRepositoryByRepoNameParams{Provider: in.Provider, RepoOwner: fragments[0], RepoName: fragments[1]})
 
-	if err == sql.ErrNoRows {
+	if errors.Is(err, sql.ErrNoRows) {
 		return nil, status.Errorf(codes.NotFound, "repository not found")
 	} else if err != nil {
 		return nil, err

--- a/pkg/controlplane/handlers_role.go
+++ b/pkg/controlplane/handlers_role.go
@@ -17,6 +17,7 @@ package controlplane
 import (
 	"context"
 	"database/sql"
+	"errors"
 
 	"github.com/go-playground/validator/v10"
 	"google.golang.org/grpc/codes"
@@ -50,7 +51,7 @@ func (s *Server) CreateRoleByOrganization(ctx context.Context,
 	// check that organization exists
 	_, err = s.store.GetOrganization(ctx, in.OrganizationId)
 	if err != nil {
-		if err == sql.ErrNoRows {
+		if errors.Is(err, sql.ErrNoRows) {
 			return nil, status.Error(codes.NotFound, "organization not found")
 		}
 		return nil, status.Errorf(codes.Internal, "failed to get organization")
@@ -99,7 +100,7 @@ func (s *Server) CreateRoleByGroup(ctx context.Context,
 	// check that organization exists
 	_, err = s.store.GetOrganization(ctx, in.OrganizationId)
 	if err != nil {
-		if err == sql.ErrNoRows {
+		if errors.Is(err, sql.ErrNoRows) {
 			return nil, status.Error(codes.NotFound, "organization not found")
 		}
 		return nil, status.Errorf(codes.Internal, "failed to get organization")
@@ -108,7 +109,7 @@ func (s *Server) CreateRoleByGroup(ctx context.Context,
 	// check that group exists
 	_, err = s.store.GetGroupByID(ctx, in.GroupId)
 	if err != nil {
-		if err == sql.ErrNoRows {
+		if errors.Is(err, sql.ErrNoRows) {
 			return nil, status.Error(codes.NotFound, "group not found")
 		}
 		return nil, status.Errorf(codes.Internal, "failed to get group by id: %s", err)
@@ -157,7 +158,7 @@ func (s *Server) DeleteRole(ctx context.Context,
 	// first check if the role exists and is not protected
 	role, err := s.store.GetRoleByID(ctx, in.Id)
 	if err != nil {
-		if err == sql.ErrNoRows {
+		if errors.Is(err, sql.ErrNoRows) {
 			return nil, status.Errorf(codes.NotFound, "role not found")
 		}
 		return nil, status.Errorf(codes.Internal, "failed to get role by id: %v", err)
@@ -308,7 +309,7 @@ func (s *Server) GetRoleById(ctx context.Context,
 
 	role, err := s.store.GetRoleByID(ctx, in.Id)
 	if err != nil {
-		if err == sql.ErrNoRows {
+		if errors.Is(err, sql.ErrNoRows) {
 			return nil, status.Errorf(codes.NotFound, "role not found")
 		}
 		return nil, status.Errorf(codes.Internal, "failed to get role: %v", err)
@@ -351,7 +352,7 @@ func (s *Server) GetRoleByName(ctx context.Context,
 
 	role, err := s.store.GetRoleByName(ctx, db.GetRoleByNameParams{OrganizationID: in.OrganizationId, Name: in.Name})
 	if err != nil {
-		if err == sql.ErrNoRows {
+		if errors.Is(err, sql.ErrNoRows) {
 			return nil, status.Error(codes.NotFound, "role not found")
 		}
 		return nil, status.Errorf(codes.Internal, "failed to get role by name: %v", err)

--- a/pkg/controlplane/handlers_user.go
+++ b/pkg/controlplane/handlers_user.go
@@ -17,6 +17,7 @@ package controlplane
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"time"
 
 	"github.com/go-playground/validator/v10"
@@ -104,7 +105,7 @@ func (s *Server) CreateUser(ctx context.Context,
 		for _, id := range in.GroupIds {
 			group, err := s.store.GetGroupByID(ctx, id)
 			if err != nil {
-				if err == sql.ErrNoRows {
+				if errors.Is(err, sql.ErrNoRows) {
 					return nil, status.Error(codes.NotFound, "group not found")
 				}
 				return nil, status.Errorf(codes.Internal, "failed to get group: %s", err)
@@ -122,7 +123,7 @@ func (s *Server) CreateUser(ctx context.Context,
 		for _, id := range in.RoleIds {
 			role, err := s.store.GetRoleByID(ctx, id)
 			if err != nil {
-				if err == sql.ErrNoRows {
+				if errors.Is(err, sql.ErrNoRows) {
 					return nil, status.Error(codes.NotFound, "role not found")
 				}
 				return nil, status.Errorf(codes.Internal, "failed to get role: %s", err)
@@ -199,7 +200,7 @@ func (s *Server) DeleteUser(ctx context.Context,
 	// first check if the user exists and is not protected
 	user, err := s.store.GetUserByID(ctx, in.Id)
 	if err != nil {
-		if err == sql.ErrNoRows {
+		if errors.Is(err, sql.ErrNoRows) {
 			return nil, status.Error(codes.NotFound, "user not found")
 		}
 		return nil, status.Errorf(codes.Internal, "failed to get user: %s", err)
@@ -425,7 +426,7 @@ func (s *Server) GetUserById(ctx context.Context,
 
 	user, err := s.store.GetUserByID(ctx, in.Id)
 	if err != nil {
-		if err == sql.ErrNoRows {
+		if errors.Is(err, sql.ErrNoRows) {
 			return nil, status.Error(codes.NotFound, "user not found")
 		}
 		return nil, status.Errorf(codes.Internal, "failed to get user: %s", err)
@@ -464,7 +465,7 @@ func (s *Server) GetUserByUserName(ctx context.Context,
 
 	user, err := s.store.GetUserByUserName(ctx, in.Username)
 	if err != nil {
-		if err == sql.ErrNoRows {
+		if errors.Is(err, sql.ErrNoRows) {
 			return nil, status.Error(codes.NotFound, "user not found")
 		}
 		return nil, status.Errorf(codes.Internal, "failed to get user: %s", err)
@@ -508,7 +509,7 @@ func (s *Server) GetUserByEmail(ctx context.Context,
 
 	user, err := s.store.GetUserByEmail(ctx, sql.NullString{String: in.Email, Valid: true})
 	if err != nil {
-		if err == sql.ErrNoRows {
+		if errors.Is(err, sql.ErrNoRows) {
 			return nil, status.Error(codes.NotFound, "user not found")
 		}
 		return nil, status.Errorf(codes.Internal, "failed to get user: %s", err)
@@ -553,7 +554,7 @@ func (s *Server) GetUser(ctx context.Context, _ *pb.GetUserRequest) (*pb.GetUser
 	// check if user exists
 	user, err := s.store.GetUserByID(ctx, claims.UserId)
 	if err != nil {
-		if err == sql.ErrNoRows {
+		if errors.Is(err, sql.ErrNoRows) {
 			return nil, status.Error(codes.NotFound, "user not found")
 		}
 		return nil, status.Errorf(codes.Internal, "failed to get user: %s", err)
@@ -616,7 +617,7 @@ func (s *Server) UpdatePassword(ctx context.Context, in *pb.UpdatePasswordReques
 	// check if the previous password was the same
 	user, err := s.store.GetUserByID(ctx, claims.UserId)
 	if err != nil {
-		if err == sql.ErrNoRows {
+		if errors.Is(err, sql.ErrNoRows) {
 			return nil, status.Error(codes.NotFound, "user not found")
 		}
 		return nil, status.Errorf(codes.Internal, "failed to get user: %s", err)
@@ -683,7 +684,7 @@ func (s *Server) UpdateProfile(ctx context.Context, in *pb.UpdateProfileRequest)
 	// get details of user
 	user, err := s.store.GetUserByID(ctx, claims.UserId)
 	if err != nil {
-		if err == sql.ErrNoRows {
+		if errors.Is(err, sql.ErrNoRows) {
 			return nil, status.Error(codes.NotFound, "user not found")
 		}
 		return nil, status.Errorf(codes.Internal, "failed to get user: %s", err)

--- a/pkg/db/repositories_test.go
+++ b/pkg/db/repositories_test.go
@@ -24,6 +24,7 @@ package db
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"testing"
 	"time"
 
@@ -37,7 +38,7 @@ type RepositoryOption func(*CreateRepositoryParams)
 func deleteRepositoryByRepoId(params CreateRepositoryParams) error {
 	repo, err := testQueries.GetRepositoryByRepoID(
 		context.Background(), GetRepositoryByRepoIDParams{Provider: params.Provider, RepoID: params.RepoID})
-	if err == sql.ErrNoRows {
+	if errors.Is(err, sql.ErrNoRows) {
 		return nil
 	}
 	if err != nil {


### PR DESCRIPTION
The following PR updates the way sql.ErrNoRow is being compared, i.e. using `errors.Is()` instead of `==`.

Fixes https://github.com/stacklok/mediator/issues/686