### PR TITLE
Add `setup-go` step to helm chart publish job

### DIFF
--- a/.github/workflows/chart-publish.yml
+++ b/.github/workflows/chart-publish.yml
@@ -29,6 +29,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Setup Go
+        uses: actions/setup-go@v4
+        with:
+          go-version-file: 'go.mod'
+
       - uses: ko-build/setup-ko@v0.6
 
       - uses: azure/setup-helm@v3


### PR DESCRIPTION
https://github.com/stacklok/mediator/pull/1362 introduced the `setup-go` command
in the befinning of a lot of our jobs. This was missed in the helm chart publish job.
