### PR TITLE
Change default reference to keycloak in docker-compose file

### DIFF
--- a/config/config.yaml.example
+++ b/config/config.yaml.example
@@ -50,7 +50,7 @@ identity:
     realm: stacklok
     client_id: minder-cli
   server:
-    issuer_url: http://localhost:8081
+    issuer_url: http://keycloak:8080
     realm: stacklok
     client_id: minder-server
     client_secret: secret


### PR DESCRIPTION
We mostly use that reference configuration for the docker-compose run.
Let's make it work with compose by default.
