### PR TITLE
Implement a quickstart command for minder

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,29 +83,18 @@ minder auth login
 
 Upon completion, you should see that the Minder Server is set to `api.stacklok.com`.
 
-## Enroll a repository provider
-
-Minder supports GitHub as a provider to enroll repositories. To enroll your provider, run:
-
-```bash
-minder provider enroll --provider github
-```
-
-A browser session will open, and you will be prompted to login to your GitHub.
-Once you have granted Minder access, you will be redirected back, and the user will be enrolled.
-The minder CLI application will report the session is complete.
-
 ## Quickstart
 
-Minder provides a "happy path" that allows you to create a profile with enabled secret scanning for
-repositories of your choice in just a few seconds. To do so, run:
+Minder provides a "happy path" that guides you through the process of creating your first profile in Minder. 
+In just a few seconds, you will register your repositories and enable secret scanning protection for all of them.
+To do so, run:
 
 ```bash
 minder quickstart --provider github
 ```
 
-This will prompt you to select the repositories you'd like to enable secret scanning for, create the `secret_scanning`
-rule type and create a profile with secret scanning enabled for the selected repositories.
+This will prompt you to enroll your provider, select the repositories you'd like, create the `secret_scanning`
+rule type and create a profile which enables secret scanning for the selected repositories.
 
 To see the status of your profile, run:
 

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ In just a few seconds, you will register your repositories and enable secret sca
 To do so, run:
 
 ```bash
-minder quickstart --provider github
+minder quickstart
 ```
 
 This will prompt you to enroll your provider, select the repositories you'd like, create the `secret_scanning`

--- a/README.md
+++ b/README.md
@@ -95,26 +95,58 @@ A browser session will open, and you will be prompted to login to your GitHub.
 Once you have granted Minder access, you will be redirected back, and the user will be enrolled.
 The minder CLI application will report the session is complete.
 
-## Register a repository
+## Quickstart
 
-Now that you've granted the GitHub app permissions to access your repositories, you can register them:
+Minder provides a "happy path" that allows you to create a profile with enabled secret scanning for
+repositories of your choice in just a few seconds. To do so, run:
 
 ```bash
-minder repo register --provider github
+minder quickstart --provider github
 ```
 
-Once you've registered the repositories, the Minder server will listen for events from GitHub and will
-automatically create the necessary webhooks for you.
+This will prompt you to select the repositories you'd like to enable secret scanning for, create the `secret_scanning`
+rule type and create a profile with secret scanning enabled for the selected repositories.
 
