### PR TITLE
Adds a link to docs readme to contribution guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,36 +2,39 @@
 # Contributing to Minder
 First off, thank you for taking the time to contribute to Minder! :+1: :tada: Minder is released under the Apache 2.0 license. If you would like to contribute something or want to hack on the code, this document should help you get started. You can find some hints for starting development in Minder's  [README](https://github.com/stacklok/minder/blob/main/README.md).
 
-### Table of contents 
-* [Code of Conduct](#Code-of-Conduct)
-* [Reporting Security Vulnerabilities](#Reporting-Security-Vulnerabilities)
-* [How to Contrubute](How-to-Contribute)
-  * [Using GitHub Issues](#Using-GitHub-Issues)
-  * [Sign the Contributor License Agreement](#Sign-the-Contributor-License-Agreement)
-  * [Pull Request Process](#Pull-Request-Process)
-  * [Commit Message Guidelines](#Commit-Message-Guidelines)
+## Table of contents 
+- [Code of Conduct](#code-of-conduct)
+- [Reporting Security Vulnerabilities](#reporting-security-vulnerabilities)
+- [How to Contribute](#how-to-contribute)
+  - [Sign the Contributor License Agreement](#sign-the-contributor-license-agreement)
+  - [Using GitHub Issues](#using-github-issues)
+  - [Not sure how to start contributing...](#not-sure-how-to-start-contributing)
+  - [Pull Request Process](#pull-request-process)
+  - [Contributing to docs](#contributing-to-docs)
+  - [Commit Message Guidelines](#commit-message-guidelines)
   
 
-### Code of Conduct
+## Code of Conduct
 This project adheres to the [Contributor Covenant](https://github.com/stacklok/minder/blob/main/CODE_OF_CONDUCT.md) code of conduct. By participating, you are expected to uphold this code. Please report unacceptable behavior to code-of-conduct@stacklok.dev.
 
-### Reporting Security Vulnerabilities
+## Reporting Security Vulnerabilities
 
 If you think you have found a security vulnerability in Minder please DO NOT disclose it publicly until we’ve had a chance to fix it. Please don’t report security vulnerabilities using GitHub issues; instead, please follow this [process](https://github.com/stacklok/minder/blob/main/SECURITY.md)
-### How to Contribute
 
-#### Using GitHub Issues
+## How to Contribute
+
+### Using GitHub Issues
 We use GitHub issues to track bugs and enhancements. If you have a general usage question, please ask in [Minder's discussion forum](https://github.com/stacklok/minder/discussions). 
 
 If you are reporting a bug, please help to speed up problem diagnosis by providing as much information as possible. Ideally, that would include a small sample project that reproduces the problem.
 
-#### Sign the Contributor License Agreement
+### Sign the Contributor License Agreement
 Before we accept a non-trivial patch or pull request, we will need you to sign the [Contributor License Agreement](https://github.com/stacklok/minder). Signing the contributor’s agreement does not grant anyone commit rights to the main repository, but it does mean that we can accept your contributions, and you will get an author credit if we do. Active contributors might be asked to join the core team and given the ability to merge pull requests.
 
-#### Not sure how to start contributing...
+### Not sure how to start contributing...
 PRs to resolve existing issues are greatly appreciated and issues labeled as ["good first issue"](https://github.com/stacklok/minder/issues?q=is%3Aopen+is%3Aissue+label%3A%22good+first+issue%22) are a great place to start!
 
-#### Pull Request Process
+### Pull Request Process
 * Create an issue outlining the fix or feature.
 * Fork the Minder repository to your own GitHub account and clone it locally.
 * Hack on your changes.
@@ -41,7 +44,8 @@ PRs to resolve existing issues are greatly appreciated and issues labeled as ["g
 * Every pull request requires a review from the core Minder team before merging.
 * Once approved, all of your commits will be squashed into a single commit with your PR title.
 
-#### Commit Message Guidelines
+### Contributing to docs
+Follow [this guide](https://github.com/stacklok/minder/blob/main/docs/README.md) for instructions on building, running, and previewing Miner's documentation.
+
+### Commit Message Guidelines
 We follow the commit formatting recommendations found on [Chris Beams' How to Write a Git Commit Message article](https://chris.beams.io/posts/git-commit/).
-
-


### PR DESCRIPTION
I was kinda lost today while trying to build the documentation to preview my changes.

This PR is adding a link to the docs readme from the contribution guidelines. It's also fixing the markdown title hierarchy and completing the ToC.

