### PR TITLE
Skip non-relevant webhook events

### DIFF
--- a/internal/events/eventer.go
+++ b/internal/events/eventer.go
@@ -33,6 +33,14 @@ import (
 	"github.com/rs/zerolog"
 )
 
+// Metadata added to Messages
+const (
+	ProviderDeliveryIdKey     = "id"
+	ProviderTypeKey           = "provider"
+	ProviderSourceKey         = "source"
+	GithubWebhookEventTypeKey = "type"
+)
+
 // Handler is an alias for the watermill handler type, which is both wordy and may be
 // detail we don't want to expose.
 type Handler = message.NoPublishHandlerFunc

--- a/internal/reconcilers/run_profile.go
+++ b/internal/reconcilers/run_profile.go
@@ -30,6 +30,7 @@ import (
 
 	"github.com/stacklok/mediator/internal/db"
 	"github.com/stacklok/mediator/internal/engine"
+	"github.com/stacklok/mediator/internal/events"
 	"github.com/stacklok/mediator/internal/util"
 	pb "github.com/stacklok/mediator/pkg/api/protobuf/go/mediator/v1"
 )
@@ -55,7 +56,7 @@ func NewProfileInitMessage(provider string, projectID uuid.UUID) (*message.Messa
 	}
 
 	msg := message.NewMessage(uuid.New().String(), evtStr)
-	msg.Metadata.Set("provider", provider)
+	msg.Metadata.Set(events.ProviderTypeKey, provider)
 	return msg, nil
 }
 
@@ -64,7 +65,7 @@ func NewProfileInitMessage(provider string, projectID uuid.UUID) (*message.Messa
 // for the group and sending a profile evaluation event for each one.
 func (e *Reconciler) handleProfileInitEvent(msg *message.Message) error {
 	ctx := msg.Context()
-	prov := msg.Metadata.Get("provider")
+	prov := msg.Metadata.Get(events.ProviderTypeKey)
 
 	var evt ProfileInitEvent
 	if err := json.Unmarshal(msg.Payload, &evt); err != nil {


### PR DESCRIPTION
This patch makes mediator more strict when it comes to mapping webhook
events, as not all events should trigger entity evaluation. Previously,
we have been using repo evaluation as sort of a fallback, but in busy
repositories with many PRs and issues, this could cause mediator to just
spin all the time.

Fixes: #1267
