### PR TITLE
chore: use interfaces for actions and evaluation params

### DIFF
--- a/cmd/dev/app/rule_type/rule_type.go
+++ b/cmd/dev/app/rule_type/rule_type.go
@@ -169,17 +169,17 @@ func runEvaluationForRules(
 			Rule: frag,
 		}
 		// Perform rule evaluation
-		eng.Eval(context.Background(), inf, evalStatus)
+		evalStatus.SetEvalErr(eng.Eval(context.Background(), inf, evalStatus))
 
 		// Perform the actions, if any
-		eng.Actions(context.Background(), inf, evalStatus)
+		evalStatus.SetActionsErr(context.Background(), eng.Actions(context.Background(), inf, evalStatus))
 
-		if errors.IsActionFatalError(evalStatus.ActionsErr.RemediateErr) {
-			fmt.Printf("Remediation failed with fatal error: %s", evalStatus.ActionsErr.RemediateErr)
+		if errors.IsActionFatalError(evalStatus.GetActionsErr().RemediateErr) {
+			fmt.Printf("Remediation failed with fatal error: %s", evalStatus.GetActionsErr().RemediateErr)
 		}
 
-		if evalStatus.EvalErr != nil {
-			return fmt.Errorf("error evaluating rule type: %w", evalStatus.EvalErr)
+		if evalStatus.GetEvalErr() != nil {
+			return fmt.Errorf("error evaluating rule type: %w", evalStatus.GetEvalErr())
 		}
 
 		fmt.Printf("The rule type is valid and the entity conforms to it\n")

--- a/internal/engine/actions/alert/noop/noop.go
+++ b/internal/engine/actions/alert/noop/noop.go
@@ -59,7 +59,7 @@ func (a *Alert) Do(
 	_ interfaces.ActionCmd,
 	_ interfaces.ActionOpt,
 	_ protoreflect.ProtoMessage,
-	_ *interfaces.EvalStatusParams,
+	_ interfaces.ActionsParams,
 	_ *json.RawMessage,
 ) (json.RawMessage, error) {
 	return nil, fmt.Errorf("%s:%w", a.Class(), enginerr.ErrActionNotAvailable)

--- a/internal/engine/actions/remediate/gh_branch_protect/gh_branch_protect.go
+++ b/internal/engine/actions/remediate/gh_branch_protect/gh_branch_protect.go
@@ -106,13 +106,13 @@ func (r *GhBranchProtectRemediator) Do(
 	_ interfaces.ActionCmd,
 	remAction interfaces.ActionOpt,
 	ent protoreflect.ProtoMessage,
-	evalParams *interfaces.EvalStatusParams,
+	params interfaces.ActionsParams,
 	_ *json.RawMessage,
 ) (json.RawMessage, error) {
 	retp := &PatchTemplateParams{
 		Entity:  ent,
-		Profile: evalParams.Rule.Def.AsMap(),
-		Params:  evalParams.Rule.Params.AsMap(),
+		Profile: params.GetRule().Def.AsMap(),
+		Params:  params.GetRule().Params.AsMap(),
 	}
 
 	repo, ok := ent.(*pb.Repository)
@@ -120,7 +120,7 @@ func (r *GhBranchProtectRemediator) Do(
 		return nil, fmt.Errorf("expected repository, got %T", ent)
 	}
 
-	branch, err := util.JQReadFrom[string](ctx, ".branch", evalParams.Rule.Params.AsMap())
+	branch, err := util.JQReadFrom[string](ctx, ".branch", params.GetRule().Params.AsMap())
 	if err != nil {
 		return nil, fmt.Errorf("error reading branch from params: %w", err)
 	}

--- a/internal/engine/actions/remediate/noop/noop.go
+++ b/internal/engine/actions/remediate/noop/noop.go
@@ -59,7 +59,7 @@ func (r *Remediator) Do(
 	_ interfaces.ActionCmd,
 	_ interfaces.ActionOpt,
 	_ protoreflect.ProtoMessage,
-	_ *interfaces.EvalStatusParams,
+	_ interfaces.ActionsParams,
 	_ *json.RawMessage,
 ) (json.RawMessage, error) {
 	return nil, fmt.Errorf("%s:%w", r.Class(), enginerr.ErrActionNotAvailable)

--- a/internal/engine/actions/remediate/pull_request/pull_request.go
+++ b/internal/engine/actions/remediate/pull_request/pull_request.go
@@ -183,7 +183,7 @@ func (r *Remediator) Do(
 	_ interfaces.ActionCmd,
 	remAction interfaces.ActionOpt,
 	ent protoreflect.ProtoMessage,
-	evalParams *interfaces.EvalStatusParams,
+	params interfaces.ActionsParams,
 	_ *json.RawMessage,
 ) (json.RawMessage, error) {
 	repo, ok := ent.(*pb.Repository)
@@ -193,8 +193,8 @@ func (r *Remediator) Do(
 
 	tmplParams := &PrTemplateParams{
 		Entity:  ent,
-		Profile: evalParams.Rule.Def.AsMap(),
-		Params:  evalParams.Rule.Params.AsMap(),
+		Profile: params.GetRule().Def.AsMap(),
+		Params:  params.GetRule().Params.AsMap(),
 	}
 
 	title := new(bytes.Buffer)
@@ -222,7 +222,7 @@ func (r *Remediator) Do(
 			zerolog.Ctx(ctx).Info().Msg("PR already exists, won't create a new one")
 			return nil, nil
 		}
-		remErr = r.run(ctx, repo, title.String(), prFullBodyText, evalParams.Rule.Params.AsMap())
+		remErr = r.run(ctx, repo, title.String(), prFullBodyText, params.GetRule().Params.AsMap())
 	case interfaces.ActionOptDryRun:
 		dryRun(title.String(), prFullBodyText, r.entries)
 		remErr = nil

--- a/internal/engine/actions/remediate/rest/rest.go
+++ b/internal/engine/actions/remediate/rest/rest.go
@@ -119,13 +119,13 @@ func (r *Remediator) Do(
 	_ interfaces.ActionCmd,
 	setting interfaces.ActionOpt,
 	entity protoreflect.ProtoMessage,
-	evalParams *interfaces.EvalStatusParams,
+	params interfaces.ActionsParams,
 	_ *json.RawMessage,
 ) (json.RawMessage, error) {
 	retp := &EndpointTemplateParams{
 		Entity:  entity,
-		Profile: evalParams.Rule.Def.AsMap(),
-		Params:  evalParams.Rule.Params.AsMap(),
+		Profile: params.GetRule().Def.AsMap(),
+		Params:  params.GetRule().Params.AsMap(),
 	}
 
 	endpoint := new(bytes.Buffer)

--- a/internal/engine/eval_status.go
+++ b/internal/engine/eval_status.go
@@ -48,10 +48,6 @@ func (e *Executor) createEvalStatusParams(
 		ProfileID:  profileID,
 		RepoID:     uuid.MustParse(inf.OwnershipData[RepositoryIDEventKey]),
 		EntityType: entities.EntityTypeToDB(inf.Type),
-		ActionsErr: evalerrors.ActionsError{
-			RemediateErr: evalerrors.ErrActionSkipped,
-			AlertErr:     evalerrors.ErrActionSkipped,
-		},
 	}
 
 	artifactID, ok := inf.OwnershipData[ArtifactIDEventKey]
@@ -113,85 +109,85 @@ func (e *Executor) createEvalStatusParams(
 
 func (e *Executor) createOrUpdateEvalStatus(
 	ctx context.Context,
-	evalParams *engif.EvalStatusParams,
+	params *engif.EvalStatusParams,
 ) error {
 	logger := zerolog.Ctx(ctx)
 	// Make sure evalParams is not nil
-	if evalParams == nil {
+	if params == nil {
 		return fmt.Errorf("createEvalStatusParams cannot be nil")
 	}
 
 	// Check if we should skip silently
-	if errors.Is(evalParams.EvalErr, evalerrors.ErrEvaluationSkipSilently) {
+	if errors.Is(params.GetEvalErr(), evalerrors.ErrEvaluationSkipSilently) {
 		logger.Debug().
-			Str("repo_id", evalParams.RepoID.String()).
-			Str("entity_type", string(evalParams.EntityType)).
-			Str("rule_type_id", evalParams.RuleTypeID.String()).
-			Str("profile_id", evalParams.ProfileID.String()).
+			Str("repo_id", params.RepoID.String()).
+			Str("entity_type", string(params.EntityType)).
+			Str("rule_type_id", params.RuleTypeID.String()).
+			Str("profile_id", params.ProfileID.String()).
 			Msg("rule evaluation skipped silently")
 		return nil
 	}
 
 	// Upsert evaluation
 	id, err := e.querier.UpsertRuleEvaluations(ctx, db.UpsertRuleEvaluationsParams{
-		ProfileID: evalParams.ProfileID,
+		ProfileID: params.ProfileID,
 		RepositoryID: uuid.NullUUID{
-			UUID:  evalParams.RepoID,
+			UUID:  params.RepoID,
 			Valid: true,
 		},
-		ArtifactID: evalParams.ArtifactID,
-		Entity:     evalParams.EntityType,
-		RuleTypeID: evalParams.RuleTypeID,
+		ArtifactID: params.ArtifactID,
+		Entity:     params.EntityType,
+		RuleTypeID: params.RuleTypeID,
 	})
 
 	if err != nil {
 		logger.Err(err).
-			Str("repo_id", evalParams.RepoID.String()).
-			Str("entity_type", string(evalParams.EntityType)).
-			Str("profile_id", evalParams.ProfileID.String()).
+			Str("repo_id", params.RepoID.String()).
+			Str("entity_type", string(params.EntityType)).
+			Str("profile_id", params.ProfileID.String()).
 			Msg("error upserting rule evaluation")
 		return err
 	}
 	// Upsert evaluation details
 	_, err = e.querier.UpsertRuleDetailsEval(ctx, db.UpsertRuleDetailsEvalParams{
 		RuleEvalID: id,
-		Status:     evalerrors.ErrorAsEvalStatus(evalParams.EvalErr),
-		Details:    evalerrors.ErrorAsEvalDetails(evalParams.EvalErr),
+		Status:     evalerrors.ErrorAsEvalStatus(params.GetEvalErr()),
+		Details:    evalerrors.ErrorAsEvalDetails(params.GetEvalErr()),
 	})
 
 	if err != nil {
 		logger.Err(err).
-			Str("repo_id", evalParams.RepoID.String()).
-			Str("entity_type", string(evalParams.EntityType)).
-			Str("profile_id", evalParams.ProfileID.String()).
+			Str("repo_id", params.RepoID.String()).
+			Str("entity_type", string(params.EntityType)).
+			Str("profile_id", params.ProfileID.String()).
 			Msg("error upserting rule evaluation details")
 		return err
 	}
 	// Upsert remediation details
 	_, err = e.querier.UpsertRuleDetailsRemediate(ctx, db.UpsertRuleDetailsRemediateParams{
 		RuleEvalID: id,
-		Status:     evalerrors.ErrorAsRemediationStatus(evalParams.ActionsErr.RemediateErr),
-		Details:    errorAsActionDetails(evalParams.ActionsErr.RemediateErr),
+		Status:     evalerrors.ErrorAsRemediationStatus(params.GetActionsErr().RemediateErr),
+		Details:    errorAsActionDetails(params.GetActionsErr().RemediateErr),
 	})
 	if err != nil {
 		logger.Err(err).
-			Str("repo_id", evalParams.RepoID.String()).
-			Str("entity_type", string(evalParams.EntityType)).
-			Str("profile_id", evalParams.ProfileID.String()).
+			Str("repo_id", params.RepoID.String()).
+			Str("entity_type", string(params.EntityType)).
+			Str("profile_id", params.ProfileID.String()).
 			Msg("error upserting rule remediation details")
 	}
 	// Upsert alert details
 	_, err = e.querier.UpsertRuleDetailsAlert(ctx, db.UpsertRuleDetailsAlertParams{
 		RuleEvalID: id,
-		Status:     evalerrors.ErrorAsAlertStatus(evalParams.ActionsErr.AlertErr),
-		Details:    errorAsActionDetails(evalParams.ActionsErr.AlertErr),
-		Metadata:   evalParams.ActionsErr.AlertMeta,
+		Status:     evalerrors.ErrorAsAlertStatus(params.GetActionsErr().AlertErr),
+		Details:    errorAsActionDetails(params.GetActionsErr().AlertErr),
+		Metadata:   params.GetActionsErr().AlertMeta,
 	})
 	if err != nil {
 		logger.Err(err).
-			Str("repo_id", evalParams.RepoID.String()).
-			Str("entity_type", string(evalParams.EntityType)).
-			Str("profile_id", evalParams.ProfileID.String()).
+			Str("repo_id", params.RepoID.String()).
+			Str("entity_type", string(params.EntityType)).
+			Str("profile_id", params.ProfileID.String()).
 			Msg("error upserting rule alert details")
 	}
 	return err

--- a/internal/engine/executor.go
+++ b/internal/engine/executor.go
@@ -142,10 +142,10 @@ func (e *Executor) evalEntityEvent(
 			}
 
 			// Evaluate the rule
-			rte.Eval(ctx, inf, evalParams)
+			evalParams.SetEvalErr(rte.Eval(ctx, inf, evalParams))
 
 			// Perform actions, if any
-			rte.Actions(ctx, inf, evalParams)
+			evalParams.SetActionsErr(ctx, rte.Actions(ctx, inf, evalParams))
 
 			// Log the evaluation
 			logEval(ctx, inf, evalParams)
@@ -227,25 +227,25 @@ func (e *Executor) getEvaluator(
 func logEval(
 	ctx context.Context,
 	inf *EntityInfoWrapper,
-	evalParams *engif.EvalStatusParams) {
+	params *engif.EvalStatusParams) {
 	logger := zerolog.Ctx(ctx).Debug().
-		Str("profile", evalParams.Profile.Name).
-		Str("ruleType", evalParams.Rule.Type).
+		Str("profile", params.Profile.Name).
+		Str("ruleType", params.Rule.Type).
 		Str("projectId", inf.ProjectID.String()).
-		Str("repositoryId", evalParams.RepoID.String())
+		Str("repositoryId", params.RepoID.String())
 
-	if evalParams.ArtifactID.Valid {
-		logger = logger.Str("artifactId", evalParams.ArtifactID.UUID.String())
+	if params.ArtifactID.Valid {
+		logger = logger.Str("artifactId", params.ArtifactID.UUID.String())
 	}
 
 	// log evaluation
-	logger.Err(evalParams.EvalErr).Msg("evaluated rule")
+	logger.Err(params.GetEvalErr()).Msg("evaluated rule")
 
 	// log remediation
-	logAction(ctx, "remediate", evalParams.ActionsErr.RemediateErr)
+	logAction(ctx, "remediate", params.GetActionsErr().RemediateErr)
 
 	// log alert
-	logAction(ctx, "alert", evalParams.ActionsErr.AlertErr)
+	logAction(ctx, "alert", params.GetActionsErr().AlertErr)
 }
 
 func logAction(ctx context.Context, actionType string, err error) {


### PR DESCRIPTION
The following PR updates the evaluator and the actions engine to use dedicated interfaces for using the eval params.

Fixes https://github.com/stacklok/mediator/issues/1274