### PR TITLE
Handle PR statuses when setting branch protection rules

### DIFF
--- a/internal/engine/actions/remediate/gh_branch_protect/gh_branch_protect.go
+++ b/internal/engine/actions/remediate/gh_branch_protect/gh_branch_protect.go
@@ -207,6 +207,15 @@ func protectionResultToRequest(res *github.Protection) *github.ProtectionRequest
 		RequiredStatusChecks:       res.RequiredStatusChecks,
 	}
 
+	if req.RequiredStatusChecks != nil {
+		if req.RequiredStatusChecks.Checks != nil && len(req.RequiredStatusChecks.Contexts) > 0 {
+			// if both are set, the API will return an error as Contexts is now deprecated
+			// but at the same time the API does return both fields, so we filter the deprecated
+			// one manually
+			req.RequiredStatusChecks.Contexts = nil
+		}
+	}
+
 	if res.EnforceAdmins != nil {
 		req.EnforceAdmins = res.EnforceAdmins.Enabled
 	}


### PR DESCRIPTION
The GH API returns both `Protection.RequiredStatusChecks.Contexts` which
is deprecated and `Protection.RequiredStatusChecks.Checks` which is
supposed to be used now on GET, but the PUT update needs to only set one
or the other.

Let's filter out the deprecated field so that setting branch protection
rules when commit statuses are in place works fine.

Fixes: #1596
