### PR TITLE
providers: Change the signature of NewRequest to accept body as interface{}

### DIFF
--- a/internal/providers/github/github_rest.go
+++ b/internal/providers/github/github_rest.go
@@ -381,7 +381,7 @@ func (c *RestClient) GetAuthenticatedUser(ctx context.Context) (*github.User, er
 // which will be resolved to the BaseURL of the Client. Relative URLS should
 // always be specified without a preceding slash. If specified, the value
 // pointed to by body is JSON encoded and included as the request body.
-func (c *RestClient) NewRequest(method, url string, body io.Reader) (*http.Request, error) {
+func (c *RestClient) NewRequest(method, url string, body any) (*http.Request, error) {
 	return c.client.NewRequest(method, url, body)
 }
 

--- a/internal/providers/github/mock/github.go
+++ b/internal/providers/github/mock/github.go
@@ -6,7 +6,6 @@ package mockgh
 
 import (
 	context "context"
-	io "io"
 	http "net/http"
 	reflect "reflect"
 
@@ -157,7 +156,7 @@ func (mr *MockRESTMockRecorder) GetToken() *gomock.Call {
 }
 
 // NewRequest mocks base method.
-func (m *MockREST) NewRequest(method, url string, body io.Reader) (*http.Request, error) {
+func (m *MockREST) NewRequest(method, url string, body any) (*http.Request, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "NewRequest", method, url, body)
 	ret0, _ := ret[0].(*http.Request)
@@ -464,7 +463,7 @@ func (mr *MockGitHubMockRecorder) ListReviews(arg0, arg1, arg2, arg3, arg4 inter
 }
 
 // NewRequest mocks base method.
-func (m *MockGitHub) NewRequest(method, url string, body io.Reader) (*http.Request, error) {
+func (m *MockGitHub) NewRequest(method, url string, body any) (*http.Request, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "NewRequest", method, url, body)
 	ret0, _ := ret[0].(*http.Request)

--- a/internal/providers/http/http.go
+++ b/internal/providers/http/http.go
@@ -71,14 +71,18 @@ func (h *REST) GetToken() string {
 }
 
 // NewRequest creates an HTTP request.
-func (h *REST) NewRequest(method, endpoint string, body io.Reader) (*http.Request, error) {
+func (h *REST) NewRequest(method, endpoint string, body any) (*http.Request, error) {
 	targetURL := endpoint
 	if h.baseURL != nil {
 		u := h.baseURL.JoinPath(endpoint)
 		targetURL = u.String()
 	}
 
-	return http.NewRequest(method, targetURL, body)
+	reader, ok := body.(io.Reader)
+	if !ok {
+		return nil, fmt.Errorf("body is not an io.Reader")
+	}
+	return http.NewRequest(method, targetURL, reader)
 }
 
 // Do executes an HTTP request.

--- a/pkg/providers/v1/providers.go
+++ b/pkg/providers/v1/providers.go
@@ -21,7 +21,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io"
 	"net/http"
 
 	"github.com/go-git/go-git/v5"
@@ -53,7 +52,7 @@ type REST interface {
 	Provider
 
 	// NewRequest creates an HTTP request.
-	NewRequest(method, url string, body io.Reader) (*http.Request, error)
+	NewRequest(method, url string, body any) (*http.Request, error)
 
 	// Do executes an HTTP request.
 	Do(ctx context.Context, req *http.Request) (*http.Response, error)


### PR DESCRIPTION
The providers.REST interface defined a NewRequest() method that was
implemented by the generic HTTP REST provider as well as the github REST
provider. However, the two implementations treat the body of the request
a bit differently - the HTTP REST provider treats the body as a generic
`io.Reader` which was also exposed in the high level interface, but the
github NewRequest treats the body as an interface that can be
JSON-encoded.

And because io.Reader doesn't really encode to JSON easily, but [expects to be
able to infer the types](https://pkg.go.dev/encoding/json#Marshal) from the
interface it's encoding, I think it's better to just expose `interface{}` in
the high-level provider interface and let the lower-level implementation deal
with the conversion. This way the caller would know to pass e.g.
`map[string]any` instead of plain io.Reader.

If we want to keep the reader in the high level interface, then another
option might be to encode the io.Reader into map[string]any in the
`RestClient.NewRequest` method.
