### PR TITLE
Point CLI to production by default

### DIFF
--- a/cmd/cli/app/auth/auth_login.go
+++ b/cmd/cli/app/auth/auth_login.go
@@ -41,6 +41,7 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
+	"github.com/stacklok/minder/internal/constants"
 	mcrypto "github.com/stacklok/minder/internal/crypto"
 	"github.com/stacklok/minder/internal/util"
 	"github.com/stacklok/minder/internal/util/cli"
@@ -76,7 +77,7 @@ will be saved to $XDG_CONFIG_HOME/minder/credentials.json`,
 		ctx := context.Background()
 
 		issuerUrlStr := util.GetConfigValue(viper.GetViper(), "identity.cli.issuer_url", "identity-url", cmd,
-			"https://auth.staging.stacklok.dev").(string)
+			constants.IdentitySeverURL).(string)
 		realm := util.GetConfigValue(viper.GetViper(), "identity.cli.realm", "identity-realm", cmd, "stacklok").(string)
 		clientID := util.GetConfigValue(viper.GetViper(), "identity.cli.client_id", "identity-client", cmd, "minder-cli").(string)
 

--- a/cmd/cli/app/auth/auth_logout.go
+++ b/cmd/cli/app/auth/auth_logout.go
@@ -29,6 +29,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 
+	"github.com/stacklok/minder/internal/constants"
 	"github.com/stacklok/minder/internal/util"
 	"github.com/stacklok/minder/internal/util/cli"
 )
@@ -48,7 +49,7 @@ var auth_logoutCmd = &cobra.Command{
 		util.ExitNicelyOnError(err, "Error removing credentials")
 
 		issuerUrlStr := util.GetConfigValue(viper.GetViper(), "identity.cli.issuer_url", "identity-url", cmd,
-			"https://auth.staging.stacklok.dev").(string)
+			constants.IdentitySeverURL).(string)
 		realm := util.GetConfigValue(viper.GetViper(), "identity.cli.realm", "identity-realm", cmd, "stacklok").(string)
 
 		parsedURL, err := url.Parse(issuerUrlStr)

--- a/internal/constants/doc.go
+++ b/internal/constants/doc.go
@@ -1,0 +1,17 @@
+//
+// Copyright 2023 Stacklok, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package constants contains constants used throughout the application.
+package constants

--- a/internal/constants/prod.go
+++ b/internal/constants/prod.go
@@ -1,0 +1,25 @@
+//go:build !staging
+
+//
+// Copyright 2023 Stacklok, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package constants
+
+const (
+	// IdentitySeverURL is the URL of the identity server
+	IdentitySeverURL = "https://auth.stacklok.com"
+	// MinderGRPCHost is the host of the minder gRPC server
+	MinderGRPCHost = "api.stacklok.com"
+)

--- a/internal/constants/staging.go
+++ b/internal/constants/staging.go
@@ -1,0 +1,25 @@
+//go:build staging
+
+//
+// Copyright 2023 Stacklok, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package constants
+
+const (
+	// IdentitySeverURL is the URL of the identity server
+	IdentitySeverURL = "https://auth.staging.stacklok.dev"
+	// MinderGRPCHost is the host of the minder gRPC server
+	MinderGRPCHost = "staging.stacklok.dev"
+)

--- a/internal/util/helpers.go
+++ b/internal/util/helpers.go
@@ -54,6 +54,7 @@ import (
 	"google.golang.org/protobuf/reflect/protoreflect"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
+	"github.com/stacklok/minder/internal/constants"
 	"github.com/stacklok/minder/internal/db"
 	"github.com/stacklok/minder/internal/util/jsonyaml"
 	minderv1 "github.com/stacklok/minder/pkg/api/protobuf/go/minder/v1"
@@ -142,12 +143,12 @@ func (JWTTokenCredentials) RequireTransportSecurity() bool {
 
 // GrpcForCommand is a helper for getting a testing connection from cobra flags
 func GrpcForCommand(cmd *cobra.Command, v *viper.Viper) (*grpc.ClientConn, error) {
-	grpc_host := GetConfigValue(v, "grpc_server.host", "grpc-host", cmd, "staging.stacklok.dev").(string)
+	grpc_host := GetConfigValue(v, "grpc_server.host", "grpc-host", cmd, constants.MinderGRPCHost).(string)
 	grpc_port := GetConfigValue(v, "grpc_server.port", "grpc-port", cmd, 443).(int)
 	insecureDefault := grpc_host == "localhost" || grpc_host == "127.0.0.1" || grpc_host == "::1"
 	allowInsecure := GetConfigValue(v, "grpc_server.insecure", "grpc-insecure", cmd, insecureDefault).(bool)
 
-	issuerUrl := GetConfigValue(v, "identity.cli.issuer_url", "identity-url", cmd, "https://auth.staging.stacklok.dev").(string)
+	issuerUrl := GetConfigValue(v, "identity.cli.issuer_url", "identity-url", cmd, constants.IdentitySeverURL).(string)
 	realm := GetConfigValue(v, "identity.cli.realm", "identity-realm", cmd, "stacklok").(string)
 	clientId := GetConfigValue(v, "identity.cli.client_id", "identity-client", cmd, "minder-cli").(string)
 


### PR DESCRIPTION
We can still point to staging for testing, but that needs to be done through
a `staging` golang build tag.
