### PR TITLE
Fix artifact_signature rule schema

### DIFF
--- a/examples/github/rule-types/artifact_signature.yaml
+++ b/examples/github/rule-types/artifact_signature.yaml
@@ -19,6 +19,7 @@ def:
   in_entity: artifact
   # Defines the schema for parameters that will be passed to the rule
   param_schema:
+    type: object
     properties:
       name:
         type: string
@@ -38,16 +39,14 @@ def:
       - tags
   # Defines the schema for writing a rule with this rule being checked
   rule_schema:
+    type: "object"
     properties:
-      artifact_signature:
-        type: "object"
-        properties:
-          is_signed:
-            type: boolean
-            description: "Set to true to enforce artifact being signed."
-          is_verified:
-            type: boolean
-            description: "Set to true to enforce artifact signature being verified."
+      is_signed:
+        type: boolean
+        description: "Set to true to enforce artifact being signed."
+      is_verified:
+        type: boolean
+        description: "Set to true to enforce artifact signature being verified."
   # Defines the configuration for ingesting data relevant for the rule
   ingest:
     type: artifact


### PR DESCRIPTION
The rule schema made it so that the validation expected a call as follows:

```yaml
  - type: artifact_signature
    params:
      tags: [main]
      name: test
    def:
      artifact_signature:
        is_signed: true
        is_verified: true
        is_bundle_verified: true
```

This fixes removes the extra `properties` so we can make a simpler call as the
one we have already defined in the sample profile.
