### PR TITLE
cleanup: don't expand generated API files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -8,7 +8,9 @@
 /docs/docs/cli/*.md linguist-generated=true
 /docs/docs/db/schema.md linguist-generated=true
 /docs/docs/protodocs/proto.md linguist-generated=true
-/pkg/generated/** linguist-generated=true
+/pkg/api/openapi/** linguist-generated=true
+/pkg/api/protobuf/go/mediator/v1/*.pb.go linguist-generated=true
+/pkg/api/protobuf/go/mediator/v1/*.gw.go linguist-generated=true
 /internal/db/db.go linguist-generated=true
 /internal/db/models.go linguist-generated=true
 /internal/db/querier.go linguist-generated=true


### PR DESCRIPTION
A recent PR (https://github.com/stacklok/mediator/pull/1017) moved the generated API
files to `pkg/api`, however, the `.gitattributes` file wasn't updated. This reflect
the changes and adds a more specific configuration.
