### PR TITLE
golangci-lint: Turn on `exhaustive` linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -57,6 +57,7 @@ linters:
   disable-all: true
   enable:
     - lll
+    - exhaustive
     - goconst
     - gocyclo
     - gofmt

--- a/cmd/dev/app/rule_type/rule_type.go
+++ b/cmd/dev/app/rule_type/rule_type.go
@@ -187,6 +187,10 @@ func readEntityFromFile(fpath string, entType pb.Entity) (protoreflect.ProtoMess
 		out = &pb.VersionedArtifact{}
 	case pb.Entity_ENTITY_PULL_REQUESTS:
 		out = &pb.PullRequest{}
+	case pb.Entity_ENTITY_BUILD_ENVIRONMENTS:
+		return nil, fmt.Errorf("build environments not yet supported")
+	case pb.Entity_ENTITY_UNSPECIFIED:
+		return nil, fmt.Errorf("entity type unspecified")
 	default:
 		return nil, fmt.Errorf("unknown entity type: %s", entType)
 	}

--- a/internal/engine/entity_event.go
+++ b/internal/engine/entity_event.go
@@ -314,6 +314,10 @@ func pbEntityTypeToString(t pb.Entity) (string, error) {
 		return VersionedArtifactEventEntityType, nil
 	case pb.Entity_ENTITY_PULL_REQUESTS:
 		return PullRequestEventEntityType, nil
+	case pb.Entity_ENTITY_BUILD_ENVIRONMENTS:
+		return "", fmt.Errorf("build environments not yet supported")
+	case pb.Entity_ENTITY_UNSPECIFIED:
+		return "", fmt.Errorf("entity type unspecified")
 	default:
 		return "", fmt.Errorf("unknown entity type: %s", t.String())
 	}

--- a/internal/engine/eval/vulncheck/config.go
+++ b/internal/engine/eval/vulncheck/config.go
@@ -81,6 +81,9 @@ func pbEcosystemAsString(ecosystem pb.DepEcosystem) string {
 	switch ecosystem {
 	case pb.DepEcosystem_DEP_ECOSYSTEM_NPM:
 		return "npm"
+	case pb.DepEcosystem_DEP_ECOSYSTEM_UNSPECIFIED:
+		// this shouldn't happen
+		return ""
 	default:
 		return ""
 	}

--- a/internal/engine/ingester/diff/parse.go
+++ b/internal/engine/ingester/diff/parse.go
@@ -29,6 +29,8 @@ func newEcosystemParser(eco DependencyEcosystem) ecosystemParser {
 	switch eco {
 	case DepEcosystemNPM:
 		return npmParse
+	case DepEcosystemNone:
+		return nil
 	default:
 		return nil
 	}

--- a/internal/engine/pipeline_policy.go
+++ b/internal/engine/pipeline_policy.go
@@ -206,6 +206,8 @@ func GetRulesForEntity(p *pb.PipelinePolicy, entity pb.Entity) ([]*pb.PipelinePo
 		return p.Artifact, nil
 	case pb.Entity_ENTITY_PULL_REQUESTS:
 		return p.PullRequest, nil
+	case pb.Entity_ENTITY_UNSPECIFIED:
+		return nil, fmt.Errorf("entity type unspecified")
 	default:
 		return nil, fmt.Errorf("unknown entity: %s", entity)
 	}
@@ -339,6 +341,9 @@ func rowInfoToPolicyMap(
 		policy.Artifact = ruleset
 	case pb.Entity_ENTITY_PULL_REQUESTS:
 		policy.PullRequest = ruleset
+	case pb.Entity_ENTITY_UNSPECIFIED:
+		// This shouldn't happen
+		log.Printf("unknown entity found in database: %s", entity)
 	}
 
 	return policy

--- a/pkg/controlplane/handlers_policy.go
+++ b/pkg/controlplane/handlers_policy.go
@@ -361,10 +361,7 @@ func getRuleEvalEntityInfo(
 		return entityInfo
 	}
 
-	// linter complaints that switches with one-case are bad, but I think that a switch is more extensible for future
-	// nolint:revive
-	switch entityType.Entities {
-	case db.EntitiesArtifact:
+	if entityType.Entities == db.EntitiesArtifact {
 		artifact, err := store.GetArtifactByID(ctx, selector.Int32)
 		if err != nil {
 			log.Printf("error getting artifact: %v", err)

--- a/pkg/entities/entities.go
+++ b/pkg/entities/entities.go
@@ -72,6 +72,8 @@ func IsValidEntity(entity pb.Entity) bool {
 	case pb.Entity_ENTITY_REPOSITORIES, pb.Entity_ENTITY_BUILD_ENVIRONMENTS,
 		pb.Entity_ENTITY_ARTIFACTS, pb.Entity_ENTITY_PULL_REQUESTS:
 		return true
+	case pb.Entity_ENTITY_UNSPECIFIED:
+		return false
 	}
 	return false
 }
@@ -130,6 +132,8 @@ func EntityTypeToDB(entity pb.Entity) db.Entities {
 		dbEnt = db.EntitiesArtifact
 	case pb.Entity_ENTITY_PULL_REQUESTS:
 		dbEnt = db.EntitiesPullRequest
+	case pb.Entity_ENTITY_UNSPECIFIED:
+		// This shouldn't happen
 	}
 
 	return dbEnt


### PR DESCRIPTION
This checks that we have a case for all `enum` values in switch statements.

This also fixes all the warnings presented by the linter.
