### PR TITLE
auth: Handle more `auth` parameters via the central configuration

### DIFF
--- a/cmd/server/app/serve.go
+++ b/cmd/server/app/serve.go
@@ -49,6 +49,10 @@ var serveCmd = &cobra.Command{
 			return fmt.Errorf("unable to read config: %w", err)
 		}
 
+		if err := cfg.Validate(); err != nil {
+			return fmt.Errorf("invalid config: %w", err)
+		}
+
 		ctx = logger.FromFlags(cfg.LoggingConfig).WithContext(ctx)
 		zerolog.Ctx(ctx).Info().Msgf("Initializing logger in level: %s", cfg.LoggingConfig.Level)
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -18,6 +18,7 @@
 package config
 
 import (
+	"github.com/go-playground/validator/v10"
 	"github.com/spf13/viper"
 )
 
@@ -30,7 +31,7 @@ type Config struct {
 	Metrics       MetricsConfig    `mapstructure:"metrics"`
 	Database      DatabaseConfig   `mapstructure:"database"`
 	Salt          CryptoConfig     `mapstructure:"salt"`
-	Auth          AuthConfig       `mapstructure:"auth"`
+	Auth          AuthConfig       `mapstructure:"auth" validate:"required"`
 }
 
 // ReadConfigFromViper reads the configuration from the given Viper instance.
@@ -43,6 +44,13 @@ func ReadConfigFromViper(v *viper.Viper) (*Config, error) {
 	return &cfg, nil
 }
 
