### PR TITLE
webhook: Don't process events from repositories that are not registered

### DIFF
--- a/pkg/controlplane/handlers_githubwebhooks.go
+++ b/pkg/controlplane/handlers_githubwebhooks.go
@@ -837,6 +837,12 @@ func getRepoInformationFromPayload(
 		}
 		return db.Repository{}, fmt.Errorf("error getting repository: %w", err)
 	}
+
+	if dbrepo.GroupID == 0 {
+		return db.Repository{}, fmt.Errorf("no group found for repository %s/%s: %w",
+			dbrepo.RepoOwner, dbrepo.RepoName, ErrRepoNotFound)
+	}
+
 	return dbrepo, nil
 }
 


### PR DESCRIPTION
This returns an error if the repository does not belong to a group. This way we won't
have funky issues when trying to evaluate a policy for a non-existent group.
