### PR TITLE
Instantiate mock client for each test in branch protection remediations test

### DIFF
--- a/internal/engine/actions/remediate/gh_branch_protect/gh_branch_protect_test.go
+++ b/internal/engine/actions/remediate/gh_branch_protect/gh_branch_protect_test.go
@@ -247,13 +247,13 @@ func TestBranchProtectionRemediate(t *testing.T) {
 		},
 	}
 
-	mockClient := mock_ghclient.NewMockGitHub(ctrl)
-
 	for _, tt := range tests {
 		tt := tt
 
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
+
+			mockClient := mock_ghclient.NewMockGitHub(ctrl)
 
 			engine, err := NewGhBranchProtectRemediator(tt.newRemArgs.actionType, tt.newRemArgs.ghp, tt.newRemArgs.pbuild)
 			if tt.wantInitErr {


### PR DESCRIPTION
This ensures we're not overwriting `EXPECT` calls in between the parallel
tests and thus ensuring we don't have race conditions.
