### PR TITLE
Fix deprecated msg for docs build

### DIFF
--- a/docs/redocly.yml
+++ b/docs/redocly.yml
@@ -13,5 +13,5 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-features.openapi:
+theme.openapi:
   hideDownloadButton: true


### PR DESCRIPTION
<img width="1565" alt="image" src="https://github.com/stacklok/minder/assets/16540482/1a8a6915-074e-4a40-b3c5-b573122afab3">
