### PR TITLE
Set ID in rule type update response

### DIFF
--- a/internal/controlplane/handlers_ruletype.go
+++ b/internal/controlplane/handlers_ruletype.go
@@ -264,6 +264,10 @@ func (s *Server) UpdateRuleType(
 		return nil, status.Errorf(codes.Unknown, "failed to create rule type: %s", err)
 	}
 
+	// ensure ID is set
+	rtypeIDStr := rtdb.ID.String()
+	in.Id = &rtypeIDStr
+
 	return &minderv1.UpdateRuleTypeResponse{
 		RuleType: in,
 	}, nil


### PR DESCRIPTION
We might not get the rule ID as part of the call, so we need to ensure to set it. Else,
the client code will segfault.