-Now you can run `minder` commands against the public instance of Minder where you can manage your registered repositories
-and create custom profiles that would help ensure your repositories are configured consistently and securely.
+To see the status of your profile, run:
+
+```bash
+minder profile_status list --profile quickstart-profile --detailed
+```
+
+You should see the overall profile status and a detailed view of the rule evaluation statuses for each of your registered repositories.
+
+Minder will continue to keep track of your repositories and will ensure to fix any drifts from the desired state by
+using the `remediate` feature or alert you, if needed, using the `alert` feature.
+
+Congratulations! 🎉 You've now successfully created your first profile!
+
+## What's next?
+
+You can now continue to explore Minder's features by adding or removing more repositories, create more profiles with
+various rules, and much more. There's a lot more to Minder than just secret scanning. 
+
+The `secret_scanning` rule is just one of the many rule types that Minder supports. 
+
+You can see the full list of ready-to-use rules and profiles
+maintained by Minder's team here - [stacklok/minder-rules-and-profiles](https://github.com/stacklok/minder-rules-and-profiles).
+
+In case there's something you don't find there yet, Minder is designed to be extensible.
+This allows for users to create their own custom rule types and profiles and ensure the specifics of their security
+posture are attested to.
+
+Now that you have everything set up, you can continue to run `minder` commands against the public instance of Minder
+where you can manage your registered repositories, create profiles, rules and much more, so you can ensure your repositories are
+configured consistently and securely.
 
 For more information about `minder`, see:
 * `minder` CLI commands - [Docs](https://minder-docs.stacklok.dev/ref/cli/minder).
 * `minder` REST API Documentation - [Docs](https://minder-docs.stacklok.dev/ref/api).
+* `minder` rules and profiles maintained by Minder's team - [GitHub](https://github.com/stacklok/minder-rules-and-profiles).
 * Minder documentation - [Docs](https://minder-docs.stacklok.dev).
 
 # Development
+
+This section describes how to build and run Minder from source.
 
 ## Build from source
 

--- a/cmd/cli/app/profile/profile_create.go
+++ b/cmd/cli/app/profile/profile_create.go
@@ -95,8 +95,8 @@ within a minder control plane.`,
 			return fmt.Errorf("error creating profile: %w", err)
 		}
 
-		table := initializeTable(cmd)
-		renderProfileTable(resp.GetProfile(), table)
+		table := InitializeTable(cmd)
+		RenderProfileTable(resp.GetProfile(), table)
 		table.Render()
 		return nil
 	},

--- a/cmd/cli/app/profile/profile_get.go
+++ b/cmd/cli/app/profile/profile_get.go
@@ -97,9 +97,9 @@ func init() {
 }
 
 func handleGetTableOutput(cmd *cobra.Command, profile *pb.Profile) {
-	table := initializeTable(cmd)
+	table := InitializeTable(cmd)
 
-	renderProfileTable(profile, table)
+	RenderProfileTable(profile, table)
 
 	table.Render()
 }

--- a/cmd/cli/app/profile/profile_list.go
+++ b/cmd/cli/app/profile/profile_list.go
@@ -104,10 +104,10 @@ func init() {
 }
 
 func handleListTableOutput(cmd *cobra.Command, resp *pb.ListProfilesResponse) {
-	table := initializeTable(cmd)
+	table := InitializeTable(cmd)
 
 	for _, v := range resp.Profiles {
-		renderProfileTable(v, table)
+		RenderProfileTable(v, table)
 	}
 	table.Render()
 }

--- a/cmd/cli/app/profile/profile_update.go
+++ b/cmd/cli/app/profile/profile_update.go
@@ -95,8 +95,8 @@ within a minder control plane.`,
 			return fmt.Errorf("error updating profile: %w", err)
 		}
 
-		table := initializeTable(cmd)
-		renderProfileTable(resp.GetProfile(), table)
+		table := InitializeTable(cmd)
+		RenderProfileTable(resp.GetProfile(), table)
 		table.Render()
 		return nil
 	},

--- a/cmd/cli/app/profile/table_render.go
+++ b/cmd/cli/app/profile/table_render.go
@@ -24,7 +24,8 @@ import (
 	minderv1 "github.com/stacklok/minder/pkg/api/protobuf/go/minder/v1"
 )
 
-func initializeTable(cmd *cobra.Command) *tablewriter.Table {
+// InitializeTable initializes the table for rendering profiles
+func InitializeTable(cmd *cobra.Command) *tablewriter.Table {
 	table := tablewriter.NewWriter(cmd.OutOrStdout())
 	table.SetHeader([]string{"Id", "Name", "Provider", "Entity", "Rule", "Rule Params", "Rule Definition"})
 	table.SetRowLine(true)
@@ -36,7 +37,8 @@ func initializeTable(cmd *cobra.Command) *tablewriter.Table {
 	return table
 }
 
-func renderProfileTable(
+// RenderProfileTable renders the profile table
+func RenderProfileTable(
 	p *minderv1.Profile,
 	table *tablewriter.Table,
 ) {

--- a/cmd/cli/app/quickstart/embed/profile.yaml
+++ b/cmd/cli/app/quickstart/embed/profile.yaml
@@ -1,0 +1,26 @@
+#  Copyright 2023 Stacklok, Inc.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+---
+# sample profile for the quickstart command
+version: v1
+type: profile
+name: quickstart-profile
+context:
+  provider: github
+alert: "on"
+remediate: "on"
+repository:
+  - type: secret_scanning
+    def:
+      enabled: true

--- a/cmd/cli/app/quickstart/embed/secret_scanning.yaml
+++ b/cmd/cli/app/quickstart/embed/secret_scanning.yaml
@@ -1,0 +1,71 @@
+#  Copyright 2023 Stacklok, Inc.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+---
+version: v1
+type: rule-type
+name: secret_scanning
+context:
+  provider: github
+description: Verifies that secret scanning is enabled for a given repository.
+guidance: |
+  Secret scanning is a feature that scans repositories for secrets and alerts
+  the repository owner when a secret is found. To enable this feature in GitHub,
+  you must enable it in the repository settings.
+
+  For more information, see
+  https://docs.github.com/en/github/administering-a-repository/about-secret-scanning
+def:
+  # Defines the section of the pipeline the rule will appear in.
+  # This will affect the template used to render multiple parts
+  # of the rule.
+  in_entity: repository
+  # Defines the schema for writing a rule with this rule being checked
+  rule_schema:
+    properties:
+      enabled:
+        type: boolean
+        default: true
+  # Defines the configuration for ingesting data relevant for the rule
+  ingest:
+    type: rest
+    rest:
+      # This is the path to the data source. Given that this will evaluate
+      # for each repository in the organization, we use a template that
+      # will be evaluated for each repository. The structure to use is the
+      # protobuf structure for the entity that is being evaluated.
+      endpoint: "/repos/{{.Entity.Owner}}/{{.Entity.Name}}"
+      # This is the method to use to retrieve the data. It should already default to JSON
+      parse: json
+  # Defines the configuration for evaluating data ingested against the given profile
+  eval:
+    type: jq
+    jq:
+      # Ingested points to the data retrieved in the `ingest` section
+      - ingested:
+          def: '.security_and_analysis.secret_scanning.status == "enabled"'
+        # profile points to the profile itself.
+        profile:
+          def: ".enabled"
+  remediate:
+    type: rest
+    rest:
+      method: PATCH
+      endpoint: "/repos/{{.Entity.Owner}}/{{.Entity.Name}}"
+      body: |
+        { "security_and_analysis": {"secret_scanning": { "status": "enabled" } } }
+  # Defines the configuration for alerting on the rule
+  alert:
+    type: security_advisory
+    security_advisory:
+      severity: "medium"

--- a/cmd/cli/app/quickstart/quickstart.go
+++ b/cmd/cli/app/quickstart/quickstart.go
@@ -283,25 +283,20 @@ var cmd = &cobra.Command{
 				if st.Code() != codes.AlreadyExists {
 					return fmt.Errorf("error creating profile: %w", err)
 				}
-				cmd.Println("Profile already exists")
-				return nil
+				cmd.Println("Hey, it seems you already tried the quickstart command and created such a profile. " +
+					"In case you have registered new repositories this time, the profile will be already applied " +
+					"to them.")
+			} else {
+				return fmt.Errorf("error creating profile: %w", err)
 			}
-			return fmt.Errorf("error creating profile: %w", err)
+		} else {
+			table := profile.InitializeTable(cmd)
+			profile.RenderProfileTable(resp.GetProfile(), table)
+			table.Render()
 		}
-
-		table := profile.InitializeTable(cmd)
-		profile.RenderProfileTable(resp.GetProfile(), table)
-		table.Render()
 
 		// Finish - Confirm profile creation
-		yes = cli.PrintYesNoPrompt(cmd,
-			stepPromptMsgFinish,
-			"Finish?",
-			"Quickstart operation completed.")
-		if !yes {
-			return nil
-		}
-
+		cli.PrintCmd(cmd, cli.WarningBanner.Render(stepPromptMsgFinish))
 		return nil
 	},
 }

--- a/cmd/cli/app/quickstart/quickstart.go
+++ b/cmd/cli/app/quickstart/quickstart.go
@@ -1,0 +1,190 @@
+//
+// Copyright 2023 Stacklok, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package quickstart provides the quickstart command for the minder CLI
+// which is used to provide the means to quickly get started with minder.
+package quickstart
+
+import (
+	"embed"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"github.com/stacklok/minder/cmd/cli/app"
+	"github.com/stacklok/minder/cmd/cli/app/profile"
+	"github.com/stacklok/minder/cmd/cli/app/repo"
+	"github.com/stacklok/minder/internal/engine"
+	"github.com/stacklok/minder/internal/util"
+	"github.com/stacklok/minder/internal/util/cli"
+	minderv1 "github.com/stacklok/minder/pkg/api/protobuf/go/minder/v1"
+)
+
+//go:embed embed*
+var content embed.FS
+
+var cmd = &cobra.Command{
+	Use:   "quickstart",
+	Short: "Quickstart minder",
+	Long:  "The quickstart command provide the means to quickly get started with minder",
+	PreRun: func(cmd *cobra.Command, args []string) {
+		if err := viper.BindPFlags(cmd.Flags()); err != nil {
+			fmt.Fprintf(os.Stderr, "Error binding flags: %s\n", err)
+		}
+	},
+	RunE: func(cmd *cobra.Command, args []string) error {
+		proj := viper.GetString("project")
+		provider := viper.GetString("provider")
+		// Get the grpc connection and other resources
+		conn, err := util.GrpcForCommand(cmd, viper.GetViper())
+		if err != nil {
+			return fmt.Errorf("error getting grpc connection: %w", err)
+		}
+		defer conn.Close()
+
+		// Prompt to register repositories
+		results, msg, err := repo.RegisterCmd(cmd, args)
+		util.ExitNicelyOnError(err, msg)
+
+		var registeredRepos []string
+		for _, result := range results {
+			repo := fmt.Sprintf("%s/%s", result.Repository.Owner, result.Repository.Name)
+			registeredRepos = append(registeredRepos, repo)
+		}
+
+		// Confirm user wants to proceed with the quickstart process of creating a rule type
+		yes := cli.PrintYesNoPrompt(cmd,
+			"You are about to create a rule of type - secret_scanning:",
+			"Proceed?",
+			"Quickstart operation cancelled.")
+		if !yes {
+			return nil
+		}
+
+		// Create a client for the profile and rule type service
+		client := minderv1.NewProfileServiceClient(conn)
+
+		// Creating the rule type
+		cmd.Println("Creating rule type...")
+
+		// Load the rule type from the embedded file system
+		preader, _ := content.Open("embed/secret_scanning.yaml")
+		rt, err := minderv1.ParseRuleType(preader)
+		if err != nil {
+			return fmt.Errorf("error parsing rule type: %w", err)
+		}
+		if rt.Context == nil {
+			rt.Context = &minderv1.Context{}
+		}
+
+		if proj != "" {
+			rt.Context.Project = &proj
+		}
+
+		if provider != "" {
+			rt.Context.Provider = provider
+		}
+
+		// Create the rule type in minder (new context, so we don't time out)
+		ctx, cancel := util.GetAppContext()
+		defer cancel()
+
+		_, err = client.CreateRuleType(ctx, &minderv1.CreateRuleTypeRequest{
+			RuleType: rt,
+		})
+		if err != nil {
+			if st, ok := status.FromError(err); ok {
+				if st.Code() != codes.AlreadyExists {
+					return fmt.Errorf("error creating rule type from: %w", err)
+				}
+				cmd.Println("Rule type secret_scanning already exists")
+			} else {
+				return fmt.Errorf("error creating rule type from: %w", err)
+			}
+		}
+
+		// Confirm user wants to proceed with the quickstart process of creating a profile
+		yes = cli.PrintYesNoPrompt(cmd,
+			fmt.Sprintf(
+				"You are about to create a profile in Minder with the following properties:\n\n"+
+					"Rules: secret_scanning (enabled)\n\nSelected repositories:\n\n%s",
+				strings.Join(registeredRepos[:], "\n"),
+			),
+			"Proceed?",
+			"Quickstart operation cancelled.")
+		if !yes {
+			return nil
+		}
+
+		// Creating the profile
+		cmd.Println("Creating profile...")
+		preader, _ = content.Open("embed/profile.yaml")
+
+		// Load the profile from the embedded file system
+		p, err := engine.ParseYAML(preader)
+		if err != nil {
+			return fmt.Errorf("error parsing profile: %w", err)
+		}
+
+		if p.Context == nil {
+			rt.Context = &minderv1.Context{}
+		}
+
+		if proj != "" {
+			p.Context.Project = &proj
+		}
+
+		if provider != "" {
+			p.Context.Provider = provider
+		}
+
+		// Create the profile in minder (new context, so we don't time out)
+		ctx, cancel = util.GetAppContext()
+		defer cancel()
+
+		resp, err := client.CreateProfile(ctx, &minderv1.CreateProfileRequest{
+			Profile: p,
+		})
+		if err != nil {
+			if st, ok := status.FromError(err); ok {
+				if st.Code() != codes.AlreadyExists {
+					return fmt.Errorf("error creating profile: %w", err)
+				}
+				cmd.Println("Profile already exists")
+				return nil
+			}
+			return fmt.Errorf("error creating profile: %w", err)
+		}
+
+		table := profile.InitializeTable(cmd)
+		profile.RenderProfileTable(resp.GetProfile(), table)
+		table.Render()
+		return nil
+	},
+}
+
+func init() {
+	app.RootCmd.AddCommand(cmd)
+	cmd.Flags().StringP("project", "r", "", "Project to create the quickstart profile in")
+	cmd.Flags().StringP("provider", "p", "", "Name of the provider")
+	if err := cmd.MarkFlagRequired("provider"); err != nil {
+		_, _ = fmt.Fprintf(os.Stderr, "Error marking flag as required: %s\n", err)
+	}
+}

--- a/cmd/cli/app/quickstart/quickstart.go
+++ b/cmd/cli/app/quickstart/quickstart.go
@@ -304,10 +304,7 @@ var cmd = &cobra.Command{
 func init() {
 	app.RootCmd.AddCommand(cmd)
 	cmd.Flags().StringP("project", "r", "", "Project to create the quickstart profile in")
-	cmd.Flags().StringP("provider", "p", "", "Name of the provider")
+	cmd.Flags().StringP("provider", "p", "github", "Name of the provider")
 	cmd.Flags().StringP("token", "t", "", "Personal Access Token (PAT) to use for enrollment")
 	cmd.Flags().StringP("owner", "o", "", "Owner to filter on for provider resources")
-	if err := cmd.MarkFlagRequired("provider"); err != nil {
-		_, _ = fmt.Fprintf(os.Stderr, "Error marking flag as required: %s\n", err)
-	}
 }

--- a/cmd/cli/main.go
+++ b/cmd/cli/main.go
@@ -24,6 +24,7 @@ import (
 	_ "github.com/stacklok/minder/cmd/cli/app/profile"
 	_ "github.com/stacklok/minder/cmd/cli/app/profile_status"
 	_ "github.com/stacklok/minder/cmd/cli/app/provider"
+	_ "github.com/stacklok/minder/cmd/cli/app/quickstart"
 	_ "github.com/stacklok/minder/cmd/cli/app/repo"
 	_ "github.com/stacklok/minder/cmd/cli/app/rule_type"
 	_ "github.com/stacklok/minder/cmd/cli/app/version"

--- a/internal/util/statuses.go
+++ b/internal/util/statuses.go
@@ -186,12 +186,15 @@ func (s *NiceStatus) Error() string {
 // ExitNicelyOnError print a message and exit with the right code
 func ExitNicelyOnError(err error, message string) {
 	if err != nil {
+		if message != "" {
+			fmt.Fprintf(os.Stderr, "%s: ", message)
+		}
 		if rpcStatus, ok := status.FromError(err); ok {
 			nice := FromRpcError(rpcStatus)
-			fmt.Fprintf(os.Stderr, "%s: %s\n", message, nice)
+			fmt.Fprintf(os.Stderr, "%s\n", nice)
 			os.Exit(int(nice.Code))
 		} else {
-			fmt.Fprintf(os.Stderr, "%s: %s\n", message, err)
+			fmt.Fprintf(os.Stderr, "%s\n", err)
 			os.Exit(1)
 		}
 	}


### PR DESCRIPTION
The following PR implements a quickstart command which is intended to provide a happy path to getting started with minder and be executed after a user has authenticated and enrolled their provider.

Covers the following functionality:

* Prompts the user to enroll their repository provider
* Prompts the user to register one or more repositories with Minder
* Prompts the user to create a `secret_scanning` rule type
* Prompts the user to create a profile called `quickstart-profile` with the `secret_scanning` rule type set to `enabled` for their registered repositories.

Screenshots: 
* Step 0 - Welcome
<img width="807" alt="image" src="https://github.com/stacklok/minder/assets/16540482/d3f764f5-671d-4068-bcec-bb76406c14b8">
* Step 1 - Provider enrollment
<img width="808" alt="image" src="https://github.com/stacklok/minder/assets/16540482/9f55c29a-b559-4474-90a3-4dbc8385b583">
* Step 2 - Repository registration
<img width="812" alt="image" src="https://github.com/stacklok/minder/assets/16540482/fa0f53a9-2fe4-4e10-800f-9aea8e0b8d28">
<img width="797" alt="image" src="https://github.com/stacklok/minder/assets/16540482/4775e0d9-3082-4875-8a66-4c8d15c116a5">
* Step 3 - Prompt for confirming the creation of secret scanning rule type
<img width="948" alt="image" src="https://github.com/stacklok/minder/assets/16540482/6e8ce2ff-85fb-408d-a7ae-2484b8367c99">
* Step 4 - Prompt for confirming the creation of a profile using that rule type and the list of repos it will be applied to
<img width="811" alt="image" src="https://github.com/stacklok/minder/assets/16540482/419a1de5-c7bf-40ff-b7e2-b0128249def6">
* Step 5 - Confirmation of the created profile
<img width="804" alt="image" src="https://github.com/stacklok/minder/assets/16540482/68d6b173-d618-4c35-a9e4-5da71c7fc038">

Fixes https://github.com/stacklok/minder/issues/1652