### PR TITLE
handlers_user: Include db err in the internal error

### DIFF
--- a/internal/controlplane/handlers_user.go
+++ b/internal/controlplane/handlers_user.go
@@ -156,25 +156,25 @@ func (s *Server) CreateUser(ctx context.Context,
 		FirstName: *stringToNullString(in.FirstName), LastName: *stringToNullString(in.LastName),
 		IsProtected: *in.IsProtected, NeedsPasswordChange: needsPassPtr})
 	if err != nil {
-		return nil, status.Errorf(codes.Internal, "failed to create user")
+		return nil, status.Errorf(codes.Internal, "failed to create user: %s", err)
 	}
 
 	// now attach the groups and roles
 	for _, id := range in.GroupIds {
 		_, err := qtx.AddUserGroup(ctx, db.AddUserGroupParams{UserID: user.ID, GroupID: id})
 		if err != nil {
-			return nil, status.Errorf(codes.Internal, "failed to add user to group")
+			return nil, status.Errorf(codes.Internal, "failed to add user to group: %s", err)
 		}
 	}
 	for _, id := range in.RoleIds {
 		_, err := qtx.AddUserRole(ctx, db.AddUserRoleParams{UserID: user.ID, RoleID: id})
 		if err != nil {
-			return nil, status.Errorf(codes.Internal, "failed to add user to role")
+			return nil, status.Errorf(codes.Internal, "failed to add user to role: %s", err)
 		}
 	}
 	err = s.store.Commit(tx)
 	if err != nil {
-		return nil, status.Errorf(codes.Internal, "failed to commit transaction")
+		return nil, status.Errorf(codes.Internal, "failed to commit transaction: %s", err)
 	}
 
 	return &pb.CreateUserResponse{Id: user.ID, OrganizationId: user.OrganizationID, Email: &user.Email.String,


### PR DESCRIPTION
Errors like these are what we would print e.g. when adding a duplicate
user:
```
{"level":"error","Resource":{"service":"mediator.v1.UserService","method":"CreateUser"},"Attributes":{"http.code":"Internal","http.content-type":["application/grpc"],"http.duration":"550.55325ms","http.user_agent":["grpc-go/1.58.1"],"exception.message":"rpc
error: code = Internal desc = failed to create
user"},"Timestamp":1695131280165826000}
```

Now we get:
```
{"level":"error","Resource":{"service":"mediator.v1.UserService","method":"CreateUser"},"Attributes":{"http.code":"Internal","http.content-type":["application/grpc"],"http.duration":"547.674ms","http.user_agent":["grpc-go/1.58.1"],"exception.message":"rpc
error: code = Internal desc = failed to create user: pq: duplicate key
value violates unique constraint
\"users_organization_id_username_lower_idx\""},"Timestamp":1695131520115208000}
```

The user still gets just an internal error in the CLI, but at least we
see what's going on in the server logs.
