### PR TITLE
fix: config: Fix usage of global viper instance

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -68,8 +68,8 @@ func ReadConfigFromViper(v *viper.Viper) (*Config, error) {
 // SetViperDefaults sets the default values for the configuration to be picked
 // up by viper
 func SetViperDefaults(v *viper.Viper) {
-	viper.SetEnvPrefix("mediator")
-	viper.SetEnvKeyReplacer(strings.NewReplacer(".", "_"))
+	v.SetEnvPrefix("mediator")
+	v.SetEnvKeyReplacer(strings.NewReplacer(".", "_"))
 	setViperStructDefaults(v, "", Config{})
 }
 


### PR DESCRIPTION
We were accidentally using it and it was causing a race condition. This fixes the
race condition in our tests.
