### PR TITLE
docs: adds prerequisites to the register a repo getting started page

### DIFF
--- a/docs/docs/getting_started/register_repos.md
+++ b/docs/docs/getting_started/register_repos.md
@@ -3,6 +3,12 @@ title: Register Repositories
 sidebar_position: 30
 ---
 
+## Prerequisites
+
+* [The `minder` CLI application](./install_cli.md)
+* [A Minder account](./login.md)
+* [An enrolled GitHub token](./login.md#enrolling-the-github-provider) that is either an Owner in the organization or an Admin on the repositories
+
 ## Register repositories
 
 Now that you have enrolled with GitHub as a provider, you can now register repositories. We will use the `repo` command.


### PR DESCRIPTION
👋 As I was following the [Getting Started guide](https://docs.stacklok.com/minder/getting_started/) I got stuck on the [Register a repo step](https://docs.stacklok.com/minder/getting_started/register_repos) since even though I did auth, I missed enrolling.

For those of us who suck at reading docs, I am adding a Prerequisites section to the register a repo page, following the example of the other steps.