### PR TITLE
fix: Track rule type instantiations in profiles

### DIFF
--- a/database/migrations/000001_init.up.sql
+++ b/database/migrations/000001_init.up.sql
@@ -201,6 +201,15 @@ CREATE TABLE entity_profiles (
     updated_at TIMESTAMP NOT NULL DEFAULT NOW()
 );
 
+-- This table is used to track the rules associated with a profile
+CREATE TABLE entity_profile_rules (
+    id UUID NOT NULL DEFAULT gen_random_uuid() PRIMARY KEY,
+    entity_profile_id UUID NOT NULL REFERENCES entity_profiles(id) ON DELETE CASCADE,
+    rule_type_id UUID NOT NULL REFERENCES rule_type(id) ON DELETE CASCADE,
+    created_at TIMESTAMP NOT NULL DEFAULT NOW(),
+    UNIQUE (entity_profile_id, rule_type_id)
+);
+
 create type eval_status_types as enum ('success', 'failure', 'error', 'skipped', 'pending');
 
 create type remediation_status_types as enum ('success', 'failure', 'error', 'skipped', 'not_available');

--- a/database/mock/store.go
+++ b/database/mock/store.go
@@ -1278,6 +1278,21 @@ func (mr *MockStoreMockRecorder) ListProfilesByProjectID(arg0, arg1 interface{})
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListProfilesByProjectID", reflect.TypeOf((*MockStore)(nil).ListProfilesByProjectID), arg0, arg1)
 }
 
