### PR TITLE
chore: ensure evalStatusParams implement eval and action interfaces

### DIFF
--- a/internal/engine/interfaces/interface.go
+++ b/internal/engine/interfaces/interface.go
@@ -133,6 +133,10 @@ type EvalStatusParams struct {
 	actionsErr       evalerrors.ActionsError
 }
 
+// Ensure EvalStatusParams implements the necessary interfaces
+var _ ActionsParams = (*EvalStatusParams)(nil)
+var _ EvalParams = (*EvalStatusParams)(nil)
+
 // GetEvalErr returns the evaluation error
 func (e *EvalStatusParams) GetEvalErr() error {
 	return e.evalErr


### PR DESCRIPTION
As per the comment from @jhrozek, ensure EvalStatusParams implements the necessary interfaces