### PR TITLE
Annotate Pods for Prometheus Metrics Collection

### DIFF
--- a/deployment/helm/templates/_helpers.tpl
+++ b/deployment/helm/templates/_helpers.tpl
@@ -15,7 +15,7 @@ app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{/*
 Common annotations
 */}}
-{{- define "common.annotations" -}}
+{{- define "common.annotations.pods" -}}
 prometheus.io/scrape: "true"
 prometheus.io/port: "9090"
 prometheus.io/path: "/metrics"

--- a/deployment/helm/templates/deployment.yaml
+++ b/deployment/helm/templates/deployment.yaml
@@ -30,7 +30,7 @@ spec:
         app: '{{ include "common.names.name" . }}'
       annotations:
         # This includes a newline, so ko sees this as valid yaml
-        # {{ include "common.annotations" (dict "customAnnotations" .Values.commonAnnotations "context" $ ) | nindent 8 }}
+        # {{ include "common.annotations.pods" (dict "customAnnotationsPods" .Values.commonAnnotationsPods "context" $ ) | nindent 8 }}
     spec:
       serviceAccountName: mediator
       containers:


### PR DESCRIPTION
https://github.com/stacklok/mediator/issues/1097

### Overview:

Prometheus relies on annotations to discover which pods to scrape metrics from. This issue covers the addition of the necessary annotations to the relevant pods (for Mediator), enabling Prometheus to dynamically and accurately discover and scrape them.

### Goals:

1. Annotate the `mediator` pods to expose the metrics endpoint to Prometheus.
2. Ensure that the annotations are correctly picked up by Prometheus for scraping.
3. Maintain a standard scrape configuration that can be easily scaled and managed across different pods/services in the future.

### Acceptance Criteria:

1. After deployment, the `mediator` pods should have the appropriate `prometheus.io` annotations.
2. Prometheus should start scraping metrics from the `mediator` pods based on the annotations.
3. There should be visible metric data in Prometheus (and AMP, when integrated) related to the `mediator` pods.
