### PR TITLE
Implement a LICENSE rule type

### DIFF
--- a/examples/github/rule-types/license.yaml
+++ b/examples/github/rule-types/license.yaml
@@ -6,9 +6,8 @@ context:
   provider: github
 description: Verifies that there's a license file of a given type present in the repository.
 guidance: |
-  The following rule type ensures that a license file is present in the repository and that the license type specified 
-  in it is as expected. If the license type is not specified (license_type = ""), then only the presence of the
-  license file is checked.
+  The license rule type ensures that a license file is present in the repository and its license type complies with
+  the configured license type in your profile.
 
   For more information, see
   https://docs.github.com/en/communities/setting-up-your-project-for-healthy-contributions/adding-a-license-to-a-repository


### PR DESCRIPTION
The following rule type allows for:

* Ensuring only the presence of a LICENSE file (when `license_type = ""` is left blank)
```yaml
---
# Sample profile for validating the presence of a license file
version: v1
type: profile
name: license
context:
  provider: github
repository:
  - type: license
    def:
      license_filename: LICENSE
      license_type: ""
```
* Ensuring the present LICENSE file contains a given license type, i.e. Apache.
```yaml
---
# Sample profile for validating the presence of a license file and its type
version: v1
type: profile
name: license
context:
  provider: github
repository:
  - type: license
    def:
      license_filename: LICENSE
      license_type: "Apache"
```
* The file name of the license is not hardcoded to allow for flexibility
* The licence type check just verifies if the configured keyword is present in the license file. It doesn't ensure that the legal content in that file matches the configured license type.

Motivated by the discussion in https://github.com/stacklok/minder/pull/1413#discussion_r1380837037