### PR TITLE
Add `read_only` flag to docker-compose

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -32,6 +32,7 @@ services:
       # "--github-client-secret-file=/secrets/github_client_secret",
       ]
     restart: always # keep the server running
+    read_only: true
     ports:
       - "8080:8080"
       - "8090:8090"


### PR DESCRIPTION
This ensures that the minder server can run with a read-only filesystem.

The next step will be to set up this flag in our helm chart to harden the deployment.
