### PR TITLE
fix: update rule type descriptions to be consistent

### DIFF
--- a/examples/github/rule-types/actions_check_pinned_tags.yaml
+++ b/examples/github/rule-types/actions_check_pinned_tags.yaml
@@ -18,11 +18,11 @@ guidance: |
   https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions
 def:
   # Defines the section of the pipeline the rule will appear in.
-  # This will affect the template that is used to render multiple parts
+  # This will affect the template used to render multiple parts
   # of the rule.
   in_entity: repository
   # Defines the schema for writing a rule with this rule being checked
-  # In this case there is no settings that need to be configured
+  # In this case there are no settings that need to be configured
   rule_schema: {}
   # Defines the configuration for ingesting data relevant for the rule
   ingest:
@@ -30,8 +30,8 @@ def:
     git:
       branch: main
   # Defines the configuration for evaluating data ingested against the given profile
-  # This example uses the checks for that github actions are using pinned tags
-  # for the uses directive, in the form of SHA-1 hash
+  # This example uses the checks for that GitHub actions are using pinned tags
+  # for the use directive, in the form of SHA-1 hash.
   # For example, this wil fail:
   # uses: actions/checkout@v2
   # This will pass:

--- a/examples/github/rule-types/allowed_selected_actions.yaml
+++ b/examples/github/rule-types/allowed_selected_actions.yaml
@@ -15,7 +15,7 @@ guidance: |
   https://docs.github.com/en/rest/actions/permissions#set-allowed-actions-and-reusable-workflows-for-a-repository
 def:
   # Defines the section of the pipeline the rule will appear in.
-  # This will affect the template that is used to render multiple parts
+  # This will affect the template used to render multiple parts
   # of the rule.
   in_entity: repository
   # Defines the schema for writing a rule with this rule being checked

--- a/examples/github/rule-types/artifact_signature.yaml
+++ b/examples/github/rule-types/artifact_signature.yaml
@@ -14,7 +14,7 @@ guidance: |
   https://docs.sigstore.dev/signing/signing_with_containers
 def:
   # Defines the section of the pipeline the rule will appear in.
-  # This will affect the template that is used to render multiple parts
+  # This will affect the template used to render multiple parts
   # of the rule.
   in_entity: artifact
   # Defines the schema for parameters that will be passed to the rule

--- a/examples/github/rule-types/branch_protection_allow_deletions.yaml
+++ b/examples/github/rule-types/branch_protection_allow_deletions.yaml
@@ -6,13 +6,13 @@ context:
   provider: github
 description: Whether the branch can be deleted
 guidance: |
-  ## Allow users with push access to delete matching branches.
+  Allow users with push access to delete matching branches.
 
   For more information, see
   https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-protected-branches/managing-a-branch-protection-rule
 def:
   # Defines the section of the pipeline the rule will appear in.
-  # This will affect the template that is used to render multiple parts
+  # This will affect the template used to render multiple parts
   # of the rule.
   in_entity: repository
   # Defines the schema for parameters that will be passed to the rule

--- a/examples/github/rule-types/branch_protection_allow_force_pushes.yaml
+++ b/examples/github/rule-types/branch_protection_allow_force_pushes.yaml
@@ -6,13 +6,13 @@ context:
   provider: github
 description: Whether force pushes are allowed to the branch
 guidance: |
-  ## Permit force pushes for all users with push access.
+  Permit force pushes for all users with push access.
 
   For more information, see
   https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-protected-branches/managing-a-branch-protection-rule
 def:
   # Defines the section of the pipeline the rule will appear in.
-  # This will affect the template that is used to render multiple parts
+  # This will affect the template used to render multiple parts
   # of the rule.
   in_entity: repository
   # Defines the schema for parameters that will be passed to the rule

--- a/examples/github/rule-types/branch_protection_allow_fork_syncing.yaml
+++ b/examples/github/rule-types/branch_protection_allow_fork_syncing.yaml
@@ -6,13 +6,13 @@ context:
   provider: github
 description: Whether users can pull changes from upstream when the branch is locked
 guidance: |
-  ## A locked branch cannot be pulled from
+  A locked branch cannot be pulled from
 
   For more information, see
   https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-protected-branches/managing-a-branch-protection-rule
 def:
   # Defines the section of the pipeline the rule will appear in.
