### PR TITLE
Don't fail provider enroll if browser wasn't opened

### DIFF
--- a/cmd/cli/app/provider/provider_enroll.go
+++ b/cmd/cli/app/provider/provider_enroll.go
@@ -169,7 +169,7 @@ actions such as adding repositories.`,
 
 		if err := browser.OpenURL(resp.GetUrl()); err != nil {
 			fmt.Fprintf(os.Stderr, "Error opening browser: %s\n", err)
-			os.Exit(1)
+			fmt.Println("Please copy and paste the URL into a browser.")
 		}
 		openTime := time.Now().Unix()
 


### PR DESCRIPTION
If we're running the provider enroll command from a container, the browser won't be opened. But we can still open a browser manually and complete the enroll.

This changes the provider enroll call and allows one to continue for such cases.