### PR TITLE
Fix rule_type templates to align with the recent refactoring

### DIFF
--- a/docs/docs/profile_engine/manage_profiles.md
+++ b/docs/docs/profile_engine/manage_profiles.md
@@ -83,7 +83,7 @@ def:
       # for each repository in the organization, we use a template that
       # will be evaluated for each repository. The structure to use is the
       # protobuf structure for the entity that is being evaluated.
-      endpoint: "/repos/{{.Entity.Owner}}/{{.Entity.Repository}}"
+      endpoint: "/repos/{{.Entity.Owner}}/{{.Entity.Name}}"
       # This is the method to use to retrieve the data. It should already default to JSON
       parse: json
   # Defines the configuration for evaluating data ingested against the given profile

--- a/examples/github/repository.yaml
+++ b/examples/github/repository.yaml
@@ -1,6 +1,6 @@
 ---
 owner: stacklok
-repository: Demo-Repo-Go
+name: Demo-Repo-Go
 repoId: 605597568
 HookUrl:
 clone_url: "https://github.com/stacklok/Demo-Repo-Go.git"

--- a/examples/github/rule-types/allowed_selected_actions.yaml
+++ b/examples/github/rule-types/allowed_selected_actions.yaml
@@ -41,7 +41,7 @@ def:
       # for each repository in the organization, we use a template that
       # will be evaluated for each repository. The structure to use is the
       # protobuf structure for the entity that is being evaluated.
-      endpoint: "/repos/{{.Entity.Owner}}/{{.Entity.Repository}}/actions/permissions/selected-actions"
+      endpoint: "/repos/{{.Entity.Owner}}/{{.Entity.Name}}/actions/permissions/selected-actions"
       # This is the method to use to retrieve the data. It should already default to JSON
       parse: json
   # Defines the configuration for evaluating data ingested against the given profile
@@ -66,6 +66,6 @@ def:
     type: rest
     rest:
       method: PUT
-      endpoint: "/repos/{{.Entity.Owner}}/{{.Entity.Repository}}/actions/permissions/selected-actions"
+      endpoint: "/repos/{{.Entity.Owner}}/{{.Entity.Name}}/actions/permissions/selected-actions"
       body: |
         {"github_owned_allowed":{{ .Profile.github_owned_allowed }},"verified_allowed":{{ .Profile.verified_allowed }},"patterns_allowed":[{{range $index, $pattern := .Profile.patterns_allowed}}{{if $index}},{{end}}"{{ $pattern }}"{{end}}]}

--- a/examples/github/rule-types/branch_protection.yaml
+++ b/examples/github/rule-types/branch_protection.yaml
@@ -79,7 +79,7 @@ def:
       # for each repository in the organization, we use a template that
       # will be evaluated for each repository. The structure to use is the
       # protobuf structure for the entity that is being evaluated.
-      endpoint: '/repos/{{.Entity.Owner}}/{{.Entity.Repository}}/branches/{{ index .Params "branch" }}/protection'
+      endpoint: '/repos/{{.Entity.Owner}}/{{.Entity.Name}}/branches/{{ index .Params "branch" }}/protection'
       # This is the method to use to retrieve the data. It should already default to JSON
       parse: json
   # Defines the configuration for evaluating data ingested against the given profile

--- a/examples/github/rule-types/default_workflow_permissions.yaml
+++ b/examples/github/rule-types/default_workflow_permissions.yaml
@@ -34,7 +34,7 @@ def:
   ingest:
     type: rest
     rest:
-      endpoint: "/repos/{{.Entity.Owner}}/{{.Entity.Repository}}/actions/permissions/workflow"
+      endpoint: "/repos/{{.Entity.Owner}}/{{.Entity.Name}}/actions/permissions/workflow"
       parse: json
   # Defines the configuration for evaluating data ingested against the given profile
   eval:

--- a/examples/github/rule-types/github_actions_allowed.yaml
+++ b/examples/github/rule-types/github_actions_allowed.yaml
@@ -41,7 +41,7 @@ def:
       # for each repository in the organization, we use a template that
       # will be evaluated for each repository. The structure to use is the
       # protobuf structure for the entity that is being evaluated.
