### PR TITLE
ci: Add database migration freeze CI job

### DIFF
--- a/.github/workflows/migrate-touch.yml
+++ b/.github/workflows/migrate-touch.yml
@@ -1,0 +1,31 @@
+---
+# This test verifies that Pull Requests don't touch the merged database migrations.
+# Folks should now only be adding new migrations to the `database/migrations/` directory.
+name: Database Migrations Untouched
+
+on:
+  pull_request:
+    paths:
+      - 'database/migrations/*'
+      - '.github/workflows/migrate-touch.yml'
+
+jobs:
+  verify-migrations:
+    name: Don't touch existing migrations
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Verify Migration Files
+      run: |
+        modified_files=$(git diff --name-only origin/${{ github.base_ref }}...${{ github.head_ref }} -- 'database/migrations/' | grep '.sql' || true)
+
+        if [ -n "$modified_files" ]; then
+          echo "Error: Modifying existing migration files is not allowed."
+          echo "Modified files:"
+          echo "$modified_files"
+          exit 1
+        fi
+      shell: bash


### PR DESCRIPTION
This adds a CI job that will verify that you don't touch already merged database migrations.

The idea is that if you need to modify the database, you should add an new and working migration,
to keep our deployment working.