-  # This will affect the template that is used to render multiple parts
+  # This will affect the template used to render multiple parts
   # of the rule.
   in_entity: repository
   # Defines the schema for parameters that will be passed to the rule

--- a/examples/github/rule-types/branch_protection_enabled.yaml
+++ b/examples/github/rule-types/branch_protection_enabled.yaml
@@ -14,7 +14,7 @@ guidance: |
   https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-protected-branches/managing-a-branch-protection-rule
 def:
   # Defines the section of the pipeline the rule will appear in.
-  # This will affect the template that is used to render multiple parts
+  # This will affect the template used to render multiple parts
   # of the rule.
   in_entity: repository
   # Defines the schema for parameters that will be passed to the rule

--- a/examples/github/rule-types/branch_protection_enforce_admins.yaml
+++ b/examples/github/rule-types/branch_protection_enforce_admins.yaml
@@ -6,13 +6,13 @@ context:
   provider: github
 description: Whether the protection rules apply to repository administrators
 guidance: |
-  ## Enforce required status checks for repository administrators
+  Enforce required status checks for repository administrators
 
   For more information, see
   https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-protected-branches/managing-a-branch-protection-rule
 def:
   # Defines the section of the pipeline the rule will appear in.
-  # This will affect the template that is used to render multiple parts
+  # This will affect the template used to render multiple parts
   # of the rule.
   in_entity: repository
   # Defines the schema for parameters that will be passed to the rule

--- a/examples/github/rule-types/branch_protection_lock_branch.yaml
+++ b/examples/github/rule-types/branch_protection_lock_branch.yaml
@@ -6,13 +6,13 @@ context:
   provider: github
 description: Whether the branch is locked
 guidance: |
-  ## Can set the branch as read-only. Users cannot push to the branch.
+  Can set the branch as read-only. Users cannot push to the branch.
 
   For more information, see
   https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-protected-branches/managing-a-branch-protection-rule
 def:
   # Defines the section of the pipeline the rule will appear in.
-  # This will affect the template that is used to render multiple parts
+  # This will affect the template used to render multiple parts
   # of the rule.
   in_entity: repository
   # Defines the schema for parameters that will be passed to the rule

--- a/examples/github/rule-types/branch_protection_require_conversation_resolution.yaml
+++ b/examples/github/rule-types/branch_protection_require_conversation_resolution.yaml
@@ -6,13 +6,13 @@ context:
   provider: github
 description: Whether PR reviews must be resolved before merging
 guidance: |
-  ## When enabled, all conversations on code must be resolved before a pull request can be merged into a branch that matches this rule
+  When enabled, all conversations on code must be resolved before a pull request can be merged into a branch that matches this rule
 
   For more information, see
   https://docs.github.com/github/administering-a-repository/defining-the-mergeability-of-pull-requests/about-protected-branches#require-conversation-resolution-before-merging
 def:
   # Defines the section of the pipeline the rule will appear in.
-  # This will affect the template that is used to render multiple parts
+  # This will affect the template used to render multiple parts
   # of the rule.
   in_entity: repository
   # Defines the schema for parameters that will be passed to the rule

--- a/examples/github/rule-types/branch_protection_require_linear_history.yaml
+++ b/examples/github/rule-types/branch_protection_require_linear_history.yaml
@@ -6,13 +6,13 @@ context:
   provider: github
 description: Whether the branch requires a linear history with no merge commits
 guidance: |
-  ## Prevent merge commits from being pushed to matching branches.
+  Prevent merge commits from being pushed to matching branches.
 
   For more information, see
   https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-protected-branches/managing-a-branch-protection-rule
 def:
   # Defines the section of the pipeline the rule will appear in.
-  # This will affect the template that is used to render multiple parts
+  # This will affect the template used to render multiple parts
   # of the rule.
   in_entity: repository
   # Defines the schema for parameters that will be passed to the rule

--- a/examples/github/rule-types/branch_protection_require_pull_request_approving_review_count.yaml
+++ b/examples/github/rule-types/branch_protection_require_pull_request_approving_review_count.yaml
@@ -6,13 +6,13 @@ context:
   provider: github
 description: Require a certain number of approving reviews before merging
 guidance: |
-  ## Each pull request must have a certain number of approving reviews before it can be merged into a matching branch.
+  Each pull request must have a certain number of approving reviews before it can be merged into a matching branch.
 
   For more information, see
   https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-protected-branches/managing-a-branch-protection-rule
 def:
   # Defines the section of the pipeline the rule will appear in.
