### PR TITLE
authz: Make root project/org no longer special

### DIFF
--- a/database/migrations/000001_init.up.sql
+++ b/database/migrations/000001_init.up.sql
@@ -307,20 +307,5 @@ CREATE TRIGGER update_policy_status
     EXECUTE PROCEDURE update_policy_status();
 
 -- Create default root organization and get id so we can create the root project
--- To keep existing functionality, '00000000-0000-0000-0000-000000000001' is the
--- magic number for the root organization ID
-INSERT INTO projects (id, name, is_organization) VALUES ('00000000-0000-0000-0000-000000000001'::UUID, 'Root Organization', TRUE);
+INSERT INTO projects (name, is_organization) VALUES ('Mediator Root', TRUE);
 
--- Create default root project
--- To keep existing functionality, '00000000-0000-0000-0000-000000000002' is the
--- magic number for the root project ID
-INSERT INTO projects (id, name, is_organization, parent_id)
-    SELECT '00000000-0000-0000-0000-000000000002'::UUID, 'Root Project', FALSE, '00000000-0000-0000-0000-000000000001'::UUID;
-
--- superadmin role
-INSERT INTO roles (organization_id, project_id, name, is_admin, is_protected)
-    SELECT '00000000-0000-0000-0000-000000000001'::UUID, '00000000-0000-0000-0000-000000000002'::UUID, 'Superadmin Role', TRUE, TRUE;
-
--- Create default GitHub provider
-INSERT INTO providers (name, project_id, implements, definition)
-    SELECT 'github', '00000000-0000-0000-0000-000000000002'::UUID, ARRAY ['github', 'git', 'rest']::provider_type[], '{"github": {}}';

--- a/internal/auth/jwtauth.go
+++ b/internal/auth/jwtauth.go
@@ -41,6 +41,7 @@ type UserPermissions struct {
 	ProjectIds     []uuid.UUID
 	Roles          []RoleInfo
 	OrganizationId uuid.UUID
+	IsStaff        bool
 }
 
 // JwtValidator provides the functions to validate a JWT

--- a/internal/controlplane/common.go
+++ b/internal/controlplane/common.go
@@ -59,16 +59,3 @@ func getProjectFromRequestOrDefault(ctx context.Context, in ProjectIDGetter) (uu
 	}
 	return parsedProjectID, nil
 }
-
-// Note that to keep existing functionality, we hardcode a root organization
-// and project that are predictable. This is so we can create a superadmin
-// user that can then create other users and organizations. This is a
-// temporary measure until we have a better way to bootstrap the system.
-var (
-	rootOrganization = uuid.MustParse("00000000-0000-0000-0000-000000000001")
-	rootProject      = uuid.MustParse("00000000-0000-0000-0000-000000000002")
-)
-
-const (
-	superadminRole = 1
-)

--- a/internal/controlplane/handlers_authz_test.go
+++ b/internal/controlplane/handlers_authz_test.go
@@ -34,8 +34,8 @@ func TestIsSuperadminAuthorized(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
-	orgID := rootOrganization
-	projectID := rootProject
+	orgID := uuid.New()
+	projectID := uuid.New()
 
 	request := &pb.GetProjectByIdRequest{ProjectId: projectID.String()}
 	// Create a new context and set the claims value
@@ -43,6 +43,7 @@ func TestIsSuperadminAuthorized(t *testing.T) {
 		UserId:         1,
 		OrganizationId: orgID,
 		ProjectIds:     []uuid.UUID{projectID},
+		IsStaff:        true, // TODO: remove this
 		Roles: []auth.RoleInfo{
 			{RoleID: 1, IsAdmin: true, ProjectID: &projectID, OrganizationID: orgID}},
 	})

