### PR TITLE
feat: Default to staging keycloak for identity configuration

### DIFF
--- a/cmd/cli/app/auth/auth_login.go
+++ b/cmd/cli/app/auth/auth_login.go
@@ -40,7 +40,6 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
-	"github.com/stacklok/mediator/internal/config"
 	mcrypto "github.com/stacklok/mediator/internal/crypto"
 	"github.com/stacklok/mediator/internal/util"
 	"github.com/stacklok/mediator/internal/util/cli"
@@ -74,14 +73,14 @@ will be saved to $XDG_CONFIG_HOME/mediator/credentials.json`,
 	},
 	Run: func(cmd *cobra.Command, args []string) {
 		ctx := context.Background()
-		cfg, err := config.ReadConfigFromViper(viper.GetViper())
-		util.ExitNicelyOnError(err, "unable to read config")
 
-		clientID := cfg.Identity.ClientId
+		issuerUrlStr := util.GetConfigValue("identity.issuer_url", "identity-url", cmd, "https://auth.staging.stacklok.dev").(string)
+		realm := util.GetConfigValue("identity.realm", "identity-realm", cmd, "stacklok").(string)
+		clientID := util.GetConfigValue("identity.client_id", "identity-client", cmd, "mediator-cli").(string)
 
-		parsedURL, err := url.Parse(cfg.Identity.IssuerUrl)
+		parsedURL, err := url.Parse(issuerUrlStr)
 		util.ExitNicelyOnError(err, "Error parsing issuer URL")
-		issuerUrl := parsedURL.JoinPath("realms", cfg.Identity.Realm)
+		issuerUrl := parsedURL.JoinPath("realms", realm)
 		scopes := []string{"openid"}
 		callbackPath := "/auth/callback"
 

--- a/cmd/cli/app/auth/auth_logout.go
+++ b/cmd/cli/app/auth/auth_logout.go
@@ -30,7 +30,6 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 
-	"github.com/stacklok/mediator/internal/config"
 	"github.com/stacklok/mediator/internal/util"
 	"github.com/stacklok/mediator/internal/util/cli"
 )
@@ -60,13 +59,13 @@ var auth_logoutCmd = &cobra.Command{
 		err := os.Remove(filePath)
 		util.ExitNicelyOnError(err, "Error removing credentials file")
 
-		cfg, err := config.ReadConfigFromViper(viper.GetViper())
-		util.ExitNicelyOnError(err, "Error reading config")
+		issuerUrlStr := util.GetConfigValue("identity.issuer_url", "identity-url", cmd, "https://auth.staging.stacklok.dev").(string)
+		realm := util.GetConfigValue("identity.realm", "identity-realm", cmd, "stacklok").(string)
 
-		parsedURL, err := url.Parse(cfg.Identity.IssuerUrl)
+		parsedURL, err := url.Parse(issuerUrlStr)
 		util.ExitNicelyOnError(err, "Error parsing issuer URL")
 
-		logoutUrl := parsedURL.JoinPath("realms", cfg.Identity.Realm, "protocol/openid-connect/logout")
+		logoutUrl := parsedURL.JoinPath("realms", realm, "protocol/openid-connect/logout")
 		cli.PrintCmd(cmd, cli.SuccessBanner.Render("You have successfully logged out of the CLI."))
 		cli.PrintCmd(cmd, "If you would like to log out of the browser, you can visit %s", logoutUrl.String())
 	},

--- a/cmd/cli/app/root.go
+++ b/cmd/cli/app/root.go
@@ -57,7 +57,7 @@ func init() {
 	RootCmd.PersistentFlags().String("grpc-host", "staging.stacklok.dev", "Server host")
 	RootCmd.PersistentFlags().Int("grpc-port", 443, "Server port")
 	RootCmd.PersistentFlags().Bool("grpc-insecure", false, "Allow establishing insecure connections")
-	RootCmd.PersistentFlags().String("identity-url", "http://localhost:8081", "Identity server issuer URL")
+	RootCmd.PersistentFlags().String("identity-url", "https://auth.staging.stacklok.dev", "Identity server issuer URL")
 	RootCmd.PersistentFlags().String("identity-realm", "stacklok", "Identity server realm")
 	RootCmd.PersistentFlags().String("identity-client", "mediator-cli", "Identity server client ID")
 	RootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "Config file (default is $PWD/config.yaml)")

--- a/internal/util/helpers.go
+++ b/internal/util/helpers.go
@@ -138,7 +138,7 @@ func GrpcForCommand(cmd *cobra.Command) (*grpc.ClientConn, error) {
 	insecureDefault := grpc_host == "localhost" || grpc_host == "127.0.0.1" || grpc_host == "::1"
 	allowInsecure := GetConfigValue("grpc_server.insecure", "grpc-insecure", cmd, insecureDefault).(bool)
 
-	issuerUrl := GetConfigValue("identity.issuer_url", "identity-url", cmd, "http://localhost:8081").(string)
+	issuerUrl := GetConfigValue("identity.issuer_url", "identity-url", cmd, "https://auth.staging.stacklok.dev").(string)
 	realm := GetConfigValue("identity.realm", "identity-realm", cmd, "stacklok").(string)
 	clientId := GetConfigValue("identity.client_id", "identity-client", cmd, "mediator-cli").(string)
 


### PR DESCRIPTION
This sets up the default identity parameters to use the staging keycloak. One doesn't require
a specialized configuration.
