### PR TITLE
Fix vulncheck's repo cache to be concurrency-friendly

### DIFF
--- a/internal/engine/eval/vulncheck/pkgdb.go
+++ b/internal/engine/eval/vulncheck/pkgdb.go
@@ -26,6 +26,7 @@ import (
 	"strings"
 
 	"github.com/puzpuzpuz/xsync"
+
 	"github.com/stacklok/mediator/internal/util"
 	pb "github.com/stacklok/mediator/pkg/api/protobuf/go/minder/v1"
 )


### PR DESCRIPTION
This uses xsync's Map instead of a bare map. This way we can avoid the concurrency issues.
