### PR TITLE
vulncheck: Don't try to render an empty summary table if no CVEs are found

### DIFF
--- a/internal/engine/eval/vulncheck/review.go
+++ b/internal/engine/eval/vulncheck/review.go
@@ -492,6 +492,10 @@ func (sph *summaryPrHandler) submit(ctx context.Context) error {
 
 func (sph *summaryPrHandler) generateSummary() (string, error) {
 	var summary strings.Builder
+	if len(sph.trackedDeps) == 0 {
+		summary.WriteString(noVulsFoundText)
+		return summary.String(), nil
+	}
 
 	var headerBuf bytes.Buffer
 	if err := sph.headerTmpl.Execute(&headerBuf, nil); err != nil {


### PR DESCRIPTION
Just display the same sentence we would have displayed with the other
review actions.

I'm sorry that I didn't test that case myself earlier..
