### PR TITLE
Dismiss stale reviews when reviewing PRs with vulnerable dependencies

### DIFF
--- a/internal/engine/eval/vulncheck/actions.go
+++ b/internal/engine/eval/vulncheck/actions.go
@@ -1,0 +1,49 @@
+// Copyright 2023 Stacklok, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.role/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package vulncheck provides the vulnerability check evaluator
+package vulncheck
+
+import (
+	"context"
+	"fmt"
+
+	pb "github.com/stacklok/mediator/pkg/generated/protobuf/go/mediator/v1"
+	ghclient "github.com/stacklok/mediator/pkg/providers/github"
+)
+
+type prStatusHandler interface {
+	trackVulnerableDep(
+		ctx context.Context,
+		dep *pb.PrDependencies_ContextualDependency,
+		patch patchFormatter,
+	) error
+	submit(ctx context.Context) error
+}
+
+func newPrStatusHandler(
+	ctx context.Context,
+	action action,
+	pr *pb.PullRequest,
+	client ghclient.RestAPI,
+) (prStatusHandler, error) {
+	switch action {
+	case actionRejectPr:
+		return newReviewPrHandler(ctx, pr, client)
+	case actionComment, actionPolicyOnly:
+		return nil, fmt.Errorf("action %s not implemented", action)
+	default:
+		return nil, fmt.Errorf("unknown action: %s", action)
+	}
+}

--- a/pkg/controlplane/handlers_githubwebhooks.go
+++ b/pkg/controlplane/handlers_githubwebhooks.go
@@ -303,7 +303,7 @@ func (s *Server) parseGithubEventForProcessing(
 				context.Background(), ghclient.Github, payload, msg)
 		}
 	} else if hook_type == "pull_request" {
-		if payload["action"] == "opened" {
+		if payload["action"] == "opened" || payload["action"] == "synchronize" {
 			return s.parsePullRequestModEvent(
 				context.Background(), ghclient.Github, payload, msg)
 		}

--- a/pkg/providers/github/github.go
+++ b/pkg/providers/github/github.go
@@ -67,6 +67,9 @@ type RestAPI interface {
 	GetPackageVersionById(context.Context, bool, string, string, string, int64) (*github.PackageVersion, error)
 	GetPullRequest(context.Context, string, string, int) (*github.PullRequest, error)
 	CreateReview(context.Context, string, string, int, *github.PullRequestReviewRequest) (*github.PullRequestReview, error)
+	ListReviews(context.Context, string, string, int, *github.ListOptions) ([]*github.PullRequestReview, error)
+	DismissReview(context.Context, string, string, int, int64,
+		*github.PullRequestReviewDismissalRequest) (*github.PullRequestReview, error)
 	ListFiles(context.Context, string, string, int, int, int) ([]*github.CommitFile, error)
 	GetToken() string
 	GetOwner() string

--- a/pkg/providers/github/github_rest.go
+++ b/pkg/providers/github/github_rest.go
@@ -306,6 +306,35 @@ func (c *RestClient) CreateReview(
 	return review, nil
 }
 
+// ListReviews is a wrapper for the GitHub API to list reviews
+func (c *RestClient) ListReviews(
+	ctx context.Context,
+	owner, repo string,
+	number int,
+	opt *github.ListOptions,
+) ([]*github.PullRequestReview, error) {
+	reviews, _, err := c.client.PullRequests.ListReviews(ctx, owner, repo, number, opt)
+	if err != nil {
+		return nil, fmt.Errorf("error listing reviews for PR %s/%s/%d: %w", owner, repo, number, err)
+	}
+	return reviews, nil
+}
+
+// DismissReview is a wrapper for the GitHub API to dismiss a review
+func (c *RestClient) DismissReview(
+	ctx context.Context,
+	owner, repo string,
+	prId int,
+	reviewId int64,
+	dismissalRequest *github.PullRequestReviewDismissalRequest,
+) (*github.PullRequestReview, error) {
+	review, _, err := c.client.PullRequests.DismissReview(ctx, owner, repo, prId, reviewId, dismissalRequest)
+	if err != nil {
+		return nil, fmt.Errorf("error dismissing review %d for PR %s/%s/%d: %w", reviewId, owner, repo, prId, err)
+	}
+	return review, nil
+}
+
 // GetRepository returns a single repository for the authenticated user
 func (c *RestClient) GetRepository(ctx context.Context, owner string, name string) (*github.Repository, error) {
 	// create a slice to hold the repositories


### PR DESCRIPTION
When the user accepts mediator's suggestions on PRs that container
vulnerable dependencies, we need to re-review the PR. This patch
dismisses the earlier review and adds a new one, either just commenting
that no vulnerable packages were found or listing the remainign
vulnerabilities.

Also moves the package review code behind an interface that will be used
later to just add comments and optionally set commit status to prevent
merge with vulnerable commits.

Fixes: #914
