### PR TITLE
change register repository calls to use one call per repo

### DIFF
--- a/cmd/cli/app/repo/repo_register.go
+++ b/cmd/cli/app/repo/repo_register.go
@@ -124,20 +124,27 @@ var repo_registerCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
-		// Construct the RegisterRepositoryRequest
-		request := &pb.RegisterRepositoryRequest{
-			Provider:     provider,
-			Repositories: selectedRepos,
-			ProjectId:    projectID,
+		results := []*pb.RegisterRepoResult{}
+		for idx := range selectedRepos {
+			repo := selectedRepos[idx]
+			repoRegList := []*pb.UpstreamRepositoryRef{repo}
+			// Construct the RegisterRepositoryRequest
+			request := &pb.RegisterRepositoryRequest{
+				Provider:     provider,
+				Repositories: repoRegList,
+				ProjectId:    projectID,
+			}
+
+			result, err := client.RegisterRepository(context.Background(), request)
+			if err != nil {
+				_, _ = fmt.Fprintf(os.Stderr, "Error registering repository %s: %s\n", repo.Name, err)
+				continue
+			}
+
+			results = append(results, result.Results...)
 		}
 
 		// Register the repos
-		registerResp, err := client.RegisterRepository(context.Background(), request)
-		if err != nil {
-			_, _ = fmt.Fprintf(os.Stderr, "Error registering repositories: %s\n", err)
-			os.Exit(1)
-		}
-
 		// The result gives a list of repositories with the registration status
 		// Let's parse the results and print the status
 		columns := []table.Column{
@@ -146,8 +153,8 @@ var repo_registerCmd = &cobra.Command{
 			{Title: "Message", Width: 60},
 		}
 
-		rows := make([]table.Row, len(registerResp.Results))
-		for i, result := range registerResp.Results {
+		rows := make([]table.Row, len(results))
+		for i, result := range results {
 			rows[i] = table.Row{
 				fmt.Sprintf("%s/%s", result.Repository.Owner, result.Repository.Name),
 			}


### PR DESCRIPTION
This makes processing faster and allows us to mass register repos.
