### PR TITLE
Hook up minder healthcheck to database health

### DIFF
--- a/internal/controlplane/handlers.go
+++ b/internal/controlplane/handlers.go
@@ -25,6 +25,9 @@ package controlplane
 import (
 	"context"
 
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
 	pb "github.com/stacklok/minder/pkg/api/protobuf/go/minder/v1"
 )
 
@@ -32,11 +35,9 @@ import (
 const PaginationLimit = 10
 
 // CheckHealth is a simple health check for monitoring
-// The lintcheck is disabled because the unused-receiver is required by
-// the implementation. UnimplementedHealthServiceServer is initialized
-// within the Server struct
-//
-//revive:disable:unused-receiver
 func (s *Server) CheckHealth(_ context.Context, _ *pb.CheckHealthRequest) (*pb.CheckHealthResponse, error) {
+	if err := s.store.CheckHealth(); err != nil {
+		return nil, status.Errorf(codes.Internal, "failed to check health: %v", err)
+	}
 	return &pb.CheckHealthResponse{Status: "OK"}, nil
 }

--- a/internal/controlplane/handlers_test.go
+++ b/internal/controlplane/handlers_test.go
@@ -18,13 +18,25 @@ import (
 	"context"
 	"testing"
 
+	"github.com/golang/mock/gomock"
+
+	mockdb "github.com/stacklok/minder/database/mock"
 	pb "github.com/stacklok/minder/pkg/api/protobuf/go/minder/v1"
 )
 
 func TestCheckHealth(t *testing.T) {
 	t.Parallel()
 
-	server := Server{}
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockStore := mockdb.NewMockStore(ctrl)
+
+	mockStore.EXPECT().CheckHealth().Return(nil)
+
+	server := Server{
+		store: mockStore,
+	}
 	response, err := server.CheckHealth(context.Background(), &pb.CheckHealthRequest{})
 	if err != nil {
 		t.Errorf("Error in CheckHealth: %v", err)

--- a/internal/controlplane/server_test.go
+++ b/internal/controlplane/server_test.go
@@ -18,7 +18,6 @@ package controlplane
 import (
 	"context"
 	"log"
-	"net"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -29,7 +28,6 @@ import (
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
-	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/test/bufconn"
 
 	mockdb "github.com/stacklok/minder/database/mock"
@@ -67,20 +65,6 @@ func init() {
 	httpServer.Config.ReadHeaderTimeout = 10 * time.Second
 	httpServer.Start()
 	// It would be nice if we could Close() the httpServer, but we leak it in the test instead
-}
-
-func bufDialer(context.Context, string) (net.Conn, error) {
-	return lis.Dial()
-}
-
-func getgRPCConnection() (*grpc.ClientConn, error) {
-	conn, err := grpc.DialContext(context.Background(), "bufnet",
-		grpc.WithContextDialer(bufDialer),
-		grpc.WithTransportCredentials(insecure.NewCredentials()))
-	if err != nil {
-		return nil, err
-	}
-	return conn, nil
 }
 
 func newDefaultServer(t *testing.T, mockStore *mockdb.MockStore) *Server {

--- a/internal/controlplane/server_test.go
+++ b/internal/controlplane/server_test.go
@@ -122,22 +122,6 @@ func generateTokenKey(t *testing.T) string {
 	return tokenKeyPath
 }
 
-func TestHealth(t *testing.T) {
-	t.Parallel()
-
-	conn, err := getgRPCConnection()
-	if err != nil {
-		t.Fatalf("Failed to dial bufnet: %v", err)
-	}
-	defer conn.Close()
-
-	client := pb.NewHealthServiceClient(conn)
-	_, err = client.CheckHealth(context.Background(), &pb.CheckHealthRequest{})
-	if err != nil {
-		t.Fatalf("Failed to get health: %v", err)
-	}
-}
-
 func TestWebhook(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
The intention is to link minder's health with the database and keep the
db connection open for longer.
