### PR TITLE
Fixes to the OSV rule_type and profile

### DIFF
--- a/docs/docs/understand/profiles.md
+++ b/docs/docs/understand/profiles.md
@@ -96,7 +96,7 @@ pull_request:
             url: https://registry.npmjs.org
         - name: go
           vulnerability_database_type: osv
-          vulnerability_database_endpoint: https://vuln.go.dev
+          vulnerability_database_endpoint: https://api.osv.dev/v1/query
           package_repository:
             url: https://proxy.golang.org
           sum_repository:

--- a/examples/github/profiles/profile.yaml
+++ b/examples/github/profiles/profile.yaml
@@ -131,7 +131,7 @@ pull_request:
             url: https://registry.npmjs.org
         - name: go
           vulnerability_database_type: osv
-          vulnerability_database_endpoint: https://vuln.go.dev
+          vulnerability_database_endpoint: https://api.osv.dev/v1/query
           package_repository:
             url: https://proxy.golang.org
           sum_repository:

--- a/examples/github/rule-types/pr_vulnerability_check.yaml
+++ b/examples/github/rule-types/pr_vulnerability_check.yaml
@@ -38,7 +38,7 @@ def:
           properties:
             name:
               type: string
-              description: "The name of the ecosystem to check. Currently only `npm` is supported."
+              description: "The name of the ecosystem to check. Currently `npm`, `go` and `pypi` are supported."
             vulnerability_database_type:
               type: string
               "description": "The kind of vulnerability database to use. Currently only `osv` is supported."
@@ -52,6 +52,13 @@ def:
                   type: string
                   description: "The URL of the package repository to use."
               "description": "The package repository to use."
+            sum_repository:
+              type: object
+              properties:
+                url:
+                  type: string
+                  description: "The URL of the Go sum repository to use. Only used if the ecosystem is `go`."
+              "description": "The Go sum repository to use."
   ingest:
     type: diff
     diff:


### PR DESCRIPTION
Turns out that writing docs finds issues.

- the rule type was missing the `sum_repository`. Luckily the rule still works fine if it defined extra attributes, but we should declare all we use in the schema.
- the example profile was using https://vuln.go.dev which is wrong as it doesn't directly expose the OSV endpoint (just an edpoint with a compressed file in the right format)