### PR TITLE
Remove trailing slash from rules-and-profiles entry in gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,4 +61,4 @@ docs/.docusaurus
 /deployment/helm/*.tgz
 
 # Ignore examples cloned repo
-examples/rules-and-profiles/
+examples/rules-and-profiles


### PR DESCRIPTION
This allows us to create a symlink instead of relying on explicitly cloning the repo.