-  # This will affect the template that is used to render multiple parts
+  # This will affect the template used to render multiple parts
   # of the rule.
   in_entity: repository
   # Defines the schema for parameters that will be passed to the rule

--- a/examples/github/rule-types/branch_protection_require_pull_request_code_owners_review.yaml
+++ b/examples/github/rule-types/branch_protection_require_pull_request_code_owners_review.yaml
@@ -6,13 +6,13 @@ context:
   provider: github
 description: Verifies that a branch requires review from code owners.
 guidance: |
-  ## Require an approved review in pull requests including files with a designated code owner.
+  Require an approved review in pull requests including files with a designated code owner.
 
   For more information, see
   https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-protected-branches/managing-a-branch-protection-rule
 def:
   # Defines the section of the pipeline the rule will appear in.
-  # This will affect the template that is used to render multiple parts
+  # This will affect the template used to render multiple parts
   # of the rule.
   in_entity: repository
   # Defines the schema for parameters that will be passed to the rule

--- a/examples/github/rule-types/branch_protection_require_pull_request_dismiss_stale_reviews.yaml
+++ b/examples/github/rule-types/branch_protection_require_pull_request_dismiss_stale_reviews.yaml
@@ -6,13 +6,13 @@ context:
   provider: github
 description: Require that new pushes to the branch dismiss old reviews
 guidance: |
-  ## New reviewable commits pushed to a matching branch will dismiss pull request review approvals.
+  New reviewable commits pushed to a matching branch will dismiss pull request review approvals.
 
   For more information, see
   https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-protected-branches/managing-a-branch-protection-rule
 def:
   # Defines the section of the pipeline the rule will appear in.
-  # This will affect the template that is used to render multiple parts
+  # This will affect the template used to render multiple parts
   # of the rule.
   in_entity: repository
   # Defines the schema for parameters that will be passed to the rule

--- a/examples/github/rule-types/branch_protection_require_pull_request_push_approval.yaml
+++ b/examples/github/rule-types/branch_protection_require_pull_request_push_approval.yaml
@@ -6,13 +6,13 @@ context:
   provider: github
 description: Require that the most recent push to a branch be approved by someone other than the person who pushed it.
 guidance: |
-  ## The most recent push to a branch must be approved by someone other than the person who pushed it.
+  The most recent push to a branch must be approved by someone other than the person who pushed it.
 
   For more information, see
   https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-protected-branches/managing-a-branch-protection-rule
 def:
   # Defines the section of the pipeline the rule will appear in.
-  # This will affect the template that is used to render multiple parts
+  # This will affect the template used to render multiple parts
   # of the rule.
   in_entity: repository
   # Defines the schema for parameters that will be passed to the rule

--- a/examples/github/rule-types/branch_protection_require_pull_requests.yaml
+++ b/examples/github/rule-types/branch_protection_require_pull_requests.yaml
@@ -6,13 +6,13 @@ context:
   provider: github
 description: Verifies that a branch requires pull requests
 guidance: |
-  ## Require that a pull request be opened before merging to a branch.
+  Require that a pull request be opened before merging to a branch.
 
   For more information, see
   https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-protected-branches/managing-a-branch-protection-rule
 def:
   # Defines the section of the pipeline the rule will appear in.
-  # This will affect the template that is used to render multiple parts
+  # This will affect the template used to render multiple parts
   # of the rule.
   in_entity: repository
   # Defines the schema for parameters that will be passed to the rule
@@ -71,7 +71,7 @@ def:
     gh_branch_protection:
       # Note that this rule will ever only fail if there are no PR settings at all,
       # so we can safely set the entire PR settings to an empty object. In that case,
-      # GH is actually helpful and selects sane defaults
+      # GH is actually helpful and selects reasonable defaults
       patch: |
         {"required_pull_request_reviews":{}}
   # Defines the configuration for alerting on the rule

--- a/examples/github/rule-types/branch_protection_require_signatures.yaml
+++ b/examples/github/rule-types/branch_protection_require_signatures.yaml
@@ -6,13 +6,13 @@ context:
   provider: github
 description: Whether commits to the branch must be signed
 guidance: |
-  ## Commits pushed to matching branches must have verified signatures.
+  Commits pushed to matching branches must have verified signatures.
 
   For more information, see
   https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-protected-branches/managing-a-branch-protection-rule
 def:
   # Defines the section of the pipeline the rule will appear in.
