### PR TITLE
Sequentially tag helm charts, rather than re-using the 0.1.0 version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,6 +35,7 @@ COMPOSE_ARGS?=-d
 KO_DOCKER_REPO?=ko.local
 KO_PUSH_IMAGE?=false
 KO_PLATFORMS=linux/amd64,linux/arm64
+HELM_PACKAGE_VERSION?=0.1.0
 
 default: help
 
@@ -83,7 +84,7 @@ helm:  ## build the helm chart to a local archive, using ko for the image build
 	cd deployment/helm; rm -f templates/combined.yml && \
 	    ko resolve --platform=${KO_PLATFORMS} --base-import-paths --push=${KO_PUSH_IMAGE} -f templates/ > templates/combined.yml && \
 		helm dependency update && \
-		helm package .
+		helm package --version="${HELM_PACKAGE_VERSION}" .
 
 bootstrap: ## install build deps
 	go generate -tags tools tools/tools.go

--- a/deployment/helm/Chart.lock
+++ b/deployment/helm/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 2.9.0
-digest: sha256:79214ee1797422ecbe045584630381194bf225ce0545acc0a07b6fc874ce8aad
-generated: "2023-08-22T16:15:09.700899-07:00"
+  version: 2.11.1
+digest: sha256:93eb2b5ceb4b11b640702566c1f8fce26ce636757d3a47a45e6c47057143a3d5
+generated: "2023-09-15T13:16:40.928684-07:00"


### PR DESCRIPTION
It turns out that ArgoCD really likes to cache the helm chart contents for a given tag.

We probably want different version numbers anyway, so that we can do an intentional promotion between staging and prod without needing to go crazy tracking sha256 checksums.

Our "version numbers" will look like: `0.20230915.302+ref.721b4653`, which causes them to increment for each workflow run, but also gives us clues about the date and commit SHA for each build.
