### PR TITLE
Add token_key_passphrase to file location overrides following #925

### DIFF
--- a/deployment/helm/templates/deployment.yaml
+++ b/deployment/helm/templates/deployment.yaml
@@ -63,6 +63,8 @@ spec:
             value: "/secrets/auth/refresh_token_rsa"
           - name: "AUTH.REFRESH_TOKEN_PUBLIC_KEY"
             value: "/secrets/auth/refresh_token_rsa.pub"
+          - name: "AUTH.TOKEN_KEY_PASSPHRASE"
+            value: "/secrets/auth/token_key_passphrase"
           
           # ko will always specify a digest, so we don't need to worry about
           # CRI image caching


### PR DESCRIPTION
Added the `token_key_passphrase` parameter within the `mediator-auth-secret`, but I want to find the secrets via absolute path.

Secret created with `openssl rand 32 | base64`, with an extra level of `base64` after that for Kubernetes secret encoding
