### PR TITLE
Disable read-only FS until we fix issue #1589

### DIFF
--- a/deployment/helm/templates/deployment.yaml
+++ b/deployment/helm/templates/deployment.yaml
@@ -38,7 +38,6 @@ spec:
           securityContext:
             allowPrivilegeEscalation: false
             runAsNonRoot: true
-            readOnlyRootFilesystem: true
             seccompProfile:
               type: RuntimeDefault
             capabilities:


### PR DESCRIPTION
We track go-tuf writing into /home and not being allowed to in issue
artifact signatures.
