### PR TITLE
Add watermill event histogram

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -74,6 +74,7 @@ require (
 	github.com/containerd/console v1.0.4-0.20230313162750-1ae8d489ac81 // indirect
 	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.2.0 // indirect
 	github.com/felixge/httpsnoop v1.0.3 // indirect
+	github.com/go-chi/chi/v5 v5.0.8 // indirect
 	github.com/gorilla/schema v1.2.0 // indirect
 	github.com/lestrrat-go/blackmagic v1.0.2 // indirect
 	github.com/lestrrat-go/httpcc v1.0.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -408,6 +408,8 @@ github.com/gliderlabs/ssh v0.3.5/go.mod h1:8XB4KraRrX39qHhT6yxPsHedjA08I/uBVwj4x
 github.com/go-chi/chi v4.0.2+incompatible/go.mod h1:eB3wogJHnLi3x/kFX2A+IbTBlXxmMeXJVKy9tTv1XzQ=
 github.com/go-chi/chi v4.1.2+incompatible h1:fGFk2Gmi/YKXk0OmGfBh0WgmN3XB8lVnEyNz34tQRec=
 github.com/go-chi/chi v4.1.2+incompatible/go.mod h1:eB3wogJHnLi3x/kFX2A+IbTBlXxmMeXJVKy9tTv1XzQ=
+github.com/go-chi/chi/v5 v5.0.8 h1:lD+NLqFcAi1ovnVZpsnObHGW4xb4J8lNmoYVfECH1Y0=
+github.com/go-chi/chi/v5 v5.0.8/go.mod h1:DslCQbL2OYiznFReuXYUmQ2hGd1aDpCnlMNITLSKoi8=
 github.com/go-git/gcfg v1.5.1-0.20230307220236-3a3c6141e376 h1:+zs/tPmkDkHx3U66DAb0lQFJrpS6731Oaa12ikc+DiI=
 github.com/go-git/gcfg v1.5.1-0.20230307220236-3a3c6141e376/go.mod h1:an3vInlBmSxCcxctByoQdvwPiA7DTK7jaaFDBTtu0ic=
 github.com/go-git/go-billy/v5 v5.5.0 h1:yEY4yhzCDuMGSv83oGxiBotRzhwhNr8VZyphhiu+mTU=


### PR DESCRIPTION
We're able to get a histogram of how long does it take for the
individual watermill events to execute:
```
elapsed while executing the handler function in seconds
mediator_eventer_handler_execution_time_seconds_bucket{handler_name="github.com/stacklok/mediator/internal/engine.(*Executor).HandleEntityEvent-fm-internal.entity.event",success="true",le="0.0005"}
0
mediator_eventer_handler_execution_time_seconds_bucket{handler_name="github.com/stacklok/mediator/internal/engine.(*Executor).HandleEntityEvent-fm-internal.entity.event",success="true",le="0.001"}
0
mediator_eventer_handler_execution_time_seconds_bucket{handler_name="github.com/stacklok/mediator/internal/engine.(*Executor).HandleEntityEvent-fm-internal.entity.event",success="true",le="0.0025"}
0
mediator_eventer_handler_execution_time_seconds_bucket{handler_name="github.com/stacklok/mediator/internal/engine.(*Executor).HandleEntityEvent-fm-internal.entity.event",success="true",le="0.005"}
0
mediator_eventer_handler_execution_time_seconds_bucket{handler_name="github.com/stacklok/mediator/internal/engine.(*Executor).HandleEntityEvent-fm-internal.entity.event",success="true",le="0.01"}
0
mediator_eventer_handler_execution_time_seconds_bucket{handler_name="github.com/stacklok/mediator/internal/engine.(*Executor).HandleEntityEvent-fm-internal.entity.event",success="true",le="0.025"}
0
mediator_eventer_handler_execution_time_seconds_bucket{handler_name="github.com/stacklok/mediator/internal/engine.(*Executor).HandleEntityEvent-fm-internal.entity.event",success="true",le="0.05"}
0
mediator_eventer_handler_execution_time_seconds_bucket{handler_name="github.com/stacklok/mediator/internal/engine.(*Executor).HandleEntityEvent-fm-internal.entity.event",success="true",le="0.1"}
2
mediator_eventer_handler_execution_time_seconds_bucket{handler_name="github.com/stacklok/mediator/internal/engine.(*Executor).HandleEntityEvent-fm-internal.entity.event",success="true",le="0.25"}
2
mediator_eventer_handler_execution_time_seconds_bucket{handler_name="github.com/stacklok/mediator/internal/engine.(*Executor).HandleEntityEvent-fm-internal.entity.event",success="true",le="0.5"}
2
mediator_eventer_handler_execution_time_seconds_bucket{handler_name="github.com/stacklok/mediator/internal/engine.(*Executor).HandleEntityEvent-fm-internal.entity.event",success="true",le="1"}
2
mediator_eventer_handler_execution_time_seconds_bucket{handler_name="github.com/stacklok/mediator/internal/engine.(*Executor).HandleEntityEvent-fm-internal.entity.event",success="true",le="+Inf"}
2
mediator_eventer_handler_execution_time_seconds_sum{handler_name="github.com/stacklok/mediator/internal/engine.(*Executor).HandleEntityEvent-fm-internal.entity.event",success="true"}
0.125726416
mediator_eventer_handler_execution_time_seconds_count{handler_name="github.com/stacklok/mediator/internal/engine.(*Executor).HandleEntityEvent-fm-internal.entity.event",success="true"}
2
```
