### PR TITLE
Retry processing alert if it previously failed

### DIFF
--- a/internal/engine/actions/actions.go
+++ b/internal/engine/actions/actions.go
@@ -190,7 +190,7 @@ func shouldAlert(
 	}
 
 	// Case 2 - Do nothing if the evaluation status has not changed
-	if newEval == prevEval {
+	if newEval == prevEval && prevAlert != db.AlertStatusTypesError {
 		return engif.ActionCmdDoNothing
 	}
 


### PR DESCRIPTION
While debugging with @JAORMX found the following - 

```bash
error creating security advisory: POST https://api.github.com/repos/JAORMX/service-ca-operator/security-advisories: 422 The
re was a problem validating the advisory [], action failed
```

We are getting rate limited by Github when trying to create multiple security advisories for a single repository. 

This is handled correctly by the action engine, so the solution so far is to retry processing the alert on the next time we evaluate this rule.