### PR TITLE
cli: Remove `mediatorv1` from rule type commands

### DIFF
--- a/cmd/cli/app/rule_type/rule_type_create.go
+++ b/cmd/cli/app/rule_type/rule_type_create.go
@@ -24,7 +24,7 @@ import (
 	"golang.org/x/exp/slices"
 
 	"github.com/stacklok/mediator/internal/util"
-	mediatorv1 "github.com/stacklok/mediator/pkg/api/protobuf/go/minder/v1"
+	minderv1 "github.com/stacklok/mediator/pkg/api/protobuf/go/minder/v1"
 )
 
 // RuleType_createCmd represents the profile create command
@@ -54,7 +54,7 @@ within a minder control plane.`,
 		}
 		defer conn.Close()
 
-		client := mediatorv1.NewProfileServiceClient(conn)
+		client := minderv1.NewProfileServiceClient(conn)
 		ctx, cancel := util.GetAppContext()
 		defer cancel()
 
@@ -72,13 +72,13 @@ within a minder control plane.`,
 			}
 			defer closer()
 
-			r, err := mediatorv1.ParseRuleType(preader)
+			r, err := minderv1.ParseRuleType(preader)
 			if err != nil {
 				return fmt.Errorf("error parsing rule type: %w", err)
 			}
 
 			// create a rule
-			resp, err := client.CreateRuleType(ctx, &mediatorv1.CreateRuleTypeRequest{
+			resp, err := client.CreateRuleType(ctx, &minderv1.CreateRuleTypeRequest{
 				RuleType: r,
 			})
 			if err != nil {

--- a/cmd/cli/app/rule_type/rule_type_delete.go
+++ b/cmd/cli/app/rule_type/rule_type_delete.go
@@ -23,7 +23,7 @@ import (
 	"github.com/spf13/viper"
 
 	"github.com/stacklok/mediator/internal/util"
-	pb "github.com/stacklok/mediator/pkg/api/protobuf/go/minder/v1"
+	minderv1 "github.com/stacklok/mediator/pkg/api/protobuf/go/minder/v1"
 )
 
 var ruleType_deleteCmd = &cobra.Command{
@@ -45,12 +45,12 @@ minder control plane.`,
 		util.ExitNicelyOnError(err, "Error getting grpc connection")
 		defer conn.Close()
 
-		client := pb.NewProfileServiceClient(conn)
+		client := minderv1.NewProfileServiceClient(conn)
 		ctx, cancel := util.GetAppContext()
 		defer cancel()
 
-		_, err = client.DeleteRuleType(ctx, &pb.DeleteRuleTypeRequest{
-			Context: &pb.Context{},
+		_, err = client.DeleteRuleType(ctx, &minderv1.DeleteRuleTypeRequest{
+			Context: &minderv1.Context{},
 			Id:      id,
 		})
 

--- a/cmd/cli/app/rule_type/rule_type_get.go
+++ b/cmd/cli/app/rule_type/rule_type_get.go
@@ -24,7 +24,7 @@ import (
 
 	"github.com/stacklok/mediator/cmd/cli/app"
 	"github.com/stacklok/mediator/internal/util"
-	pb "github.com/stacklok/mediator/pkg/api/protobuf/go/minder/v1"
+	minderv1 "github.com/stacklok/mediator/pkg/api/protobuf/go/minder/v1"
 )
 
 var ruleType_getCmd = &cobra.Command{
@@ -53,14 +53,14 @@ minder control plane.`,
 		util.ExitNicelyOnError(err, "Error getting grpc connection")
 		defer conn.Close()
 
-		client := pb.NewProfileServiceClient(conn)
+		client := minderv1.NewProfileServiceClient(conn)
 		ctx, cancel := util.GetAppContext()
 		defer cancel()
 
 		id := viper.GetString("id")
 
-		rtype, err := client.GetRuleTypeById(ctx, &pb.GetRuleTypeByIdRequest{
-			Context: &pb.Context{
+		rtype, err := client.GetRuleTypeById(ctx, &minderv1.GetRuleTypeByIdRequest{
+			Context: &minderv1.Context{
 				Provider: provider,
 				// TODO set up project if specified
 				// Currently it's inferred from the authorization token
@@ -101,7 +101,7 @@ func init() {
 
 }
 
-func handleGetTableOutput(cmd *cobra.Command, rtype *pb.RuleType) {
+func handleGetTableOutput(cmd *cobra.Command, rtype *minderv1.RuleType) {
 	table := initializeTable(cmd)
 
 	renderRuleTypeTable(rtype, table)

--- a/cmd/cli/app/rule_type/rule_type_list.go
+++ b/cmd/cli/app/rule_type/rule_type_list.go
@@ -24,7 +24,7 @@ import (
 
 	"github.com/stacklok/mediator/cmd/cli/app"
 	"github.com/stacklok/mediator/internal/util"
-	pb "github.com/stacklok/mediator/pkg/api/protobuf/go/minder/v1"
+	minderv1 "github.com/stacklok/mediator/pkg/api/protobuf/go/minder/v1"
 )
 
 var ruleType_listCmd = &cobra.Command{
@@ -46,7 +46,7 @@ minder control plane for an specific project.`,
 		}
 		defer conn.Close()
 
-		client := pb.NewProfileServiceClient(conn)
+		client := minderv1.NewProfileServiceClient(conn)
 		ctx, cancel := util.GetAppContext()
 		defer cancel()
 
@@ -60,8 +60,8 @@ minder control plane for an specific project.`,
 			fmt.Fprintf(os.Stderr, "Error: invalid format: %s\n", format)
 		}
 
-		resp, err := client.ListRuleTypes(ctx, &pb.ListRuleTypesRequest{
-			Context: &pb.Context{
+		resp, err := client.ListRuleTypes(ctx, &minderv1.ListRuleTypesRequest{
+			Context: &minderv1.Context{
 				Provider: provider,
 				// TODO set up project if specified
 				// Currently it's inferred from the authorization token
@@ -102,7 +102,7 @@ func init() {
 	}
 }
 
-func handleListTableOutput(cmd *cobra.Command, resp *pb.ListRuleTypesResponse) {
+func handleListTableOutput(cmd *cobra.Command, resp *minderv1.ListRuleTypesResponse) {
 	table := initializeTable(cmd)
 
 	for _, v := range resp.RuleTypes {

--- a/cmd/cli/app/rule_type/table_render.go
+++ b/cmd/cli/app/rule_type/table_render.go
@@ -19,7 +19,7 @@ import (
 	"github.com/olekukonko/tablewriter"
 	"github.com/spf13/cobra"
 
-	pb "github.com/stacklok/mediator/pkg/api/protobuf/go/minder/v1"
+	minderv1 "github.com/stacklok/mediator/pkg/api/protobuf/go/minder/v1"
 )
 
 func initializeTable(cmd *cobra.Command) *tablewriter.Table {
@@ -35,7 +35,7 @@ func initializeTable(cmd *cobra.Command) *tablewriter.Table {
 }
 
 func renderRuleTypeTable(
-	rt *pb.RuleType,
+	rt *minderv1.RuleType,
 	table *tablewriter.Table,
 ) {
 	row := []string{


### PR DESCRIPTION
This moves it to `minderv1` and moves the usages of `pb` to use `minderv1` as well.
