### PR TITLE
Don't print informational values to stdout

### DIFF
--- a/cmd/cli/app/root.go
+++ b/cmd/cli/app/root.go
@@ -18,6 +18,7 @@ package app
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -77,10 +78,10 @@ func initConfig() {
 	if err := viper.ReadInConfig(); err != nil {
 		if _, ok := err.(viper.ConfigFileNotFoundError); ok {
 			// Config file not found; use default values
-			fmt.Println("No config file present, using default values.")
+			fmt.Fprintln(os.Stderr, "No config file present, using default values.")
 		} else {
 			// Some other error occurred
-			fmt.Println("Error reading config file:", err)
+			fmt.Fprintln(os.Stderr, "Error reading config file:", err)
 		}
 	}
 }


### PR DESCRIPTION
The first message can probably be just removed. The primary reason I
want to remove these from stdout is that it makes piping `-ojson` output to `jq`
which I think should just print JSON and nothing else.
