### PR TITLE
Don't log skipping rules as errors

### DIFF
--- a/internal/engine/executor.go
+++ b/internal/engine/executor.go
@@ -263,14 +263,22 @@ func logEval(
 	evalLog.Err(params.GetEvalErr()).Msg("result - evaluation")
 
 	// log remediation
-	logger.Err(params.GetActionsErr().RemediateErr).
+	logger.Err(filterActionErrorForLogging(params.GetActionsErr().RemediateErr)).
 		Str("action", "remediate").
 		Str("action_status", string(evalerrors.ErrorAsRemediationStatus(params.GetActionsErr().RemediateErr))).
 		Msg("result - action")
 
 	// log alert
-	logger.Err(params.GetActionsErr().AlertErr).
+	logger.Err(filterActionErrorForLogging(params.GetActionsErr().AlertErr)).
 		Str("action", "alert").
 		Str("action_status", string(evalerrors.ErrorAsAlertStatus(params.GetActionsErr().AlertErr))).
 		Msg("result - action")
+}
+
+func filterActionErrorForLogging(err error) error {
+	if evalerrors.IsActionFatalError(err) {
+		return err
+	}
+
+	return nil
 }


### PR DESCRIPTION
Commit 0ef19262ce6fd6f6ff3cbe068fe8189a91f7b7ca added logging for
remediation and alert levels, but it turns out that we would even log
skipped remediations and alerts as errors which made the logs very
spammy.

Let's fix all but fatal errors.
