### PR TITLE
fix: Make event persistence configurable and set to false

### DIFF
--- a/internal/config/events.go
+++ b/internal/config/events.go
@@ -30,4 +30,6 @@ type EventConfig struct {
 type GoChannelEventConfig struct {
 	// BufferSize is the size of the buffer for the go channel
 	BufferSize int64 `mapstructure:"buffer_size" default:"0"`
+	// PersistEvents is whether or not to persist events to the channel
+	PersistEvents bool `mapstructure:"persist_events" default:"false"`
 }

--- a/internal/events/eventer.go
+++ b/internal/events/eventer.go
@@ -142,7 +142,7 @@ func instantiateDriver(driver string, cfg *config.EventConfig) (message.Publishe
 func buildGoChannelDriver(cfg *config.EventConfig) (message.Publisher, message.Subscriber, error) {
 	pubsub := gochannel.NewGoChannel(gochannel.Config{
 		OutputChannelBuffer: cfg.GoChannel.BufferSize,
-		Persistent:          true,
+		Persistent:          cfg.GoChannel.PersistEvents,
 	}, nil)
 
 	return pubsub, pubsub, nil


### PR DESCRIPTION
We're not actually using message persistence, which is wasteful for memory.

So we remove it to ensure we're not overcommitting in terms of memory usage.
