### PR TITLE
engine: Pass params to the remediate interface, too

### DIFF
--- a/internal/engine/interfaces/interface.go
+++ b/internal/engine/interfaces/interface.go
@@ -83,5 +83,10 @@ func ActionOptFromString(s *string) ActionOpt {
 
 // Remediator is the interface for a rule type remediator
 type Remediator interface {
-	Remediate(ctx context.Context, remAction ActionOpt, ent protoreflect.ProtoMessage, pol map[string]any) error
+	Remediate(
+		ctx context.Context,
+		remAction ActionOpt,
+		ent protoreflect.ProtoMessage,
+		pol map[string]any,
+		params map[string]any) error
 }

--- a/internal/engine/remediate/noop/noop.go
+++ b/internal/engine/remediate/noop/noop.go
@@ -39,6 +39,7 @@ func (_ *Remediator) Remediate(
 	_ interfaces.ActionOpt,
 	_ protoreflect.ProtoMessage,
 	_ map[string]any,
+	_ map[string]any,
 ) error {
 	return enginerr.ErrRemediationNotAvailable
 }

--- a/internal/engine/remediate/rest/rest.go
+++ b/internal/engine/remediate/rest/rest.go
@@ -100,6 +100,8 @@ type EndpointTemplateParams struct {
 	Entity any
 	// Profile are the parameters to be used in the template
 	Profile map[string]any
+	// Params are the rule instance parameters
+	Params map[string]any
 }
 
 // Remediate actually performs the remediation
@@ -108,10 +110,12 @@ func (r *Remediator) Remediate(
 	remAction interfaces.ActionOpt,
 	ent protoreflect.ProtoMessage,
 	pol map[string]any,
+	params map[string]any,
 ) error {
 	retp := &EndpointTemplateParams{
 		Entity:  ent,
 		Profile: pol,
+		Params:  params,
 	}
 
 	endpoint := new(bytes.Buffer)

--- a/internal/engine/rule_types.go
+++ b/internal/engine/rule_types.go
@@ -252,7 +252,7 @@ func (r *RuleTypeEngine) Eval(
 
 	evalErr = r.reval.Eval(ctx, pol, result)
 
-	remediateErr = r.tryRemediate(ctx, ent, pol, remAction, evalErr)
+	remediateErr = r.tryRemediate(ctx, ent, pol, params, remAction, evalErr)
 
 	return evalErr, remediateErr
 }
@@ -260,7 +260,7 @@ func (r *RuleTypeEngine) Eval(
 func (r *RuleTypeEngine) tryRemediate(
 	ctx context.Context,
 	ent protoreflect.ProtoMessage,
-	pol map[string]any,
+	pol, params map[string]any,
 	remAction engif.ActionOpt,
 	evalErr error,
 ) error {
@@ -271,7 +271,7 @@ func (r *RuleTypeEngine) tryRemediate(
 		return evalerrors.ErrRemediationSkipped
 	}
 
-	return r.rrem.Remediate(ctx, remAction, ent, pol)
+	return r.rrem.Remediate(ctx, remAction, ent, pol, params)
 }
 
 func (r *RuleTypeEngine) shouldRemediate(remAction engif.ActionOpt, evalErr error) (bool, error) {


### PR DESCRIPTION
In order to support the branch protection remediations, we need to have
access to the parameters in the remediator. Those include typically the
branch name in the case of branch protection rules.
For the branch protection remediations, we need to pass in the params as
well in order to expand the branch name.
