### PR TITLE
`EntityInfoWrapper`: Add utility function to build+publish

### DIFF
--- a/internal/engine/entity_event.go
+++ b/internal/engine/entity_event.go
@@ -22,6 +22,7 @@ import (
 	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/reflect/protoreflect"
 
+	"github.com/stacklok/mediator/internal/events"
 	"github.com/stacklok/mediator/internal/util"
 	"github.com/stacklok/mediator/pkg/entities"
 	pb "github.com/stacklok/mediator/pkg/generated/protobuf/go/mediator/v1"
@@ -151,6 +152,20 @@ func (eiw *EntityInfoWrapper) BuildMessage() (*message.Message, error) {
 
 	msg := message.NewMessage(id.String(), nil)
 	return msg, eiw.ToMessage(msg)
+}
+
+// Publish builds a message.Message and publishes it to the event bus
+func (eiw *EntityInfoWrapper) Publish(evt *events.Eventer) error {
+	msg, err := eiw.BuildMessage()
+	if err != nil {
+		return err
+	}
+
+	if err := evt.Publish(InternalEntityEventTopic, msg); err != nil {
+		return fmt.Errorf("error publishing entity event: %w", err)
+	}
+
+	return nil
 }
 
 // ToMessage sets the information to a message.Message

--- a/internal/reconcilers/artifacts.go
+++ b/internal/reconcilers/artifacts.go
@@ -221,19 +221,14 @@ func (e *Reconciler) handleArtifactsReconcilerEvent(ctx context.Context, prov st
 				},
 			}
 
-			eiw := engine.NewEntityInfoWrapper().
+			err = engine.NewEntityInfoWrapper().
 				WithProvider(prov).
 				WithVersionedArtifact(versionedArtifact).
 				WithGroupID(evt.Group).
 				WithArtifactID(newArtifact.ID).
-				WithRepositoryID(repository.ID)
-
-			msg, err := eiw.BuildMessage()
+				WithRepositoryID(repository.ID).
+				Publish(e.evt)
 			if err != nil {
-				return fmt.Errorf("error building message: %w", err)
-			}
-
-			if err := e.evt.Publish(engine.InternalEntityEventTopic, msg); err != nil {
 				return fmt.Errorf("error publishing message: %w", err)
 			}
 		}

--- a/internal/reconcilers/run_policy.go
+++ b/internal/reconcilers/run_policy.go
@@ -130,20 +130,16 @@ func (s *Reconciler) publishPolicyInitEvents(
 			UpdatedAt:  timestamppb.New(dbrepo.UpdatedAt),
 		}
 
-		eiw := engine.NewEntityInfoWrapper().
+		err := engine.NewEntityInfoWrapper().
 			WithProvider(ectx.Provider).
 			WithGroupID(ectx.Group.ID).
 			WithRepository(repo).
-			WithRepositoryID(dbrepo.ID)
-
-		msg, err := eiw.BuildMessage()
-		if err != nil {
-			return fmt.Errorf("publishPolicyInitEvents: error building message: %v", err)
-		}
+			WithRepositoryID(dbrepo.ID).
+			Publish(s.evt)
 
 		// This is a non-fatal error, so we'll just log it
 		// and continue
-		if err := s.evt.Publish(engine.InternalEntityEventTopic, msg); err != nil {
+		if err != nil {
 			return fmt.Errorf("error publishing init event for repo %d: %v", dbrepo.ID, err)
 		}
 	}
@@ -227,22 +223,17 @@ func (s *Reconciler) publishArtifactPolicyInitEvents(
 				},
 			}
 
-			eiw := engine.NewEntityInfoWrapper().
+			err := engine.NewEntityInfoWrapper().
 				WithProvider(ectx.Provider).
 				WithGroupID(ectx.Group.ID).
 				WithVersionedArtifact(versionedArtifact).
 				WithRepositoryID(dbrepo.ID).
-				WithArtifactID(dbA.ID)
-
-			msg, err := eiw.BuildMessage()
-			if err != nil {
-				log.Printf("publishPolicyInitEvents: error building message: %v", err)
-				continue
-			}
+				WithArtifactID(dbA.ID).
+				Publish(s.evt)
 
 			// This is a non-fatal error, so we'll just log it
 			// and continue
-			if err := s.evt.Publish(engine.InternalEntityEventTopic, msg); err != nil {
+			if err != nil {
 				log.Printf("error publishing init event for repo %d: %v", dbrepo.ID, err)
 				continue
 			}


### PR DESCRIPTION
Since this was the usage that the entity info wrapper was having
in some parts of the code-base, as @jhrozek suggested, it was a good idea
to just converge this into a single function
