### PR TITLE
Adjust Pi evaluator reply structure to the API response

### DIFF
--- a/internal/engine/eval/package_intelligence/actions.go
+++ b/internal/engine/eval/package_intelligence/actions.go
@@ -53,7 +53,7 @@ mediator policies. Below is a summary of the packages with low scores and their 
     <td>{{ $.DependencyName }}</td>
     <td>{{ $.DependencyScore }}</td>
     <td><a href="{{ $.BaseUrl }}/{{ $.DependencyEcosystem }}/{{ .PackageName }}" >{{ .PackageName }}</a></td>
-    <td>{{ .Summary.Score }}</td>
+    <td>{{ .Score }}</td>
   </tr>
   {{ end }}
 `
@@ -126,7 +126,7 @@ func (sph *summaryPrHandler) generateSummary() (string, error) {
 
 		nonZeroAlternatives := make([]PiAlternative, 0)
 		for _, alt := range sph.trackedAlternatives[i].piReply.Alternatives.Packages {
-			if alt.Summary.Score > sph.trackedAlternatives[i].piReply.Summary.Score {
+			if alt.Score > sph.trackedAlternatives[i].piReply.Summary.Score {
 				nonZeroAlternatives = append(nonZeroAlternatives, alt)
 			}
 		}

--- a/internal/engine/eval/package_intelligence/pi_rest_handler.go
+++ b/internal/engine/eval/package_intelligence/pi_rest_handler.go
@@ -54,10 +54,8 @@ type piClient struct {
 
 // PiAlternative is an alternative package returned from the package intelligence API
 type PiAlternative struct {
-	PackageName string `json:"package_name"`
-	Summary     struct {
-		Score float64 `json:"score"`
-	} `json:"summary"`
+	PackageName string  `json:"package_name"`
+	Score       float64 `json:"score"`
 }
 
 // PiReply is the response from the package intelligence API


### PR DESCRIPTION
The reply looks now as follows:
```
curl 'https://staging.stacklok.dev/pi/v1/report?package_name=urllib3&package_type=pypi' | jq '.alternatives'
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 11774  100 11774    0     0   8730      0  0:00:01  0:00:01 --:--:--  8753
{
  "status": "complete",
  "packages": [
    {
      "package_name": "aiohttp",
      "package_type": "pypi",
      "repo_description": "Rust friendly bindings to *nix APIs (fork with features used in cntr)",
      "score": 6.9
    },
    {
      "package_name": "httpx",
      "package_type": "pypi",
      "repo_description": "Stream based JSON parsing with a Python C-Extension around YAJL",
      "score": 6.6
    },
    {
      "package_name": "httplib2",
      "package_type": "pypi",
      "repo_description": "Small, fast HTTP client library for Python. Features persistent connections, cache, and Google App Engine support. Originally written by Joe Gregorio, now supported by community.",
      "score": 6.1
    },
    {
      "package_name": "treq",
      "package_type": "pypi",
      "repo_description": "Python requests like API built on top of Twisted's HTTP client.",
      "score": 5.9
    }
  ]
}
```
