### PR TITLE
cleanup: Remove commented out entries from policy

### DIFF
--- a/examples/github/policies/policy.yaml
+++ b/examples/github/policies/policy.yaml
@@ -46,11 +46,6 @@ repository:
         def: {}
       - type: dependabot_enabled
         def: {}
-      # Note that this only applies to private repositories.
-      # So if you want to test this, you'll need to create a private repository.
-      # - type: repo_workflow_access_level
-      #   def:
-      #     access_level: none
 artifact:
   - context: github
     rules:
@@ -62,27 +57,3 @@ artifact:
           is_signed: true
           is_verified: true
           is_bundle_verified: true
-# build_environment:
-#   - rules:  # Not specifying a context takes the default context
-#       - type: no_org_wide_github_action_permissions
-#         def:
-#           enabled: true
-# artifact:
-#   - context: github
-#     rules:
-#       - type: ctlog_entry
-#         params:
-#           rekor: 'https://rekor.acme.dev/'
-#           fulcio: 'https://fulcio.acme.dev/'
-#           tuf: 'https://tuf.acme.dev/'
-#         def:
-#           state: exists
-#   - context: quay
-#     rules:
-#       - type: ctlog_entry
-#         params:
-#           rekor: 'https://rekor.acme.dev/'
-#           fulcio: 'https://fulcio.acme.dev/'
-#           tuf: 'https://tuf.acme.dev/'
-#         def:
-#           state: exists


### PR DESCRIPTION
These do nothing but clutter-up the policy.yaml file. Let's remove them
to be able to show them off a little better :)
