### PR TITLE
profiles: Allow deleting rule_types if no profiles exist anymore

### DIFF
--- a/internal/controlplane/handlers_profile.go
+++ b/internal/controlplane/handlers_profile.go
@@ -816,7 +816,7 @@ func (s *Server) DeleteRuleType(
 
 	profileInfo, err := s.store.ListProfilesInstantiatingRuleType(ctx, ruletype.ID)
 	// We have profiles that use this rule type, so we can't delete it
-	if err == nil {
+	if err == nil && len(profileInfo) > 0 {
 		profiles := make([]string, 0, len(profileInfo))
 		for _, p := range profileInfo {
 			profiles = append(profiles, p.Name)


### PR DESCRIPTION
If no entity_profile_rules rows exist, we don't get an SQL errors, but a
slice of 0 values. This would have resulted in:
```
Details: cannot delete: rule type 58e93f07-ff77-4f11-8d6c-d9666a0348b3
is used by profiles
```

(Note that the message is trying to print which profiles by `Join()`-ing
the names, but all it has is an empty slices)
