### PR TITLE
rule_type: print remediation error even if evaluation fails

### DIFF
--- a/cmd/dev/app/rule_type/rule_type.go
+++ b/cmd/dev/app/rule_type/rule_type.go
@@ -169,12 +169,12 @@ func runEvaluationForRules(
 		}
 
 		evalErr, remediateErr := eng.Eval(context.Background(), ent, def, params, rem)
-		if evalErr != nil {
-			return fmt.Errorf("error evaluating rule type: %w", evalErr)
-		}
-
 		if errors.IsRemediateFatalError(remediateErr) {
 			fmt.Printf("Remediation failed with fatal error: %s", remediateErr)
+		}
+
+		if evalErr != nil {
+			return fmt.Errorf("error evaluating rule type: %w", evalErr)
 		}
 
 		fmt.Printf("The rule type is valid and the entity conforms to it\n")


### PR DESCRIPTION
In case the evaluation failed we would have printed a fatal error and
never print the remediation error.
