### PR TITLE
The migrate container is now called minder_migrate_1

### DIFF
--- a/.github/workflows/compose-migrate.yml
+++ b/.github/workflows/compose-migrate.yml
@@ -34,7 +34,7 @@ jobs:
       run: |
         set -e
 
-        while [ "$(docker logs mediator_migrate_1 | grep 'Database migration completed successfully')" = "" ]; do
+        while [ "$(docker logs minder_migrate_1 | grep 'Database migration completed successfully')" = "" ]; do
           sleep 1
         done
         


### PR DESCRIPTION
This should fix:
```
Error response from daemon: No such container: mediator_migrate_1
```
