### PR TITLE
Enable skipping teardown when using the `run-docker` Makefile target

### DIFF
--- a/.mk/develop.mk
+++ b/.mk/develop.mk
@@ -26,7 +26,7 @@ run-server: ## run the app
 	@go run -ldflags "-X main.version=$(shell git describe --abbrev=0 --tags)" -tags '$(BUILDTAGS)' ./cmd/server serve
 
 .PHONY: run-docker-teardown
-run-docker-teardown:
+run-docker-teardown: ## teardown the docker-compose environment
 ifeq ($(RUN_DOCKER_NO_TEARDOWN),false)
 	@echo "Running docker-compose down"
 	@$(COMPOSE) down


### PR DESCRIPTION
Now you can use an environment variable to tell our `run-docker` target
to skip the teardown phase. It may be done as follows:

```bash
export RUN_DOCKER_NO_TEARDOWN=true
```

This will result in subsequent calls to `make teardown` to skip the
`docker-compose down` call at the beginning of the run.

this is handy for cases where you're doing rapid development and want
to keep the database changes.
