### PR TITLE
Only append the status code label in http telemetry if we get a reply

### DIFF
--- a/internal/providers/telemetry/telemetry.go
+++ b/internal/providers/telemetry/telemetry.go
@@ -45,8 +45,12 @@ func (irt *instrumentedRoundTripper) RoundTrip(r *http.Request) (*http.Response,
 	labels := []attribute.KeyValue{
 		attribute.String("http_method", r.Method),
 		attribute.String("http_host", r.URL.Host),
-		attribute.Int("http_status_code", resp.StatusCode),
 	}
+
+	if resp != nil {
+		labels = append(labels, attribute.Int("http_status_code", resp.StatusCode))
+	}
+
 	irt.durationHistogram.Record(r.Context(), duration, metric.WithAttributes(labels...))
 
 	return resp, err


### PR DESCRIPTION
Or else we get a panic
