### PR TITLE
chore: hide and gitignore docker volumes for github client id and secret

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,8 +47,8 @@ Thumbs.db
 .ssh/
 cmd/server/__debug_bin
 .resolved-compose.yaml
-github_client_id/
-github_client_secret/
+.github_client_id/
+.github_client_secret/
 
 # docusaurus
 docs/node_modules

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -36,8 +36,10 @@ services:
       - "8090:8090"
     volumes:
           - ./config.yaml:/app/config.yaml:z
-          - ./github_client_id:/secrets/github_client_id:z
-          - ./github_client_secret:/secrets/github_client_secret:z
+          # If you don't want to store your GitHub client ID and secret in the main
+          # config file, point to them here:
+          # - ./.github_client_id:/secrets/github_client_id:z
+          # - ./.github_client_secret:/secrets/github_client_secret:z
           - ./.ssh:/app/.ssh:z
     environment:
       - KO_DATA_PATH=/app/


### PR DESCRIPTION
The following PR adds to gitignore the local folders mounted as docker volumes for github client id and secret in order to prevent them from being accidentally committed to GitHub. Also hides them and updates the docker compose file to not mount the volumes if we don't expect to pass them to the mediator server.