### PR TITLE
medic: print rule types as tables

### DIFF
--- a/cmd/cli/app/rule_type/rule_type_create.go
+++ b/cmd/cli/app/rule_type/rule_type_create.go
@@ -83,12 +83,10 @@ within a mediator control plane.`,
 			if err != nil {
 				return fmt.Errorf("error creating rule type: %w", err)
 			}
-			out, err := util.GetJsonFromProto(resp)
-			if err != nil {
-				return fmt.Errorf("error getting json from proto: %w", err)
-			}
 
-			fmt.Println(out)
+			table := initializeTable(cmd)
+			renderRuleTypeTable(resp.RuleType, table)
+			table.Render()
 		}
 
 		return nil

--- a/cmd/cli/app/rule_type/table_render.go
+++ b/cmd/cli/app/rule_type/table_render.go
@@ -1,0 +1,51 @@
+//
+// Copyright 2023 Stacklok, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package rule_type
+
+import (
+	"fmt"
+
+	"github.com/olekukonko/tablewriter"
+	"github.com/spf13/cobra"
+
+	pb "github.com/stacklok/mediator/pkg/generated/protobuf/go/mediator/v1"
+)
+
+func initializeTable(cmd *cobra.Command) *tablewriter.Table {
+	table := tablewriter.NewWriter(cmd.OutOrStdout())
+	table.SetHeader([]string{"Provider", "Group Name", "Id", "Name", "Description"})
+	table.SetRowLine(true)
+	table.SetRowSeparator("-")
+	table.SetAutoMergeCellsByColumnIndex([]int{0, 1, 2, 3})
+	// This is needed for the rule definition and rule parameters
+	table.SetAutoWrapText(false)
+
+	return table
+}
+
+func renderRuleTypeTable(
+	rt *pb.RuleType,
+	table *tablewriter.Table,
+) {
+	row := []string{
+		rt.Context.Provider,
+		*rt.Context.Group,
+		fmt.Sprintf("%d", *rt.Id),
+		rt.Name,
+		rt.Description,
+	}
+	table.Append(row)
+}

--- a/pkg/controlplane/handlers_policy.go
+++ b/pkg/controlplane/handlers_policy.go
@@ -776,7 +776,7 @@ func (s *Server) CreateRuleType(ctx context.Context, crt *pb.CreateRuleTypeReque
 		return nil, fmt.Errorf("cannot convert rule definition to db: %v", err)
 	}
 
-	_, err = s.store.CreateRuleType(ctx, db.CreateRuleTypeParams{
+	dbrtyp, err := s.store.CreateRuleType(ctx, db.CreateRuleTypeParams{
 		Name:        in.GetName(),
 		Provider:    entityCtx.GetProvider(),
 		GroupID:     entityCtx.GetGroup().GetID(),
@@ -787,6 +787,8 @@ func (s *Server) CreateRuleType(ctx context.Context, crt *pb.CreateRuleTypeReque
 	if err != nil {
 		return nil, status.Errorf(codes.Unknown, "failed to create rule type: %s", err)
 	}
+
+	in.Id = &dbrtyp.ID
 
 	return &pb.CreateRuleTypeResponse{
 		RuleType: in,


### PR DESCRIPTION
This adds rule type table outputs which is the new default. This prints out
the minimal information a user needs about a rule and hides the nitty-gritty details.

This also fixes a buf where the rule type ID was not being returned when creating a rule type.

Related to #876