### PR TITLE
Implements Dependabot Checks

### DIFF
--- a/examples/github/policies/policy.yaml
+++ b/examples/github/policies/policy.yaml
@@ -42,6 +42,8 @@ repository:
           can_approve_pull_request_reviews: false
       - type: codeql_enabled
         def: {}
+      - type: dependabot_enabled
+        def: {}
       # Note that this only applies to private repositories.
       # So if you want to test this, you'll need to create a private repository.
       # - type: repo_workflow_access_level

--- a/examples/github/rule-types/dependabot_enabled.yaml
+++ b/examples/github/rule-types/dependabot_enabled.yaml
@@ -1,0 +1,53 @@
+---
+version: v1
+type: rule-type
+name: dependabot_enabled
+context:
+  provider: github
+  group: Root Group
+description: Verifies that Dependabot is enabled for the repository
+guidance: |
+  Dependabot enables Automated dependency updates for repositories.
+  It is recommended that repositories have some form of automated dependency updates enabled
+  to ensure that vulnerabilities are not introduced into the codebase.
+  To configure Dependabot, follow the instructions at https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+def:
+  # Defines the section of the pipeline the rule will appear in.
+  # This will affect the template that is used to render multiple parts
+  # of the rule.
+  in_entity: repository
+  # Defines the schema for writing a rule with this rule being checked
+  # In this case there is no settings that need to be configured
+  rule_schema: {}
+  # Defines the configuration for ingesting data relevant for the rule
+  ingest:
+    type: git
+    git:
+      branch: main
+  # Defines the configuration for evaluating data ingested against the given policy
+  # This example uses the checks for a dependabot configuration in the dependabot.yml file
+  # configured to run weekly for the gomod (GoLang) package ecosystem
+  # Another example, for NPM could be:
+  # update["package-ecosystem"] == "npm"
+  # update.schedule.interval == "daily"
+  eval:
+    type: rego
+    rego:
+      type: deny-by-default
+      def: |
+        package mediator
+
+        default allow := false
+
+        allow {
+            # Read the dependabot configuration
+            fileStr := file.read("./.github/dependabot.yml")
+
+            # Parse the YAML content
+            config := yaml.unmarshal(fileStr)
+
+            # Ensure a configuration contains the npgom daily update schedule
+            update := config.updates[_]
+            update["package-ecosystem"] == "gomod"
+            update.schedule.interval == "weekly"
+        }


### PR DESCRIPTION
This example policy, checks a dependabot.yml file is present and if so, that a certain package eco-system is set to a certain update interval

Closes: #842