-  # This will affect the template that is used to render multiple parts
+  # This will affect the template used to render multiple parts
   # of the rule.
   in_entity: repository
   # Defines the schema for parameters that will be passed to the rule

--- a/examples/github/rule-types/codeql_enabled.yaml
+++ b/examples/github/rule-types/codeql_enabled.yaml
@@ -17,7 +17,7 @@ guidance: |
   https://docs.github.com/en/code-security/secure-coding/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#configuring-code-scanning-for-a-private-repository
 def:
   # Defines the section of the pipeline the rule will appear in.
-  # This will affect the template that is used to render multiple parts
+  # This will affect the template used to render multiple parts
   # of the rule.
   in_entity: repository
   # Defines the schema for writing a rule with this rule being checked

--- a/examples/github/rule-types/default_workflow_permissions.yaml
+++ b/examples/github/rule-types/default_workflow_permissions.yaml
@@ -9,7 +9,7 @@ description: |
   when running workflows in a repository, as well as if GitHub Actions
   can submit approving pull request reviews.
 guidance: |
-  Having control over the default workflow permissions for a repositry is important and allows for a better security posture.
+  Having control over the default workflow permissions for a repository is important and allows for a better security posture.
 
   For more information, see
   https://docs.github.com/en/rest/actions/permissions#set-default-workflow-permissions-for-a-repository

--- a/examples/github/rule-types/dependabot_configured.yaml
+++ b/examples/github/rule-types/dependabot_configured.yaml
@@ -14,11 +14,11 @@ guidance: |
   https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
 def:
   # Defines the section of the pipeline the rule will appear in.
-  # This will affect the template that is used to render multiple parts
+  # This will affect the template used to render multiple parts
   # of the rule.
   in_entity: repository
   # Defines the schema for writing a rule with this rule being checked
-  # In this case there is no settings that need to be configured
+  # In this case there are no settings that need to be configured
   rule_schema:
     type: object
     properties:

--- a/examples/github/rule-types/dockerfile_no_latest_tag.yaml
+++ b/examples/github/rule-types/dockerfile_no_latest_tag.yaml
@@ -10,11 +10,11 @@ guidance: |
   It is recommended to use a checksum instead, as that's immutable and will always point to the same image.
 def:
   # Defines the section of the pipeline the rule will appear in.
-  # This will affect the template that is used to render multiple parts
+  # This will affect the template used to render multiple parts
   # of the rule.
   in_entity: repository
   # Defines the schema for writing a rule with this rule being checked
-  # In this case there is no settings that need to be configured
+  # In this case there are no settings that need to be configured
   rule_schema: {}
   # Defines the configuration for ingesting data relevant for the rule
   ingest:
@@ -22,8 +22,8 @@ def:
     git:
       branch: main
   # Defines the configuration for evaluating data ingested against the given profile
-  # This example uses the checks for that github actions are using pinned tags
-  # for the uses directive, in the form of SHA-1 hash
+  # This example uses the checks for that GitHub actions are using pinned tags
+  # for the use directive, in the form of SHA-1 hash.
   # For example, this wil fail:
   # uses: actions/checkout@v2
   # This will pass:

--- a/examples/github/rule-types/github_actions_allowed.yaml
+++ b/examples/github/rule-types/github_actions_allowed.yaml
@@ -19,7 +19,7 @@ guidance: |
   https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/enabling-features-for-your-repository/managing-github-actions-settings-for-a-repository#managing-github-actions-permissions-for-your-repository
 def:
   # Defines the section of the pipeline the rule will appear in.
-  # This will affect the template that is used to render multiple parts
+  # This will affect the template used to render multiple parts
   # of the rule.
   in_entity: repository
   # Defines the schema for writing a rule with this rule being checked

--- a/examples/github/rule-types/pr_package_intelligence_check.yaml
+++ b/examples/github/rule-types/pr_package_intelligence_check.yaml
@@ -4,7 +4,7 @@ type: rule-type
 name: pr_package_intelligence_check
 context:
   provider: github
-description: Verifies that pull requests do not add any dependecies with low package intelligence scores
+description: Verifies that pull requests do not add any dependencies with low package intelligence scores
 guidance: |
   For every pull request submitted to a repository, this rule will check if the pull request
   adds a new dependency with a low package intelligence score. If a dependency with a low

