### PR TITLE
`EntityInfoWrapper.BuildMessage`: Return `nil, error`

### DIFF
--- a/internal/engine/entity_event.go
+++ b/internal/engine/entity_event.go
@@ -150,7 +150,11 @@ func (eiw *EntityInfoWrapper) BuildMessage() (*message.Message, error) {
 	}
 
 	msg := message.NewMessage(id.String(), nil)
-	return msg, eiw.ToMessage(msg)
+	if err := eiw.ToMessage(msg); err != nil {
+		return nil, err
+	}
+
+	return msg, nil
 }
 
 // ToMessage sets the information to a message.Message


### PR DESCRIPTION
This drops the "cleverness" I did before and returns `nil` if an error
is encountered, as one would expect.
