### PR TITLE
Add issuer_url for running minder outside of docker-compose

### DIFF
--- a/config/config.yaml.example
+++ b/config/config.yaml.example
@@ -50,7 +50,7 @@ identity:
     realm: stacklok
     client_id: minder-cli
   server:
-    issuer_url: http://keycloak:8080
+    issuer_url: http://keycloak:8080 # Use http://localhost:8081 instead for running minder outside of docker-compose
     realm: stacklok
     client_id: minder-server
     client_secret: secret


### PR DESCRIPTION
The following PR adds a comment with how to update the config.yaml in case you want to run minder outside of the docker-compose stack. Helpful for debugging.