### PR TITLE
rego: Fix `constraints` evaluation type and prettify result

### DIFF
--- a/internal/engine/errors/errors.go
+++ b/internal/engine/errors/errors.go
@@ -22,7 +22,7 @@ import (
 )
 
 // ErrEvaluationFailed is an error that occurs during evaluation of a rule.
-var ErrEvaluationFailed = errors.New("evaluation error")
+var ErrEvaluationFailed = errors.New("evaluation failure")
 
 // NewErrEvaluationFailed creates a new evaluation error
 func NewErrEvaluationFailed(sfmt string, args ...any) error {

--- a/internal/engine/eval/rego/result.go
+++ b/internal/engine/eval/rego/result.go
@@ -18,6 +18,7 @@ package rego
 import (
 	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/open-policy-agent/opa/rego"
 
@@ -82,17 +83,17 @@ func (*constraintsEvaluator) parseResult(rs rego.ResultSet) error {
 	}
 
 	// Gather violations into one
-	violations := make([]error, len(rs))
+	violations := make([]string, 0, len(rs))
 	for _, r := range rs {
 		v := resultToViolation(r)
 		if errors.Is(v, engerrors.ErrEvaluationFailed) {
-			violations = append(violations, v)
+			violations = append(violations, v.Error())
 		} else {
 			return fmt.Errorf("unexpected error in rego violation: %w", v)
 		}
 	}
 
-	return engerrors.NewErrEvaluationFailed("Evaluation failed: %s", violations)
+	return engerrors.NewErrEvaluationFailed("Evaluation failures: \n - %s", strings.Join(violations, "\n - "))
 }
 
 func resultToViolation(r rego.Result) error {
@@ -116,5 +117,5 @@ func resultToViolation(r rego.Result) error {
 		return fmt.Errorf("msg is not a string")
 	}
 
-	return engerrors.NewErrEvaluationFailed("Evaluation failed: %s", msgstr)
+	return engerrors.NewErrEvaluationFailed(msgstr)
 }


### PR DESCRIPTION
This fixes an issue in gathering multiple failures in the `constraints`
evaluation type for rego. It also prettifies the result so it's easier to read.
