### PR TITLE
rule: Add new rule type that checks if folks are using the `latest` tag in their Dockerfiles

### DIFF
--- a/examples/github/policies/policy.yaml
+++ b/examples/github/policies/policy.yaml
@@ -45,6 +45,8 @@ repository:
         def: {}
       - type: dependabot_enabled
         def: {}
+      - type: dockerfile_no_latest_tag
+        def: {}
 artifact:
   - context: github
     rules:

--- a/examples/github/rule-types/dockerfile_no_latest_tag.yaml
+++ b/examples/github/rule-types/dockerfile_no_latest_tag.yaml
@@ -1,0 +1,51 @@
+---
+version: v1
+type: rule-type
+name: dockerfile_no_latest_tag
+context:
+  provider: github
+  group: Root Group
+description: Verifies that the Dockerfile image references don't use the latest tag
+guidance: |
+  Using the latest tag for Docker images is not recommended as it can lead to unexpected behavior.
+  It is recommended to use a checksum instead, as that's immutable and will always point to the same image.
+def:
+  # Defines the section of the pipeline the rule will appear in.
+  # This will affect the template that is used to render multiple parts
+  # of the rule.
+  in_entity: repository
+  # Defines the schema for writing a rule with this rule being checked
+  # In this case there is no settings that need to be configured
+  rule_schema: {}
+  # Defines the configuration for ingesting data relevant for the rule
+  ingest:
+    type: git
+    git:
+      branch: master
+  # Defines the configuration for evaluating data ingested against the given policy
+  # This example uses the checks for that github actions are using pinned tags
+  # for the uses directive, in the form of SHA-1 hash
+  # For example, this wil fail:
+  # uses: actions/checkout@v2
+  # This will pass:
+  # uses: actions/checkout@f3d2b746c498f2d3d1f2d3d1f2d3d1f2d3d1f2d3
+  eval:
+    type: rego
+    rego:
+      type: constraints
+      def: |
+        package mediator
+
+        violations[{"msg": msg}] {
+          # Read Dockerfile
+          dockerfile := file.read("Dockerfile")
+
+          # Find all lines that start with FROM
+          from_lines := regex.find_n("^FROM \\S+.*^", dockerfile, -1)
+
+          # Is there the `latest` tag?
+          from_line := from_lines[_]
+          endswith(from_line, ":latest")
+
+          msg := sprintf("Dockerfile contains 'latest' tag in import: %s", [from_line])
+        }


### PR DESCRIPTION
`latest` is not recommended, so this will fail if it finds it. Currently it only checks for a `Dockerfile`
in the root directory. In the future we could smartly find Dockerfiles in the repo. but we'll do that later.
