### PR TITLE
Remove Go ecosystem config from the Pi rule-type

### DIFF
--- a/examples/github/rule-types/pr_package_intelligence_check.yaml
+++ b/examples/github/rule-types/pr_package_intelligence_check.yaml
@@ -42,8 +42,6 @@ def:
       ecosystems:
         - name: npm
           depfile: package-lock.json
-        - name: go
-          depfile: go.sum
         - name: pypi
           depfile: requirements.txt
   # Defines the configuration for evaluating data ingested against the given profile


### PR DESCRIPTION
Pi only supports NPM and PyPi (and Rust which we don't support on the
Minder side..yet..), so let's not send the Go ecosystem diffs to the
evaluator, where they would be silently skipped.
