### PR TITLE
Fix chart publish workflow

### DIFF
--- a/.github/workflows/chart-publish.yml
+++ b/.github/workflows/chart-publish.yml
@@ -40,9 +40,7 @@ jobs:
         run: |
           DATE="$(date +%Y%m%d)"
           COMMIT="$(git rev-parse --short HEAD)"
-          echo "tag=0.$DATE.$RUN_ID+ref.$COMMIT" >> "$GITHUB_OUTPUT"
-        env:
-          RUN_ID: "${{ github.run_number }}"
+          echo "tag=0.$DATE.$GITHUB_RUN_NUMBER+ref.$COMMIT" >> "$GITHUB_OUTPUT"
 
       - name: Build images and Helm Chart
         run: |


### PR DESCRIPTION
It turns out [you can't use `with` with `runs`](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepswith):

> Input parameters defined for a Docker container must use args. For more information, see `jobs.<job_id>.steps[*].with.args`.
