### PR TITLE
engine: Also traverse PullRequest rules when validating profiles

### DIFF
--- a/internal/engine/profile.go
+++ b/internal/engine/profile.go
@@ -124,6 +124,10 @@ func TraverseAllRulesForPipeline(p *pb.Profile, fn func(*pb.Profile_Rule) error)
 		return fmt.Errorf("error traversing build environment rules: %w", err)
 	}
 
+	if err := TraverseRules(p.PullRequest, fn); err != nil {
+		return fmt.Errorf("error traversing pull_request rules: %w", err)
+	}
+
 	if err := TraverseRules(p.Artifact, fn); err != nil {
 		return fmt.Errorf("error traversing artifact rules: %w", err)
 	}


### PR DESCRIPTION
We forgot to traverse Pull Request rules when validating policies. This
could result in the user creating a profile that was referencing a
rule_type that was not created.

Fixes: #1222
