### PR TITLE
provider enroll no browser

### DIFF
--- a/cmd/cli/app/provider/provider_enroll.go
+++ b/cmd/cli/app/provider/provider_enroll.go
@@ -169,7 +169,7 @@ actions such as adding repositories.`,
 
 		if err := browser.OpenURL(resp.GetUrl()); err != nil {
 			fmt.Fprintf(os.Stderr, "Error opening browser: %s\n", err)
-			os.Exit(1)
+			fmt.Println("Please copy and paste the URL into a browser.")
 		}
 		openTime := time.Now().Unix()
 


### PR DESCRIPTION
- Run minder in a read-only filesystem (#1422)
- Don't fail provider enroll if browser wasn't opened
