### PR TITLE
Add switch to migrate up/down to do one step migration, add migrate version

### DIFF
--- a/cmd/server/app/migrate.go
+++ b/cmd/server/app/migrate.go
@@ -16,6 +16,9 @@
 package app
 
 import (
+	"os"
+	"path/filepath"
+
 	"github.com/spf13/cobra"
 )
 
@@ -32,4 +35,9 @@ var migrateCmd = &cobra.Command{
 func init() {
 	RootCmd.AddCommand(migrateCmd)
 	migrateCmd.PersistentFlags().BoolP("yes", "y", false, "Answer yes to all questions")
+	migrateCmd.PersistentFlags().UintP("num-steps", "n", 0, "Number of steps to migrate")
+}
+
+func getMigrateConfigPath() string {
+	return "file://" + filepath.Join(os.Getenv("KO_DATA_PATH"), "database/migrations")
 }


### PR DESCRIPTION
When testing more complex database migrations, it's useful to do
migration one step up or down. This patch adds a new parameter to
migrate up and down that allows to specify the number of steps,
defaulting to migrating the whole way up or down.

Also adds a new migrate subcommand version that prints the current
database version.
