### PR TITLE
fix: resolve tag conflicts for versioned artifacts

### DIFF
--- a/pkg/controlplane/handlers_githubwebhooks.go
+++ b/pkg/controlplane/handlers_githubwebhooks.go
@@ -688,7 +688,7 @@ func upsertVersionedArtifact(
 				GithubWorkflow:        existing.GithubWorkflow.RawMessage,
 			})
 			if err != nil {
-				return nil, nil, fmt.Errorf("error upserting artifact_id %d with version_id %d: %w", existing.ArtifactID, existing.Version, err)
+				return nil, nil, fmt.Errorf("error upserting artifact %d with version %d: %w", existing.ArtifactID, existing.Version, err)
 			}
 		}
 	}


### PR DESCRIPTION
On each publish event for a package/artifact we insert a new record in artifact_versions which has a given set of tags associated with it. After a while we end up having multiple records that share the same tag entries (or one is a subset of the other) which is wrong given that a tag should be matched to only one image digest.

The following PR introduces the idea of searching for all existing entries that match the incoming tag value in their Tags field. If found, the existing artifact is updated by removing the incoming tag from its tags column.

Fixes https://github.com/stacklok/mediator/issues/814