-      endpoint: "/repos/{{.Entity.Owner}}/{{.Entity.Repository}}/actions/permissions"
+      endpoint: "/repos/{{.Entity.Owner}}/{{.Entity.Name}}/actions/permissions"
       # This is the method to use to retrieve the data. It should already default to JSON
       parse: json
   # Defines the configuration for evaluating data ingested against the given profile
@@ -57,6 +57,6 @@ def:
     type: rest
     rest:
       method: PUT # (jakub): PATCH doesn't seem to work
-      endpoint: "/repos/{{.Entity.Owner}}/{{.Entity.Repository}}/actions/permissions"
+      endpoint: "/repos/{{.Entity.Owner}}/{{.Entity.Name}}/actions/permissions"
       body: |
         { "enabled": true, "allowed_actions": "{{.Profile.allowed_actions}}" }

--- a/examples/github/rule-types/repo_workflow_access_level.yaml
+++ b/examples/github/rule-types/repo_workflow_access_level.yaml
@@ -33,7 +33,7 @@ def:
       # for each repository in the organization, we use a template that
       # will be evaluated for each repository. The structure to use is the
       # protobuf structure for the entity that is being evaluated.
-      endpoint: "/repos/{{.Entity.Owner}}/{{.Entity.Repository}}/actions/permissions/access"
+      endpoint: "/repos/{{.Entity.Owner}}/{{.Entity.Name}}/actions/permissions/access"
       # This is the method to use to retrieve the data. It should already default to JSON
       parse: json
   # Defines the configuration for evaluating data ingested against the given profile
@@ -50,6 +50,6 @@ def:
     type: rest
     rest:
       method: PUT
-      endpoint: "/repos/{{.Entity.Owner}}/{{.Entity.Repository}}/actions/permissions/access"
+      endpoint: "/repos/{{.Entity.Owner}}/{{.Entity.Name}}/actions/permissions/access"
       body: |
         { "access_level": "{{.Profile.access_level}}" }

--- a/examples/github/rule-types/secret_push_protection.yaml
+++ b/examples/github/rule-types/secret_push_protection.yaml
@@ -29,7 +29,7 @@ def:
       # for each repository in the organization, we use a template that
       # will be evaluated for each repository. The structure to use is the
       # protobuf structure for the entity that is being evaluated.
-      endpoint: "/repos/{{.Entity.Owner}}/{{.Entity.Repository}}"
+      endpoint: "/repos/{{.Entity.Owner}}/{{.Entity.Name}}"
       # This is the method to use to retrieve the data. It should already default to JSON
       parse: json
   # Defines the configuration for evaluating data ingested against the given profile
@@ -46,6 +46,6 @@ def:
     type: rest
     rest:
       method: PATCH
-      endpoint: "/repos/{{.Entity.Owner}}/{{.Entity.Repository}}"
+      endpoint: "/repos/{{.Entity.Owner}}/{{.Entity.Name}}"
       body: |
         { "security_and_analysis": {"secret_scanning_push_protection": { "status": "enabled" } } }

--- a/examples/github/rule-types/secret_scanning.yaml
+++ b/examples/github/rule-types/secret_scanning.yaml
@@ -31,7 +31,7 @@ def:
       # for each repository in the organization, we use a template that
       # will be evaluated for each repository. The structure to use is the
       # protobuf structure for the entity that is being evaluated.
-      endpoint: "/repos/{{.Entity.Owner}}/{{.Entity.Repository}}"
+      endpoint: "/repos/{{.Entity.Owner}}/{{.Entity.Name}}"
       # This is the method to use to retrieve the data. It should already default to JSON
       parse: json
   # Defines the configuration for evaluating data ingested against the given profile
@@ -48,6 +48,6 @@ def:
     type: rest
     rest:
       method: PATCH
-      endpoint: "/repos/{{.Entity.Owner}}/{{.Entity.Repository}}"
+      endpoint: "/repos/{{.Entity.Owner}}/{{.Entity.Name}}"
       body: |
         { "security_and_analysis": {"secret_scanning": { "status": "enabled" } } }


### PR DESCRIPTION
We forgot to fixup the templates with the recent repository refactoring,
so all our repository related rule-types started failing when they
couldn't expand a template.