--- a/internal/controlplane/handlers_keys_test.go
+++ b/internal/controlplane/handlers_keys_test.go
@@ -39,6 +39,7 @@ func TestKeysHandler(t *testing.T) {
 
 	mockStore := mockdb.NewMockStore(ctrl)
 
+	orgID := uuid.New()
 	projectID := uuid.New()
 
 	request := &pb.CreateKeyPairRequest{
@@ -48,10 +49,11 @@ func TestKeysHandler(t *testing.T) {
 
 	ctx := auth.WithPermissionsContext(context.Background(), auth.UserPermissions{
 		UserId:         1,
-		OrganizationId: rootOrganization,
-		ProjectIds:     []uuid.UUID{rootProject},
+		OrganizationId: orgID,
+		ProjectIds:     []uuid.UUID{projectID},
+		IsStaff:        true, // TODO: remove this
 		Roles: []auth.RoleInfo{
-			{RoleID: 1, IsAdmin: true, ProjectID: &rootProject, OrganizationID: rootOrganization}},
+			{RoleID: 1, IsAdmin: true, ProjectID: &projectID, OrganizationID: orgID}},
 	})
 
 	// Set the expectations for the CreateSigningKey method
@@ -93,6 +95,7 @@ func TestKeysHandler(t *testing.T) {
 func TestKeysHandler_gRPC(t *testing.T) {
 	t.Parallel()
 
+	orgID := uuid.New()
 	projectID := uuid.New()
 
 	testCases := []struct {
@@ -152,10 +155,11 @@ func TestKeysHandler_gRPC(t *testing.T) {
 	}
 	ctx := auth.WithPermissionsContext(context.Background(), auth.UserPermissions{
 		UserId:         1,
-		OrganizationId: rootOrganization,
-		ProjectIds:     []uuid.UUID{rootProject},
+		OrganizationId: orgID,
+		ProjectIds:     []uuid.UUID{projectID},
+		IsStaff:        true, // TODO: remove this
 		Roles: []auth.RoleInfo{
-			{RoleID: 1, IsAdmin: true, ProjectID: &rootProject, OrganizationID: rootOrganization}},
+			{RoleID: 1, IsAdmin: true, ProjectID: &projectID, OrganizationID: orgID}},
 	})
 
 	for i := range testCases {

--- a/internal/controlplane/handlers_oauth_test.go
+++ b/internal/controlplane/handlers_oauth_test.go
@@ -86,10 +86,8 @@ func TestGetAuthorizationURL(t *testing.T) {
 	t.Parallel()
 
 	state := "test"
-	// NOTE(jaosorior): We use the root user to avoid having to mock the
-	// authorization check.
-	orgID := rootOrganization
-	projectID := rootProject
+	orgID := uuid.New()
+	projectID := uuid.New()
 	port := sql.NullInt32{Int32: 8080, Valid: true}
 	providerID := uuid.New()
 
@@ -150,6 +148,7 @@ func TestGetAuthorizationURL(t *testing.T) {
 		UserId:         1,
 		OrganizationId: orgID,
 		ProjectIds:     []uuid.UUID{projectID},
+		IsStaff:        true, // TODO: remove this
 		Roles: []auth.RoleInfo{
 			{RoleID: 1, IsAdmin: true, ProjectID: &projectID, OrganizationID: orgID}},
 	})

--- a/internal/controlplane/handlers_organization_test.go
+++ b/internal/controlplane/handlers_organization_test.go
@@ -94,6 +94,7 @@ func TestCreateOrganization_gRPC(t *testing.T) {
 	t.Parallel()
 
 	orgID := uuid.New()
+	projectID := uuid.New()
 
 	testCases := []struct {
 		name               string
@@ -188,10 +189,11 @@ func TestCreateOrganization_gRPC(t *testing.T) {
 	// Create a new context and set the claims value
 	ctx := auth.WithPermissionsContext(context.Background(), auth.UserPermissions{
 		UserId:         1,
-		OrganizationId: rootOrganization,
-		ProjectIds:     []uuid.UUID{rootProject},
+		OrganizationId: orgID,
+		ProjectIds:     []uuid.UUID{projectID},
+		IsStaff:        true, // TODO: remove this
 		Roles: []auth.RoleInfo{
-			{RoleID: 1, IsAdmin: true, ProjectID: &rootProject, OrganizationID: rootOrganization}},
+			{RoleID: 1, IsAdmin: true, ProjectID: &projectID, OrganizationID: orgID}},
 	})
 
 	for i := range testCases {
@@ -402,8 +404,8 @@ func TestGetOrganizationDBMock(t *testing.T) {
 
 	mockStore := mockdb.NewMockStore(ctrl)
 
-	orgID := rootOrganization
-	projID := rootProject
+	orgID := uuid.New()
+	projID := uuid.New()
 	orgmeta := &OrgMeta{
 		Company: "TestCompany",
 	}
@@ -426,6 +428,7 @@ func TestGetOrganizationDBMock(t *testing.T) {
 		UserId:         1,
 		OrganizationId: expectedOrg.ID,
 		ProjectIds:     []uuid.UUID{projID},
+		IsStaff:        true, // TODO: remove this
 		Roles: []auth.RoleInfo{
 			{RoleID: 1, IsAdmin: true, ProjectID: &projID, OrganizationID: expectedOrg.ID}},
 	})
@@ -458,14 +461,18 @@ func TestGetNonExistingOrganizationDBMock(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
+	orgID := uuid.New()
+	projectID := uuid.New()
+
 	mockStore := mockdb.NewMockStore(ctrl)
 	// Create a new context and set the claims value
 	ctx := auth.WithPermissionsContext(context.Background(), auth.UserPermissions{
 		UserId:         1,
-		OrganizationId: rootOrganization,
-		ProjectIds:     []uuid.UUID{rootProject},
+		OrganizationId: orgID,
+		ProjectIds:     []uuid.UUID{projectID},
+		IsStaff:        true, // TODO: remove this
 		Roles: []auth.RoleInfo{
-			{RoleID: 1, IsAdmin: true, ProjectID: &rootProject, OrganizationID: rootOrganization}},
+			{RoleID: 1, IsAdmin: true, ProjectID: &projectID, OrganizationID: orgID}},
 	})
 
 	unexistentOrgID := uuid.New()
@@ -488,6 +495,7 @@ func TestGetNonExistingOrganizationDBMock(t *testing.T) {
 func TestGetOrganization_gRPC(t *testing.T) {
 	t.Parallel()
 
+	projectID := uuid.New()
 	orgID := uuid.New()
 	orgmeta := &OrgMeta{
 		Company: "TestCompany",
@@ -561,10 +569,11 @@ func TestGetOrganization_gRPC(t *testing.T) {
 	// Create a new context and set the claims value
 	ctx := auth.WithPermissionsContext(context.Background(), auth.UserPermissions{
 		UserId:         1,
-		OrganizationId: rootOrganization,
-		ProjectIds:     []uuid.UUID{rootProject},
+		OrganizationId: orgID,
+		ProjectIds:     []uuid.UUID{projectID},
+		IsStaff:        true, // TODO: remove this
 		Roles: []auth.RoleInfo{
-			{RoleID: 1, IsAdmin: true, ProjectID: &rootProject, OrganizationID: rootOrganization}},
+			{RoleID: 1, IsAdmin: true, ProjectID: &projectID, OrganizationID: orgID}},
 	})
 
 	for i := range testCases {
@@ -594,6 +603,7 @@ func TestGetOrganizationByNameDBMock(t *testing.T) {
 
 	mockStore := mockdb.NewMockStore(ctrl)
 
+	projectID := uuid.New()
 	orgID := uuid.New()
 
 	orgmeta := &OrgMeta{
@@ -615,10 +625,11 @@ func TestGetOrganizationByNameDBMock(t *testing.T) {
 	// Create a new context and set the claims value
 	ctx := auth.WithPermissionsContext(context.Background(), auth.UserPermissions{
 		UserId:         1,
-		OrganizationId: rootOrganization,
-		ProjectIds:     []uuid.UUID{rootProject},
+		OrganizationId: orgID,
+		ProjectIds:     []uuid.UUID{projectID},
+		IsStaff:        true, // TODO: remove this
 		Roles: []auth.RoleInfo{
-			{RoleID: 1, IsAdmin: true, ProjectID: &rootProject, OrganizationID: rootOrganization}},
+			{RoleID: 1, IsAdmin: true, ProjectID: &projectID, OrganizationID: orgID}},
 	})
 
 	mockStore.EXPECT().GetOrganizationByName(ctx, gomock.Any()).
@@ -682,6 +693,7 @@ func TestGetOrganizationByName_gRPC(t *testing.T) {
 	t.Parallel()
 
 	orgID := uuid.New()
+	projectID := uuid.New()
 
 	orgmeta := &OrgMeta{
 		Company: "TestCompany",
@@ -754,10 +766,11 @@ func TestGetOrganizationByName_gRPC(t *testing.T) {
 	// Create a new context and set the claims value
 	ctx := auth.WithPermissionsContext(context.Background(), auth.UserPermissions{
 		UserId:         1,
-		OrganizationId: rootOrganization,
-		ProjectIds:     []uuid.UUID{rootProject},
+		OrganizationId: orgID,
+		ProjectIds:     []uuid.UUID{projectID},
+		IsStaff:        true,
 		Roles: []auth.RoleInfo{
-			{RoleID: 1, IsAdmin: true, ProjectID: &rootProject, OrganizationID: rootOrganization}},
+			{RoleID: 1, IsAdmin: true, ProjectID: &projectID, OrganizationID: orgID}},
 	})
 
 	for i := range testCases {

--- a/internal/controlplane/handlers_projects_test.go
+++ b/internal/controlplane/handlers_projects_test.go
@@ -42,8 +42,8 @@ func TestCreateProjectDBMock(t *testing.T) {
 
 	mockStore := mockdb.NewMockStore(ctrl)
 
-	orgID := rootOrganization
-	projID := rootProject
+	orgID := uuid.New()
+	projID := uuid.New()
 
 	request := &pb.CreateProjectRequest{
 		OrganizationId: orgID.String(),
@@ -66,6 +66,7 @@ func TestCreateProjectDBMock(t *testing.T) {
 		UserId:         1,
 		OrganizationId: orgID,
 		ProjectIds:     []uuid.UUID{projID},
+		IsStaff:        true, // TODO: remove this
 		Roles: []auth.RoleInfo{
 			{RoleID: 1, IsAdmin: true, ProjectID: &projID, OrganizationID: orgID}},
 	})
@@ -186,10 +187,11 @@ func TestCreateProject_gRPC(t *testing.T) {
 	// Create a new context and set the claims value
 	ctx := auth.WithPermissionsContext(context.Background(), auth.UserPermissions{
 		UserId:         1,
-		OrganizationId: rootOrganization,
-		ProjectIds:     []uuid.UUID{rootProject},
+		OrganizationId: orgID,
+		ProjectIds:     []uuid.UUID{projID},
+		IsStaff:        true,
 		Roles: []auth.RoleInfo{
-			{RoleID: 1, IsAdmin: true, ProjectID: &rootProject, OrganizationID: rootOrganization}},
+			{RoleID: 1, IsAdmin: true, ProjectID: &projID, OrganizationID: orgID}},
 	})
 
 	for i := range testCases {
@@ -219,6 +221,7 @@ func TestDeleteProjectDBMock(t *testing.T) {
 
 	mockStore := mockdb.NewMockStore(ctrl)
 
+	orgID := uuid.New()
 	projID := uuid.New()
 
 	request := &pb.DeleteProjectRequest{Id: projID.String()}
@@ -226,10 +229,11 @@ func TestDeleteProjectDBMock(t *testing.T) {
 	// Create a new context and set the claims value
 	ctx := auth.WithPermissionsContext(context.Background(), auth.UserPermissions{
 		UserId:         1,
-		OrganizationId: rootOrganization,
-		ProjectIds:     []uuid.UUID{rootProject},
+		OrganizationId: orgID,
+		ProjectIds:     []uuid.UUID{projID},
+		IsStaff:        true, // TODO: remove this
 		Roles: []auth.RoleInfo{
-			{RoleID: 1, IsAdmin: true, ProjectID: &rootProject, OrganizationID: rootOrganization}},
+			{RoleID: 1, IsAdmin: true, ProjectID: &projID, OrganizationID: orgID}},
 	})
 
 	mockStore.EXPECT().
@@ -256,6 +260,7 @@ func TestDeleteProject_gRPC(t *testing.T) {
 
 	force := true
 
+	orgID := uuid.New()
 	projID := uuid.New()
 
 	testCases := []struct {
@@ -306,10 +311,11 @@ func TestDeleteProject_gRPC(t *testing.T) {
 	// Create a new context and set the claims value
 	ctx := auth.WithPermissionsContext(context.Background(), auth.UserPermissions{
 		UserId:         1,
-		OrganizationId: rootOrganization,
-		ProjectIds:     []uuid.UUID{rootProject},
+		OrganizationId: orgID,
+		ProjectIds:     []uuid.UUID{projID},
+		IsStaff:        true, // TODO: remove this
 		Roles: []auth.RoleInfo{
-			{RoleID: 1, IsAdmin: true, ProjectID: &rootProject, OrganizationID: rootOrganization}},
+			{RoleID: 1, IsAdmin: true, ProjectID: &projID, OrganizationID: orgID}},
 	})
 
 	for i := range testCases {
@@ -346,10 +352,11 @@ func TestGetProjectsDBMock(t *testing.T) {
 	// Create a new context and set the claims value
 	ctx := auth.WithPermissionsContext(context.Background(), auth.UserPermissions{
 		UserId:         1,
-		OrganizationId: rootOrganization,
-		ProjectIds:     []uuid.UUID{rootProject},
+		OrganizationId: orgID,
+		ProjectIds:     []uuid.UUID{projID},
+		IsStaff:        true, // TODO: remove this
 		Roles: []auth.RoleInfo{
-			{RoleID: 1, IsAdmin: true, ProjectID: &rootProject, OrganizationID: rootOrganization}},
+			{RoleID: 1, IsAdmin: true, ProjectID: &projID, OrganizationID: orgID}},
 	})
 
 	request := &pb.GetProjectsRequest{OrganizationId: orgID.String()}
@@ -408,8 +415,8 @@ func TestGetProjectsDBMock(t *testing.T) {
 func TestGetProjects_gRPC(t *testing.T) {
 	t.Parallel()
 
-	orgID := rootOrganization
-	projID1 := rootProject
+	orgID := uuid.New()
+	projID1 := uuid.New()
 	projID2 := uuid.New()
 
 	testCases := []struct {
@@ -491,10 +498,11 @@ func TestGetProjects_gRPC(t *testing.T) {
 			// Create a new context and set the claims value
 			ctx := auth.WithPermissionsContext(context.Background(), auth.UserPermissions{
 				UserId:         1,
-				OrganizationId: rootOrganization,
-				ProjectIds:     []uuid.UUID{rootProject},
+				OrganizationId: orgID,
+				ProjectIds:     []uuid.UUID{projID1},
+				IsStaff:        true, // TODO: remove this
 				Roles: []auth.RoleInfo{
-					{RoleID: 1, IsAdmin: true, ProjectID: &rootProject, OrganizationID: rootOrganization}},
+					{RoleID: 1, IsAdmin: true, ProjectID: &projID1, OrganizationID: orgID}},
 			})
 
 			ctrl := gomock.NewController(t)
@@ -526,10 +534,11 @@ func TestGetProjectDBMock(t *testing.T) {
 	// Create a new context and set the claims value
 	ctx := auth.WithPermissionsContext(context.Background(), auth.UserPermissions{
 		UserId:         1,
-		OrganizationId: rootOrganization,
-		ProjectIds:     []uuid.UUID{rootProject},
+		OrganizationId: orgID,
+		ProjectIds:     []uuid.UUID{projID},
+		IsStaff:        true, // TODO: remove this
 		Roles: []auth.RoleInfo{
-			{RoleID: 1, IsAdmin: true, ProjectID: &rootProject, OrganizationID: rootOrganization}},
+			{RoleID: 1, IsAdmin: true, ProjectID: &projID, OrganizationID: orgID}},
 	})
 
 	expectedProject := db.Project{
@@ -666,10 +675,11 @@ func TestGetProject_gRPC(t *testing.T) {
 	// Create a new context and set the claims value
 	ctx := auth.WithPermissionsContext(context.Background(), auth.UserPermissions{
 		UserId:         1,
-		OrganizationId: rootOrganization,
-		ProjectIds:     []uuid.UUID{rootProject},
+		OrganizationId: orgID,
+		ProjectIds:     []uuid.UUID{projID},
+		IsStaff:        true, // TODO: remove this
 		Roles: []auth.RoleInfo{
-			{RoleID: 1, IsAdmin: true, ProjectID: &rootProject, OrganizationID: rootOrganization}},
+			{RoleID: 1, IsAdmin: true, ProjectID: &projID, OrganizationID: orgID}},
 	})
 
 	for i := range testCases {

--- a/internal/controlplane/handlers_role_test.go
+++ b/internal/controlplane/handlers_role_test.go
@@ -64,10 +64,11 @@ func TestCreateRoleDBMock(t *testing.T) {
 	// Create a new context and set the claims value
 	ctx := auth.WithPermissionsContext(context.Background(), auth.UserPermissions{
 		UserId:         1,
-		OrganizationId: rootOrganization,
-		ProjectIds:     []uuid.UUID{rootProject},
+		OrganizationId: orgID,
+		ProjectIds:     []uuid.UUID{projectID},
+		IsStaff:        true, // TODO: remove this
 		Roles: []auth.RoleInfo{
-			{RoleID: 1, IsAdmin: true, ProjectID: &rootProject, OrganizationID: rootOrganization}},
+			{RoleID: 1, IsAdmin: true, ProjectID: &projectID, OrganizationID: orgID}},
 	})
 
 	mockStore.EXPECT().GetOrganization(ctx, gomock.Any())
@@ -193,10 +194,11 @@ func TestCreateRole_gRPC(t *testing.T) {
 	// Create a new context and set the claims value
 	ctx := auth.WithPermissionsContext(context.Background(), auth.UserPermissions{
 		UserId:         1,
-		OrganizationId: rootOrganization,
-		ProjectIds:     []uuid.UUID{rootProject},
+		OrganizationId: orgID,
+		ProjectIds:     []uuid.UUID{projectID},
+		IsStaff:        true, // TODO: remove this
 		Roles: []auth.RoleInfo{
-			{RoleID: 1, IsAdmin: true, ProjectID: &rootProject, OrganizationID: rootOrganization}},
+			{RoleID: 1, IsAdmin: true, ProjectID: &projectID, OrganizationID: orgID}},
 	})
 
 	for i := range testCases {
@@ -226,15 +228,19 @@ func TestDeleteRoleDBMock(t *testing.T) {
 
 	mockStore := mockdb.NewMockStore(ctrl)
 
+	orgID := uuid.New()
+	projectID := uuid.New()
+
 	request := &pb.DeleteRoleRequest{Id: 1}
 
 	// Create a new context and set the claims value
 	ctx := auth.WithPermissionsContext(context.Background(), auth.UserPermissions{
 		UserId:         1,
-		OrganizationId: rootOrganization,
-		ProjectIds:     []uuid.UUID{rootProject},
+		OrganizationId: orgID,
+		ProjectIds:     []uuid.UUID{projectID},
+		IsStaff:        true, // TODO: remove this
 		Roles: []auth.RoleInfo{
-			{RoleID: 1, IsAdmin: true, ProjectID: &rootProject, OrganizationID: rootOrganization}},
+			{RoleID: 1, IsAdmin: true, ProjectID: &projectID, OrganizationID: orgID}},
 	})
 
 	mockStore.EXPECT().GetRoleByID(ctx, gomock.Any())
@@ -258,6 +264,9 @@ func TestDeleteRole_gRPC(t *testing.T) {
 	t.Parallel()
 
 	force := true
+
+	orgID := uuid.New()
+	projectID := uuid.New()
 
 	testCases := []struct {
 		name               string
@@ -310,10 +319,11 @@ func TestDeleteRole_gRPC(t *testing.T) {
 	// Create a new context and set the claims value
 	ctx := auth.WithPermissionsContext(context.Background(), auth.UserPermissions{
 		UserId:         1,
-		OrganizationId: rootOrganization,
-		ProjectIds:     []uuid.UUID{rootProject},
+		OrganizationId: orgID,
+		ProjectIds:     []uuid.UUID{projectID},
+		IsStaff:        true, // TODO: remove this
 		Roles: []auth.RoleInfo{
-			{RoleID: 1, IsAdmin: true, ProjectID: &rootProject, OrganizationID: rootOrganization}},
+			{RoleID: 1, IsAdmin: true, ProjectID: &projectID, OrganizationID: orgID}},
 	})
 
 	for i := range testCases {
@@ -344,8 +354,8 @@ func TestGetRolesDBMock(t *testing.T) {
 	mockStore := mockdb.NewMockStore(ctrl)
 
 	// use root so we can do the operation
-	orgID := rootOrganization
-	projectID := rootProject
+	orgID := uuid.New()
+	projectID := uuid.New()
 
 	request := &pb.GetRolesRequest{OrganizationId: orgID.String()}
 
@@ -371,6 +381,7 @@ func TestGetRolesDBMock(t *testing.T) {
 		UserId:         1,
 		OrganizationId: orgID,
 		ProjectIds:     []uuid.UUID{projectID},
+		IsStaff:        true, // TODO: remove this
 		Roles: []auth.RoleInfo{
 			{RoleID: 1, IsAdmin: true, ProjectID: &projectID, OrganizationID: orgID}},
 	})
@@ -401,6 +412,7 @@ func TestGetRoles_gRPC(t *testing.T) {
 	t.Parallel()
 
 	orgID := uuid.New()
+	projectID := uuid.New()
 
 	testCases := []struct {
 		name               string
@@ -468,10 +480,11 @@ func TestGetRoles_gRPC(t *testing.T) {
 	// Create a new context and set the claims value
 	ctx := auth.WithPermissionsContext(context.Background(), auth.UserPermissions{
 		UserId:         1,
-		OrganizationId: rootOrganization,
-		ProjectIds:     []uuid.UUID{rootProject},
+		OrganizationId: orgID,
+		ProjectIds:     []uuid.UUID{projectID},
+		IsStaff:        true, // TODO: remove this
 		Roles: []auth.RoleInfo{
-			{RoleID: 1, IsAdmin: true, ProjectID: &rootProject, OrganizationID: rootOrganization}},
+			{RoleID: 1, IsAdmin: true, ProjectID: &projectID, OrganizationID: orgID}},
 	})
 
 	for i := range testCases {
@@ -503,8 +516,8 @@ func TestGetRoleDBMock(t *testing.T) {
 
 	request := &pb.GetRoleByIdRequest{Id: 1}
 
-	orgID := rootOrganization
-	projectID := rootProject
+	orgID := uuid.New()
+	projectID := uuid.New()
 
 	expectedRole := db.Role{
 		ID:             1,
@@ -518,6 +531,7 @@ func TestGetRoleDBMock(t *testing.T) {
 		UserId:         1,
 		OrganizationId: orgID,
 		ProjectIds:     []uuid.UUID{projectID},
+		IsStaff:        true, // TODO: remove this
 		Roles: []auth.RoleInfo{
 			{RoleID: 1, IsAdmin: true, ProjectID: &projectID, OrganizationID: orgID}},
 	})
@@ -550,8 +564,8 @@ func TestGetNonExistingRoleDBMock(t *testing.T) {
 
 	mockStore := mockdb.NewMockStore(ctrl)
 
-	orgID := rootOrganization
-	projectID := rootProject
+	orgID := uuid.New()
+	projectID := uuid.New()
 
 	request := &pb.GetRoleByIdRequest{Id: 5}
 	// Create a new context and set the claims value
@@ -559,6 +573,7 @@ func TestGetNonExistingRoleDBMock(t *testing.T) {
 		UserId:         1,
 		OrganizationId: orgID,
 		ProjectIds:     []uuid.UUID{projectID},
+		IsStaff:        true, // TODO: remove this
 		Roles: []auth.RoleInfo{
 			{RoleID: 1, IsAdmin: true, ProjectID: &projectID, OrganizationID: orgID}},
 	})
@@ -580,6 +595,7 @@ func TestGetRole_gRPC(t *testing.T) {
 	t.Parallel()
 
 	orgID := uuid.New()
+	projectID := uuid.New()
 
 	testCases := []struct {
 		name               string
@@ -641,10 +657,11 @@ func TestGetRole_gRPC(t *testing.T) {
 	// Create a new context and set the claims value
 	ctx := auth.WithPermissionsContext(context.Background(), auth.UserPermissions{
 		UserId:         1,
-		OrganizationId: rootOrganization,
-		ProjectIds:     []uuid.UUID{rootProject},
+		OrganizationId: orgID,
+		ProjectIds:     []uuid.UUID{projectID},
+		IsStaff:        true,
 		Roles: []auth.RoleInfo{
-			{RoleID: 1, IsAdmin: true, ProjectID: &rootProject, OrganizationID: rootOrganization}},
+			{RoleID: 1, IsAdmin: true, ProjectID: &projectID, OrganizationID: orgID}},
 	})
 
 	for i := range testCases {


### PR DESCRIPTION
This instead relies on keycloak claims to determine if a user is a member of staff
or not. Thus removing the "specialness" from the root project and organization.

Note that this is simply an intermediary step before we start removing the superadmin user entirely.