### PR TITLE
Run minder in a read-only filesystem

### DIFF
--- a/deployment/helm/templates/deployment.yaml
+++ b/deployment/helm/templates/deployment.yaml
@@ -38,6 +38,7 @@ spec:
           securityContext:
             allowPrivilegeEscalation: false
             runAsNonRoot: true
+            readOnlyRootFilesystem: true
             seccompProfile:
               type: RuntimeDefault
             capabilities:


### PR DESCRIPTION
This changes the helm chart to configure the minder `Deployment` to use a read-only
root filesystem. This helps us harden the deployment and makes it harder for an
attacker to keep a persistent rootkit in the pod.

Note that the docker-compose set up has already been using this setting to
ensure we don't break minder.
