### PR TITLE
Include assets into docker-compose mount

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -36,6 +36,7 @@ services:
       - "8090:8090"
     volumes:
           - ./config.yaml:/app/config.yaml:z
+          - ./assets:/assets:z
           # If you don't want to store your GitHub client ID and secret in the main
           # config file, point to them here:
           # - ./.github_client_id:/secrets/github_client_id:z


### PR DESCRIPTION
This is helpful for us to be able to show the stacklok logo when using `make run-docker`
