### PR TITLE
Pi evaluator: don't report low scores

### DIFF
--- a/internal/engine/eval/package_intelligence/actions.go
+++ b/internal/engine/eval/package_intelligence/actions.go
@@ -125,8 +125,8 @@ func (sph *summaryPrHandler) generateSummary() (string, error) {
 		var rowBuf bytes.Buffer
 
 		nonZeroAlternatives := make([]PiAlternative, 0)
-		for _, alt := range sph.trackedAlternatives[i].piReply.Alternatives {
-			if alt.Summary.Score != 0 {
+		for _, alt := range sph.trackedAlternatives[i].piReply.Alternatives.Packages {
+			if alt.Summary.Score > sph.trackedAlternatives[i].piReply.Summary.Score {
 				nonZeroAlternatives = append(nonZeroAlternatives, alt)
 			}
 		}


### PR DESCRIPTION
We used to report scores that were above zero (scored at all or not
malware), but it doesn't make sense to report packages that have lower
score than the one already used.
