### PR TITLE
Point to Trusty instance via an environment variable

### DIFF
--- a/deployment/helm/templates/deployment.yaml
+++ b/deployment/helm/templates/deployment.yaml
@@ -69,6 +69,8 @@ spec:
             value: "/secrets/auth/token_key_passphrase"
           - name: "MEDIATOR_IDENTITY_SERVER_CLIENT_SECRET_FILE"
             value: "/secrets/identity/identity_client_secret"
+          - name: "MEDIATOR_UNSTABLE_TRUSTY_ENDPOINT"
+            value: "{{ .Values.trusty.endpoint }}"
           
           # ko will always specify a digest, so we don't need to worry about
           # CRI image caching

--- a/deployment/helm/values.yaml
+++ b/deployment/helm/values.yaml
@@ -27,6 +27,9 @@ hostname: "mediator.example.com"
 db:
   host: "postgres.postgres"
 
+trusty:
+  endpoint: "http://pi.pi:8000"
+
 # NOTE: we are migrating from AWS-specific annotations to a "pre-create the service account" model.
 # If serviceAccounts.migrate or serviceAccount.server are set, these values will be ignored.
 aws:


### PR DESCRIPTION
To make sure we're talking to the right trusty instance through the
k8s service name.
