### PR TITLE
Update login instructions in docs

### DIFF
--- a/docs/docs/getting_started/login.md
+++ b/docs/docs/getting_started/login.md
@@ -14,6 +14,18 @@ Minder consists of a client-side CLI tool and a server-side component.  The serv
 
 If you don't want to run your own Minder server, Stacklok hosts a public instance.  See [Logging in to the Stacklok-hosted Instance](#logging-in-to-the-stacklok-hosted-instance) below.
 
+## Logging in to the Stacklok-hosted instance
+
+The `minder` CLI defaults to using the hosted Stacklok environment.  When using the hosted environment, you do not need to set up a server; you simply log in to the Stacklok authentication instance using your GitHub credentials.
+
+You can use the Stacklok hosted environment by running:
+
+```bash
+minder auth login
+```
+
+A new browser window will open and you will be prompted to log in to the Stacklok instance using your GitHub credentials.  Once you have logged in, proceed to enroll your credentials in Minder.
+
 ## Logging in to your own Minder instance
 
 To log in to a Minder server which you are running (self-hosted), you will need to know the URL of the Minder server and of the Keycloak instance used for authentication.  If you are using [`docker-compose` to run Minder on your local machine](../run_minder_server/run_the_server.md), these addresses will be `localhost:8090` for Minder and `localhost:8081` for Keycloak.
@@ -40,18 +52,6 @@ Your access credentials have been saved to ~/.config/minder/credentials.json
 ```
 
 Once you have logged in, you'll want to [enroll your GitHub credentials in Minder so that it can act on your behalf](#enrolling-the-github-provider).
-
-## Logging in to the Stacklok-hosted instance
-
-The `minder` CLI defaults to using the hosted Stacklok environment.  When using the hosted environment, you do not need to set up a server; you simply log in to the Stacklok authentication instance using your GitHub credentials.
-
-You can use the Stacklok hosted environment by running:
-
-```bash
-minder auth login
-```
-
-A new browser window will open and you will be prompted to log in to the Stacklok instance using your GitHub credentials.  Once you have logged in, proceed to enroll your credentials in Minder.
 
 ## Enrolling the GitHub Provider
 


### PR DESCRIPTION
My assumption is that when people are getting started they will use the hosted instance more often, therefore those instructions should appear first.