--- a/examples/github/rule-types/pr_vulnerability_check.yaml
+++ b/examples/github/rule-types/pr_vulnerability_check.yaml
@@ -4,7 +4,7 @@ type: rule-type
 name: pr_vulnerability_check
 context:
   provider: github
-description: Verifies that pull requests do not add any vulnerable dependecies
+description: Verifies that pull requests do not add any vulnerable dependencies
 guidance: |
   For every pull request submitted to a repository, this rule will check if the pull request
   adds a new dependency with known vulnerabilities. If it does, the rule will fail and the

--- a/examples/github/rule-types/repo_workflow_access_level.yaml
+++ b/examples/github/rule-types/repo_workflow_access_level.yaml
@@ -10,11 +10,11 @@ description: |
 guidance: |
   Actions and reusable workflows in your private repositories can be shared with other private repositories owned by the same user or organization.
 
-  For information about private repositories, see
+  For more information, see
   https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/enabling-features-for-your-repository/managing-github-actions-settings-for-a-repository#allowing-access-to-components-in-a-private-repository
 def:
   # Defines the section of the pipeline the rule will appear in.
-  # This will affect the template that is used to render multiple parts
+  # This will affect the template used to render multiple parts
   # of the rule.
   in_entity: repository
   # Defines the schema for writing a rule with this rule being checked

--- a/examples/github/rule-types/secret_push_protection.yaml
+++ b/examples/github/rule-types/secret_push_protection.yaml
@@ -4,15 +4,15 @@ type: rule-type
 name: secret_push_protection
 context:
   provider: github
-description: Verfies that secret push protection is enabled for a given repository.
+description: Verifies that secret push protection is enabled for a given repository.
 guidance: |
   You can use secret scanning to prevent supported secrets from being pushed into your repository by enabling secret scanning push protection.
 
-  For more information on how to configure this, see
+  For more information, see
   https://docs.github.com/en/code-security/secret-scanning/push-protection-for-repositories-and-organizations#enabling-secret-scanning-as-a-push-protection-for-a-repository
 def:
   # Defines the section of the pipeline the rule will appear in.
-  # This will affect the template that is used to render multiple parts
+  # This will affect the template used to render multiple parts
   # of the rule.
   in_entity: repository
   # Defines the schema for writing a rule with this rule being checked

--- a/examples/github/rule-types/secret_scanning.yaml
+++ b/examples/github/rule-types/secret_scanning.yaml
@@ -14,7 +14,7 @@ guidance: |
   https://docs.github.com/en/github/administering-a-repository/about-secret-scanning
 def:
   # Defines the section of the pipeline the rule will appear in.
-  # This will affect the template that is used to render multiple parts
+  # This will affect the template used to render multiple parts
   # of the rule.
   in_entity: repository
   # Defines the schema for writing a rule with this rule being checked

--- a/examples/github/rule-types/trivy_action_enabled.yaml
+++ b/examples/github/rule-types/trivy_action_enabled.yaml
@@ -6,14 +6,10 @@ context:
   provider: github
 description: Verifies that the Trivy action is enabled for the repository and scanning
 guidance: |
-  ## Please set up trivy!
-
   Trivy is an open source vulnerability scanner for repositories, containers and other
   artifacts provided by Aqua Security. It is used to scan for vulnerabilities in the
   codebase and dependencies. This rule ensures that the Trivy action is enabled for
   the repository and scanning is performed.
-
-  For more information on the Trivy action, see https://github.com/marketplace/actions/aqua-security-trivy
 
   Set it up by adding the following to your workflow:
 
@@ -25,13 +21,16 @@ guidance: |
       format: json
       exit-code: 1
   ```
+  
+  For more information, see
+  https://github.com/marketplace/actions/aqua-security-trivy
 def:
   # Defines the section of the pipeline the rule will appear in.
-  # This will affect the template that is used to render multiple parts
+  # This will affect the template used to render multiple parts
   # of the rule.
   in_entity: repository
   # Defines the schema for writing a rule with this rule being checked
-  # In this case there is no settings that need to be configured
+  # In this case there are no settings that need to be configured
   rule_schema: {}
   # Defines the configuration for ingesting data relevant for the rule
   ingest:


### PR DESCRIPTION
The following PR:
* Updates part of the rule type guidances which had `##` which messed up the rendering when they were used later in alerts
* Applies the auto-suggestions from the IDE for some grammar things

Fixes https://github.com/stacklok/mediator/issues/1258