### PR TITLE
Add postgres connection pool instrumentation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -35,6 +35,8 @@ require (
 	github.com/robfig/cron/v3 v3.0.1
 	github.com/rs/zerolog v1.31.0
 	github.com/secure-systems-lab/go-securesystemslib v0.7.0
+	github.com/signalfx/splunk-otel-go/instrumentation/database/sql/splunksql v1.9.0
+	github.com/signalfx/splunk-otel-go/instrumentation/github.com/lib/pq/splunkpq v1.9.0
 	github.com/sigstore/cosign/v2 v2.2.0
 	github.com/sigstore/sigstore v1.7.4
 	github.com/spf13/cobra v1.7.0
@@ -82,6 +84,7 @@ require (
 	github.com/sagikazarmark/locafero v0.3.0 // indirect
 	github.com/sagikazarmark/slog-shim v0.1.0 // indirect
 	github.com/segmentio/asm v1.2.0 // indirect
+	github.com/signalfx/splunk-otel-go/instrumentation/internal v1.9.0 // indirect
 	github.com/sourcegraph/conc v0.3.0 // indirect
 	github.com/xi2/xz v0.0.0-20171230120015-48954b6210f8 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -921,6 +921,12 @@ github.com/sergi/go-diff v1.3.1/go.mod h1:aMJSSKb2lpPvRNec0+w3fl7LP9IOFzdc9Pa4NF
 github.com/shibumi/go-pathspec v1.3.0 h1:QUyMZhFo0Md5B8zV8x2tesohbb5kfbpTi9rBnKh5dkI=
 github.com/shibumi/go-pathspec v1.3.0/go.mod h1:Xutfslp817l2I1cZvgcfeMQJG5QnU2lh5tVaaMCl3jE=
 github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
+github.com/signalfx/splunk-otel-go/instrumentation/database/sql/splunksql v1.9.0 h1:Jk5yE1mlIHhI01P2vINMon3VGyDoutR+uta1LLVcM5E=
+github.com/signalfx/splunk-otel-go/instrumentation/database/sql/splunksql v1.9.0/go.mod h1:R0iO8Gf+o6Ur6lgXnkV6XTLMKj0LiTxogPu4w+9SCR0=
+github.com/signalfx/splunk-otel-go/instrumentation/github.com/lib/pq/splunkpq v1.9.0 h1:XHa4AvHOILKn8uznpyArd5FNejP9VaUE1DuBDhaU3IA=
+github.com/signalfx/splunk-otel-go/instrumentation/github.com/lib/pq/splunkpq v1.9.0/go.mod h1:FacW6APpBAij4HJO7v5Z/q4DX8XwtjpnaESWUYfZ3gY=
+github.com/signalfx/splunk-otel-go/instrumentation/internal v1.9.0 h1:jMtn6yQVWkZv5hP27xyszjf9Yc9nzz6U9ogalwD3HkI=
+github.com/signalfx/splunk-otel-go/instrumentation/internal v1.9.0/go.mod h1:LNoiOUmMI77p93X9bnFej+eYLTbsPfifgyW28oKMIOI=
 github.com/sigstore/cosign/v2 v2.2.0 h1:MV/ALD1/e/JgxXXCdCNxlIRk2NB3Irb4MKPozd8SPR8=
 github.com/sigstore/cosign/v2 v2.2.0/go.mod h1:Kcm7lTZbpiEpA3wPCqRygTUdLpX8CNT+36rODTCBr1M=
 github.com/sigstore/fulcio v1.4.0 h1:05+k8BFvwTQzfCkVxESWzCN4b70KIRliGYz0Upmdrs8=

--- a/internal/config/db.go
+++ b/internal/config/db.go
@@ -25,6 +25,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/feature/rds/auth"
 	"github.com/rs/zerolog"
+	"github.com/signalfx/splunk-otel-go/instrumentation/database/sql/splunksql"
 	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
 
@@ -98,7 +99,7 @@ func (c *DatabaseConfig) GetDBURI(ctx context.Context) string {
 // GetDBConnection returns a connection to the database
 func (c *DatabaseConfig) GetDBConnection(ctx context.Context) (*sql.DB, string, error) {
 	uri := c.GetDBURI(ctx)
-	conn, err := sql.Open("postgres", uri)
+	conn, err := splunksql.Open("postgres", uri)
 	if err != nil {
 		return nil, "", err
 	}

--- a/internal/controlplane/server.go
+++ b/internal/controlplane/server.go
@@ -24,8 +24,8 @@ import (
 	"time"
 
 	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
-	_ "github.com/lib/pq" // This is required for the postgres driver
 	"github.com/prometheus/client_golang/prometheus/promhttp"
+	_ "github.com/signalfx/splunk-otel-go/instrumentation/github.com/lib/pq/splunkpq" // Auto-instrumented version of lib/pq
 	"go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"

--- a/internal/util/helpers.go
+++ b/internal/util/helpers.go
@@ -43,7 +43,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
-	_ "github.com/lib/pq" // nolint
+	_ "github.com/signalfx/splunk-otel-go/instrumentation/github.com/lib/pq/splunkpq" // nolint
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	"golang.org/x/term"


### PR DESCRIPTION
I was looking at https://opentelemetry.io/ecosystem/registry/?s=sql&component=&language=go and saw that splunk had some `pq` bindings.

Per https://pkg.go.dev/github.com/signalfx/splunk-otel-go/instrumentation/database/sql/splunksql#section-readme, this only includes the following metrics, no distributions / error rates on SQL queries:

```
db.client.connections.usage ({connection}) - The number of connections that are currently in state described by the state attribute
db.client.connections.max ({connection}) - The maximum number of open connections allowed
db.client.connections.wait_time (ms) - The time it took to obtain an open connection from the pool
```