### PR TITLE
Sort CSV list of known entities to prevent needless doc updates

### DIFF
--- a/pkg/entities/entities.go
+++ b/pkg/entities/entities.go
@@ -20,6 +20,8 @@ package entities
 import (
 	"strings"
 
+	"golang.org/x/exp/slices"
+
 	"github.com/stacklok/mediator/pkg/db"
 	pb "github.com/stacklok/mediator/pkg/generated/protobuf/go/mediator/v1"
 )
@@ -89,6 +91,7 @@ func KnownTypesCSV() string {
 		keys = append(keys, pbToEntityType[pb.Entity(pbval)].String())
 	}
 
+	slices.Sort(keys)
 	return strings.Join(keys, ",")
 }
 


### PR DESCRIPTION
We return a comma-separated list of known entities which is used to
generate the known entities in error messages and help output, but it
turns out that the order is not stable because we read the known
entities from iterating over a map. Let's sort the keys before returning
them to prevent getting documentation update PRs that just switch the
order.
