### PR TITLE
Don't error CLI on a lack of config 

### DIFF
--- a/cmd/cli/app/root.go
+++ b/cmd/cli/app/root.go
@@ -75,6 +75,12 @@ func initConfig() {
 	viper.AutomaticEnv()
 
 	if err := viper.ReadInConfig(); err != nil {
-		fmt.Println("Error reading config file:", err)
+		if _, ok := err.(viper.ConfigFileNotFoundError); ok {
+			// Config file not found; use default values
+			fmt.Println("No config file present, using default values.")
+		} else {
+			// Some other error occurred
+			fmt.Println("Error reading config file:", err)
+		}
 	}
 }


### PR DESCRIPTION
A lot of users will download medic and not pre-create a config file, they should not be shown an error and instead informed.

<img width="1228" alt="image" src="https://github.com/stacklok/mediator/assets/7058938/8619a3aa-56fc-41b6-b932-4febef3beb62">
