### PR TITLE
Fix OAuthService endpoint that got fixed manually

### DIFF
--- a/deployment/helm/templates/ingress.yaml
+++ b/deployment/helm/templates/ingress.yaml
@@ -47,7 +47,7 @@ spec:
             name: mediator-grpc
             port:
               name: grpc
-      - path: /mediator.v1.OauthService
+      - path: /mediator.v1.OAuthService
         pathType: Prefix
         backend:
           service:


### PR DESCRIPTION
Found via:

```shell
helm upgrade --dry-run -n mediator mediator oci://ghcr.io/stacklok/mediator/helm/mediator --values values-extracted.yaml > /tmp/update-output
vi /tmp/update-output
kubectl diff -n mediator -f /tmp/update-output
```

Which had the expected changes:
- `migrateup` job
- `dbname` config changes
- image URL changes

And this change, which seems to have been due to manual fixing after the `helm install`, and never made it back into the chart.  `mediator.proto` confirms the `OAuthService` spelling.

```diff
@@ -43,7 +43,7 @@
             name: mediator-grpc
             port:
               name: grpc
-        path: /mediator.v1.OAuthService
+        path: /mediator.v1.OauthService
         pathType: Prefix
       - backend:
           service:
```
