### PR TITLE
docs: Update documentation with reference to detailed status

### DIFF
--- a/docs/docs/policy_engine/manage_policies.md
+++ b/docs/docs/policy_engine/manage_policies.md
@@ -189,8 +189,8 @@ Policy status can be checked using the following commands
 medic policy_status list --policy 1
 ```
 
-or
+To view all of the rule evaluations, use the following
 
 ```bash
-medic policy get --id 1 --output yaml
+medic policy_status list --policy 1 --detailed
 ```


### PR DESCRIPTION
This updates the doc to indicate folks how to retrieve the "detailed" status,
which refers to the individual rule evaluations per entity.
