### PR TITLE
Add `docker` dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -39,3 +39,7 @@ updates:
       # facebook/docusaurus#8940 docusaurus uses v1
       - dependency-name: "prism-react-renderer"
         update-types: ["version-update:semver-major"]
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
This makes sure that we get updates for any dockerfiles we use in Mediator.
