### PR TITLE
Rename `medev` to `mindev`

### DIFF
--- a/.mk/build.mk
+++ b/.mk/build.mk
@@ -14,13 +14,13 @@
 # limitations under the License.
 
 .PHONY: build
-build: build-minder-cli build-minder-server build-medev ## build all binaries
+build: build-minder-cli build-minder-server build-mindev ## build all binaries
 
 
-.PHONY: build-medev
-build-medev: ## build golang binary
-	@echo "Building medev..."
-	@CGO_ENABLED=0 go build -trimpath -tags '$(BUILDTAGS)' -o ./bin/medev ./cmd/dev
+.PHONY: build-mindev
+build-mindev: ## build mindev golang binary
+	@echo "Building mindev..."
+	@CGO_ENABLED=0 go build -trimpath -tags '$(BUILDTAGS)' -o ./bin/mindev ./cmd/dev
 
 .PHONY: build-minder-cli
 build-minder-cli: ## build minder cli

--- a/cmd/dev/app/root.go
+++ b/cmd/dev/app/root.go
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package app provides the root command for the medev CLI
+// Package app provides the root command for the mindev CLI
 package app
 
 import (
@@ -30,8 +30,8 @@ var (
 
 	// RootCmd represents the base command when called without any subcommands
 	RootCmd = &cobra.Command{
-		Use:   "medev",
-		Short: "medev provides developer tooling for minder",
+		Use:   "mindev",
+		Short: "mindev provides developer tooling for minder",
 		Long: `For more information about minder, please visit:
 https://docs.stacklok.com/minder`,
 	}


### PR DESCRIPTION
`mindev` is a small command line utility to help us add minder development
utilities. e.g. debugging tools for rule types and profiles.
