### PR TITLE
Reconcile the PiReply struct with recent changes to Pi

### DIFF
--- a/internal/engine/eval/package_intelligence/actions.go
+++ b/internal/engine/eval/package_intelligence/actions.go
@@ -125,8 +125,8 @@ func (sph *summaryPrHandler) generateSummary() (string, error) {
 		var rowBuf bytes.Buffer
 
 		nonZeroAlternatives := make([]PiAlternative, 0)
-		for _, alt := range sph.trackedAlternatives[i].piReply.Alternatives {
-			if alt.Summary.Score != 0 {
+		for _, alt := range sph.trackedAlternatives[i].piReply.Alternatives.Packages {
+			if alt.Summary.Score > sph.trackedAlternatives[i].piReply.Summary.Score {
 				nonZeroAlternatives = append(nonZeroAlternatives, alt)
 			}
 		}

--- a/internal/engine/eval/package_intelligence/pi_rest_handler.go
+++ b/internal/engine/eval/package_intelligence/pi_rest_handler.go
@@ -67,7 +67,10 @@ type PiReply struct {
 	Summary     struct {
 		Score float64 `json:"score"`
 	} `json:"summary"`
-	Alternatives []PiAlternative `json:"alternatives"`
+	Alternatives struct {
+		Status   string          `json:"status"`
+		Packages []PiAlternative `json:"packages"`
+	} `json:"alternatives"`
 }
 
 func newPiClient(baseUrl string) *piClient {


### PR DESCRIPTION
The Pi Evaluator stopped working because Pi changed its response
structure.

This patch reconciles the Pi changes with the struct we use to parse the
reply.
