### PR TITLE
fix: helpers: use viper instance instead of global

### DIFF
--- a/cmd/cli/app/apply/apply.go
+++ b/cmd/cli/app/apply/apply.go
@@ -72,7 +72,7 @@ var ApplyCmd = &cobra.Command{
 		util.ExitNicelyOnError(err, "Error binding flags")
 	},
 	Run: func(cmd *cobra.Command, args []string) {
-		f := util.GetConfigValue("file", "file", cmd, "").(string)
+		f := util.GetConfigValue(viper.GetViper(), "file", "file", cmd, "").(string)
 
 		var data []byte
 		var err error

--- a/cmd/cli/app/artifact/artifact_get.go
+++ b/cmd/cli/app/artifact/artifact_get.go
@@ -36,7 +36,7 @@ var artifact_getCmd = &cobra.Command{
 		}
 	},
 	RunE: func(cmd *cobra.Command, args []string) error {
-		tag := util.GetConfigValue("tag", "tag", cmd, "").(string)
+		tag := util.GetConfigValue(viper.GetViper(), "tag", "tag", cmd, "").(string)
 		artifactID := viper.GetString("id")
 		latest_versions := viper.GetInt32("latest-versions")
 
@@ -46,7 +46,7 @@ var artifact_getCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
-		conn, err := util.GrpcForCommand(cmd)
+		conn, err := util.GrpcForCommand(cmd, viper.GetViper())
 		util.ExitNicelyOnError(err, "Error getting grpc connection")
 		defer conn.Close()
 

--- a/cmd/cli/app/artifact/artifact_list.go
+++ b/cmd/cli/app/artifact/artifact_list.go
@@ -41,7 +41,7 @@ var artifact_listCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		format := viper.GetString("output")
 
-		provider := util.GetConfigValue("provider", "provider", cmd, "").(string)
+		provider := util.GetConfigValue(viper.GetViper(), "provider", "provider", cmd, "").(string)
 		if provider != auth.Github {
 			return fmt.Errorf("only %s is supported at this time", auth.Github)
 		}
@@ -56,7 +56,7 @@ var artifact_listCmd = &cobra.Command{
 			return fmt.Errorf("invalid output format: %s", format)
 		}
 
-		conn, err := util.GrpcForCommand(cmd)
+		conn, err := util.GrpcForCommand(cmd, viper.GetViper())
 		util.ExitNicelyOnError(err, "Error getting grpc connection")
 		defer conn.Close()
 

--- a/cmd/cli/app/auth/auth_delete.go
+++ b/cmd/cli/app/auth/auth_delete.go
@@ -54,7 +54,7 @@ var auth_deleteCmd = &cobra.Command{
 		ctx, cancel := util.GetAppContext()
 		defer cancel()
 
-		conn, err := util.GrpcForCommand(cmd)
+		conn, err := util.GrpcForCommand(cmd, viper.GetViper())
 		util.ExitNicelyOnError(err, "Error getting grpc connection")
 		defer conn.Close()
 		client := pb.NewUserServiceClient(conn)

--- a/cmd/cli/app/auth/auth_login.go
+++ b/cmd/cli/app/auth/auth_login.go
@@ -74,10 +74,10 @@ will be saved to $XDG_CONFIG_HOME/minder/credentials.json`,
 	Run: func(cmd *cobra.Command, args []string) {
 		ctx := context.Background()
 
-		issuerUrlStr := util.GetConfigValue("identity.cli.issuer_url", "identity-url", cmd,
+		issuerUrlStr := util.GetConfigValue(viper.GetViper(), "identity.cli.issuer_url", "identity-url", cmd,
 			"https://auth.staging.stacklok.dev").(string)
-		realm := util.GetConfigValue("identity.cli.realm", "identity-realm", cmd, "stacklok").(string)
-		clientID := util.GetConfigValue("identity.cli.client_id", "identity-client", cmd, "mediator-cli").(string)
+		realm := util.GetConfigValue(viper.GetViper(), "identity.cli.realm", "identity-realm", cmd, "stacklok").(string)
+		clientID := util.GetConfigValue(viper.GetViper(), "identity.cli.client_id", "identity-client", cmd, "mediator-cli").(string)
 
 		parsedURL, err := url.Parse(issuerUrlStr)
 		util.ExitNicelyOnError(err, "Error parsing issuer URL")
@@ -161,7 +161,7 @@ will be saved to $XDG_CONFIG_HOME/minder/credentials.json`,
 			fmt.Println(err)
 		}
 
-		conn, err := util.GrpcForCommand(cmd)
+		conn, err := util.GrpcForCommand(cmd, viper.GetViper())
 		util.ExitNicelyOnError(err, "Error getting grpc connection")
 		defer conn.Close()
 		client := pb.NewUserServiceClient(conn)

--- a/cmd/cli/app/auth/auth_logout.go
+++ b/cmd/cli/app/auth/auth_logout.go
@@ -47,9 +47,9 @@ var auth_logoutCmd = &cobra.Command{
 		err := util.RemoveCredentials()
 		util.ExitNicelyOnError(err, "Error removing credentials")
 
-		issuerUrlStr := util.GetConfigValue("identity.cli.issuer_url", "identity-url", cmd,
+		issuerUrlStr := util.GetConfigValue(viper.GetViper(), "identity.cli.issuer_url", "identity-url", cmd,
 			"https://auth.staging.stacklok.dev").(string)
-		realm := util.GetConfigValue("identity.cli.realm", "identity-realm", cmd, "stacklok").(string)
+		realm := util.GetConfigValue(viper.GetViper(), "identity.cli.realm", "identity-realm", cmd, "stacklok").(string)
 
 		parsedURL, err := url.Parse(issuerUrlStr)
 		util.ExitNicelyOnError(err, "Error parsing issuer URL")

--- a/cmd/cli/app/auth/auth_revoke_provider.go
+++ b/cmd/cli/app/auth/auth_revoke_provider.go
@@ -44,16 +44,16 @@ var Auth_revokeproviderCmd = &cobra.Command{
 	},
 	Run: func(cmd *cobra.Command, args []string) {
 		// check if we need to revoke all tokens or the user one
-		all := util.GetConfigValue("all", "all", cmd, false).(bool)
+		all := util.GetConfigValue(viper.GetViper(), "all", "all", cmd, false).(bool)
 		project := viper.GetString("project-id")
-		provider := util.GetConfigValue("provider", "provider", cmd, "").(string)
+		provider := util.GetConfigValue(viper.GetViper(), "provider", "provider", cmd, "").(string)
 
 		if all && project != "" {
 			fmt.Fprintf(os.Stderr, "Error: you can't use --all and --project-id together\n")
 			os.Exit(1)
 		}
 
-		conn, err := util.GrpcForCommand(cmd)
+		conn, err := util.GrpcForCommand(cmd, viper.GetViper())
 		util.ExitNicelyOnError(err, "Error getting grpc connection")
 		defer conn.Close()
 

--- a/cmd/cli/app/profile/profile_create.go
+++ b/cmd/cli/app/profile/profile_create.go
@@ -41,7 +41,7 @@ within a minder control plane.`,
 		}
 	},
 	RunE: func(cmd *cobra.Command, args []string) error {
-		f := util.GetConfigValue("file", "file", cmd, "").(string)
+		f := util.GetConfigValue(viper.GetViper(), "file", "file", cmd, "").(string)
 		proj := viper.GetString("project")
 
 		var err error
@@ -66,7 +66,7 @@ within a minder control plane.`,
 			preader = fopen
 		}
 
-		conn, err := util.GrpcForCommand(cmd)
+		conn, err := util.GrpcForCommand(cmd, viper.GetViper())
 		util.ExitNicelyOnError(err, "Error getting grpc connection")
 		defer conn.Close()
 

--- a/cmd/cli/app/profile/profile_delete.go
+++ b/cmd/cli/app/profile/profile_delete.go
@@ -41,7 +41,7 @@ minder control plane.`,
 		id := viper.GetString("id")
 		provider := viper.GetString("provider")
 
-		conn, err := util.GrpcForCommand(cmd)
+		conn, err := util.GrpcForCommand(cmd, viper.GetViper())
 
 		util.ExitNicelyOnError(err, "Error getting grpc connection")
 		defer conn.Close()

--- a/cmd/cli/app/profile/profile_get.go
+++ b/cmd/cli/app/profile/profile_get.go
@@ -45,7 +45,7 @@ minder control plane.`,
 			return fmt.Errorf("error: invalid format: %s", format)
 		}
 
-		conn, err := util.GrpcForCommand(cmd)
+		conn, err := util.GrpcForCommand(cmd, viper.GetViper())
 		util.ExitNicelyOnError(err, "Error getting grpc connection")
 		defer conn.Close()
 

--- a/cmd/cli/app/profile/profile_list.go
+++ b/cmd/cli/app/profile/profile_list.go
@@ -40,7 +40,7 @@ minder control plane for an specific project.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		format := viper.GetString("output")
 
-		conn, err := util.GrpcForCommand(cmd)
+		conn, err := util.GrpcForCommand(cmd, viper.GetViper())
 		if err != nil {
 			return fmt.Errorf("error getting grpc connection: %w", err)
 		}

--- a/cmd/cli/app/profile_status/profile_status_get.go
+++ b/cmd/cli/app/profile_status/profile_status_get.go
@@ -39,7 +39,7 @@ minder control plane for an specific provider/project or profile id, entity type
 		}
 	},
 	RunE: func(cmd *cobra.Command, args []string) error {
-		conn, err := util.GrpcForCommand(cmd)
+		conn, err := util.GrpcForCommand(cmd, viper.GetViper())
 		if err != nil {
 			return fmt.Errorf("error getting grpc connection: %w", err)
 		}

--- a/cmd/cli/app/profile_status/profile_status_list.go
+++ b/cmd/cli/app/profile_status/profile_status_list.go
@@ -38,7 +38,7 @@ minder control plane for an specific provider/project or profile id.`,
 		}
 	},
 	RunE: func(cmd *cobra.Command, args []string) error {
-		conn, err := util.GrpcForCommand(cmd)
+		conn, err := util.GrpcForCommand(cmd, viper.GetViper())
 		if err != nil {
 			return fmt.Errorf("error getting grpc connection: %w", err)
 		}

--- a/cmd/cli/app/provider/provider_enroll.go
+++ b/cmd/cli/app/provider/provider_enroll.go
@@ -120,16 +120,16 @@ actions such as adding repositories.`,
 		}
 	},
 	Run: func(cmd *cobra.Command, args []string) {
-		provider := util.GetConfigValue("provider", "provider", cmd, "").(string)
+		provider := util.GetConfigValue(viper.GetViper(), "provider", "provider", cmd, "").(string)
 		if provider != ghclient.Github {
 			fmt.Fprintf(os.Stderr, "Only %s is supported at this time\n", ghclient.Github)
 			os.Exit(1)
 		}
 		project := viper.GetString("project-id")
-		pat := util.GetConfigValue("token", "token", cmd, "").(string)
-		owner := util.GetConfigValue("owner", "owner", cmd, "").(string)
+		pat := util.GetConfigValue(viper.GetViper(), "token", "token", cmd, "").(string)
+		owner := util.GetConfigValue(viper.GetViper(), "owner", "owner", cmd, "").(string)
 
-		conn, err := util.GrpcForCommand(cmd)
+		conn, err := util.GrpcForCommand(cmd, viper.GetViper())
 		util.ExitNicelyOnError(err, "Error getting grpc connection")
 		defer conn.Close()
 

--- a/cmd/cli/app/repo/repo_get.go
+++ b/cmd/cli/app/repo/repo_get.go
@@ -46,10 +46,10 @@ var repo_getCmd = &cobra.Command{
 	},
 	RunE: func(cmd *cobra.Command, args []string) error {
 
-		provider := util.GetConfigValue("provider", "provider", cmd, "").(string)
+		provider := util.GetConfigValue(viper.GetViper(), "provider", "provider", cmd, "").(string)
 		repoid := viper.GetString("repo-id")
 		format := viper.GetString("output")
-		name := util.GetConfigValue("name", "name", cmd, "").(string)
+		name := util.GetConfigValue(viper.GetViper(), "name", "name", cmd, "").(string)
 
 		// if name is set, repo-id cannot be set
 		if name != "" && repoid != "" {
@@ -74,7 +74,7 @@ var repo_getCmd = &cobra.Command{
 			return fmt.Errorf("invalid output format: %s", format)
 		}
 
-		conn, err := util.GrpcForCommand(cmd)
+		conn, err := util.GrpcForCommand(cmd, viper.GetViper())
 		util.ExitNicelyOnError(err, "Error getting grpc connection")
 		defer conn.Close()
 
@@ -101,7 +101,7 @@ var repo_getCmd = &cobra.Command{
 			repository = resp.Repository
 		}
 
-		status := util.GetConfigValue("status", "status", cmd, false).(bool)
+		status := util.GetConfigValue(viper.GetViper(), "status", "status", cmd, false).(bool)
 		if status {
 			// TODO: implement this
 		} else {

--- a/cmd/cli/app/repo/repo_list.go
+++ b/cmd/cli/app/repo/repo_list.go
@@ -40,7 +40,7 @@ var repo_listCmd = &cobra.Command{
 	},
 	RunE: func(cmd *cobra.Command, args []string) error {
 
-		provider := util.GetConfigValue("provider", "provider", cmd, "").(string)
+		provider := util.GetConfigValue(viper.GetViper(), "provider", "provider", cmd, "").(string)
 		if provider != github.Github {
 			return fmt.Errorf("only %s is supported at this time", github.Github)
 		}
@@ -56,7 +56,7 @@ var repo_listCmd = &cobra.Command{
 			return fmt.Errorf("invalid output format: %s", format)
 		}
 
-		conn, err := util.GrpcForCommand(cmd)
+		conn, err := util.GrpcForCommand(cmd, viper.GetViper())
 		util.ExitNicelyOnError(err, "Error getting grpc connection")
 		defer conn.Close()
 

--- a/cmd/cli/app/repo/repo_register.go
+++ b/cmd/cli/app/repo/repo_register.go
@@ -55,14 +55,14 @@ var repo_registerCmd = &cobra.Command{
 		}
 	},
 	Run: func(cmd *cobra.Command, args []string) {
-		provider := util.GetConfigValue("provider", "provider", cmd, "").(string)
+		provider := util.GetConfigValue(viper.GetViper(), "provider", "provider", cmd, "").(string)
 		if provider != github.Github {
 			fmt.Fprintf(os.Stderr, "Only %s is supported at this time\n", github.Github)
 			os.Exit(1)
 		}
 		projectID := viper.GetString("project-id")
 
-		conn, err := util.GrpcForCommand(cmd)
+		conn, err := util.GrpcForCommand(cmd, viper.GetViper())
 		util.ExitNicelyOnError(err, "Error getting grpc connection")
 		defer conn.Close()
 

--- a/cmd/cli/app/rule_type/rule_type_create.go
+++ b/cmd/cli/app/rule_type/rule_type_create.go
@@ -48,7 +48,7 @@ within a minder control plane.`,
 			return fmt.Errorf("error validating file arg: %w", err)
 		}
 
-		conn, err := util.GrpcForCommand(cmd)
+		conn, err := util.GrpcForCommand(cmd, viper.GetViper())
 		if err != nil {
 			return fmt.Errorf("error getting grpc connection: %w", err)
 		}

--- a/cmd/cli/app/rule_type/rule_type_delete.go
+++ b/cmd/cli/app/rule_type/rule_type_delete.go
@@ -40,7 +40,7 @@ minder control plane.`,
 		// delete the profile via GRPC
 		id := viper.GetString("id")
 
-		conn, err := util.GrpcForCommand(cmd)
+		conn, err := util.GrpcForCommand(cmd, viper.GetViper())
 
 		util.ExitNicelyOnError(err, "Error getting grpc connection")
 		defer conn.Close()

--- a/cmd/cli/app/rule_type/rule_type_get.go
+++ b/cmd/cli/app/rule_type/rule_type_get.go
@@ -49,7 +49,7 @@ minder control plane.`,
 			return fmt.Errorf("error: invalid format: %s", format)
 		}
 
-		conn, err := util.GrpcForCommand(cmd)
+		conn, err := util.GrpcForCommand(cmd, viper.GetViper())
 		util.ExitNicelyOnError(err, "Error getting grpc connection")
 		defer conn.Close()
 

--- a/cmd/cli/app/rule_type/rule_type_list.go
+++ b/cmd/cli/app/rule_type/rule_type_list.go
@@ -40,7 +40,7 @@ minder control plane for an specific project.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		format := viper.GetString("output")
 
-		conn, err := util.GrpcForCommand(cmd)
+		conn, err := util.GrpcForCommand(cmd, viper.GetViper())
 		if err != nil {
 			return fmt.Errorf("error getting grpc connection: %w", err)
 		}

--- a/internal/util/helpers.go
+++ b/internal/util/helpers.go
@@ -78,8 +78,8 @@ var (
 //
 // Returns:
 // - The updated configuration value based on the flag, if it is set, or the original value otherwise.
-func GetConfigValue(key string, flagName string, cmd *cobra.Command, defaultValue interface{}) interface{} {
-	value := viper.Get(key)
+func GetConfigValue(v *viper.Viper, key string, flagName string, cmd *cobra.Command, defaultValue interface{}) interface{} {
+	value := v.Get(key)
 	if cmd.Flags().Changed(flagName) {
 		switch defaultValue.(type) {
 		case string:
@@ -141,15 +141,15 @@ func (JWTTokenCredentials) RequireTransportSecurity() bool {
 }
 
 // GrpcForCommand is a helper for getting a testing connection from cobra flags
-func GrpcForCommand(cmd *cobra.Command) (*grpc.ClientConn, error) {
-	grpc_host := GetConfigValue("grpc_server.host", "grpc-host", cmd, "staging.stacklok.dev").(string)
-	grpc_port := GetConfigValue("grpc_server.port", "grpc-port", cmd, 443).(int)
+func GrpcForCommand(cmd *cobra.Command, v *viper.Viper) (*grpc.ClientConn, error) {
+	grpc_host := GetConfigValue(v, "grpc_server.host", "grpc-host", cmd, "staging.stacklok.dev").(string)
+	grpc_port := GetConfigValue(v, "grpc_server.port", "grpc-port", cmd, 443).(int)
 	insecureDefault := grpc_host == "localhost" || grpc_host == "127.0.0.1" || grpc_host == "::1"
-	allowInsecure := GetConfigValue("grpc_server.insecure", "grpc-insecure", cmd, insecureDefault).(bool)
+	allowInsecure := GetConfigValue(v, "grpc_server.insecure", "grpc-insecure", cmd, insecureDefault).(bool)
 
-	issuerUrl := GetConfigValue("identity.cli.issuer_url", "identity-url", cmd, "https://auth.staging.stacklok.dev").(string)
-	realm := GetConfigValue("identity.cli.realm", "identity-realm", cmd, "stacklok").(string)
-	clientId := GetConfigValue("identity.cli.client_id", "identity-client", cmd, "mediator-cli").(string)
+	issuerUrl := GetConfigValue(v, "identity.cli.issuer_url", "identity-url", cmd, "https://auth.staging.stacklok.dev").(string)
+	realm := GetConfigValue(v, "identity.cli.realm", "identity-realm", cmd, "stacklok").(string)
+	clientId := GetConfigValue(v, "identity.cli.client_id", "identity-client", cmd, "mediator-cli").(string)
 
 	return GetGrpcConnection(grpc_host, grpc_port, allowInsecure, issuerUrl, realm, clientId)
 }

--- a/internal/util/helpers_test.go
+++ b/internal/util/helpers_test.go
@@ -75,7 +75,9 @@ func TestGetConfigValue(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			viper.Set(tc.key, tc.defaultValue)
+			v := viper.New()
+
+			v.Set(tc.key, tc.defaultValue)
 
 			cmd := &cobra.Command{}
 			switch tc.defaultValue.(type) {
@@ -100,7 +102,7 @@ func TestGetConfigValue(t *testing.T) {
 				}
 			}
 
-			result := util.GetConfigValue(tc.key, tc.flagName, cmd, tc.defaultValue)
+			result := util.GetConfigValue(v, tc.key, tc.flagName, cmd, tc.defaultValue)
 			assert.Equal(t, tc.expected, result)
 		})
 	}


### PR DESCRIPTION
This is a good practice anyway and helps solve the race condition issues in our tests.
