### PR TITLE
Add enhanced user agent informtion to CLI

### DIFF
--- a/cmd/cli/app/version/version.go
+++ b/cmd/cli/app/version/version.go
@@ -22,6 +22,7 @@ import (
 	"github.com/stacklok/minder/cmd/cli/app"
 	"github.com/stacklok/minder/internal/constants"
 	"github.com/stacklok/minder/internal/util/cli"
+	"github.com/stacklok/minder/internal/util/cli/useragent"
 )
 
 // VersionCmd is the version command
@@ -31,6 +32,7 @@ var VersionCmd = &cobra.Command{
 	Long:  `The minder version command prints the version of the minder CLI.`,
 	Run: func(cmd *cobra.Command, _ []string) {
 		cli.PrintCmd(cmd, constants.VerboseCLIVersion)
+		cli.PrintCmd(cmd, "User Agent: %s", useragent.GetUserAgent())
 	},
 }
 

--- a/internal/constants/version.go
+++ b/internal/constants/version.go
@@ -44,7 +44,7 @@ const (
 	verboseTemplate = `Version: {{.Version}}
 Go Version: {{.GoVersion}}
 Git Commit: {{.Commit}}
-Built: {{.Time}}
+Commit Date: {{.Time}}
 OS/Arch: {{.OS}}/{{.Arch}}
 Dirty: {{.Modified}}`
 )

--- a/internal/util/cli/useragent/useragent.go
+++ b/internal/util/cli/useragent/useragent.go
@@ -1,0 +1,46 @@
+//
+// Copyright 2023 Stacklok, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// NOTE: This file is for stubbing out client code for proof of concept
+// purposes. It will / should be removed in the future.
+// Until then, it is not covered by unit tests and should not be used
+// It does make a good example of how to use the generated client code
+// for others to use as a reference.
+
+// Package useragent contains utilities for setting up the CLI's user agent
+package useragent
+
+import (
+	"fmt"
+	"runtime"
+
+	"github.com/stacklok/minder/internal/constants"
+)
+
+// GetUserAgent returns the user agent string for the CLI
+// Note that the user agent used here replicates the user agent used by the
+// browsers.
+// e.g. <product>/<product-version> (<system-information>) <platform> (<platform-details>) <extensions>
+//
+// In our case, we'll leave extensions empty.
+func GetUserAgent() string {
+	product := "minder-cli"
+	productVersion := constants.CLIVersion
+
+	userAgent := fmt.Sprintf("%s/%s (%s) %s (%s)",
+		product, productVersion, runtime.GOOS, runtime.GOARCH, runtime.Version())
+
+	return userAgent
+}


### PR DESCRIPTION
This replicates the user agent format that browsers use in order to
get more relevant debugging information without revealing any PII.
