### PR TITLE
rego: Add option to skip for `deny-by-default` evaluator

### DIFF
--- a/examples/github/policies/policy.yaml
+++ b/examples/github/policies/policy.yaml
@@ -43,8 +43,16 @@ repository:
         def: {}
       - type: actions_check_pinned_tags
         def: {}
-      - type: dependabot_enabled
-        def: {}
+      - type: dependabot_configured
+        def:
+          package_ecosystem: gomod
+          schedule_interval: weekly
+          apply_if_file: go.mod
+      - type: dependabot_configured
+        def:
+          package_ecosystem: npm
+          schedule_interval: weekly
+          apply_if_file: package.json
       - type: dockerfile_no_latest_tag
         def: {}
       - type: trivy_action_enabled

--- a/examples/github/rule-types/dependabot_configured.yaml
+++ b/examples/github/rule-types/dependabot_configured.yaml
@@ -1,11 +1,11 @@
 ---
 version: v1
 type: rule-type
-name: dependabot_enabled
+name: dependabot_configured
 context:
   provider: github
   group: Root Group
-description: Verifies that Dependabot is enabled for the repository
+description: Verifies that Dependabot is configured for the repository
 guidance: |
   Dependabot enables Automated dependency updates for repositories.
   It is recommended that repositories have some form of automated dependency updates enabled
@@ -20,7 +20,27 @@ def:
   in_entity: repository
   # Defines the schema for writing a rule with this rule being checked
   # In this case there is no settings that need to be configured
-  rule_schema: {}
+  rule_schema:
+    type: object
+    properties:
+      package_ecosystem:
+        type: string
+        description: |
+          The package ecosystem that the rule applies to.
+          For example, npm, docker, github-actions, etc.
+      schedule_interval:
+        type: string
+        description: |
+          The interval that the rule should be evaluated.
+          For example, daily, weekly, monthly, etc.
+      apply_if_file:
+        type: string
+        description: |
+          Optional. If specified, the rule will only be evaluated if the given file exists.
+          This is useful for rules that are only applicable to certain types of repositories.
+    required:
+      - package_ecosystem
+      - schedule_interval
   # Defines the configuration for ingesting data relevant for the rule
   ingest:
     type: git
@@ -28,7 +48,7 @@ def:
       branch: main
   # Defines the configuration for evaluating data ingested against the given policy
   # This example uses the checks for a dependabot configuration in the dependabot.yml file
-  # configured to run weekly for the gomod (GoLang) package ecosystem
+  # configured to run weekly for the package ecosystem specified.
   # Another example, for NPM could be:
   # update["package-ecosystem"] == "npm"
   # update.schedule.interval == "daily"
@@ -41,6 +61,7 @@ def:
 
         default allow := false
 
+        # Set allow if we don't need to skip and the rule evaluation passes
         allow {
             # Read the dependabot configuration
             fileStr := file.read("./.github/dependabot.yml")
@@ -48,8 +69,14 @@ def:
             # Parse the YAML content
             config := yaml.unmarshal(fileStr)
 
-            # Ensure a configuration contains the npgom daily update schedule
+            # Ensure a configuration contains the package ecosystem daily update schedule
             update := config.updates[_]
-            update["package-ecosystem"] == "gomod"
-            update.schedule.interval == "weekly"
+            update["package-ecosystem"] == input.policy.package_ecosystem
+            update.schedule.interval == input.policy.schedule_interval
+        }
+
+        # We skip if the apply_if_file is specified and the file does not exist
+        skip {
+            input.policy.apply_if_file != ""
+            not file.exists(input.policy.apply_if_file)
         }


### PR DESCRIPTION
There are cases where a policy is not applicable for an entity. e.g. We shouldn't check for npm dependencies on a golang repository.

This PR allows us to skip a rule evaluation in the rego engine if we mark a `skip` expression in the rego policy.

An example was added to the dependabot rule. We may skip the rule if a certain dependency file doesn't exist.

The rule was renamed to `dependabot_configured` to reflect the name, and the policy may now take paramters that
define the package ecosystem, interval schedule, and finally the file that should exist for the rule to apply.
