### PR TITLE
Allow registering private repos specified in github.allowed_private_repos

### DIFF
--- a/internal/controlplane/handlers_repositories.go
+++ b/internal/controlplane/handlers_repositories.go
@@ -91,7 +91,7 @@ func (s *Server) RegisterRepository(ctx context.Context,
 
 	allEvents := []string{"*"}
 	resultData, err := s.registerWebhookForRepository(
-		ctx, p, upstreamRepos, allEvents)
+		ctx, p, projectID, upstreamRepos, allEvents)
 	if err != nil {
 		return nil, err
 	}
@@ -400,7 +400,7 @@ func (s *Server) ListRemoteRepositoriesFromProvider(
 
 	for idx, rem := range remoteRepos {
 		// Skip private repositories
-		if rem.IsPrivate {
+		if rem.IsPrivate && !projectAllowsPrivateRepos(ctx, s.store, projectID) {
 			continue
 		}
 		remoteRepo := remoteRepos[idx]


### PR DESCRIPTION
This is not somethign we'll advertise much and might even remove in
favor of handling private repos in general, but this addition would help
us enroll mediator with mediator soon.
