### PR TITLE
chore: disable registering private repositories

### DIFF
--- a/cmd/cli/app/repo/repo_register.go
+++ b/cmd/cli/app/repo/repo_register.go
@@ -80,9 +80,7 @@ var repo_registerCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
-		cli.PrintCmd(cmd, "Found %d registered repositories\n", len(listResp.Results))
-
-		// Get list of remot repos
+		// Get a list of remote repos
 		remoteListResp, err := client.ListRemoteRepositoriesFromProvider(ctx, &pb.ListRemoteRepositoriesFromProviderRequest{
 			Provider:  provider,
 			ProjectId: projectID,
@@ -91,8 +89,6 @@ var repo_registerCmd = &cobra.Command{
 			cli.PrintCmd(cmd, "Error getting list of remote repos: %s\n", err)
 			os.Exit(1)
 		}
-
-		cli.PrintCmd(cmd, "Found %d remote repositories\n", len(remoteListResp.Results))
 
 		// Unregistered repos are in remoteListResp but not in listResp
 		// build a list of unregistered repos
@@ -114,7 +110,8 @@ var repo_registerCmd = &cobra.Command{
 			}
 		}
 
-		cli.PrintCmd(cmd, "Found %d unregistered repositories\n", len(unregisteredRepos))
+		cli.PrintCmd(cmd, "Found %d remote repositories: %d registered and %d unregistered.\n",
+			len(remoteListResp.Results), len(listResp.Results), len(unregisteredRepos))
 
 		// Get the selected repos
 		selectedRepos, err := getSelectedRepositories(unregisteredRepos, cfgFlagRepos)

--- a/internal/controlplane/handlers_repositories.go
+++ b/internal/controlplane/handlers_repositories.go
@@ -414,7 +414,11 @@ func (s *Server) ListRemoteRepositoriesFromProvider(
 		Results: make([]*pb.UpstreamRepositoryRef, 0, len(remoteRepos)),
 	}
 
-	for idx := range remoteRepos {
+	for idx, rem := range remoteRepos {
+		// Skip private repositories
+		if rem.IsPrivate {
+			continue
+		}
 		remoteRepo := remoteRepos[idx]
 		repo := &pb.UpstreamRepositoryRef{
 			Owner:  remoteRepo.Owner,


### PR DESCRIPTION
The following PR updates:
- Disables listing (therefore being able to register) private repositories.
- Disables processing private repositories when trying to register a repo
- Grouped a few prints into a single line for `repo register`

Fixes #1083 

PS. I guess we can merge this right before the MVP if we want to keep using private repos for development.