### PR TITLE
Add capability for users to delete their account in IdP

### DIFF
--- a/identity/scripts/initialize.sh
+++ b/identity/scripts/initialize.sh
@@ -17,10 +17,22 @@
 
 set -euo pipefail
 
+# Wait for Keycloak to start and authenticate with admin credentials
 while ! /opt/keycloak/bin/kcadm.sh config credentials --server http://keycloak:8080 --realm master --user "$KEYCLOAK_ADMIN" --password "$KEYCLOAK_ADMIN_PASSWORD"; do
   sleep 1
 done
 
+# Create realm stacklok
 /opt/keycloak/bin/kcadm.sh create realms -s realm=stacklok -s loginTheme=keycloak -s enabled=true
+
+# Create client mediator-cli
 /opt/keycloak/bin/kcadm.sh create clients -r stacklok -s clientId=mediator-cli -s 'redirectUris=["http://localhost/*"]' -s publicClient=true -s enabled=true
+
+# Create client mediator-ui
 /opt/keycloak/bin/kcadm.sh create clients -r stacklok -s clientId=mediator-ui -s 'redirectUris=["http://localhost/*"]' -s publicClient=true -s enabled=true
+
+# Add account deletion capability to stacklok realm (see https://www.keycloak.org/docs/latest/server_admin/#authentication-operations)
+/opt/keycloak/bin/kcadm.sh update "/authentication/required-actions/delete_account" -r stacklok -b '{ "alias" : "delete_account", "name" : "Delete Account", "providerId" : "delete_account", "enabled" : true, "defaultAction" : false, "priority" : 60, "config" : { }}'
+
+# Give all users permission to delete their own account
+/opt/keycloak/bin/kcadm.sh add-roles -r stacklok --rname default-roles-stacklok --rolename delete-account --cclientid account


### PR DESCRIPTION
Fix #1117

To try locally:
1) Restart Keycloak container `docker-compose up -d keycloak`
2) Configure GitHub login `make KC_GITHUB_CLIENT_ID=<client_id> KC_GITHUB_CLIENT_SECRET=<client_secret> github-login`
3) Register user by logging in `medic auth login`
4) Navigate to http://localhost:8081/realms/stacklok/login-actions/required-action?execution=delete_account&client_id=account-console and go through account deletion flow

Note, this only deletes the user account in Keycloak, not in the mediator DB.