+// ListProfilesInstantiatingRuleType mocks base method.
+func (m *MockStore) ListProfilesInstantiatingRuleType(arg0 context.Context, arg1 uuid.UUID) ([]db.ListProfilesInstantiatingRuleTypeRow, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListProfilesInstantiatingRuleType", arg0, arg1)
+	ret0, _ := ret[0].([]db.ListProfilesInstantiatingRuleTypeRow)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListProfilesInstantiatingRuleType indicates an expected call of ListProfilesInstantiatingRuleType.
+func (mr *MockStoreMockRecorder) ListProfilesInstantiatingRuleType(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListProfilesInstantiatingRuleType", reflect.TypeOf((*MockStore)(nil).ListProfilesInstantiatingRuleType), arg0, arg1)
+}
+
 // ListProvidersByProjectID mocks base method.
 func (m *MockStore) ListProvidersByProjectID(arg0 context.Context, arg1 uuid.UUID) ([]db.Provider, error) {
 	m.ctrl.T.Helper()
@@ -1617,4 +1632,19 @@ func (m *MockStore) UpsertRuleEvaluationStatus(arg0 context.Context, arg1 db.Ups
 func (mr *MockStoreMockRecorder) UpsertRuleEvaluationStatus(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpsertRuleEvaluationStatus", reflect.TypeOf((*MockStore)(nil).UpsertRuleEvaluationStatus), arg0, arg1)
+}
+
+// UpsertRuleInstantiation mocks base method.
+func (m *MockStore) UpsertRuleInstantiation(arg0 context.Context, arg1 db.UpsertRuleInstantiationParams) (db.EntityProfileRule, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpsertRuleInstantiation", arg0, arg1)
+	ret0, _ := ret[0].(db.EntityProfileRule)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// UpsertRuleInstantiation indicates an expected call of UpsertRuleInstantiation.
+func (mr *MockStoreMockRecorder) UpsertRuleInstantiation(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpsertRuleInstantiation", reflect.TypeOf((*MockStore)(nil).UpsertRuleInstantiation), arg0, arg1)
 }

--- a/database/query/profiles.sql
+++ b/database/query/profiles.sql
@@ -29,3 +29,20 @@ WHERE profiles.project_id = $1;
 -- name: DeleteProfile :exec
 DELETE FROM profiles
 WHERE id = $1;
+
+-- name: UpsertRuleInstantiation :one
+INSERT INTO entity_profile_rules (entity_profile_id, rule_type_id)
+VALUES ($1, $2)
+ON CONFLICT (entity_profile_id, rule_type_id) DO NOTHING RETURNING *;
+
+-- name: ListProfilesInstantiatingRuleType :many
+-- get profile information that instantiate a rule. This is done by joining the profiles with entity_profiles, then correlating those
+-- with entity_profile_rules. The rule_type_id is used to filter the results. Note that we only really care about the overal profile,
+-- so we only return the profile information. We also should group the profiles so that we don't get duplicates.
+SELECT profiles.id, profiles.name, profiles.created_at FROM profiles
+JOIN entity_profiles ON profiles.id = entity_profiles.profile_id 
+JOIN entity_profile_rules ON entity_profiles.id = entity_profile_rules.entity_profile_id
+WHERE entity_profile_rules.rule_type_id = $1
+GROUP BY profiles.id;
+
+

--- a/internal/db/models.go
+++ b/internal/db/models.go
@@ -266,6 +266,13 @@ type EntityProfile struct {
 	UpdatedAt       time.Time       `json:"updated_at"`
 }
 
+type EntityProfileRule struct {
+	ID              uuid.UUID `json:"id"`
+	EntityProfileID uuid.UUID `json:"entity_profile_id"`
+	RuleTypeID      uuid.UUID `json:"rule_type_id"`
+	CreatedAt       time.Time `json:"created_at"`
+}
+
 type Profile struct {
 	ID        uuid.UUID         `json:"id"`
 	Name      string            `json:"name"`

--- a/internal/db/querier.go
+++ b/internal/db/querier.go
@@ -91,6 +91,10 @@ type Querier interface {
 	ListArtifactsByRepoID(ctx context.Context, repositoryID uuid.UUID) ([]Artifact, error)
 	ListOrganizations(ctx context.Context, arg ListOrganizationsParams) ([]Project, error)
 	ListProfilesByProjectID(ctx context.Context, projectID uuid.UUID) ([]ListProfilesByProjectIDRow, error)
+	// get profile information that instantiate a rule. This is done by joining the profiles with entity_profiles, then correlating those
+	// with entity_profile_rules. The rule_type_id is used to filter the results. Note that we only really care about the overal profile,
+	// so we only return the profile information. We also should group the profiles so that we don't get duplicates.
+	ListProfilesInstantiatingRuleType(ctx context.Context, ruleTypeID uuid.UUID) ([]ListProfilesInstantiatingRuleTypeRow, error)
 	ListProvidersByProjectID(ctx context.Context, projectID uuid.UUID) ([]Provider, error)
 	ListRegisteredRepositoriesByProjectIDAndProvider(ctx context.Context, arg ListRegisteredRepositoriesByProjectIDAndProviderParams) ([]Repository, error)
 	ListRepositoriesByOwner(ctx context.Context, arg ListRepositoriesByOwnerParams) ([]Repository, error)
@@ -114,6 +118,7 @@ type Querier interface {
 	UpsertArtifact(ctx context.Context, arg UpsertArtifactParams) (Artifact, error)
 	UpsertArtifactVersion(ctx context.Context, arg UpsertArtifactVersionParams) (ArtifactVersion, error)
 	UpsertRuleEvaluationStatus(ctx context.Context, arg UpsertRuleEvaluationStatusParams) error
+	UpsertRuleInstantiation(ctx context.Context, arg UpsertRuleInstantiationParams) (EntityProfileRule, error)
 }
 
 var _ Querier = (*Queries)(nil)


### PR DESCRIPTION
This starts tracking rule type instantions in profiles by introducing a table to track
these. This table is populated when creating a new profile and is checked
before deleting a rule type. We thus not allow folks to delete rule types
if there is a profile instantiating it.

Note that the rule type IDs and profile IDs are tracked in the `entity_profile_rules`
table using a the `ON DELETE CASCADE` feature. Thus, when a profile is deleted, the
instantiations get cleaned up as well.

Note that we currently don't support updated profiles (yet), so there was nowhere to
add this logic for such a case. This will need to be considered once that feature is
implemented.

Closes: https://github.com/stacklok/mediator/issues/1112
