### PR TITLE
`rule_type create`: Print one table instead of many

### DIFF
--- a/cmd/cli/app/rule_type/rule_type_create.go
+++ b/cmd/cli/app/rule_type/rule_type_create.go
@@ -64,6 +64,8 @@ within a mediator control plane.`,
 			return fmt.Errorf("error expanding file args: %w", err)
 		}
 
+		table := initializeTable(cmd)
+
 		for _, f := range expfiles {
 			preader, closer, err := util.OpenFileArg(f, cmd.InOrStdin())
 			if err != nil {
@@ -84,10 +86,10 @@ within a mediator control plane.`,
 				return fmt.Errorf("error creating rule type: %w", err)
 			}
 
-			table := initializeTable(cmd)
 			renderRuleTypeTable(resp.RuleType, table)
-			table.Render()
 		}
+
+		table.Render()
 
 		return nil
 	},


### PR DESCRIPTION
When bulk-creating rule types, this prints everything in one table instead of
printing out many, making the output look more clean and compact.
