### PR TITLE
Add back the trusty rule_type and an example to profile.yaml

### DIFF
--- a/examples/github/profiles/profile.yaml
+++ b/examples/github/profiles/profile.yaml
@@ -141,3 +141,11 @@ pull_request:
           vulnerability_database_endpoint: https://api.osv.dev/v1/query
           package_repository:
             url: https://pypi.org/pypi
+  - type: pr_trusty_check
+    def:
+      action: summary
+      ecosystem_config:
+        - name: npm
+          score: 5
+        - name: pypi
+          score: 5

--- a/examples/github/rule-types/pr_trusty_check.yaml
+++ b/examples/github/rule-types/pr_trusty_check.yaml
@@ -1,0 +1,50 @@
+---
+version: v1
+type: rule-type
+name: pr_trusty_check
+context:
+  provider: github
+description: Verifies that pull requests do not add any dependencies with low Trusty scores
+guidance: |
+  For every pull request submitted to a repository, this rule will check if the pull request
+  adds a new dependency with a low Trusty score. If a dependency with a low
+  score is added, the PR will commented on or even rejected, depending on the configuration.
+def:
+  in_entity: pull_request
+  rule_schema:
+    type: object
+    properties:
+      action:
+        type: string
+        description: "The action to take if a package with a low score is found."
+        enum:
+          # the evaluator engine will merely pass on an error, marking the profile as failed if a packages with low scores is found
+          - profile_only
+          # the evaluator engine will add a single summary comment with a table listing the packages with low scores found
+          - summary
+        default: review
+      ecosystem_config:
+        type: array
+        description: "The configuration for the ecosystems to check."
+        items:
+          type: object
+          properties:
+            name:
+              type: string
+              description: "The name of the ecosystem to check. Currently only `npm` and `pypi` are supported."
+            pi_threshold:
+              type: number
+              description: "The minimum Trusty score for a dependency to be considered safe."
+              default: 5
+  ingest:
+    type: diff
+    diff:
+      ecosystems:
+        - name: npm
+          depfile: package-lock.json
+        - name: pypi
+          depfile: requirements.txt
+  # Defines the configuration for evaluating data ingested against the given profile
+  eval:
+    type: trusty
+    trusty: {}


### PR DESCRIPTION
I'm pretty sure this must have been a bad rebase of commit
20dfa79119871fef11be1fdcb33f457276494155 which seems to have removed the
trusty rule_type. Oops.

Also let's add an example to profile.yaml
