### PR TITLE
Release minder to microsoft/winget-pkgs and remove private setting for SLSA

### DIFF
--- a/.github/workflows/releaser.yml
+++ b/.github/workflows/releaser.yml
@@ -114,7 +114,6 @@ jobs:
     with:
       base64-subjects: "${{ needs.release.outputs.hashes }}"
       upload-assets: true # upload to a new release
-      private-repository: true # remove this line after going public
   verification:
     name: Verify provenance of assets (SLSA3)
     needs:

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -79,7 +79,7 @@ winget:
       branch: "minder-{{.Version}}"
       token: "{{ .Env.WINGET_GITHUB_TOKEN }}"
       pull_request:
-        enabled: false # TODO: enable once we release
+        enabled: true
         draft: false
         base:
           owner: microsoft


### PR DESCRIPTION
Merge this once we go public 👍 

This enables opening a PR to winget-pkgs and removes the private setting for SLSA.

@dussab @lukehinds:
Note that the winget-pkgs integration is about goreleaser generating all of the files and opening a PR against their repository. 

We would then need to go and click on the PR checkboxes each time we release (unless we buy the paid version of goreleaser). 

Also on the first time we publish, we have to go through their CLA confirmation.

