### PR TITLE
Don't reuse the configured Trusty http endpoint for the PR reply, use a constant instead

### DIFF
--- a/internal/constants/prod.go
+++ b/internal/constants/prod.go
@@ -22,4 +22,6 @@ const (
 	IdentitySeverURL = "https://auth.stacklok.com"
 	// MinderGRPCHost is the host of the minder gRPC server
 	MinderGRPCHost = "api.stacklok.com"
+	// TrustyHttpURL is the URL of the trusty server
+	TrustyHttpURL = "https://trustypkg.dev/"
 )

--- a/internal/constants/staging.go
+++ b/internal/constants/staging.go
@@ -22,4 +22,6 @@ const (
 	IdentitySeverURL = "https://auth.staging.stacklok.dev"
 	// MinderGRPCHost is the host of the minder gRPC server
 	MinderGRPCHost = "staging.stacklok.dev"
+	// TrustyHttpURL is the URL of the trusty server
+	TrustyHttpURL = "https://app.staging.stacklok.dev/"
 )

--- a/internal/engine/eval/trusty/actions.go
+++ b/internal/engine/eval/trusty/actions.go
@@ -19,10 +19,10 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"net/url"
 	"strings"
 	"text/template"
 
+	"github.com/stacklok/minder/internal/constants"
 	pb "github.com/stacklok/minder/pkg/api/protobuf/go/minder/v1"
 	provifv1 "github.com/stacklok/minder/pkg/providers/v1"
 )
@@ -112,15 +112,6 @@ func (sph *summaryPrHandler) generateSummary() (string, error) {
 	}
 	summary.WriteString(headerBuf.String())
 
-	piUrl, err := url.Parse(sph.trustyUrl)
-	if err != nil {
-		return "", fmt.Errorf("could not parse trustyUrl: %w", err)
-	}
-	appUrl := url.URL{
-		Scheme: piUrl.Scheme,
-		Host:   fmt.Sprintf("app.%s", piUrl.Host),
-	}
-
 	for i := range sph.trackedAlternatives {
 		var rowBuf bytes.Buffer
 
@@ -142,7 +133,7 @@ func (sph *summaryPrHandler) generateSummary() (string, error) {
 			DependencyName:      sph.trackedAlternatives[i].Dependency.Name,
 			DependencyScore:     sph.trackedAlternatives[i].trustyReply.Summary.Score,
 			Alternatives:        higherScoringAlternatives,
-			BaseUrl:             appUrl.String(),
+			BaseUrl:             constants.TrustyHttpURL,
 		}); err != nil {
 			return "", fmt.Errorf("could not execute template: %w", err)
 		}


### PR DESCRIPTION
When we first developed the Trusty evaluator, we had a configurable
Trusty endpoint which we used to both talk to the API endpoint and to
construct the HTTP URL to link to a package alternative.

Nowadays, we use the name/namespace of the k8s service to contact trusty by
default (See PR #1313 and #1401), but that means our PR replies were
pointing to `http://pi.pi:8000` as well.

Instead, let's use the new prod/staging constants to add a HTTP URL of a
Trusty instance and point to that.

Since Trusty is a hosted service only, let's just use a constant.
