### PR TITLE
cleanup: Make mediator wait for keycloak's health in compose file

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -59,6 +59,8 @@ services:
     depends_on:
       postgres:
         condition: service_healthy
+      keycloak:
+        condition: service_healthy
 #      migrate:
 #        condition: service_completed_successfully
   migrate:


### PR DESCRIPTION
This allows us developers to have keycloak ready to run when trying to run
commands against mediator. e.g. I've encountered many times where I try to
set up github login but keycloak is still spawning up.