+// Validate validates the configuration
+func (cfg *Config) Validate() error {
+	validator := validator.New(validator.WithRequiredStructEnabled())
+
+	return validator.Struct(cfg)
+}
+
 // SetViperDefaults sets the default values for the configuration to be picked
 // up by viper
 func SetViperDefaults(v *viper.Viper) {
@@ -50,4 +58,5 @@ func SetViperDefaults(v *viper.Viper) {
 	SetTracingViperDefaults(v)
 	SetMetricsViperDefaults(v)
 	SetCryptoViperDefaults(v)
+	SetAuthViperDefaults(v)
 }

--- a/internal/controlplane/handlers_auth.go
+++ b/internal/controlplane/handlers_auth.go
@@ -19,12 +19,9 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
-	"os"
-	"path/filepath"
 	"time"
 
 	"github.com/go-playground/validator/v10"
-	"github.com/spf13/viper"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
@@ -40,28 +37,19 @@ type loginValidation struct {
 	Password string `validate:"min=8,containsany=_.;?&@"`
 }
 
-func generateToken(ctx context.Context, store db.Store, userId int32) (string, string, int64, int64, auth.UserClaims, error) {
+func (s *Server) generateToken(
+	ctx context.Context,
+	store db.Store,
+	userId int32,
+) (string, string, int64, int64, auth.UserClaims, error) {
 	emptyClaims := auth.UserClaims{}
 
-	// read private key for generating token and refresh token
-	privateKeyPath := viper.GetString("auth.access_token_private_key")
-	if privateKeyPath == "" {
-		return "", "", 0, 0, emptyClaims, fmt.Errorf("could not read private access token key")
-	}
-
-	privateKeyPath = filepath.Clean(privateKeyPath)
-	keyBytes, err := os.ReadFile(privateKeyPath)
+	keyBytes, err := s.cfg.Auth.GetAccessTokenPrivateKey()
 	if err != nil {
-		return "", "", 0, 0, emptyClaims, fmt.Errorf("failed to read access token key: %s", err)
+		return "", "", 0, 0, emptyClaims, fmt.Errorf("failed to read access token key: %w", err)
 	}
 
-	refreshPrivateKeyPath := viper.GetString("auth.refresh_token_private_key")
-	if refreshPrivateKeyPath == "" {
-		return "", "", 0, 0, emptyClaims, fmt.Errorf("unable to read private refresh token key")
-	}
-
-	refreshPrivateKeyPath = filepath.Clean(refreshPrivateKeyPath)
-	refreshKeyBytes, err := os.ReadFile(refreshPrivateKeyPath)
+	refreshKeyBytes, err := s.cfg.Auth.GetRefreshTokenPrivateKey()
 	if err != nil {
 		return "", "", 0, 0, emptyClaims, fmt.Errorf("failed to read refresh token key: %s", err)
 	}
@@ -76,8 +64,8 @@ func generateToken(ctx context.Context, store db.Store, userId int32) (string, s
 		claims,
 		keyBytes,
 		refreshKeyBytes,
-		viper.GetInt64("auth.token_expiry"),
-		viper.GetInt64("auth.refresh_expiry"),
+		s.cfg.Auth.TokenExpiry,
+		s.cfg.Auth.RefreshExpiry,
 	)
 
 	if err != nil {
@@ -113,7 +101,7 @@ func (s *Server) LogIn(ctx context.Context, in *pb.LogInRequest) (*pb.LogInRespo
 	}
 
 	accessToken, refreshToken, accessTokenExpirationTime, refreshTokenExpirationTime,
-		claims, err := generateToken(ctx, s.store, user.ID)
+		claims, err := s.generateToken(ctx, s.store, user.ID)
 
 	if err != nil {
 		return nil, status.Error(codes.Internal, fmt.Sprintf("Failed to generate token: %s", err))
@@ -167,13 +155,8 @@ func (s *Server) RevokeUserToken(ctx context.Context, req *pb.RevokeUserTokenReq
 
 }
 
-func parseRefreshToken(token string, store db.Store) (int32, error) {
-	// need to read pub key from file
-	publicKeyPath := viper.GetString("auth.refresh_token_public_key")
-	if publicKeyPath == "" {
-		return 0, fmt.Errorf("could not read refresh token public key")
-	}
-	pubKeyData, err := os.ReadFile(filepath.Clean(publicKeyPath))
+func (s *Server) parseRefreshToken(token string, store db.Store) (int32, error) {
+	pubKeyData, err := s.cfg.Auth.GetRefreshTokenPublicKey()
 	if err != nil {
 		return 0, fmt.Errorf("failed to read refresh token public key file")
 	}
@@ -200,13 +183,13 @@ func (s *Server) RefreshToken(ctx context.Context, _ *pb.RefreshTokenRequest) (*
 		return nil, status.Errorf(codes.Unauthenticated, "no refresh token found")
 	}
 
-	userId, err := parseRefreshToken(refresh, s.store)
+	userId, err := s.parseRefreshToken(refresh, s.store)
 	if err != nil {
 		return nil, status.Errorf(codes.Unauthenticated, "invalid token: %v", err)
 	}
 
 	// regenerate and return tokens
-	accessToken, _, accessTokenExpirationTime, _, _, err := generateToken(ctx, s.store, userId)
+	accessToken, _, accessTokenExpirationTime, _, _, err := s.generateToken(ctx, s.store, userId)
 
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "Failed to generate token")

--- a/internal/controlplane/handlers_auth_test.go
+++ b/internal/controlplane/handlers_auth_test.go
@@ -21,7 +21,6 @@ import (
 	"time"
 
 	"github.com/golang/mock/gomock"
-	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc/codes"
@@ -58,8 +57,6 @@ func TestLogin_gRPC(t *testing.T) {
 	rtpPath := filepath.Join(tmpdir, "refresh_token_private.pem")
 
 	// prepare keys for signing tokens
-	viper.SetDefault("auth.access_token_private_key", atpPath)
-	viper.SetDefault("auth.refresh_token_private_key", rtpPath)
 	err = util.RandomPrivateKeyFile(2048, atpPath)
 	require.NoError(t, err, "Error generating access token private key")
 	err = util.RandomPrivateKeyFile(2048, rtpPath)
@@ -125,6 +122,8 @@ func TestLogin_gRPC(t *testing.T) {
 			tc.buildStubs(mockStore)
 
 			server := newDefaultServer(t, mockStore)
+			server.cfg.Auth.AccessTokenPrivateKey = atpPath
+			server.cfg.Auth.RefreshTokenPrivateKey = rtpPath
 
 			resp, err := server.LogIn(context.Background(), tc.req)
 			tc.checkResponse(t, resp, err)
@@ -190,14 +189,9 @@ func TestRefreshToken_gRPC(t *testing.T) {
 	atPubPath := filepath.Join(tmpdir, "access_token_public.pem")
 	rtPrivPath := filepath.Join(tmpdir, "refresh_token_private.pem")
 	rtPubPath := filepath.Join(tmpdir, "refresh_token_public.pem")
+	tokenKeyPath := generateTokenKey(t)
 
 	// prepare keys for signing tokens
-	viper.SetDefault("auth.access_token_private_key", atPrivPath)
-	viper.SetDefault("auth.access_token_public_key", atPubPath)
-	viper.SetDefault("auth.refresh_token_private_key", rtPrivPath)
-	viper.SetDefault("auth.refresh_token_public_key", rtPubPath)
-	viper.SetDefault("auth.token_expiry", 3600)
-	viper.SetDefault("auth.refresh_expiry", 86400)
 	err := util.RandomKeypairFile(2048, atPrivPath, atPubPath)
 	require.NoError(t, err, "Error generating access token key pair")
 
@@ -215,8 +209,22 @@ func TestRefreshToken_gRPC(t *testing.T) {
 	mockStoreToken.EXPECT().GetUserByID(ctxToken, gomock.Any())
 	mockStoreToken.EXPECT().GetUserGroups(ctxToken, gomock.Any())
 	mockStoreToken.EXPECT().GetUserRoles(ctxToken, gomock.Any())
+
+	srv := newDefaultServer(t, mockStoreToken, &config.Config{
+		Auth: config.AuthConfig{
+			AccessTokenPrivateKey:  atPrivPath,
+			AccessTokenPublicKey:   atPubPath,
+			RefreshTokenPrivateKey: rtPrivPath,
+			RefreshTokenPublicKey:  rtPubPath,
+			TokenExpiry:            3600,
+			RefreshExpiry:          86400,
+			TokenKey:               tokenKeyPath,
+		},
+	})
+	require.NoError(t, err, "Error creating server")
+
 	// generate a token
-	_, refreshToken, _, _, _, err := generateToken(ctxToken, mockStoreToken, 1)
+	_, refreshToken, _, _, _, err := srv.generateToken(ctxToken, mockStoreToken, 1)
 	if err != nil {
 		t.Fatalf("Error generating token: %v", err)
 	}

--- a/internal/controlplane/handlers_authz.go
+++ b/internal/controlplane/handlers_authz.go
@@ -17,14 +17,11 @@ package controlplane
 import (
 	"context"
 	"fmt"
-	"os"
-	"path/filepath"
 	"strings"
 	"time"
 
 	gauth "github.com/grpc-ecosystem/go-grpc-middleware/v2/interceptors/auth"
 	"github.com/rs/zerolog"
-	"github.com/spf13/viper"
 	"golang.org/x/exp/slices"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
@@ -40,19 +37,15 @@ import (
 	mediator "github.com/stacklok/mediator/pkg/generated/protobuf/go/mediator/v1"
 )
 
-func parseToken(token string, store db.Store) (auth.UserClaims, error) {
+func (s *Server) parseTokenForAuthz(token string) (auth.UserClaims, error) {
 	var claims auth.UserClaims
 	// need to read pub key from file
-	publicKeyPath := viper.GetString("auth.access_token_public_key")
-	if publicKeyPath == "" {
-		return claims, fmt.Errorf("could not read public key")
-	}
-	pubKeyData, err := os.ReadFile(filepath.Clean(publicKeyPath))
+	pubKeyData, err := s.cfg.Auth.GetAccessTokenPublicKey()
 	if err != nil {
 		return claims, fmt.Errorf("failed to read public key file")
 	}
 
-	userClaims, err := auth.VerifyToken(token, pubKeyData, store)
+	userClaims, err := auth.VerifyToken(token, pubKeyData, s.store)
 	if err != nil {
 		return claims, fmt.Errorf("failed to verify token: %v", err)
 	}
@@ -204,7 +197,7 @@ func AuthUnaryInterceptor(ctx context.Context, req interface{}, info *grpc.Unary
 	}
 
 	server := info.Server.(*Server)
-	claims, err := parseToken(token, server.store)
+	claims, err := server.parseTokenForAuthz(token)
 	if err != nil {
 		return nil, status.Errorf(codes.Unauthenticated, "invalid auth token: %v", err)
 	}

--- a/internal/controlplane/server_test.go
+++ b/internal/controlplane/server_test.go
@@ -81,19 +81,26 @@ func getgRPCConnection() (*grpc.ClientConn, error) {
 	return conn, nil
 }
 
-func newDefaultServer(t *testing.T, mockStore *mockdb.MockStore) *Server {
+func newDefaultServer(t *testing.T, mockStore *mockdb.MockStore, cfg ...*config.Config) *Server {
 	t.Helper()
 
 	evt, err := events.Setup()
 	require.NoError(t, err, "failed to setup eventer")
 
-	tokenKeyPath := generateTokenKey(t)
+	var c *config.Config
+	if len(cfg) > 0 {
+		c = cfg[0]
+	} else {
+		tokenKeyPath := generateTokenKey(t)
 
-	server, err := NewServer(mockStore, evt, &config.Config{
-		Auth: config.AuthConfig{
-			TokenKey: tokenKeyPath,
-		},
-	})
+		c = &config.Config{
+			Auth: config.AuthConfig{
+				TokenKey: tokenKeyPath,
+			},
+		}
+	}
+
+	server, err := NewServer(mockStore, evt, c)
 	require.NoError(t, err, "failed to create server")
 	return server
 }


### PR DESCRIPTION
This handles the rest of the `auth` parameters via the centralized configuration construct as opposed
to calling viper directly from the handlers.
