### PR TITLE
cleanup: Move validations and parsing to our exported package

### DIFF
--- a/cmd/cli/app/policy/table_render.go
+++ b/cmd/cli/app/policy/table_render.go
@@ -21,8 +21,7 @@ import (
 	"google.golang.org/protobuf/types/known/structpb"
 	"gopkg.in/yaml.v2"
 
-	"github.com/stacklok/mediator/internal/entities"
-	pb "github.com/stacklok/mediator/pkg/api/protobuf/go/mediator/v1"
+	mediatorv1 "github.com/stacklok/mediator/pkg/api/protobuf/go/mediator/v1"
 )
 
 func initializeTable(cmd *cobra.Command) *tablewriter.Table {
@@ -38,26 +37,26 @@ func initializeTable(cmd *cobra.Command) *tablewriter.Table {
 }
 
 func renderPolicyTable(
-	p *pb.Policy,
+	p *mediatorv1.Policy,
 	table *tablewriter.Table,
 ) {
 	// repositories
-	renderEntityRuleSets(p, entities.RepositoryEntity, p.Repository, table)
+	renderEntityRuleSets(p, mediatorv1.RepositoryEntity, p.Repository, table)
 
 	// build_environments
-	renderEntityRuleSets(p, entities.BuildEnvironmentEntity, p.BuildEnvironment, table)
+	renderEntityRuleSets(p, mediatorv1.BuildEnvironmentEntity, p.BuildEnvironment, table)
 
 	// artifacts
-	renderEntityRuleSets(p, entities.ArtifactEntity, p.Artifact, table)
+	renderEntityRuleSets(p, mediatorv1.ArtifactEntity, p.Artifact, table)
 
 	// artifacts
-	renderEntityRuleSets(p, entities.PullRequestEntity, p.PullRequest, table)
+	renderEntityRuleSets(p, mediatorv1.PullRequestEntity, p.PullRequest, table)
 }
 
 func renderEntityRuleSets(
-	p *pb.Policy,
-	entType entities.EntityType,
-	rs []*pb.Policy_Rule,
+	p *mediatorv1.Policy,
+	entType mediatorv1.EntityType,
+	rs []*mediatorv1.Policy_Rule,
 	table *tablewriter.Table,
 ) {
 	for idx := range rs {
@@ -68,9 +67,9 @@ func renderEntityRuleSets(
 }
 
 func renderRuleTable(
-	p *pb.Policy,
-	entType entities.EntityType,
-	rule *pb.Policy_Rule,
+	p *mediatorv1.Policy,
+	entType mediatorv1.EntityType,
+	rule *mediatorv1.Policy_Rule,
 	table *tablewriter.Table,
 ) {
 

--- a/cmd/cli/app/policy_status/policy_status_get.go
+++ b/cmd/cli/app/policy_status/policy_status_get.go
@@ -25,7 +25,7 @@ import (
 	"github.com/stacklok/mediator/cmd/cli/app"
 	"github.com/stacklok/mediator/internal/entities"
 	"github.com/stacklok/mediator/internal/util"
-	pb "github.com/stacklok/mediator/pkg/api/protobuf/go/mediator/v1"
+	mediatorv1 "github.com/stacklok/mediator/pkg/api/protobuf/go/mediator/v1"
 )
 
 var policystatus_getCmd = &cobra.Command{
@@ -45,7 +45,7 @@ mediator control plane for an specific provider/group or policy id, entity type 
 		}
 		defer conn.Close()
 
-		client := pb.NewPolicyServiceClient(conn)
+		client := mediatorv1.NewPolicyServiceClient(conn)
 		ctx, cancel := util.GetAppContext()
 		defer cancel()
 
@@ -66,15 +66,15 @@ mediator control plane for an specific provider/group or policy id, entity type 
 			return fmt.Errorf("provider must be set")
 		}
 
-		req := &pb.GetPolicyStatusByIdRequest{
-			Context: &pb.Context{
+		req := &mediatorv1.GetPolicyStatusByIdRequest{
+			Context: &mediatorv1.Context{
 				Provider: provider,
 			},
 			PolicyId: policyId,
-			EntitySelector: &pb.GetPolicyStatusByIdRequest_Entity{
-				Entity: &pb.GetPolicyStatusByIdRequest_EntityTypedId{
+			EntitySelector: &mediatorv1.GetPolicyStatusByIdRequest_Entity{
+				Entity: &mediatorv1.GetPolicyStatusByIdRequest_EntityTypedId{
 					Id:   entityId,
-					Type: entities.FromString(entityType),
+					Type: mediatorv1.EntityFromString(entityType),
 				},
 			},
 		}

--- a/cmd/cli/app/rule_type/rule_type_create.go
+++ b/cmd/cli/app/rule_type/rule_type_create.go
@@ -23,9 +23,8 @@ import (
 	"github.com/spf13/viper"
 	"golang.org/x/exp/slices"
 
-	"github.com/stacklok/mediator/internal/engine"
 	"github.com/stacklok/mediator/internal/util"
-	pb "github.com/stacklok/mediator/pkg/api/protobuf/go/mediator/v1"
+	mediatorv1 "github.com/stacklok/mediator/pkg/api/protobuf/go/mediator/v1"
 )
 
 // RuleType_createCmd represents the policy create command
@@ -55,7 +54,7 @@ within a mediator control plane.`,
 		}
 		defer conn.Close()
 
-		client := pb.NewPolicyServiceClient(conn)
+		client := mediatorv1.NewPolicyServiceClient(conn)
 		ctx, cancel := util.GetAppContext()
 		defer cancel()
 
@@ -73,13 +72,13 @@ within a mediator control plane.`,
 			}
 			defer closer()
 
-			r, err := engine.ParseRuleType(preader)
+			r, err := mediatorv1.ParseRuleType(preader)
 			if err != nil {
 				return fmt.Errorf("error parsing rule type: %w", err)
 			}
 
 			// create a rule
-			resp, err := client.CreateRuleType(ctx, &pb.CreateRuleTypeRequest{
+			resp, err := client.CreateRuleType(ctx, &mediatorv1.CreateRuleTypeRequest{
 				RuleType: r,
 			})
 			if err != nil {

--- a/cmd/dev/app/rule_type/rule_type.go
+++ b/cmd/dev/app/rule_type/rule_type.go
@@ -33,10 +33,9 @@ import (
 	"github.com/stacklok/mediator/internal/db"
 	"github.com/stacklok/mediator/internal/engine"
 	"github.com/stacklok/mediator/internal/engine/eval/rego"
-	"github.com/stacklok/mediator/internal/entities"
 	"github.com/stacklok/mediator/internal/providers"
 	"github.com/stacklok/mediator/internal/util"
-	pb "github.com/stacklok/mediator/pkg/api/protobuf/go/mediator/v1"
+	mediatorv1 "github.com/stacklok/mediator/pkg/api/protobuf/go/mediator/v1"
 )
 
 // TestCmd is the root command for the rule subcommands
@@ -91,7 +90,7 @@ func testCmdRun(cmd *cobra.Command, _ []string) error {
 		return fmt.Errorf("error reading rule type from file: %w", err)
 	}
 
-	ent, err := readEntityFromFile(epath.Value.String(), entities.FromString(rt.Def.InEntity))
+	ent, err := readEntityFromFile(epath.Value.String(), mediatorv1.EntityFromString(rt.Def.InEntity))
 	if err != nil {
 		return fmt.Errorf("error reading entity from file: %w", err)
 	}
@@ -135,7 +134,7 @@ func testCmdRun(cmd *cobra.Command, _ []string) error {
 	return runEvaluationForRules(eng, ent, rules)
 }
 
-func runEvaluationForRules(eng *engine.RuleTypeEngine, ent protoreflect.ProtoMessage, frags []*pb.Policy_Rule) error {
+func runEvaluationForRules(eng *engine.RuleTypeEngine, ent protoreflect.ProtoMessage, frags []*mediatorv1.Policy_Rule) error {
 	for idx := range frags {
 		frag := frags[idx]
 
@@ -166,20 +165,20 @@ func runEvaluationForRules(eng *engine.RuleTypeEngine, ent protoreflect.ProtoMes
 	return nil
 }
 
-func readRuleTypeFromFile(fpath string) (*pb.RuleType, error) {
+func readRuleTypeFromFile(fpath string) (*mediatorv1.RuleType, error) {
 	f, err := os.Open(filepath.Clean(fpath))
 	if err != nil {
 		return nil, fmt.Errorf("error opening file: %w", err)
 	}
 
-	return engine.ParseRuleType(f)
+	return mediatorv1.ParseRuleType(f)
 }
 
 // readEntityFromFile reads an entity from a file and returns it as a protobuf
 // golang structure.
 // TODO: We probably want to move this code to a utility once we land the server
 // side code.
-func readEntityFromFile(fpath string, entType pb.Entity) (protoreflect.ProtoMessage, error) {
+func readEntityFromFile(fpath string, entType mediatorv1.Entity) (protoreflect.ProtoMessage, error) {
 	f, err := os.Open(filepath.Clean(fpath))
 	if err != nil {
 		return nil, fmt.Errorf("error opening file: %w", err)
@@ -194,15 +193,15 @@ func readEntityFromFile(fpath string, entType pb.Entity) (protoreflect.ProtoMess
 	var out protoreflect.ProtoMessage
 
 	switch entType {
-	case pb.Entity_ENTITY_REPOSITORIES:
-		out = &pb.RepositoryResult{}
-	case pb.Entity_ENTITY_ARTIFACTS:
-		out = &pb.VersionedArtifact{}
-	case pb.Entity_ENTITY_PULL_REQUESTS:
-		out = &pb.PullRequest{}
-	case pb.Entity_ENTITY_BUILD_ENVIRONMENTS:
+	case mediatorv1.Entity_ENTITY_REPOSITORIES:
+		out = &mediatorv1.RepositoryResult{}
+	case mediatorv1.Entity_ENTITY_ARTIFACTS:
+		out = &mediatorv1.VersionedArtifact{}
+	case mediatorv1.Entity_ENTITY_PULL_REQUESTS:
+		out = &mediatorv1.PullRequest{}
+	case mediatorv1.Entity_ENTITY_BUILD_ENVIRONMENTS:
 		return nil, fmt.Errorf("build environments not yet supported")
-	case pb.Entity_ENTITY_UNSPECIFIED:
+	case mediatorv1.Entity_ENTITY_UNSPECIFIED:
 		return nil, fmt.Errorf("entity type unspecified")
 	default:
 		return nil, fmt.Errorf("unknown entity type: %s", entType)

--- a/internal/engine/entity_event.go
+++ b/internal/engine/entity_event.go
@@ -25,7 +25,7 @@ import (
 	"github.com/stacklok/mediator/internal/entities"
 	"github.com/stacklok/mediator/internal/events"
 	"github.com/stacklok/mediator/internal/util"
-	pb "github.com/stacklok/mediator/pkg/api/protobuf/go/mediator/v1"
+	mediatorv1 "github.com/stacklok/mediator/pkg/api/protobuf/go/mediator/v1"
 )
 
 // EntityInfoWrapper is a helper struct to gather information
@@ -52,7 +52,7 @@ type EntityInfoWrapper struct {
 	Provider      string
 	GroupID       int32
 	Entity        protoreflect.ProtoMessage
-	Type          pb.Entity
+	Type          mediatorv1.Entity
 	OwnershipData map[string]string
 }
 
@@ -95,24 +95,24 @@ func (eiw *EntityInfoWrapper) WithProvider(provider string) *EntityInfoWrapper {
 }
 
 // WithVersionedArtifact sets the entity to a versioned artifact
-func (eiw *EntityInfoWrapper) WithVersionedArtifact(va *pb.VersionedArtifact) *EntityInfoWrapper {
-	eiw.Type = pb.Entity_ENTITY_ARTIFACTS
+func (eiw *EntityInfoWrapper) WithVersionedArtifact(va *mediatorv1.VersionedArtifact) *EntityInfoWrapper {
+	eiw.Type = mediatorv1.Entity_ENTITY_ARTIFACTS
 	eiw.Entity = va
 
 	return eiw
 }
 
 // WithRepository sets the entity to a repository
-func (eiw *EntityInfoWrapper) WithRepository(r *pb.RepositoryResult) *EntityInfoWrapper {
-	eiw.Type = pb.Entity_ENTITY_REPOSITORIES
+func (eiw *EntityInfoWrapper) WithRepository(r *mediatorv1.RepositoryResult) *EntityInfoWrapper {
+	eiw.Type = mediatorv1.Entity_ENTITY_REPOSITORIES
 	eiw.Entity = r
 
 	return eiw
 }
 
 // WithPullRequest sets the entity to a repository
-func (eiw *EntityInfoWrapper) WithPullRequest(p *pb.PullRequest) *EntityInfoWrapper {
-	eiw.Type = pb.Entity_ENTITY_PULL_REQUESTS
+func (eiw *EntityInfoWrapper) WithPullRequest(p *mediatorv1.PullRequest) *EntityInfoWrapper {
+	eiw.Type = mediatorv1.Entity_ENTITY_PULL_REQUESTS
 	eiw.Entity = p
 
 	return eiw
@@ -149,24 +149,24 @@ func (eiw *EntityInfoWrapper) WithPullRequestNumber(id int32) *EntityInfoWrapper
 
 // AsRepository sets the entity type to a repository
 func (eiw *EntityInfoWrapper) AsRepository() *EntityInfoWrapper {
-	eiw.Type = pb.Entity_ENTITY_REPOSITORIES
-	eiw.Entity = &pb.RepositoryResult{}
+	eiw.Type = mediatorv1.Entity_ENTITY_REPOSITORIES
+	eiw.Entity = &mediatorv1.RepositoryResult{}
 
 	return eiw
 }
 
 // AsVersionedArtifact sets the entity type to a versioned artifact
 func (eiw *EntityInfoWrapper) AsVersionedArtifact() *EntityInfoWrapper {
-	eiw.Type = pb.Entity_ENTITY_ARTIFACTS
-	eiw.Entity = &pb.VersionedArtifact{}
+	eiw.Type = mediatorv1.Entity_ENTITY_ARTIFACTS
+	eiw.Entity = &mediatorv1.VersionedArtifact{}
 
 	return eiw
 }
 
 // AsPullRequest sets the entity type to a pull request
 func (eiw *EntityInfoWrapper) AsPullRequest() {
-	eiw.Type = pb.Entity_ENTITY_PULL_REQUESTS
-	eiw.Entity = &pb.PullRequest{}
+	eiw.Type = mediatorv1.Entity_ENTITY_PULL_REQUESTS
+	eiw.Entity = &mediatorv1.PullRequest{}
 }
 
 // BuildMessage builds a message.Message from the information
@@ -311,17 +311,17 @@ func (eiw *EntityInfoWrapper) evalStatusParams(
 	return params
 }
 
-func pbEntityTypeToString(t pb.Entity) (string, error) {
+func pbEntityTypeToString(t mediatorv1.Entity) (string, error) {
 	switch t {
-	case pb.Entity_ENTITY_REPOSITORIES:
+	case mediatorv1.Entity_ENTITY_REPOSITORIES:
 		return RepositoryEventEntityType, nil
-	case pb.Entity_ENTITY_ARTIFACTS:
+	case mediatorv1.Entity_ENTITY_ARTIFACTS:
 		return VersionedArtifactEventEntityType, nil
-	case pb.Entity_ENTITY_PULL_REQUESTS:
+	case mediatorv1.Entity_ENTITY_PULL_REQUESTS:
 		return PullRequestEventEntityType, nil
-	case pb.Entity_ENTITY_BUILD_ENVIRONMENTS:
+	case mediatorv1.Entity_ENTITY_BUILD_ENVIRONMENTS:
 		return "", fmt.Errorf("build environments not yet supported")
-	case pb.Entity_ENTITY_UNSPECIFIED:
+	case mediatorv1.Entity_ENTITY_UNSPECIFIED:
 		return "", fmt.Errorf("entity type unspecified")
 	default:
 		return "", fmt.Errorf("unknown entity type: %s", t.String())

--- a/internal/engine/executor_test.go
+++ b/internal/engine/executor_test.go
@@ -32,8 +32,7 @@ import (
 	"github.com/stacklok/mediator/internal/crypto"
 	"github.com/stacklok/mediator/internal/db"
 	"github.com/stacklok/mediator/internal/engine"
-	"github.com/stacklok/mediator/internal/entities"
-	pb "github.com/stacklok/mediator/pkg/api/protobuf/go/mediator/v1"
+	mediatorv1 "github.com/stacklok/mediator/pkg/api/protobuf/go/mediator/v1"
 )
 
 const (
@@ -114,7 +113,7 @@ func TestExecutor_handleEntityEvent(t *testing.T) {
 		}, nil)
 
 	// list one policy
-	crs := []*pb.Policy_Rule{
+	crs := []*mediatorv1.Policy_Rule{
 		{
 			Type: passthroughRuleType,
 			Def:  &structpb.Struct{},
@@ -140,18 +139,18 @@ func TestExecutor_handleEntityEvent(t *testing.T) {
 		}, nil)
 
 	// get relevant rule
-	ruleTypeDef := &pb.RuleType_Definition{
-		InEntity:   entities.RepositoryEntity.String(),
+	ruleTypeDef := &mediatorv1.RuleType_Definition{
+		InEntity:   mediatorv1.RepositoryEntity.String(),
 		RuleSchema: &structpb.Struct{},
-		Ingest: &pb.RuleType_Definition_Ingest{
+		Ingest: &mediatorv1.RuleType_Definition_Ingest{
 			Type: "builtin",
-			Builtin: &pb.BuiltinType{
+			Builtin: &mediatorv1.BuiltinType{
 				Method: "Passthrough",
 			},
 		},
-		Eval: &pb.RuleType_Definition_Eval{
+		Eval: &mediatorv1.RuleType_Definition_Eval{
 			Type: "rego",
-			Rego: &pb.RuleType_Definition_Eval_Rego{
+			Rego: &mediatorv1.RuleType_Definition_Eval_Rego{
 				Type: "deny-by-default",
 				Def: `package mediator
 default allow = true`,
@@ -207,7 +206,7 @@ default allow = true`,
 	eiw := engine.NewEntityInfoWrapper().
 		WithProvider(providerName).
 		WithGroupID(groupID).
-		WithRepository(&pb.RepositoryResult{
+		WithRepository(&mediatorv1.RepositoryResult{
 			Repository: "test",
 			RepoId:     123,
 			CloneUrl:   "github.com/foo/bar.git",

--- a/internal/engine/policy.go
+++ b/internal/engine/policy.go
@@ -304,7 +304,7 @@ func rowInfoToPolicyMap(
 	entity db.Entities,
 	contextualRules json.RawMessage,
 ) *pb.Policy {
-	if !entities.IsValidEntity(entities.EntityTypeFromDB(entity)) {
+	if !entities.EntityTypeFromDB(entity).IsValid() {
 		log.Printf("unknown entity found in database: %s", entity)
 		return nil
 	}

--- a/internal/engine/rule_types_test.go
+++ b/internal/engine/rule_types_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/stacklok/mediator/internal/engine"
+	mediatorv1 "github.com/stacklok/mediator/pkg/api/protobuf/go/mediator/v1"
 )
 
 func TestExampleRulesAreValidatedCorrectly(t *testing.T) {
@@ -55,7 +56,7 @@ func TestExampleRulesAreValidatedCorrectly(t *testing.T) {
 			defer f.Close()
 
 			t.Log("parsing rule type", path)
-			rt, err := engine.ParseRuleType(f)
+			rt, err := mediatorv1.ParseRuleType(f)
 			require.NoError(t, err, "failed to parse rule type %s", path)
 			require.NotNil(t, rt, "failed to parse rule type %s", path)
 

--- a/internal/entities/entities.go
+++ b/internal/entities/entities.go
@@ -13,8 +13,9 @@
 // limitations under the License.
 // Package rule provides the CLI subcommand for managing rules
 
-// Package entities contains helper functions to convert to and from
-// validate and print the Entity protobuf enum
+// Package entities contains internal helper functions to deal with,
+// validate and print the Entity protobuf enum. Mostly to interact
+// with the database.
 package entities
 
 import (
@@ -23,80 +24,21 @@ import (
 	"golang.org/x/exp/slices"
 
 	"github.com/stacklok/mediator/internal/db"
-	pb "github.com/stacklok/mediator/pkg/api/protobuf/go/mediator/v1"
+	mediatorv1 "github.com/stacklok/mediator/pkg/api/protobuf/go/mediator/v1"
 )
-
-// EntityType is the type of entity
-type EntityType string
-
-// Entity types as string-like enums. Used in CLI and other user-facing code
-const (
-	// RepositoryEntity is a repository entity
-	RepositoryEntity EntityType = "repository"
-	// BuildEnvironmentEntity is a build environment entity
-	BuildEnvironmentEntity EntityType = "build_environment"
-	// ArtifactEntity is an artifact entity
-	ArtifactEntity EntityType = "artifact"
-	// PullRequestEntity is a pull request entity
-	PullRequestEntity EntityType = "pull_request"
-	// UnknownEntity is an explicitly unknown entity
-	UnknownEntity EntityType = "unknown"
-)
-
-// String returns the string representation of the entity type
-func (e EntityType) String() string {
-	return string(e)
-}
-
-// Enum value maps for Entity.
-var (
-	entityTypeToPb = map[EntityType]pb.Entity{
-		RepositoryEntity:       pb.Entity_ENTITY_REPOSITORIES,
-		BuildEnvironmentEntity: pb.Entity_ENTITY_BUILD_ENVIRONMENTS,
-		ArtifactEntity:         pb.Entity_ENTITY_ARTIFACTS,
-		PullRequestEntity:      pb.Entity_ENTITY_PULL_REQUESTS,
-		UnknownEntity:          pb.Entity_ENTITY_UNSPECIFIED,
-	}
-	pbToEntityType = map[pb.Entity]EntityType{
-		pb.Entity_ENTITY_REPOSITORIES:       RepositoryEntity,
-		pb.Entity_ENTITY_BUILD_ENVIRONMENTS: BuildEnvironmentEntity,
-		pb.Entity_ENTITY_ARTIFACTS:          ArtifactEntity,
-		pb.Entity_ENTITY_PULL_REQUESTS:      PullRequestEntity,
-		pb.Entity_ENTITY_UNSPECIFIED:        UnknownEntity,
-	}
-)
-
-// IsValidEntity returns true if the entity type is valid
-func IsValidEntity(entity pb.Entity) bool {
-	switch entity {
-	case pb.Entity_ENTITY_REPOSITORIES, pb.Entity_ENTITY_BUILD_ENVIRONMENTS,
-		pb.Entity_ENTITY_ARTIFACTS, pb.Entity_ENTITY_PULL_REQUESTS:
-		return true
-	case pb.Entity_ENTITY_UNSPECIFIED:
-		return false
-	}
-	return false
-}
-
-// FromString returns the Entity enum from a string. Typically used in CLI
-// when constructing a protobuf message
-func FromString(entity string) pb.Entity {
-	et := EntityType(strings.ToLower(entity))
-	// take advantage of the default value of the map being pb.Entity_ENTITY_UNSPECIFIED
-	return entityTypeToPb[et]
-}
 
 // KnownTypesCSV returns a comma separated list of known entity types. Useful for UI
 func KnownTypesCSV() string {
 	var keys []string
 
 	// Iterate through the map and append keys to the slice
-	for _, pbval := range pb.Entity_value {
+	for _, pbval := range mediatorv1.Entity_value {
+		ent := mediatorv1.Entity(pbval)
 		// PRs are not a first-class object
-		if !IsValidEntity(pb.Entity(pbval)) || pb.Entity(pbval) == pb.Entity_ENTITY_PULL_REQUESTS {
+		if !ent.IsValid() || ent == mediatorv1.Entity_ENTITY_PULL_REQUESTS {
 			continue
 		}
-		keys = append(keys, pbToEntityType[pb.Entity(pbval)].String())
+		keys = append(keys, ent.ToString())
 	}
 
 	slices.Sort(keys)
@@ -104,35 +46,35 @@ func KnownTypesCSV() string {
 }
 
 // EntityTypeFromDB returns the entity type from the database entity
-func EntityTypeFromDB(entity db.Entities) pb.Entity {
+func EntityTypeFromDB(entity db.Entities) mediatorv1.Entity {
 	switch entity {
 	case db.EntitiesRepository:
-		return pb.Entity_ENTITY_REPOSITORIES
+		return mediatorv1.Entity_ENTITY_REPOSITORIES
 	case db.EntitiesBuildEnvironment:
-		return pb.Entity_ENTITY_BUILD_ENVIRONMENTS
+		return mediatorv1.Entity_ENTITY_BUILD_ENVIRONMENTS
 	case db.EntitiesArtifact:
-		return pb.Entity_ENTITY_ARTIFACTS
+		return mediatorv1.Entity_ENTITY_ARTIFACTS
 	case db.EntitiesPullRequest:
-		return pb.Entity_ENTITY_PULL_REQUESTS
+		return mediatorv1.Entity_ENTITY_PULL_REQUESTS
 	default:
-		return pb.Entity_ENTITY_UNSPECIFIED
+		return mediatorv1.Entity_ENTITY_UNSPECIFIED
 	}
 }
 
 // EntityTypeToDB returns the database entity from the protobuf entity type
-func EntityTypeToDB(entity pb.Entity) db.Entities {
+func EntityTypeToDB(entity mediatorv1.Entity) db.Entities {
 	var dbEnt db.Entities
 
 	switch entity {
-	case pb.Entity_ENTITY_REPOSITORIES:
+	case mediatorv1.Entity_ENTITY_REPOSITORIES:
 		dbEnt = db.EntitiesRepository
-	case pb.Entity_ENTITY_BUILD_ENVIRONMENTS:
+	case mediatorv1.Entity_ENTITY_BUILD_ENVIRONMENTS:
 		dbEnt = db.EntitiesBuildEnvironment
-	case pb.Entity_ENTITY_ARTIFACTS:
+	case mediatorv1.Entity_ENTITY_ARTIFACTS:
 		dbEnt = db.EntitiesArtifact
-	case pb.Entity_ENTITY_PULL_REQUESTS:
+	case mediatorv1.Entity_ENTITY_PULL_REQUESTS:
 		dbEnt = db.EntitiesPullRequest
-	case pb.Entity_ENTITY_UNSPECIFIED:
+	case mediatorv1.Entity_ENTITY_UNSPECIFIED:
 		// This shouldn't happen
 	}
 

--- a/pkg/api/protobuf/go/mediator/v1/entities.go
+++ b/pkg/api/protobuf/go/mediator/v1/entities.go
@@ -1,0 +1,87 @@
+// Copyright 2023 Stacklok, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package _go
+
+import "strings"
+
+// EntityType is the type of entity
+type EntityType string
+
+// Entity types as string-like enums. Used in CLI and other user-facing code
+const (
+	// RepositoryEntity is a repository entity
+	RepositoryEntity EntityType = "repository"
+	// BuildEnvironmentEntity is a build environment entity
+	BuildEnvironmentEntity EntityType = "build_environment"
+	// ArtifactEntity is an artifact entity
+	ArtifactEntity EntityType = "artifact"
+	// PullRequestEntity is a pull request entity
+	PullRequestEntity EntityType = "pull_request"
+	// UnknownEntity is an explicitly unknown entity
+	UnknownEntity EntityType = "unknown"
+)
+
+// String returns the string representation of the entity type
+func (e EntityType) String() string {
+	return string(e)
+}
+
+// Enum value maps for Entity.
+var (
+	entityTypeToPb = map[EntityType]Entity{
+		RepositoryEntity:       Entity_ENTITY_REPOSITORIES,
+		BuildEnvironmentEntity: Entity_ENTITY_BUILD_ENVIRONMENTS,
+		ArtifactEntity:         Entity_ENTITY_ARTIFACTS,
+		PullRequestEntity:      Entity_ENTITY_PULL_REQUESTS,
+		UnknownEntity:          Entity_ENTITY_UNSPECIFIED,
+	}
+	pbToEntityType = map[Entity]EntityType{
+		Entity_ENTITY_REPOSITORIES:       RepositoryEntity,
+		Entity_ENTITY_BUILD_ENVIRONMENTS: BuildEnvironmentEntity,
+		Entity_ENTITY_ARTIFACTS:          ArtifactEntity,
+		Entity_ENTITY_PULL_REQUESTS:      PullRequestEntity,
+		Entity_ENTITY_UNSPECIFIED:        UnknownEntity,
+	}
+)
+
+// IsValid returns true if the entity type is valid
+func (entity Entity) IsValid() bool {
+	switch entity {
+	case Entity_ENTITY_REPOSITORIES, Entity_ENTITY_BUILD_ENVIRONMENTS,
+		Entity_ENTITY_ARTIFACTS, Entity_ENTITY_PULL_REQUESTS:
+		return true
+	case Entity_ENTITY_UNSPECIFIED:
+		return false
+	}
+	return false
+}
+
+// ToString returns the string representation of the entity type
+func (entity Entity) ToString() string {
+	t, ok := pbToEntityType[entity]
+	if !ok {
+		return UnknownEntity.String()
+	}
+
+	return t.String()
+}
+
+// EntityFromString returns the Entity enum from a string. Typically used in CLI
+// when constructing a protobuf message
+func EntityFromString(entity string) Entity {
+	et := EntityType(strings.ToLower(entity))
+	// take advantage of the default value of the map being Entity_ENTITY_UNSPECIFIED
+	return entityTypeToPb[et]
+}

--- a/pkg/api/protobuf/go/mediator/v1/rule_types.go
+++ b/pkg/api/protobuf/go/mediator/v1/rule_types.go
@@ -1,0 +1,40 @@
+// Copyright 2023 Stacklok, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package _go
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+
+	"github.com/stacklok/mediator/internal/util"
+)
+
+// ParseRuleType parses a rule type from a reader
+func ParseRuleType(r io.Reader) (*RuleType, error) {
+	// We transcode to JSON so we can decode it straight to the protobuf structure
+	w := &bytes.Buffer{}
+	if err := util.TranscodeYAMLToJSON(r, w); err != nil {
+		return nil, fmt.Errorf("error converting yaml to json: %w", err)
+	}
+
+	rt := &RuleType{}
+	if err := json.NewDecoder(w).Decode(rt); err != nil {
+		return nil, fmt.Errorf("error decoding json: %w", err)
+	}
+
+	return rt, nil
+}

--- a/pkg/api/protobuf/go/mediator/v1/validators.go
+++ b/pkg/api/protobuf/go/mediator/v1/validators.go
@@ -15,6 +15,7 @@
 package _go
 
 import (
+	"errors"
 	"fmt"
 )
 
@@ -42,6 +43,71 @@ func (rpcfg *RESTProviderConfig) Validate() error {
 	// protobuf-generated structs, so we have to do this manually.
 	if rpcfg.GetBaseUrl() == "" {
 		return fmt.Errorf("base_url is required")
+	}
+
+	return nil
+}
+
+// Ensure Entity implements the Validator interface
+var _ Validator = (*Entity)(nil)
+
+var (
+	// ErrInvalidEntity is returned when an entity is invalid
+	ErrInvalidEntity = errors.New("invalid entity")
+)
+
+// Validate ensures that an entity is valid
+func (entity *Entity) Validate() error {
+	if !entity.IsValid() {
+		return fmt.Errorf("%w: invalid entity type: %s", ErrInvalidEntity, entity.String())
+	}
+
+	return nil
+}
+
+var (
+	// ErrInvalidRuleType is returned when a rule type is invalid
+	ErrInvalidRuleType = errors.New("invalid rule type")
+	// ErrInvalidRuleTypeDefinition is returned when a rule type definition is invalid
+	ErrInvalidRuleTypeDefinition = errors.New("invalid rule type definition")
+)
+
+// Ensure RuleType implements the Validator interface
+var _ Validator = (*RuleType)(nil)
+
+// Validate ensures that a rule type is valid
+func (rt *RuleType) Validate() error {
+	if rt == nil {
+		return fmt.Errorf("%w: rule type is nil", ErrInvalidRuleType)
+	}
+
+	if rt.Def == nil {
+		return fmt.Errorf("%w: rule type definition is nil", ErrInvalidRuleType)
+	}
+
+	if err := rt.Def.Validate(); err != nil {
+		return errors.Join(ErrInvalidRuleType, err)
+	}
+
+	return nil
+}
+
+// Validate validates a rule type definition
+func (def *RuleType_Definition) Validate() error {
+	// if !entities.IsValidEntity(entities.FromString(def.InEntity)) {
+	// 	return fmt.Errorf("%w: invalid entity type: %s", ErrInvalidRuleTypeDefinition, def.InEntity)
+	// }
+
+	if def.RuleSchema == nil {
+		return fmt.Errorf("%w: rule schema is nil", ErrInvalidRuleTypeDefinition)
+	}
+
+	if def.Ingest == nil {
+		return fmt.Errorf("%w: data ingest is nil", ErrInvalidRuleTypeDefinition)
+	}
+
+	if def.Eval == nil {
+		return fmt.Errorf("%w: data eval is nil", ErrInvalidRuleTypeDefinition)
 	}
 
 	return nil


### PR DESCRIPTION
This makes our exported protobuf library more useful by moving
a bunch of parsing and validation methods in there. The idea is that
our library should be more standalone and we shoulnd't need to rely
as much on CLI utilities as we do today.

This also started using the import `mediatorv1` instead of `pb` when importing
the protobuf library. This is to make the code clearer.