### PR TITLE
Return errNotHandled silently

### DIFF
--- a/internal/controlplane/handlers_githubwebhooks.go
+++ b/internal/controlplane/handlers_githubwebhooks.go
@@ -519,7 +519,9 @@ func parsePullRequestModEvent(
 	}
 
 	dbPr, err := reconcilePrWithDb(ctx, store, dbrepo, prEvalInfo)
-	if err != nil {
+	if errors.Is(err, errNotHandled) {
+		return err
+	} else if err != nil {
 		return fmt.Errorf("error reconciling PR with DB: %w", err)
 	}
 


### PR DESCRIPTION
The `errNotHandled` error was ignored later, but still printed which is
confusing.
