### PR TITLE
Link PRs with rule_evaluation_status properly

### DIFF
--- a/database/migrations/000008_remove_null_prs.down.sql
+++ b/database/migrations/000008_remove_null_prs.down.sql
@@ -1,0 +1,15 @@
+-- Copyright 2023 Stacklok, Inc
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--      http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+-- this down migration is intentionally empty. It's here to make sure that migrations run at all.

--- a/database/migrations/000008_remove_null_prs.up.sql
+++ b/database/migrations/000008_remove_null_prs.up.sql
@@ -1,0 +1,22 @@
+-- Copyright 2023 Stacklok, Inc
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--      http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+BEGIN;
+
+-- see bug #1608: we were not linking PRs properly with rule evaluations. Just drop those rows, there's nothing
+-- we can do with them.
+DELETE FROM rule_evaluations WHERE entity = 'pull_request' AND pull_request_id IS NULL;
+
+-- transaction commit
+COMMIT;

--- a/internal/engine/eval_status.go
+++ b/internal/engine/eval_status.go
@@ -135,9 +135,10 @@ func (e *Executor) createOrUpdateEvalStatus(
 			UUID:  params.RepoID,
 			Valid: true,
 		},
-		ArtifactID: params.ArtifactID,
-		Entity:     params.EntityType,
-		RuleTypeID: params.RuleTypeID,
+		ArtifactID:    params.ArtifactID,
+		Entity:        params.EntityType,
+		RuleTypeID:    params.RuleTypeID,
+		PullRequestID: params.PullRequestID,
 	})
 
 	if err != nil {


### PR DESCRIPTION
For some reason (probably refactoring and merging too many patches at
the same time?) we no longer linked PRs with evaluation results. This
meant that once a PR was merged, the evaluation result was still
included.- Also link PR IDs with evaluation status

To get rid of the dangling references, we delete them in a migration. This is OK, because there are only two events that we listen on:
- PR is opened - in this case we upsert a PR entry
- PR is closed - in this case we delete a PR entry and ignore ErrNoRows

Fixes: #1608
