### PR TITLE
chore: prefix viper env vars with mediator

### DIFF
--- a/deployment/helm/templates/deployment.yaml
+++ b/deployment/helm/templates/deployment.yaml
@@ -59,17 +59,17 @@ spec:
           - "--github-client-id-file=/secrets/app/client_id"
           - "--github-client-secret-file=/secrets/app/client_secret"
           env:
-          - name: "AUTH_ACCESS_TOKEN_PRIVATE_KEY"
+          - name: "MEDIATOR_AUTH_ACCESS_TOKEN_PRIVATE_KEY"
             value: "/secrets/auth/access_token_rsa"
-          - name: "AUTH_ACCESS_TOKEN_PUBLIC_KEY"
+          - name: "MEDIATOR_AUTH_ACCESS_TOKEN_PUBLIC_KEY"
             value: "/secrets/auth/access_token_rsa.pub"
-          - name: "AUTH_REFRESH_TOKEN_PRIVATE_KEY"
+          - name: "MEDIATOR_AUTH_REFRESH_TOKEN_PRIVATE_KEY"
             value: "/secrets/auth/refresh_token_rsa"
-          - name: "AUTH_REFRESH_TOKEN_PUBLIC_KEY"
+          - name: "MEDIATOR_AUTH_REFRESH_TOKEN_PUBLIC_KEY"
             value: "/secrets/auth/refresh_token_rsa.pub"
-          - name: "AUTH_TOKEN_KEY"
+          - name: "MEDIATOR_AUTH_TOKEN_KEY"
             value: "/secrets/auth/token_key_passphrase"
-          - name: "IDENTITY_SERVER_CLIENT_SECRET_FILE"
+          - name: "MEDIATOR_IDENTITY_SERVER_CLIENT_SECRET_FILE"
             value: "/secrets/identity/identity_client_secret"
           
           # ko will always specify a digest, so we don't need to worry about

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -49,11 +49,11 @@ services:
       # Use viper environment variables to set specific paths to keys;
       # these values are relative paths in config.yaml, but it's not clear
       # what they are relative _to_...
-      - AUTH_ACCESS_TOKEN_PRIVATE_KEY=/app/.ssh/access_token_rsa
-      - AUTH_ACCESS_TOKEN_PUBLIC_KEY=/app/.ssh/access_token_rsa.pub
-      - AUTH_REFRESH_TOKEN_PRIVATE_KEY=/app/.ssh/refresh_token_rsa
-      - AUTH_REFRESH_TOKEN_PUBLIC_KEY=/app/.ssh/refresh_token_rsa.pub
-      - AUTH_TOKEN_KEY=/app/.ssh/token_key_passphrase
+      - MEDIATOR_AUTH_ACCESS_TOKEN_PRIVATE_KEY=/app/.ssh/access_token_rsa
+      - MEDIATOR_AUTH_ACCESS_TOKEN_PUBLIC_KEY=/app/.ssh/access_token_rsa.pub
+      - MEDIATOR_AUTH_REFRESH_TOKEN_PRIVATE_KEY=/app/.ssh/refresh_token_rsa
+      - MEDIATOR_AUTH_REFRESH_TOKEN_PUBLIC_KEY=/app/.ssh/refresh_token_rsa.pub
+      - MEDIATOR_AUTH_TOKEN_KEY=/app/.ssh/token_key_passphrase
     networks:
       - app_net
     depends_on:

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -67,6 +67,7 @@ func ReadConfigFromViper(v *viper.Viper) (*Config, error) {
 // SetViperDefaults sets the default values for the configuration to be picked
 // up by viper
 func SetViperDefaults(v *viper.Viper) {
+	viper.SetEnvPrefix("mediator")
 	viper.SetEnvKeyReplacer(strings.NewReplacer(".", "_"))
 	setViperStructDefaults(v, "", Config{})
 }


### PR DESCRIPTION
The following PR updates the default viper config to search for "MEDIATOR_" prefixed environment variables. 

It also updates the relevant env var names in the helm chart and the docker compose yaml.

Fixes https://github.com/stacklok/mediator/issues/1158