### PR TITLE
cleanup: Make default project names more readable

### DIFF
--- a/internal/controlplane/handlers_organization.go
+++ b/internal/controlplane/handlers_organization.go
@@ -81,7 +81,7 @@ func (s *Server) CreateOrganization(ctx context.Context,
 
 	if in.CreateDefaultRecords {
 		// we need to create the default records for the organization
-		defaultProject, defaultRoles, err := CreateDefaultRecordsForOrg(ctx, qtx, org)
+		defaultProject, defaultRoles, err := CreateDefaultRecordsForOrg(ctx, qtx, org, org.Name+"-project")
 		if err != nil {
 			return nil, err
 		}
@@ -99,7 +99,7 @@ func (s *Server) CreateOrganization(ctx context.Context,
 
 // CreateDefaultRecordsForOrg creates the default records, such as projects, roles and provider for the organization
 func CreateDefaultRecordsForOrg(ctx context.Context, qtx db.Querier,
-	org db.Project) (*pb.ProjectRecord, []*pb.RoleRecord, error) {
+	org db.Project, projectName string) (*pb.ProjectRecord, []*pb.RoleRecord, error) {
 	projectmeta := &ProjectMeta{
 		IsProtected: true,
 		Description: fmt.Sprintf("Default admin project for %s", org.Name),
@@ -116,7 +116,7 @@ func CreateDefaultRecordsForOrg(ctx context.Context, qtx db.Querier,
 			UUID:  org.ID,
 			Valid: true,
 		},
-		Name:     fmt.Sprintf("%s-admin", org.Name),
+		Name:     projectName,
 		Metadata: jsonmeta,
 	})
 	if err != nil {

--- a/internal/controlplane/handlers_user.go
+++ b/internal/controlplane/handlers_user.go
@@ -80,15 +80,20 @@ func (s *Server) CreateUser(ctx context.Context,
 		return nil, status.Errorf(codes.Internal, "failed to marshal org metadata: %s", err)
 	}
 
+	baseName := subject
+	if token.PreferredUsername() != "" {
+		baseName = token.PreferredUsername()
+	}
+
 	// otherwise self-enroll user, by creating a new org and project and making the user an admin of those
 	organization, err := qtx.CreateOrganization(ctx, db.CreateOrganizationParams{
-		Name:     subject + "-org",
+		Name:     baseName + "-org",
 		Metadata: marshaled,
 	})
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "failed to create organization: %s", err)
 	}
-	orgProject, orgRoles, err := CreateDefaultRecordsForOrg(ctx, qtx, organization)
+	orgProject, orgRoles, err := CreateDefaultRecordsForOrg(ctx, qtx, organization, baseName)
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "failed to create default organization records: %s", err)
 	}


### PR DESCRIPTION
This takes the `preferred_username` claim (if available) and uses that to
determine the user's project when self-enrolling. Thus resulting in more
human-readable names.

A sample run would look as follows:

![image](https://github.com/stacklok/mediator/assets/145564/6d639bca-15b1-400f-ae08-0470f7ceb5fb)

