### PR TITLE
Add more rest remediations

### DIFF
--- a/examples/github/rule-types/allowed_selected_actions.yaml
+++ b/examples/github/rule-types/allowed_selected_actions.yaml
@@ -62,3 +62,10 @@ def:
           def: ".patterns_allowed"
         profile:
           def: ".patterns_allowed"
+  remediate:
+    type: rest
+    rest:
+      method: PUT
+      endpoint: "/repos/{{.Entity.Owner}}/{{.Entity.Repository}}/actions/permissions/selected-actions"
+      body: |
+        {"github_owned_allowed":{{ .Profile.github_owned_allowed }},"verified_allowed":{{ .Profile.verified_allowed }},"patterns_allowed":[{{range $index, $pattern := .Profile.patterns_allowed}}{{if $index}},{{end}}"{{ $pattern }}"{{end}}]}

--- a/examples/github/rule-types/repo_workflow_access_level.yaml
+++ b/examples/github/rule-types/repo_workflow_access_level.yaml
@@ -46,3 +46,10 @@ def:
         # profile points to the profile itself.
         profile:
           def: '.access_level'
+  remediate:
+    type: rest
+    rest:
+      method: PUT
+      endpoint: "/repos/{{.Entity.Owner}}/{{.Entity.Repository}}/actions/permissions/access"
+      body: |
+        { "access_level": "{{.Profile.access_level}}" }

--- a/examples/github/rule-types/secret_push_protection.yaml
+++ b/examples/github/rule-types/secret_push_protection.yaml
@@ -42,3 +42,10 @@ def:
         # profile points to the profile itself.
         profile:
           def: ".enabled"
+  remediate:
+    type: rest
+    rest:
+      method: PATCH
+      endpoint: "/repos/{{.Entity.Owner}}/{{.Entity.Repository}}"
+      body: |
+        { "security_and_analysis": {"secret_scanning_push_protection": { "status": "enabled" } } }

--- a/examples/github/rule-types/secret_scanning.yaml
+++ b/examples/github/rule-types/secret_scanning.yaml
@@ -44,3 +44,10 @@ def:
         # profile points to the profile itself.
         profile:
           def: ".enabled"
+  remediate:
+    type: rest
+    rest:
+      method: PATCH
+      endpoint: "/repos/{{.Entity.Owner}}/{{.Entity.Repository}}"
+      body: |
+        { "security_and_analysis": {"secret_scanning": { "status": "enabled" } } }


### PR DESCRIPTION
Adds several more REST remediations. The only remaining ones are branch
protection which still need some work due to the way they work (you need to
PUT the whole request body, so we need to figure out a way to merge the
existing request)

To test them, you can either click the button in the UI to disable the secret
scanning or call:
```
curl -L -X PATCH \
-H "Accept: application/vnd.github+json" \
-H "Authorization: Bearer $TOKEN" \
-H "X-GitHub-Api-Version: 2022-11-28" \
https://api.github.com/repos/jakubtestorg/testrepo \
-d '{ "security_and_analysis": {"secret_scanning": { "status": "disabled" } } }'
```

To test the selected actions:
```
curl -L -X PUT \
-H "Accept: application/vnd.github+json" \
-H "Authorization: Bearer $TOKEN" \
-H "X-GitHub-Api-Version: 2022-11-28" \
https://api.github.com/repos/jakubtestorg/testrepo/actions/permissions \
-d '{ "enabled": true, "allowed_actions": "all" }'
```

You should see your actions being reverted by mediator - note that for some reason
GH doesn't send a webhook back once you set the allowed_actions, so you might want
to trigger reconcile via another way..
