### PR TITLE
eventer: Add extra logging and retriable events

### DIFF
--- a/internal/events/error.go
+++ b/internal/events/error.go
@@ -1,0 +1,33 @@
+//
+// Copyright 2023 Stacklok, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package events
+
+import (
+	"errors"
+	"fmt"
+)
+
+var (
+	// ErrRetriable is an error that may be retried. All other errors encountered
+	// by watermill be simply logged and ignored.
+	ErrRetriable = errors.New("retriable error")
+)
+
+// NewRetriableError creates a new retriable error
+func NewRetriableError(sfmt string, args ...any) error {
+	msg := fmt.Sprintf(sfmt, args...)
+	return fmt.Errorf("%w: %s", ErrRetriable, msg)
+}


### PR DESCRIPTION
This wraps the eventer with extra logging for easier debugging. It also stops retrying errors in an infinite loop and instead will only retry events if they're explicitly marked as such with the `ErrRetriable` error type.
