### PR TITLE
fix: race condition for signed versioned artifacts

### DIFF
--- a/pkg/controlplane/handlers_githubwebhooks.go
+++ b/pkg/controlplane/handlers_githubwebhooks.go
@@ -588,12 +588,10 @@ func gatherVersionedArtifact(
 			return nil, fmt.Errorf("error looking up version by signature tag: %w", lookupErr)
 		}
 		if storedVersion == nil {
-			// not much we can do about the version not being there, let's hope the signed container arrives later
-			// but don't return nil, there's no point in retrying either
+			// return an error that would be caught by the webhook HTTP handler and not retried
 			return nil, ErrArtifactNotFound
 		}
 		// let's continue with the stored version
-
 		// now get information for signature and workflow
 		err = storeSignatureAndWorkflowInVersion(
 			ctx, cli, artifact.Owner, artifact.Name, transformTag(tagIsSigErr.signatureTag), storedVersion)


### PR DESCRIPTION
The following PR fixes a race condition happening depending on the order of receiving events for signed versioned artifacts. The result was a never ending loop trying to process the artifact publish event.

Marking as draft since it was created during debugging with Jakub. It will be converted once we agree on the solution.