### PR TITLE
PathEscape artifact name to process artifacts with slash in the name

### DIFF
--- a/internal/providers/github/github_rest.go
+++ b/internal/providers/github/github_rest.go
@@ -445,8 +445,8 @@ func (c *RestClient) GetBaseURL() string {
 // which will be resolved to the BaseURL of the Client. Relative URLS should
 // always be specified without a preceding slash. If specified, the value
 // pointed to by body is JSON encoded and included as the request body.
-func (c *RestClient) NewRequest(method, url string, body any) (*http.Request, error) {
-	return c.client.NewRequest(method, url, body)
+func (c *RestClient) NewRequest(method, requestUrl string, body any) (*http.Request, error) {
+	return c.client.NewRequest(method, requestUrl, body)
 }
 
 // Do sends an API request and returns the API response.

--- a/internal/providers/github/github_rest.go
+++ b/internal/providers/github/github_rest.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 
 	"github.com/google/go-github/v53/github"
 
@@ -211,6 +212,7 @@ func (c *RestClient) GetPackageByName(ctx context.Context, isOrg bool, owner str
 	var pkg *github.Package
 	var err error
 
+	package_name = url.PathEscape(package_name)
 	if isOrg {
 		pkg, _, err = c.client.Organizations.GetPackage(ctx, owner, package_type, package_name)
 		if err != nil {
@@ -232,6 +234,7 @@ func (c *RestClient) GetPackageVersions(ctx context.Context, isOrg bool, owner s
 	var err error
 	state := "active"
 
+	package_name = url.PathEscape(package_name)
 	if isOrg {
 		versions, _, err = c.client.Organizations.PackageGetAllVersions(ctx, owner, package_type,
 			package_name, &github.PackageListOptions{PackageType: &package_type, State: &state})
@@ -255,6 +258,8 @@ func (c *RestClient) GetPackageVersionByTag(ctx context.Context, isOrg bool, own
 	var versions []*github.PackageVersion
 	var err error
 	state := "active"
+
+	package_name = url.PathEscape(package_name)
 
 	if isOrg {
 		versions, _, err = c.client.Organizations.PackageGetAllVersions(ctx, owner, package_type,
@@ -294,6 +299,8 @@ func (c *RestClient) GetPackageVersionById(
 ) (*github.PackageVersion, error) {
 	var pkgVersion *github.PackageVersion
 	var err error
+
+	packageName = url.PathEscape(packageName)
 
 	if isOrg {
 		pkgVersion, _, err = c.client.Organizations.PackageGetVersion(ctx, owner, packageType, packageName, version)

--- a/internal/providers/github/github_test.go
+++ b/internal/providers/github/github_test.go
@@ -16,6 +16,8 @@ package github
 
 import (
 	"context"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -35,4 +37,82 @@ func TestNewRestClient(t *testing.T) {
 
 	assert.NoError(t, err)
 	assert.NotNil(t, client)
+}
+
+func TestArtifactAPIEscapes(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		testHandler http.HandlerFunc
+		cliFn       func(cli *RestClient)
+		wantErr     bool
+	}{
+		{
+			name: "GetPackageByName escapes the package name",
+			testHandler: func(w http.ResponseWriter, r *http.Request) {
+				assert.Equal(t, "/orgs/stacklok/packages/container/helm%2Fmediator", r.URL.RequestURI())
+				w.WriteHeader(http.StatusOK)
+			},
+			cliFn: func(cli *RestClient) {
+				_, err := cli.GetPackageByName(context.Background(), true, "stacklok", "container", "helm/mediator")
+				assert.NoError(t, err)
+			},
+		},
+		{
+			name: "GetPackageVersions escapes the package name",
+			testHandler: func(w http.ResponseWriter, r *http.Request) {
+				assert.Equal(t, "/orgs/stacklok/packages/container/helm%2Fmediator/versions?package_type=container&state=active", r.URL.RequestURI())
+				w.WriteHeader(http.StatusOK)
+			},
+			cliFn: func(cli *RestClient) {
+				_, err := cli.GetPackageVersions(context.Background(), true, "stacklok", "container", "helm/mediator")
+				assert.NoError(t, err)
+			},
+		},
+		{
+			name: "GetPackageVersionByTag escapes the package name",
+			testHandler: func(w http.ResponseWriter, r *http.Request) {
+				assert.Equal(t, "/orgs/stacklok/packages/container/helm%2Fmediator/versions?package_type=container&state=active", r.URL.RequestURI())
+				w.WriteHeader(http.StatusOK)
+			},
+			cliFn: func(cli *RestClient) {
+				_, err := cli.GetPackageVersionByTag(context.Background(), true, "stacklok", "container", "helm/mediator", "v1.0.0")
+				assert.NoError(t, err)
+			},
+		},
+		{
+			name: "GetPackageVersionByID escapes the package name",
+			testHandler: func(w http.ResponseWriter, r *http.Request) {
+				assert.Equal(t, "/orgs/stacklok/packages/container/helm%2Fmediator/versions/123", r.URL.RequestURI())
+				w.WriteHeader(http.StatusOK)
+			},
+			cliFn: func(cli *RestClient) {
+				_, err := cli.GetPackageVersionById(context.Background(), true, "stacklok", "container", "helm/mediator", 123)
+				assert.NoError(t, err)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			testServer := httptest.NewServer(tt.testHandler)
+			defer testServer.Close()
+
+			client, err := NewRestClient(context.Background(), &minderv1.GitHubProviderConfig{
+				Endpoint: testServer.URL + "/",
+			},
+				provtelemetry.NewNoopMetrics(),
+				"token", "")
+			assert.NoError(t, err)
+			assert.NotNil(t, client)
+
+			tt.cliFn(client)
+		})
+	}
+
 }


### PR DESCRIPTION
e.g. to get the minder helm chart, we need the API to call:
```
https://api.github.com/orgs/stacklok/packages/container/package/minder%2Fhelm%2Fminder
```
but we've been seeing a bunch of:
```
GET
https://api.github.com/orgs/stacklok/packages/container/minder/helm/minder:
404 Not Found
```
in the logs.
