### PR TITLE
Allow ServiceAccounts to be passed in to the chart

### DIFF
--- a/deployment/helm/templates/deployment.yaml
+++ b/deployment/helm/templates/deployment.yaml
@@ -30,7 +30,7 @@ spec:
       annotations:
         {{ include "common.annotations.pods" (dict "customAnnotationsPods" .Values.commonAnnotationsPods "context" $ ) | nindent 8 }}
     spec:
-      serviceAccountName: mediator
+      serviceAccountName: {{ .Values.serviceAccounts.server | default "mediator" }}
       containers:
         - name: mediator
           # restricted security context:

--- a/deployment/helm/templates/job.yaml
+++ b/deployment/helm/templates/job.yaml
@@ -15,6 +15,7 @@
 # We need a separate service account for the db-update job, because
 # it runs as a helm pre-install hook, and the mediator service account
 # won't have been installed at that point.
+{{ if eq .Values.serviceAccounts.migrate "" }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -27,6 +28,7 @@ metadata:
     {{ include "common.labels.standard" (dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
 imagePullSecrets:
 - name: mediator-pull-secret
+{{ end }}
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -69,7 +71,7 @@ spec:
       labels:
         app: db-init
     spec:
-      serviceAccountName: db-update
+      serviceAccountName: {{ .Values.serviceAccounts.migrate | default "db-update" }}
       restartPolicy: Never
       containers:
         - name: mediator-dbinit

--- a/deployment/helm/templates/serviceaccount.yaml
+++ b/deployment/helm/templates/serviceaccount.yaml
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+{{ if eq .Values.serviceAccounts.server "" }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -22,3 +23,4 @@ metadata:
     eks.amazonaws.com/role-arn: "arn:aws:iam::{{ .Values.aws.accountID }}:role/{{ .Values.aws.server.iamRole }}"
 imagePullSecrets:
 - name: mediator-pull-secret
+{{ end }}

--- a/deployment/helm/values.yaml
+++ b/deployment/helm/values.yaml
@@ -27,12 +27,19 @@ hostname: "mediator.example.com"
 db:
   host: "postgres.postgres"
 
+# NOTE: we are migrating from AWS-specific annotations to a "pre-create the service account" model.
+# If serviceAccounts.migrate or serviceAccount.server are set, these values will be ignored.
 aws:
   accountID: "123456789012"
   migrate:
     iamRole: "mediator_migrate_role"
   server:
     iamRole: "mediator_server_role"
+
+serviceAccounts:
+  # If non-empty, mediator will use the named ServiceAccount resources rather than creating a ServiceAccount
+  migrate: ""
+  server: ""
 
 migrationSettings:
   image: ko://github.com/stacklok/mediator/cmd/server

--- a/docs/docs/understand/providers.md
+++ b/docs/docs/understand/providers.md
@@ -1,6 +1,6 @@
 ---
 title: Minder providers
-sidebar_position: 20
+sidebar_position: 10
 ---
 
 # Providers in Minder


### PR DESCRIPTION
This will make it easier to use the accounts for ExternalSecrets, and to associate the service accounts with image pull secrets
