### PR TITLE
WIP: go executor go!

### DIFF
--- a/cmd/server/app/serve.go
+++ b/cmd/server/app/serve.go
@@ -109,7 +109,7 @@ var serveCmd = &cobra.Command{
 			return fmt.Errorf("unable to create server: %w", err)
 		}
 
-		exec, err := engine.NewExecutor(store, &cfg.Auth, engine.WithProviderMetrics(providerMetrics))
+		exec, err := engine.NewExecutor(ctx, store, &cfg.Auth, engine.WithProviderMetrics(providerMetrics))
 		if err != nil {
 			return fmt.Errorf("unable to create executor: %w", err)
 		}

--- a/internal/engine/executor_test.go
+++ b/internal/engine/executor_test.go
@@ -15,6 +15,7 @@
 package engine_test
 
 import (
+	"context"
 	"encoding/base64"
 	"encoding/json"
 	"os"
@@ -235,7 +236,11 @@ default allow = true`,
 	err = os.WriteFile(tokenKeyPath, []byte(fakeTokenKey), 0600)
 	require.NoError(t, err, "expected no error")
 
-	e, err := engine.NewExecutor(mockStore, &config.AuthConfig{
+	testTimeout := 5 * time.Second
+	ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
+	defer cancel()
+
+	e, err := engine.NewExecutor(ctx, mockStore, &config.AuthConfig{
 		TokenKey: tokenKeyPath,
 	})
 	require.NoError(t, err, "expected no error")
@@ -253,4 +258,6 @@ default allow = true`,
 	require.NoError(t, err, "expected no error")
 
 	require.NoError(t, e.HandleEntityEvent(msg), "expected no error")
+
+	e.Wait()
 }


### PR DESCRIPTION
This limits the executor event handling code to just parse the message. It
subsequently spawns a goroutine to do the actual evaluation.

The intent is to not block the message handler when we're receiving events
so we'd have faster executions.
