### PR TITLE
fix: don't upsert empty tags as valid value

### DIFF
--- a/internal/controlplane/handlers_githubwebhooks.go
+++ b/internal/controlplane/handlers_githubwebhooks.go
@@ -780,7 +780,7 @@ func upsertVersionedArtifact(
 			// Rebuild the Tags list removing anything that would conflict
 			newTags := slices.DeleteFunc(strings.Split(existing.Tags.String, ","), func(in string) bool { return in == incomingTag })
 			newTagsSQL := sql.NullString{String: strings.Join(newTags, ",")}
-			newTagsSQL.Valid = len(newTags) > 0
+			newTagsSQL.Valid = len(newTagsSQL.String) > 0
 			// Update the versioned artifact row in the store (we shouldn't change anything else except the tags value)
 			_, err := qtx.UpsertArtifactVersion(ctx, db.UpsertArtifactVersionParams{
 				ArtifactID:            existing.ArtifactID,


### PR DESCRIPTION
Fixes an issue of pushing an empty string as valid (causing len(tags) !=0) in case there was only one tag previously and we removed it upon update. 