### PR TITLE
tests: Run with -race

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -105,8 +105,8 @@ bootstrap: ## install build deps
 	# Make sure the keys are readable by the docker user
 	chmod 644 .ssh/*
 
-test: clean ## display test coverage
-	go test -json -v ./... | gotestfmt
+test: clean ## run unit tests
+	go test -race -json -v ./... | gotestfmt
 
 clean: ## clean up environment
 	rm -rf dist/* & rm -rf bin/*

--- a/internal/util/helpers_test.go
+++ b/internal/util/helpers_test.go
@@ -28,7 +28,7 @@ import (
 	"github.com/stacklok/mediator/internal/util"
 )
 
-func TestGetConfigValue(t *testing.T) {
+func TestGetConfigValue(t *testing.T) { //nolint:tparallel // we test viper which triggers data races
 	t.Parallel()
 
 	testCases := []struct {
@@ -69,11 +69,10 @@ func TestGetConfigValue(t *testing.T) {
 		},
 	}
 
-	for _, tc := range testCases {
+	for _, tc := range testCases { //nolint:paralleltest // we test viper which triggers data races
 		tc := tc
 
 		t.Run(tc.name, func(t *testing.T) {
-			t.Parallel()
 
 			viper.Set(tc.key, tc.defaultValue)
 


### PR DESCRIPTION
We should run our unit tests with `-race` by default. There turned out
to be one test that didn't work well with `-race`, I think it's because
viper is just not concurrent-safe, so I disabled the parallel runs there
and suppressed the linter warning.
