### PR TITLE
Fix .goreleaser.yaml

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -40,7 +40,7 @@ archives:
         format: zip
 # This section defines how to release to homebrew.
 brews:
-  - homepage: 'https://github.com/stacklok/mediator'
+  - homepage: 'https://github.com/stacklok/minder'
     description: 'minder is the client CLI for interacting with Minder by Stacklok.'
     folder: Formula
     commit_author:
@@ -57,13 +57,13 @@ winget:
   - name: minder
     publisher: stacklok
     license: Apache-2.0
-    license_url: "https://github.com/stacklok/mediator/blob/main/LICENSE"
+    license_url: "https://github.com/stacklok/minder/blob/main/LICENSE"
     copyright: Stacklok, Inc.
     homepage: https://stacklok.com
     short_description: 'minder is the client CLI for interacting with Minder by Stacklok.'
-    publisher_support_url: "https://github.com/stacklok/mediator/issues/new/choose"
+    publisher_support_url: "https://github.com/stacklok/minder/issues/new/choose"
     package_identifier: "stacklok.minder"
-    url_template: "https://github.com/stacklok/mediator/releases/download/{{ .Tag }}/{{ .ArtifactName }}"
+    url_template: "https://github.com/stacklok/minder/releases/download/{{ .Tag }}/{{ .ArtifactName }}"
     skip_upload: auto
     release_notes: "{{.Changelog}}"
     tags:
@@ -102,7 +102,7 @@ release:
   prerelease: auto
   github:
     owner: stacklok
-    name: mediator
+    name: minder
 # This section defines how and which artifacts we want to sign for the release.
 signs:
   - cmd: cosign


### PR DESCRIPTION
Goreleaser was failing to push the released packages due to the repo renaming.