### PR TITLE
ci: Build `medev` as part of the `build` Makefile target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,6 +58,7 @@ build: ## build golang binary
 	# @go build -ldflags "-X main.version=$(shell git describe --abbrev=0 --tags)" -o bin/$(projectname)
 	CGO_ENABLED=0 go build -trimpath -o ./bin/medic ./cmd/cli
 	CGO_ENABLED=0 go build -trimpath -o ./bin/$(projectname)-server ./cmd/server
+	CGO_ENABLED=0 go build -trimpath -o ./bin/medev ./cmd/dev
 
 run-cli: ## run the CLI, needs additional arguments
 	@go run -ldflags "-X main.version=$(shell git describe --abbrev=0 --tags)"  ./cmd/cli


### PR DESCRIPTION
We were not building it before, this fixes that and thus validates it's always
in a "buildable" state.
