### PR TITLE
Extend the PR vuln check docs with commit status

### DIFF
--- a/docs/docs/how-to/pr_reviews.md
+++ b/docs/docs/how-to/pr_reviews.md
@@ -12,7 +12,17 @@ import TabItem from '@theme/TabItem';
 
 ## Create the PR vulnerability check rule
 Start by creating a rule that checks if a pull request adds a new dependency with known vulnerabilities. If it does,
-Minder will review the PR and suggest changes.  
+Minder will review the PR and suggest changes.
+
+Note that Minder is only able to review a PR if it's running under a different
+user than the one that created the PR. If the PR is created by the same user,
+Minder only provide a comment with the vulnerability information. An alternative
+is to use the `commit-status` action instead of `review` where Minder will set
+the commit status to `failure` if the PR introduces a new vulnerability which can
+then be used to block the PR. This requires an additional step though, where
+the repo needs to require the `minder.stacklok.dev/pr-vulncheck` status to
+be passing.
+
 This is a reference rule provider by the Minder team.
 
 Fetch all the reference rules by cloning the [minder-rules-and-profiles repository](https://github.com/stacklok/minder-rules-and-profiles).

--- a/internal/engine/eval/vulncheck/review.go
+++ b/internal/engine/eval/vulncheck/review.go
@@ -32,7 +32,7 @@ import (
 
 const (
 	reviewBodyMagicComment = "<!-- mediator: pr-review-body -->"
-	commitStatusContext    = "mediator.stacklok.dev/pr-vulncheck"
+	commitStatusContext    = "minder.stacklok.dev/pr-vulncheck"
 	vulnsFoundText         = `
 Mediator found vulnerable dependencies in this PR. Either push an updated
 version or accept the proposed changes. Note that accepting the changes will


### PR DESCRIPTION
We should also mention this feature since we expect that many users will self-enroll
