### PR TITLE
`medev`: a CLI tool to work with mediator

### DIFF
--- a/cmd/dev/app/root.go
+++ b/cmd/dev/app/root.go
@@ -1,0 +1,65 @@
+//
+// Copyright 2023 Stacklok, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package app provides the root command for the medev CLI
+package app
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+
+	"github.com/stacklok/mediator/internal/util"
+)
+
+var (
+	cfgFile string // config file (default is $PWD/config.yaml)
+
+	// RootCmd represents the base command when called without any subcommands
+	RootCmd = &cobra.Command{
+		Use:   "medev",
+		Short: "medev provides developer tooling for the mediator",
+		Long: `For more information about mediator, please visit:
+https://docs.stacklok.com/mediator/medev/overview.html`,
+	}
+)
+
+// Execute adds all child commands to the root command and sets flags appropriately.
+func Execute() {
+	err := RootCmd.Execute()
+	util.ExitNicelyOnError(err, "Error on execute")
+}
+
+func init() {
+	cobra.OnInitialize(initConfig)
+	RootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is $PWD/config.yaml)")
+}
+
+func initConfig() {
+	if cfgFile != "" {
+		viper.SetConfigFile(cfgFile)
+	} else {
+		// use defaults
+		viper.SetConfigName("config")
+		viper.AddConfigPath(".")
+	}
+	viper.SetConfigType("yaml")
+	viper.AutomaticEnv()
+
+	if err := viper.ReadInConfig(); err != nil {
+		fmt.Println("Error reading config file:", err)
+	}
+}

--- a/cmd/dev/app/rule_type/rule_type.go
+++ b/cmd/dev/app/rule_type/rule_type.go
@@ -11,8 +11,9 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-// Package rule provides the CLI subcommand for managing rules
 
+// Package rule_type provides the CLI subcommand for developing rules
+// e.g. the 'rule type test' subcommand.
 package rule_type
 
 import (
@@ -28,6 +29,7 @@ import (
 	"github.com/spf13/viper"
 	"google.golang.org/protobuf/reflect/protoreflect"
 
+	"github.com/stacklok/mediator/cmd/dev/app"
 	"github.com/stacklok/mediator/internal/engine"
 	"github.com/stacklok/mediator/internal/util"
 	"github.com/stacklok/mediator/pkg/entities"
@@ -37,15 +39,15 @@ import (
 
 // TestCmd is the root command for the rule subcommands
 var testCmd = &cobra.Command{
-	Use:          "test",
+	Use:          "rule type test",
 	Short:        "test a rule type definition",
-	Long:         `The 'rule_type test' subcommand allows you test a rule type definition`,
+	Long:         `The 'rule type test' subcommand allows you test a rule type definition`,
 	RunE:         testCmdRun,
 	SilenceUsage: true,
 }
 
 func init() {
-	ruleTypeCmd.AddCommand(testCmd)
+	app.RootCmd.AddCommand(testCmd)
 	testCmd.Flags().StringP("rule-type", "r", "", "file to read rule type definition from")
 	testCmd.Flags().StringP("entity", "e", "", "YAML file containing the entity to test the rule against")
 	testCmd.Flags().StringP("policy", "p", "", "YAML file containing a policy to test the rule against")

--- a/cmd/dev/main.go
+++ b/cmd/dev/main.go
@@ -1,0 +1,26 @@
+//
+// Copyright 2023 Stacklok, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package main provides the entrypoint for the mediator cli
+package main
+
+import (
+	"github.com/stacklok/mediator/cmd/dev/app"
+	_ "github.com/stacklok/mediator/cmd/dev/app/rule_type"
+)
+
+func main() {
+	app.Execute()
+}


### PR DESCRIPTION
The intention is to separate development (e.g. rule type development) tools from
the day-to-day CLI utilities. This makes the `medic` CLI slimmer and allows us to pack
more dependencies and functionality into the new `medev` command.

For now, this merely separates the code, subsequent PRs will deal with releasing a
binary.
