### PR TITLE
Don't retry all handler errors

### DIFF
--- a/internal/events/eventer.go
+++ b/internal/events/eventer.go
@@ -171,9 +171,11 @@ func (e *Eventer) Register(
 				})
 
 				if retriable {
-					return nil
+					// if the error is retriable, return it so that the message is retried
+					return err
 				}
-				return err
+				// otherwise, we've done all we can, so return nil so that the message is acked
+				return nil
 			}
 
 			return nil


### PR DESCRIPTION
Our retry logic seems to have been reversed. We should be only retrying
errors that are marked as retriable by returning an error to the event
handler. Otherwise, let's just log an error and be done with the event.

Fixes: #1259
