### PR TITLE
Set SIGSTORE_NO_CACHE=true in minder

### DIFF
--- a/deployment/helm/templates/deployment.yaml
+++ b/deployment/helm/templates/deployment.yaml
@@ -64,6 +64,8 @@ spec:
             value: "/secrets/identity/identity_client_secret"
           - name: "MINDER_UNSTABLE_TRUSTY_ENDPOINT"
             value: "{{ .Values.trusty.endpoint }}"
+          - name: "SIGSTORE_NO_CACHE"
+            value: "true"
           
           # ko will always specify a digest, so we don't need to worry about
           # CRI image caching

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -54,6 +54,7 @@ services:
       - MINDER_AUTH_REFRESH_TOKEN_PRIVATE_KEY=/app/.ssh/refresh_token_rsa
       - MINDER_AUTH_REFRESH_TOKEN_PUBLIC_KEY=/app/.ssh/refresh_token_rsa.pub
       - MINDER_AUTH_TOKEN_KEY=/app/.ssh/token_key_passphrase
+      - SIGSTORE_NO_CACHE=true
     networks:
       - app_net
     depends_on:


### PR DESCRIPTION
Disable file system caching of tuf metadata for minder.

In sigstore/sigstore there's a [SIGSTORE_NO_CACHE](https://github.com/sigstore/sigstore/blob/ee007c4780d59fec556ddf09607cfefcd63923e1/pkg/tuf/client.go#L57) env var that apparently should allow cosign to work without storing anything on disk which would allows us to keep having a readonly file system for minder.

Related to: https://github.com/stacklok/minder/pull/1606 and https://github.com/stacklok/minder/issues/1589