### PR TITLE
dev: Add log message when rule violation happens

### DIFF
--- a/pkg/controlplane/handlers_policy.go
+++ b/pkg/controlplane/handlers_policy.go
@@ -159,6 +159,7 @@ func (s *Server) CreatePolicy(ctx context.Context,
 	if err != nil {
 		var violation *engine.RuleValidationError
 		if errors.As(err, &violation) {
+			log.Printf("error validating rule: %v", violation)
 			return nil, status.Errorf(codes.InvalidArgument, "policy contained invalid rule: %s", violation.RuleType)
 		}
 


### PR DESCRIPTION
If a policy calls a rule and it fails validation, this logs the violation
on the server so developers are also able to debug the issue.
