### PR TITLE
Normalize python package names before sending to OSV

### DIFF
--- a/internal/engine/ingester/diff/parse.go
+++ b/internal/engine/ingester/diff/parse.go
@@ -19,6 +19,7 @@ import (
 	"bufio"
 	"encoding/json"
 	"fmt"
+	"regexp"
 	"strings"
 
 	"github.com/stacklok/minder/internal/util"
@@ -119,10 +120,16 @@ func pyReqNormalizeLine(line string) string {
 func pyReqAddPkgName(depList []*pb.Dependency, pkgName, version string) []*pb.Dependency {
 	dep := &pb.Dependency{
 		Ecosystem: pb.DepEcosystem_DEP_ECOSYSTEM_PYPI,
-		Name:      pkgName,
+		Name:      pyNormalizeName(pkgName),
 		Version:   version,
 	}
 	return append(depList, dep)
+}
+
+func pyNormalizeName(pkgName string) string {
+	regex := regexp.MustCompile(`[-_.]+`)
+	result := regex.ReplaceAllString(pkgName, "-")
+	return strings.ToLower(result)
 }
 
 func goParse(patch string) ([]*pb.Dependency, error) {

--- a/internal/engine/ingester/diff/parse_test.go
+++ b/internal/engine/ingester/diff/parse_test.go
@@ -303,6 +303,20 @@ func TestPyPiParse(t *testing.T) {
 			expectedCount:        0,
 			expectedDependencies: []*pb.Dependency{},
 		},
+		{
+			description: "Single addition, uppercase",
+			content: `
+ Flask
++ Django==3.2.21`,
+			expectedCount: 1,
+			expectedDependencies: []*pb.Dependency{
+				{
+					Ecosystem: pb.DepEcosystem_DEP_ECOSYSTEM_PYPI,
+					Name:      "django",
+					Version:   "3.2.21",
+				},
+			},
+		},
 	}
 	for _, tt := range tests {
 		tt := tt


### PR DESCRIPTION
Fix #1633