### PR TITLE
Log the full remediation and alert error

### DIFF
--- a/internal/engine/executor.go
+++ b/internal/engine/executor.go
@@ -263,13 +263,13 @@ func logEval(
 	evalLog.Err(params.GetEvalErr()).Msg("result - evaluation")
 
 	// log remediation
-	logger.Debug().
+	logger.Err(params.GetActionsErr().RemediateErr).
 		Str("action", "remediate").
 		Str("action_status", string(evalerrors.ErrorAsRemediationStatus(params.GetActionsErr().RemediateErr))).
 		Msg("result - action")
 
 	// log alert
-	logger.Debug().
+	logger.Err(params.GetActionsErr().AlertErr).
 		Str("action", "alert").
 		Str("action_status", string(evalerrors.ErrorAsAlertStatus(params.GetActionsErr().AlertErr))).
 		Msg("result - action")


### PR DESCRIPTION
We didn't really log the error it seems, it was visible in the status
and in the database, but having it in logs is useful, too.

If the error we pass is `nil`, the log message would be `Info` instead.
