### PR TITLE
ci: Detect `IF NOT EXISTS` in migration scripts

### DIFF
--- a/.github/workflows/compose-migrate.yml
+++ b/.github/workflows/compose-migrate.yml
@@ -38,7 +38,7 @@ jobs:
       run: |
         set -e
 
-        tables=$(grep -Ri 'CREATE TABLE' database/migrations | sed 's/.*CREATE TABLE \(.*\) (/\1/i')
+        tables=$(grep -Ri 'CREATE TABLE' database/migrations | sed -E 's/.*CREATE TABLE (IF NOT EXISTS )?(.*) \(/\2/i')
         for table in $tables; do
           docker exec $(docker ps -a | grep postgres | awk '{print $1}') psql -U postgres -d mediator -c "SELECT * FROM $table"
         done 


### PR DESCRIPTION
In order to make sure we actually create the tables we specified in our migration script,
we have a CI test that matches the `CREATE` statements with the tables actually found in the
database.

The script didn't work with the `IF NOT EXISTS` statement. This fixes that.
