### PR TITLE
Add support for sidecars to migrate and minder, add tests for same

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,6 +15,9 @@ jobs:
         with:
           go-version-file: 'go.mod'
 
+      - name: Set up helm (test dependency)
+        uses: azure/setup-helm@v3
+
       # Install gotestfmt on the VM running the action.
       - name: Set up gotestfmt
         uses: GoTestTools/gotestfmt-action@v2

--- a/deployment/helm/templates/deployment.yaml
+++ b/deployment/helm/templates/deployment.yaml
@@ -66,6 +66,9 @@ spec:
             value: "{{ .Values.trusty.endpoint }}"
           - name: "SIGSTORE_NO_CACHE"
             value: "true"
+          {{- if .Values.deploymentSettings.extraEnv }}
+          {{- toYaml .Values.deploymentSettings.extraEnv | nindent 10 }}
+          {{- end }}
           
           # ko will always specify a digest, so we don't need to worry about
           # CRI image caching
@@ -100,8 +103,11 @@ spec:
           - name: identity-secrets
             mountPath: /secrets/identity
           {{- if .Values.deploymentSettings.extraVolumeMounts }}
-          {{- toYaml .Values.deploymentSettings.extraVolumeMounts | nindent 12 }}
+          {{- toYaml .Values.deploymentSettings.extraVolumeMounts | nindent 10 }}
           {{- end }}
+        {{- if .Values.deploymentSettings.sidecarContainers }}
+        {{- toYaml .Values.deploymentSettings.sidecarContainers | nindent 8 }}
+        {{- end }}
       volumes:
       - name: config
         configMap:

--- a/deployment/helm/templates/job.yaml
+++ b/deployment/helm/templates/job.yaml
@@ -100,9 +100,19 @@ spec:
           imagePullPolicy: {{ .Values.migrationSettings.imagePullPolicy }}
           resources:
             {{- toYaml .Values.migrationSettings.resources | nindent 12 }}
+          {{- if .Values.migrationSettings.extraEnv }}
+          env:
+          {{- toYaml .Values.migrationSettings.extraEnv | nindent 12 }}
+          {{- end }}
           volumeMounts:
           - name: config
             mountPath: /config
+          {{- if .Values.migrationSettings.extraVolumeMounts }}
+          {{- toYaml .Values.migrationSettings.extraVolumeMounts | nindent 10 }}
+          {{- end }}
+        {{- if .Values.migrationSettings.sidecarContainers }}
+        {{- toYaml .Values.migrationSettings.sidecarContainers | nindent 8 }}
+        {{- end }}
       volumes:
       - name: config
         configMap:
@@ -112,4 +122,7 @@ spec:
             path: config.yaml
           - key: overrides.yaml
             path: overrides.yaml
+      {{- if .Values.migrationSettings.extraVolumes }}
+      {{- toYaml .Values.migrationSettings.extraVolumes | nindent 6 }}
+      {{- end }}
  

--- a/deployment/helm/values.yaml
+++ b/deployment/helm/values.yaml
@@ -64,6 +64,12 @@ migrationSettings:
     limits:
       cpu: 1
       memory: 300Mi
+  # Additional volumes to mount
+  extraVolumes: null
+  # Additional volume mounts
+  extraVolumeMounts: null
+  # Additional configuration for sidecar containers
+  sidecarContainers: null
 
 # Configurable settings for the main deployment
 deploymentSettings:
@@ -84,6 +90,8 @@ deploymentSettings:
     authSecretName: "minder-auth-secrets"
     appSecretName: "minder-github-secrets"
     identitySecretName: "minder-identity-secrets"
+  # Additional configuration for sidecar containers
+  sidecarContainers: null
 
 
 # Additional configuration yaml beyond what's in config.yaml.example
@@ -93,3 +101,4 @@ extra_config: |
 # Additional configuration yaml that's applied to the migration job
 extra_config_migrate: |
   # Add even more content here
+

--- a/deployment/helm_tests/basic.yaml
+++ b/deployment/helm_tests/basic.yaml
@@ -1,0 +1,63 @@
+hostname: "minder-test.example.com"
+db:
+  host: postgres.postgres.svc
+
+serviceAccounts:
+  server: minder
+  migrate: migrate-job
+
+ingress:
+  annotations:
+    cert-manager.io/cluster-issuer: prod-issuer
+
+hpaSettings:
+  minReplicas: 1
+  maxReplicas: 3
+  metrics:
+    cpu:
+      targetAverageUtilization: 60
+
+deploymentSettings:
+  resources:
+    requests:
+      cpu: 0.5
+      memory: 800Mi
+    limits:
+      cpu: 1
+      memory: 1.8Gi
+  secrets:
+    authSecretName: "minder-auth-secrets"
+    appSecretName: "minder-github-api-secrets"
+    identitySecretName: "minder-identity-secrets"
+
+extra_config: |
+  database:
+    dbuser: minder
+    dbname: minder
+    sslmode: disabled
+
+  identity:
+    server:
+      issuer_url: http://keycloak-deployment.keycloak.svc:80
+      realm: minder
+      client_id: minder-server
+
+  github:
+    redirect_uri: "https://minder-test.example.com/api/v1/auth/callback/github"
+
+  webhook-config:
+    external_webhook_url: "https://minder-test.example.com/api/v1/webhook/github"
+    external_ping_url: "https://minder-test.example.com/api/v1/health"
+    webhook_secret: "this-is-unused"
+
+  events:
+    driver: go-channel
+    router_close_timeout: 30
+    go-channel:
+      buffer_size: 200
+
+extra_config_migrate: |
+  database:
+    dbuser: migrate-job
+    dbname: minder
+    sslmode: disabled

--- a/deployment/helm_tests/basic.yaml
+++ b/deployment/helm_tests/basic.yaml
@@ -1,3 +1,17 @@
+# Copyright 2023 Stacklok, Inc
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 hostname: "minder-test.example.com"
 db:
   host: postgres.postgres.svc

--- a/deployment/helm_tests/basic.yaml-out
+++ b/deployment/helm_tests/basic.yaml-out
@@ -1,0 +1,818 @@
+---
+# Source: minder/templates/configmap.yaml
+# Copyright 2023 Stacklok, Inc
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: minder-config
+  labels:
+    
+    app.kubernetes.io/instance: minder
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: minder
+    app.kubernetes.io/version: "2023-07-31"
+    helm.sh/chart: minder-0.1.0
+data:
+  config.yaml: |
+    
+    #
+    # Copyright 2023 Stacklok, Inc.
+    #
+    # Licensed under the Apache License, Version 2.0 (the "License");
+    # you may not use this file except in compliance with the License.
+    # You may obtain a copy of the License at
+    #
+    #     http://www.apache.org/licenses/LICENSE-2.0
+    #
+    # Unless required by applicable law or agreed to in writing, software
+    # distributed under the License is distributed on an "AS IS" BASIS,
+    # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    # See the License for the specific language governing permissions and
+    # limitations under the License.
+    
+    # HTTP, gRPC & metrics server configuration
+    http_server:
+      host: "127.0.0.1"
+      port: 8080
+    grpc_server:
+      host: "127.0.0.1"
+      port: 8090
+    metric_server:
+      host: "127.0.0.1"
+      port: 9090
+    
+    logging:
+      level: "debug"
+      format: "json"
+      #logFile: "/var/log/minder.log"
+    
+    tracing:
+      enabled: false
+      #sample_ratio: 0.1
+    
+    metrics:
+      enabled: true
+    
+    database:
+      dbhost: "localhost"
+      dbport: 5432
+      dbuser: postgres
+      dbpass: postgres
+      dbname: minder
+      sslmode: disable
+    
+    identity:
+      cli:
+        issuer_url: http://localhost:8081
+        realm: stacklok
+        client_id: minder-cli
+      server:
+        issuer_url: http://keycloak:8080 # Use http://localhost:8081 instead for running minder outside of docker-compose
+        realm: stacklok
+        client_id: minder-server
+        client_secret: secret
+    
+    # Crypto (these should be ultimately stored in a secure vault)
+    # The token key can be generated with:
+    #   openssl rand -base64 32 > .ssh/token_key_passphrase
+    auth:
+      token_key: "./.ssh/token_key_passphrase"
+    
+    # Password Salting, these values are using argon2id
+    # https://en.wikipedia.org/wiki/Argon2
+    # Argon has resistance against side-channel timing attacks and tradeoff attacks
+    # but it is computationally expensive.
+    # If this is a problematic, we could use bcrypt instead.
+    # https://en.wikipedia.org/wiki/Bcrypt
+    salt:
+      # The amount of memory used by the algorithm (in kibibytes).
+      memory: 65536
+      # the amount of iterations
+      iterations:  50
+      # degree of parallelism (number of threads)
+      parallelism: 4
+      # the length of the salt to be used
+      salt_length: 16
+      # the desired number of returned bytes
+      key_length: 32
+    
+    # Webhook Configuration
+    # change example.com to an exposed IP / domain
+    # webhook_secret is set withing the webhook sent to github. Github then signs
+    # the payload sent to minder and minder verifies.
+    webhook-config:
+      external_webhook_url: "https://example.com/api/v1/webhook/github"
+      external_ping_url: "https://example.com/api/v1/health"
+      webhook_secret: "your-password"
+    
+    # OAuth2 Configuration (used during enrollment)
+    # These values are to be set within the GitHub OAuth2 App page
+    github:
+        client_id: "abcde....."
+        client_secret: "abcde....."
+        payload_secret: "your-password"
+        redirect_uri: "http://localhost:8080/api/v1/auth/callback/github"
+        # [*] for all events. It can also be a list such as [push,branch_protection_rule].
+        # Please check complete list on https://docs.github.com/es/webhooks-and-events/webhooks/webhook-events-and-payloads
+        events: ["*"]
+    
+    events:
+      driver: go-channel
+      router_close_timeout: 10
+      go-channel: {}
+    
+  overrides.yaml: |
+    
+    database:
+      dbuser: minder
+      dbname: minder
+      sslmode: disabled
+    
+    identity:
+      server:
+        issuer_url: http://keycloak-deployment.keycloak.svc:80
+        realm: minder
+        client_id: minder-server
+    
+    github:
+      redirect_uri: "https://minder-test.example.com/api/v1/auth/callback/github"
+    
+    webhook-config:
+      external_webhook_url: "https://minder-test.example.com/api/v1/webhook/github"
+      external_ping_url: "https://minder-test.example.com/api/v1/health"
+      webhook_secret: "this-is-unused"
+    
+    events:
+      driver: go-channel
+      router_close_timeout: 30
+      go-channel:
+        buffer_size: 200
+---
+# Source: minder/templates/service.yaml
+# Copyright 2023 Stacklok, Inc
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: minder-http
+  annotations:
+    alb.ingress.kubernetes.io/healthcheck-path: "/api/v1/health"
+  labels:
+    
+    app.kubernetes.io/instance: minder
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: minder
+    app.kubernetes.io/version: "2023-07-31"
+    helm.sh/chart: minder-0.1.0
+spec:
+  type: ClusterIP
+  ports:
+    - port: !!int "8080"
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    app: minder
+---
+# Source: minder/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: minder-grpc
+  annotations:
+    alb.ingress.kubernetes.io/backend-protocol-version: "GRPC"
+    alb.ingress.kubernetes.io/healthcheck-protocol: "HTTP"
+    alb.ingress.kubernetes.io/healthcheck-path: "/minder.v1.HealthService/CheckHealth"
+    # For some reason, ALB defaults to 12 (unimplemented) as a success code
+    alb.ingress.kubernetes.io/success-codes: "0"
+  labels:
+    
+    app.kubernetes.io/instance: minder
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: minder
+    app.kubernetes.io/version: "2023-07-31"
+    helm.sh/chart: minder-0.1.0
+spec:
+  type: ClusterIP
+  ports:
+    - port: !!int "8090"
+      targetPort: grpc
+      protocol: TCP
+      name: grpc
+  selector:
+    app: minder
+---
+# Source: minder/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: minder-metrics
+  labels:
+  
+    app.kubernetes.io/instance: minder
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: minder
+    app.kubernetes.io/version: "2023-07-31"
+    helm.sh/chart: minder-0.1.0
+spec:
+  type: ClusterIP
+  ports:
+    - port: !!int "9090"
+      targetPort: http
+      protocol: TCP
+      name: metrics
+  selector:
+    app: minder
+---
+# Source: minder/templates/deployment.yaml
+# Copyright 2023 Stacklok, Inc
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: minder
+  labels:
+    
+    app.kubernetes.io/instance: minder
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: minder
+    app.kubernetes.io/version: "2023-07-31"
+    helm.sh/chart: minder-0.1.0
+spec:
+  # We'll use autoscaling, sometimes clamped to one instance
+  selector:
+    matchLabels:
+      app: 'minder'
+  template:
+    metadata:
+      labels:
+        app: 'minder'
+      annotations:
+        
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "9090"
+        prometheus.io/path: "/metrics"
+    spec:
+      serviceAccountName: minder
+      containers:
+        - name: minder
+          # restricted security context:
+          # https://kubernetes.io/docs/concepts/security/pod-security-standards/
+          securityContext:
+            allowPrivilegeEscalation: false
+            runAsNonRoot: true
+            readOnlyRootFilesystem: true
+            seccompProfile:
+              type: RuntimeDefault
+            capabilities:
+              drop:
+                - ALL
+          image: ko://github.com/stacklok/minder/cmd/server
+          args:
+          - "serve"
+          - "--db-host=postgres.postgres.svc"
+          - "--config=/config/config.yaml"
+          # We use two config files, one with all the defaults, and one with
+          # additional override values from helm.  (This is a viper feature.)
+          - "--config=/config/overrides.yaml"
+          - "--grpc-host=0.0.0.0"
+          - "--http-host=0.0.0.0"
+          - "--metric-host=0.0.0.0"
+          - "--github-client-id-file=/secrets/app/client_id"
+          - "--github-client-secret-file=/secrets/app/client_secret"
+          env:
+          - name: "MINDER_AUTH_TOKEN_KEY"
+            value: "/secrets/auth/token_key_passphrase"
+          - name: "MINDER_IDENTITY_SERVER_CLIENT_SECRET_FILE"
+            value: "/secrets/identity/identity_client_secret"
+          - name: "MINDER_UNSTABLE_TRUSTY_ENDPOINT"
+            value: "http://pi.pi:8000"
+          - name: "SIGSTORE_NO_CACHE"
+            value: "true"
+          
+          # ko will always specify a digest, so we don't need to worry about
+          # CRI image caching
+          imagePullPolicy: "IfNotPresent"
+          ports:
+            - name: http
+              containerPort: !!int "8080"
+              protocol: TCP
+            - name: grpc
+              containerPort: !!int "8090"
+              protocol: TCP
+            - name: metric
+              containerPort: !!int "9090"
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /api/v1/health
+              port: http
+          readinessProbe:
+            httpGet:
+              path: /api/v1/health
+              port: http
+          resources:
+            limits:
+              cpu: 1
+              memory: 1.8Gi
+            requests:
+              cpu: 0.5
+              memory: 800Mi
+          volumeMounts:
+          - name: config
+            mountPath: /config
+          - name: auth-secrets
+            mountPath: /secrets/auth
+          - name: app-secrets
+            mountPath: /secrets/app
+          - name: identity-secrets
+            mountPath: /secrets/identity
+      volumes:
+      - name: config
+        configMap:
+          name: minder-config
+          items:
+          - key: config.yaml
+            path: config.yaml
+          - key: overrides.yaml
+            path: overrides.yaml
+      - name: auth-secrets
+        secret:
+          secretName: minder-auth-secrets
+      - name: app-secrets
+        secret:
+          secretName: minder-github-api-secrets
+      - name: identity-secrets
+        secret:
+          secretName: minder-identity-secrets
+---
+# Source: minder/templates/hpa.yaml
+# Copyright 2023 Stacklok, Inc
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: minder
+  labels:
+    
+    app.kubernetes.io/instance: minder
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: minder
+    app.kubernetes.io/version: "2023-07-31"
+    helm.sh/chart: minder-0.1.0
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: minder
+  minReplicas: 1
+  maxReplicas: 3
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: 60
+---
+# Source: minder/templates/ingress.yaml
+# Copyright 2023 Stacklok, Inc
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: minder
+  labels:
+    
+    app.kubernetes.io/instance: minder
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: minder
+    app.kubernetes.io/version: "2023-07-31"
+    helm.sh/chart: minder-0.1.0
+  annotations: 
+    cert-manager.io/cluster-issuer: prod-issuer
+spec:
+  # Don't set ingressClassName for now, assume default
+  tls:
+  - hosts:
+    - "minder-test.example.com"
+    secretName: minder-tls
+  rules:
+  - host: "minder-test.example.com"
+    http:
+      paths:
+      # We use Prefix matches on gRPC service names because Ingress API
+      # doesn't support matching on Content-Type: application/grpc
+      - path: /grpc.reflection.v1alpha.ServerReflection
+        pathType: Prefix
+        backend:
+          service:
+            name: minder-grpc
+            port:
+              name: grpc
+      - path: /minder.v1.OAuthService
+        pathType: Prefix
+        backend:
+          service:
+            name: minder-grpc
+            port:
+              name: grpc
+      - path: /minder.v1.AuthService
+        pathType: Prefix
+        backend:
+          service:
+            name: minder-grpc
+            port:
+              name: grpc
+      - path: /minder.v1.ArtifactService
+        pathType: Prefix
+        backend:
+          service:
+            name: minder-grpc
+            port:
+              name: grpc
+      - path: /minder.v1.VulnerabilitiesService
+        pathType: Prefix
+        backend:
+          service:
+            name: minder-grpc
+            port:
+              name: grpc
+      - path: /minder.v1.SecretsService
+        pathType: Prefix
+        backend:
+          service:
+            name: minder-grpc
+            port:
+              name: grpc
+      - path: /minder.v1.RepositoryService
+        pathType: Prefix
+        backend:
+          service:
+            name: minder-grpc
+            port:
+              name: grpc
+      - path: /minder.v1.BranchProtectionService
+        pathType: Prefix
+        backend:
+          service:
+            name: minder-grpc
+            port:
+              name: grpc
+      - path: /minder.v1.OrganizationService
+        pathType: Prefix
+        backend:
+          service:
+            name: minder-grpc
+            port:
+              name: grpc
+      - path: /minder.v1.GroupService
+        pathType: Prefix
+        backend:
+          service:
+            name: minder-grpc
+            port:
+              name: grpc
+      - path: /minder.v1.RoleService
+        pathType: Prefix
+        backend:
+          service:
+            name: minder-grpc
+            port:
+              name: grpc
+      - path: /minder.v1.UserService
+        pathType: Prefix
+        backend:
+          service:
+            name: minder-grpc
+            port:
+              name: grpc
+      - path: /minder.v1.ProfileService
+        pathType: Prefix
+        backend:
+          service:
+            name: minder-grpc
+            port:
+              name: grpc
+      - path: /minder.v1.KeyService
+        pathType: Prefix
+        backend:
+          service:
+            name: minder-grpc
+            port:
+              name: grpc
+      - path: /
+        pathType: Prefix
+        backend:
+          service:
+            name: minder-http
+            port:
+              name: http
+---
+# Source: minder/templates/job.yaml
+# Copyright 2023 Stacklok, Inc
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# We need a separate service account for the db-update job, because
+# it runs as a helm pre-install hook, and the minder service account
+# won't have been installed at that point.
+---
+# Source: minder/templates/serviceaccount.yaml
+# Copyright 2023 Stacklok, Inc
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+---
+# Source: minder/templates/tests/test-connection.yaml
+# Copyright 2023 Stacklok, Inc
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+---
+# Source: minder/templates/job.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: db-update-config
+  annotations:
+    helm.sh/hook-delete-policy: before-hook-creation
+    helm.sh/hook: pre-install,pre-upgrade
+  labels:
+    helm.sh/chart: 'minder-0.1.0'
+    app.kubernetes.io/name: minder
+    app.kubernetes.io/instance: "minder"
+    app.kubernetes.io/version: "2023-07-31"
+    app.kubernetes.io/managed-by: "Helm"
+data:
+  config.yaml: |
+    
+    #
+    # Copyright 2023 Stacklok, Inc.
+    #
+    # Licensed under the Apache License, Version 2.0 (the "License");
+    # you may not use this file except in compliance with the License.
+    # You may obtain a copy of the License at
+    #
+    #     http://www.apache.org/licenses/LICENSE-2.0
+    #
+    # Unless required by applicable law or agreed to in writing, software
+    # distributed under the License is distributed on an "AS IS" BASIS,
+    # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    # See the License for the specific language governing permissions and
+    # limitations under the License.
+    
+    # HTTP, gRPC & metrics server configuration
+    http_server:
+      host: "127.0.0.1"
+      port: 8080
+    grpc_server:
+      host: "127.0.0.1"
+      port: 8090
+    metric_server:
+      host: "127.0.0.1"
+      port: 9090
+    
+    logging:
+      level: "debug"
+      format: "json"
+      #logFile: "/var/log/minder.log"
+    
+    tracing:
+      enabled: false
+      #sample_ratio: 0.1
+    
+    metrics:
+      enabled: true
+    
+    database:
+      dbhost: "localhost"
+      dbport: 5432
+      dbuser: postgres
+      dbpass: postgres
+      dbname: minder
+      sslmode: disable
+    
+    identity:
+      cli:
+        issuer_url: http://localhost:8081
+        realm: stacklok
+        client_id: minder-cli
+      server:
+        issuer_url: http://keycloak:8080 # Use http://localhost:8081 instead for running minder outside of docker-compose
+        realm: stacklok
+        client_id: minder-server
+        client_secret: secret
+    
+    # Crypto (these should be ultimately stored in a secure vault)
+    # The token key can be generated with:
+    #   openssl rand -base64 32 > .ssh/token_key_passphrase
+    auth:
+      token_key: "./.ssh/token_key_passphrase"
+    
+    # Password Salting, these values are using argon2id
+    # https://en.wikipedia.org/wiki/Argon2
+    # Argon has resistance against side-channel timing attacks and tradeoff attacks
+    # but it is computationally expensive.
+    # If this is a problematic, we could use bcrypt instead.
+    # https://en.wikipedia.org/wiki/Bcrypt
+    salt:
+      # The amount of memory used by the algorithm (in kibibytes).
+      memory: 65536
+      # the amount of iterations
+      iterations:  50
+      # degree of parallelism (number of threads)
+      parallelism: 4
+      # the length of the salt to be used
+      salt_length: 16
+      # the desired number of returned bytes
+      key_length: 32
+    
+    # Webhook Configuration
+    # change example.com to an exposed IP / domain
+    # webhook_secret is set withing the webhook sent to github. Github then signs
+    # the payload sent to minder and minder verifies.
+    webhook-config:
+      external_webhook_url: "https://example.com/api/v1/webhook/github"
+      external_ping_url: "https://example.com/api/v1/health"
+      webhook_secret: "your-password"
+    
+    # OAuth2 Configuration (used during enrollment)
+    # These values are to be set within the GitHub OAuth2 App page
+    github:
+        client_id: "abcde....."
+        client_secret: "abcde....."
+        payload_secret: "your-password"
+        redirect_uri: "http://localhost:8080/api/v1/auth/callback/github"
+        # [*] for all events. It can also be a list such as [push,branch_protection_rule].
+        # Please check complete list on https://docs.github.com/es/webhooks-and-events/webhooks/webhook-events-and-payloads
+        events: ["*"]
+    
+    events:
+      driver: go-channel
+      router_close_timeout: 10
+      go-channel: {}
+    
+  overrides.yaml: |
+    
+    database:
+      dbuser: migrate-job
+      dbname: minder
+      sslmode: disabled
+---
+# Source: minder/templates/job.yaml
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: db-update
+  annotations:
+    helm.sh/hook-delete-policy: hook-succeeded
+    helm.sh/hook: pre-install,pre-upgrade
+    helm.sh/hook-weight: "5"
+  labels:
+    helm.sh/chart: 'minder-0.1.0'
+    app.kubernetes.io/name: minder
+    app.kubernetes.io/instance: "minder"
+    app.kubernetes.io/version: "2023-07-31"
+    app.kubernetes.io/managed-by: "Helm"
+spec:
+  template:
+    metadata:
+      labels:
+        app: db-init
+    spec:
+      serviceAccountName: migrate-job
+      restartPolicy: Never
+      containers:
+        - name: minder-dbinit
+          # restricted security context:
+          # https://kubernetes.io/docs/concepts/security/pod-security-standards/
+          securityContext:
+            allowPrivilegeEscalation: false
+            runAsNonRoot: true
+            seccompProfile:
+              type: RuntimeDefault
+            capabilities:
+              drop:
+                - ALL
+          image: ko://github.com/stacklok/minder/cmd/server
+          args:
+          - "migrate"
+          - "up"
+          - "--yes"
+          - "--db-host=postgres.postgres.svc"
+          - "--config=/config/config.yaml"
+          # We use two config files, one with all the defaults, and one with
+          # additional override values from helm.  (This is a viper feature.)
+          - "--config=/config/overrides.yaml"
+          # ko will always specify a digest, so we don't need to worry about
+          # CRI image caching
+          imagePullPolicy: IfNotPresent
+          resources:
+            limits:
+              cpu: 1
+              memory: 300Mi
+            requests:
+              cpu: 200m
+              memory: 200Mi
+          volumeMounts:
+          - name: config
+            mountPath: /config
+      volumes:
+      - name: config
+        configMap:
+          name: db-update-config
+          items:
+          - key: config.yaml
+            path: config.yaml
+          - key: overrides.yaml
+            path: overrides.yaml

--- a/deployment/helm_tests/helm_test.go
+++ b/deployment/helm_tests/helm_test.go
@@ -1,0 +1,73 @@
+package main
+
+import (
+	"bytes"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"gopkg.in/yaml.v3"
+)
+
+var overwrite = flag.Bool("overwrite", false, "Whether to overwrite the expected output files")
+
+func Test_HelmValues(t *testing.T) {
+	t.Parallel()
+
+	testDir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("Unable to get current directory: %v", err)
+	}
+	yamlFiles, err := filepath.Glob("*.yaml")
+	if err != nil {
+		t.Fatalf("Unable to find YAML files: %v", err)
+	}
+
+	for _, yamlFile := range yamlFiles {
+		filename := filepath.Join(testDir, yamlFile)
+		t.Run(yamlFile, func(t *testing.T) {
+			t.Parallel()
+
+			cmd := exec.Command("helm", "template", "minder", "-f", filename, "--debug", "../helm")
+
+			out, err := cmd.Output()
+			if err != nil {
+				var exit *exec.ExitError
+				if errors.As(err, &exit) {
+					t.Log(string(exit.Stderr))
+				}
+				t.Fatalf("Unable to run helm template: %v", err)
+			}
+			if *overwrite {
+				if err := os.WriteFile(fmt.Sprintf("%s-out", filename), out, 0644); err != nil {
+					t.Fatalf("Unable to write output file: %v", err)
+				}
+			}
+
+			want, err := os.ReadFile(fmt.Sprintf("%s-out", filename))
+			if err != nil {
+				t.Fatalf("Unable to read expected file: %v", err)
+			}
+
+			if diff := cmp.Diff(string(want), string(out)); diff != "" {
+				t.Errorf("Helm template output mismatch (-want +got):\n%s", diff)
+			}
+
+			// Verify that files parse as yaml.  Helm should error anyway, but this double-checks
+			var value map[string]interface{}
+			decoder := yaml.NewDecoder(bytes.NewReader(out))
+			for ; err == nil; err = decoder.Decode(&value) {
+
+			}
+			if !errors.Is(err, io.EOF) {
+				t.Errorf("Got error parsing yaml: %v", err)
+			}
+		})
+	}
+}

--- a/deployment/helm_tests/helm_test.go
+++ b/deployment/helm_tests/helm_test.go
@@ -44,6 +44,11 @@ func Test_HelmValues(t *testing.T) {
 		t.Fatalf("Unable to find YAML files: %v", err)
 	}
 
+	cmd := exec.Command("helm", "dependency", "update", "../helm")
+	if output, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("Unable to run helm dependency update: %v\n%s", err, output)
+	}
+
 	for _, yamlFile := range yamlFiles {
 		filename := filepath.Join(testDir, yamlFile)
 		t.Run(yamlFile, func(t *testing.T) {

--- a/deployment/helm_tests/helm_test.go
+++ b/deployment/helm_tests/helm_test.go
@@ -1,3 +1,18 @@
+//
+// Copyright 2023 Stacklok, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package main
 
 import (
@@ -34,6 +49,7 @@ func Test_HelmValues(t *testing.T) {
 		t.Run(yamlFile, func(t *testing.T) {
 			t.Parallel()
 
+			// nolint:gosec // G204 warns of subprocess launched with variable, but we control the variable (above)
 			cmd := exec.Command("helm", "template", "minder", "-f", filename, "--debug", "../helm")
 
 			out, err := cmd.Output()
@@ -45,7 +61,7 @@ func Test_HelmValues(t *testing.T) {
 				t.Fatalf("Unable to run helm template: %v", err)
 			}
 			if *overwrite {
-				if err := os.WriteFile(fmt.Sprintf("%s-out", filename), out, 0644); err != nil {
+				if err := os.WriteFile(fmt.Sprintf("%s-out", filename), out, 0600); err != nil {
 					t.Fatalf("Unable to write output file: %v", err)
 				}
 			}

--- a/deployment/helm_tests/sidecar.yaml
+++ b/deployment/helm_tests/sidecar.yaml
@@ -1,0 +1,107 @@
+hostname: "minder-test.example.com"
+db:
+  host: postgres.postgres.svc
+
+serviceAccounts:
+  server: minder
+  migrate: migrate-job
+
+ingress:
+  annotations:
+    cert-manager.io/cluster-issuer: prod-issuer
+
+hpaSettings:
+  minReplicas: 1
+  maxReplicas: 3
+  metrics:
+    cpu:
+      targetAverageUtilization: 60
+
+deploymentSettings:
+  resources:
+    requests:
+      cpu: 0.5
+      memory: 800Mi
+    limits:
+      cpu: 1
+      memory: 1.8Gi
+  secrets:
+    authSecretName: "minder-auth-secrets"
+    appSecretName: "minder-github-api-secrets"
+    identitySecretName: "minder-identity-secrets"
+  extraEnv:
+  - name: "PGPASSFILE"
+    value: "/secrets/db/.pgpass"
+  extraVolumeMounts:
+  - name: db-password
+    mountPath: /secrets/db
+  extraVolumes:
+  - name: db-password
+    emptyDir:
+      medium: Memory
+      sizeLimit: 1Mi
+  sidecarContainers:
+  - name: fetch-secrets
+    image: bitnami/kubectl
+    command: ["/bin/bash"]
+    args: 
+    - "-c"
+    - "while true; do kubectl get secret minder-db-password -o jsonpath='{.data.password}' | base64 -d > /secrets/db/.pgpass; sleep 300; done"
+    volumeMounts:
+    - name: db-password
+      mountPath: /secrets/db
+
+migrationSettings:
+  sidecarContainers:
+  - name: fetch-secrets
+    image: bitnami/kubectl
+    command: ["/bin/bash"]
+    args: 
+    - "-c"
+    - "while true; do kubectl get secret minder-migrate-password -o jsonpath='{.data.password}' | base64 -d > /secrets/db/.pgpass; sleep 300; done"
+    volumeMounts:
+    - name: db-password
+      mountPath: /secrets/db
+  extraEnv:
+  - name: "PGPASSFILE"
+    value: "/secrets/db/.pgpass"
+  extraVolumeMounts:
+  - name: db-password
+    mountPath: /secrets/db
+  extraVolumes:
+  - name: db-password
+    emptyDir:
+      medium: Memory
+      sizeLimit: 1Mi
+
+extra_config: |
+  database:
+    dbuser: minder
+    dbname: minder
+    sslmode: disabled
+
+  identity:
+    server:
+      issuer_url: http://keycloak-deployment.keycloak.svc:80
+      realm: minder
+      client_id: minder-server
+
+  github:
+    redirect_uri: "https://minder-test.example.com/api/v1/auth/callback/github"
+
+  webhook-config:
+    external_webhook_url: "https://minder-test.example.com/api/v1/webhook/github"
+    external_ping_url: "https://minder-test.example.com/api/v1/health"
+    webhook_secret: "this-is-unused"
+
+  events:
+    driver: go-channel
+    router_close_timeout: 30
+    go-channel:
+      buffer_size: 200
+
+extra_config_migrate: |
+  database:
+    dbuser: migrate-job
+    dbname: minder
+    sslmode: disabled

--- a/deployment/helm_tests/sidecar.yaml
+++ b/deployment/helm_tests/sidecar.yaml
@@ -1,3 +1,17 @@
+# Copyright 2023 Stacklok, Inc
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 hostname: "minder-test.example.com"
 db:
   host: postgres.postgres.svc

--- a/deployment/helm_tests/sidecar.yaml-out
+++ b/deployment/helm_tests/sidecar.yaml-out
@@ -1,0 +1,857 @@
+---
+# Source: minder/templates/configmap.yaml
+# Copyright 2023 Stacklok, Inc
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: minder-config
+  labels:
+    
+    app.kubernetes.io/instance: minder
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: minder
+    app.kubernetes.io/version: "2023-07-31"
+    helm.sh/chart: minder-0.1.0
+data:
+  config.yaml: |
+    
+    #
+    # Copyright 2023 Stacklok, Inc.
+    #
+    # Licensed under the Apache License, Version 2.0 (the "License");
+    # you may not use this file except in compliance with the License.
+    # You may obtain a copy of the License at
+    #
+    #     http://www.apache.org/licenses/LICENSE-2.0
+    #
+    # Unless required by applicable law or agreed to in writing, software
+    # distributed under the License is distributed on an "AS IS" BASIS,
+    # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    # See the License for the specific language governing permissions and
+    # limitations under the License.
+    
+    # HTTP, gRPC & metrics server configuration
+    http_server:
+      host: "127.0.0.1"
+      port: 8080
+    grpc_server:
+      host: "127.0.0.1"
+      port: 8090
+    metric_server:
+      host: "127.0.0.1"
+      port: 9090
+    
+    logging:
+      level: "debug"
+      format: "json"
+      #logFile: "/var/log/minder.log"
+    
+    tracing:
+      enabled: false
+      #sample_ratio: 0.1
+    
+    metrics:
+      enabled: true
+    
+    database:
+      dbhost: "localhost"
+      dbport: 5432
+      dbuser: postgres
+      dbpass: postgres
+      dbname: minder
+      sslmode: disable
+    
+    identity:
+      cli:
+        issuer_url: http://localhost:8081
+        realm: stacklok
+        client_id: minder-cli
+      server:
+        issuer_url: http://keycloak:8080 # Use http://localhost:8081 instead for running minder outside of docker-compose
+        realm: stacklok
+        client_id: minder-server
+        client_secret: secret
+    
+    # Crypto (these should be ultimately stored in a secure vault)
+    # The token key can be generated with:
+    #   openssl rand -base64 32 > .ssh/token_key_passphrase
+    auth:
+      token_key: "./.ssh/token_key_passphrase"
+    
+    # Password Salting, these values are using argon2id
+    # https://en.wikipedia.org/wiki/Argon2
+    # Argon has resistance against side-channel timing attacks and tradeoff attacks
+    # but it is computationally expensive.
+    # If this is a problematic, we could use bcrypt instead.
+    # https://en.wikipedia.org/wiki/Bcrypt
+    salt:
+      # The amount of memory used by the algorithm (in kibibytes).
+      memory: 65536
+      # the amount of iterations
+      iterations:  50
+      # degree of parallelism (number of threads)
+      parallelism: 4
+      # the length of the salt to be used
+      salt_length: 16
+      # the desired number of returned bytes
+      key_length: 32
+    
+    # Webhook Configuration
+    # change example.com to an exposed IP / domain
+    # webhook_secret is set withing the webhook sent to github. Github then signs
+    # the payload sent to minder and minder verifies.
+    webhook-config:
+      external_webhook_url: "https://example.com/api/v1/webhook/github"
+      external_ping_url: "https://example.com/api/v1/health"
+      webhook_secret: "your-password"
+    
+    # OAuth2 Configuration (used during enrollment)
+    # These values are to be set within the GitHub OAuth2 App page
+    github:
+        client_id: "abcde....."
+        client_secret: "abcde....."
+        payload_secret: "your-password"
+        redirect_uri: "http://localhost:8080/api/v1/auth/callback/github"
+        # [*] for all events. It can also be a list such as [push,branch_protection_rule].
+        # Please check complete list on https://docs.github.com/es/webhooks-and-events/webhooks/webhook-events-and-payloads
+        events: ["*"]
+    
+    events:
+      driver: go-channel
+      router_close_timeout: 10
+      go-channel: {}
+    
+  overrides.yaml: |
+    
+    database:
+      dbuser: minder
+      dbname: minder
+      sslmode: disabled
+    
+    identity:
+      server:
+        issuer_url: http://keycloak-deployment.keycloak.svc:80
+        realm: minder
+        client_id: minder-server
+    
+    github:
+      redirect_uri: "https://minder-test.example.com/api/v1/auth/callback/github"
+    
+    webhook-config:
+      external_webhook_url: "https://minder-test.example.com/api/v1/webhook/github"
+      external_ping_url: "https://minder-test.example.com/api/v1/health"
+      webhook_secret: "this-is-unused"
+    
+    events:
+      driver: go-channel
+      router_close_timeout: 30
+      go-channel:
+        buffer_size: 200
+---
+# Source: minder/templates/service.yaml
+# Copyright 2023 Stacklok, Inc
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: minder-http
+  annotations:
+    alb.ingress.kubernetes.io/healthcheck-path: "/api/v1/health"
+  labels:
+    
+    app.kubernetes.io/instance: minder
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: minder
+    app.kubernetes.io/version: "2023-07-31"
+    helm.sh/chart: minder-0.1.0
+spec:
+  type: ClusterIP
+  ports:
+    - port: !!int "8080"
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    app: minder
+---
+# Source: minder/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: minder-grpc
+  annotations:
+    alb.ingress.kubernetes.io/backend-protocol-version: "GRPC"
+    alb.ingress.kubernetes.io/healthcheck-protocol: "HTTP"
+    alb.ingress.kubernetes.io/healthcheck-path: "/minder.v1.HealthService/CheckHealth"
+    # For some reason, ALB defaults to 12 (unimplemented) as a success code
+    alb.ingress.kubernetes.io/success-codes: "0"
+  labels:
+    
+    app.kubernetes.io/instance: minder
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: minder
+    app.kubernetes.io/version: "2023-07-31"
+    helm.sh/chart: minder-0.1.0
+spec:
+  type: ClusterIP
+  ports:
+    - port: !!int "8090"
+      targetPort: grpc
+      protocol: TCP
+      name: grpc
+  selector:
+    app: minder
+---
+# Source: minder/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: minder-metrics
+  labels:
+  
+    app.kubernetes.io/instance: minder
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: minder
+    app.kubernetes.io/version: "2023-07-31"
+    helm.sh/chart: minder-0.1.0
+spec:
+  type: ClusterIP
+  ports:
+    - port: !!int "9090"
+      targetPort: http
+      protocol: TCP
+      name: metrics
+  selector:
+    app: minder
+---
+# Source: minder/templates/deployment.yaml
+# Copyright 2023 Stacklok, Inc
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: minder
+  labels:
+    
+    app.kubernetes.io/instance: minder
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: minder
+    app.kubernetes.io/version: "2023-07-31"
+    helm.sh/chart: minder-0.1.0
+spec:
+  # We'll use autoscaling, sometimes clamped to one instance
+  selector:
+    matchLabels:
+      app: 'minder'
+  template:
+    metadata:
+      labels:
+        app: 'minder'
+      annotations:
+        
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "9090"
+        prometheus.io/path: "/metrics"
+    spec:
+      serviceAccountName: minder
+      containers:
+        - name: minder
+          # restricted security context:
+          # https://kubernetes.io/docs/concepts/security/pod-security-standards/
+          securityContext:
+            allowPrivilegeEscalation: false
+            runAsNonRoot: true
+            readOnlyRootFilesystem: true
+            seccompProfile:
+              type: RuntimeDefault
+            capabilities:
+              drop:
+                - ALL
+          image: ko://github.com/stacklok/minder/cmd/server
+          args:
+          - "serve"
+          - "--db-host=postgres.postgres.svc"
+          - "--config=/config/config.yaml"
+          # We use two config files, one with all the defaults, and one with
+          # additional override values from helm.  (This is a viper feature.)
+          - "--config=/config/overrides.yaml"
+          - "--grpc-host=0.0.0.0"
+          - "--http-host=0.0.0.0"
+          - "--metric-host=0.0.0.0"
+          - "--github-client-id-file=/secrets/app/client_id"
+          - "--github-client-secret-file=/secrets/app/client_secret"
+          env:
+          - name: "MINDER_AUTH_TOKEN_KEY"
+            value: "/secrets/auth/token_key_passphrase"
+          - name: "MINDER_IDENTITY_SERVER_CLIENT_SECRET_FILE"
+            value: "/secrets/identity/identity_client_secret"
+          - name: "MINDER_UNSTABLE_TRUSTY_ENDPOINT"
+            value: "http://pi.pi:8000"
+          - name: "SIGSTORE_NO_CACHE"
+            value: "true"
+          - name: PGPASSFILE
+            value: /secrets/db/.pgpass
+          
+          # ko will always specify a digest, so we don't need to worry about
+          # CRI image caching
+          imagePullPolicy: "IfNotPresent"
+          ports:
+            - name: http
+              containerPort: !!int "8080"
+              protocol: TCP
+            - name: grpc
+              containerPort: !!int "8090"
+              protocol: TCP
+            - name: metric
+              containerPort: !!int "9090"
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /api/v1/health
+              port: http
+          readinessProbe:
+            httpGet:
+              path: /api/v1/health
+              port: http
+          resources:
+            limits:
+              cpu: 1
+              memory: 1.8Gi
+            requests:
+              cpu: 0.5
+              memory: 800Mi
+          volumeMounts:
+          - name: config
+            mountPath: /config
+          - name: auth-secrets
+            mountPath: /secrets/auth
+          - name: app-secrets
+            mountPath: /secrets/app
+          - name: identity-secrets
+            mountPath: /secrets/identity
+          - mountPath: /secrets/db
+            name: db-password
+        - args:
+          - -c
+          - while true; do kubectl get secret minder-db-password -o jsonpath='{.data.password}'
+            | base64 -d > /secrets/db/.pgpass; sleep 300; done
+          command:
+          - /bin/bash
+          image: bitnami/kubectl
+          name: fetch-secrets
+          volumeMounts:
+          - mountPath: /secrets/db
+            name: db-password
+      volumes:
+      - name: config
+        configMap:
+          name: minder-config
+          items:
+          - key: config.yaml
+            path: config.yaml
+          - key: overrides.yaml
+            path: overrides.yaml
+      - name: auth-secrets
+        secret:
+          secretName: minder-auth-secrets
+      - name: app-secrets
+        secret:
+          secretName: minder-github-api-secrets
+      - name: identity-secrets
+        secret:
+          secretName: minder-identity-secrets
+      - emptyDir:
+          medium: Memory
+          sizeLimit: 1Mi
+        name: db-password
+---
+# Source: minder/templates/hpa.yaml
+# Copyright 2023 Stacklok, Inc
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: minder
+  labels:
+    
+    app.kubernetes.io/instance: minder
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: minder
+    app.kubernetes.io/version: "2023-07-31"
+    helm.sh/chart: minder-0.1.0
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: minder
+  minReplicas: 1
+  maxReplicas: 3
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: 60
+---
+# Source: minder/templates/ingress.yaml
+# Copyright 2023 Stacklok, Inc
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: minder
+  labels:
+    
+    app.kubernetes.io/instance: minder
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: minder
+    app.kubernetes.io/version: "2023-07-31"
+    helm.sh/chart: minder-0.1.0
+  annotations: 
+    cert-manager.io/cluster-issuer: prod-issuer
+spec:
+  # Don't set ingressClassName for now, assume default
+  tls:
+  - hosts:
+    - "minder-test.example.com"
+    secretName: minder-tls
+  rules:
+  - host: "minder-test.example.com"
+    http:
+      paths:
+      # We use Prefix matches on gRPC service names because Ingress API
+      # doesn't support matching on Content-Type: application/grpc
+      - path: /grpc.reflection.v1alpha.ServerReflection
+        pathType: Prefix
+        backend:
+          service:
+            name: minder-grpc
+            port:
+              name: grpc
+      - path: /minder.v1.OAuthService
+        pathType: Prefix
+        backend:
+          service:
+            name: minder-grpc
+            port:
+              name: grpc
+      - path: /minder.v1.AuthService
+        pathType: Prefix
+        backend:
+          service:
+            name: minder-grpc
+            port:
+              name: grpc
+      - path: /minder.v1.ArtifactService
+        pathType: Prefix
+        backend:
+          service:
+            name: minder-grpc
+            port:
+              name: grpc
+      - path: /minder.v1.VulnerabilitiesService
+        pathType: Prefix
+        backend:
+          service:
+            name: minder-grpc
+            port:
+              name: grpc
+      - path: /minder.v1.SecretsService
+        pathType: Prefix
+        backend:
+          service:
+            name: minder-grpc
+            port:
+              name: grpc
+      - path: /minder.v1.RepositoryService
+        pathType: Prefix
+        backend:
+          service:
+            name: minder-grpc
+            port:
+              name: grpc
+      - path: /minder.v1.BranchProtectionService
+        pathType: Prefix
+        backend:
+          service:
+            name: minder-grpc
+            port:
+              name: grpc
+      - path: /minder.v1.OrganizationService
+        pathType: Prefix
+        backend:
+          service:
+            name: minder-grpc
+            port:
+              name: grpc
+      - path: /minder.v1.GroupService
+        pathType: Prefix
+        backend:
+          service:
+            name: minder-grpc
+            port:
+              name: grpc
+      - path: /minder.v1.RoleService
+        pathType: Prefix
+        backend:
+          service:
+            name: minder-grpc
+            port:
+              name: grpc
+      - path: /minder.v1.UserService
+        pathType: Prefix
+        backend:
+          service:
+            name: minder-grpc
+            port:
+              name: grpc
+      - path: /minder.v1.ProfileService
+        pathType: Prefix
+        backend:
+          service:
+            name: minder-grpc
+            port:
+              name: grpc
+      - path: /minder.v1.KeyService
+        pathType: Prefix
+        backend:
+          service:
+            name: minder-grpc
+            port:
+              name: grpc
+      - path: /
+        pathType: Prefix
+        backend:
+          service:
+            name: minder-http
+            port:
+              name: http
+---
+# Source: minder/templates/job.yaml
+# Copyright 2023 Stacklok, Inc
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# We need a separate service account for the db-update job, because
+# it runs as a helm pre-install hook, and the minder service account
+# won't have been installed at that point.
+---
+# Source: minder/templates/serviceaccount.yaml
+# Copyright 2023 Stacklok, Inc
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+---
+# Source: minder/templates/tests/test-connection.yaml
+# Copyright 2023 Stacklok, Inc
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+---
+# Source: minder/templates/job.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: db-update-config
+  annotations:
+    helm.sh/hook-delete-policy: before-hook-creation
+    helm.sh/hook: pre-install,pre-upgrade
+  labels:
+    helm.sh/chart: 'minder-0.1.0'
+    app.kubernetes.io/name: minder
+    app.kubernetes.io/instance: "minder"
+    app.kubernetes.io/version: "2023-07-31"
+    app.kubernetes.io/managed-by: "Helm"
+data:
+  config.yaml: |
+    
+    #
+    # Copyright 2023 Stacklok, Inc.
+    #
+    # Licensed under the Apache License, Version 2.0 (the "License");
+    # you may not use this file except in compliance with the License.
+    # You may obtain a copy of the License at
+    #
+    #     http://www.apache.org/licenses/LICENSE-2.0
+    #
+    # Unless required by applicable law or agreed to in writing, software
+    # distributed under the License is distributed on an "AS IS" BASIS,
+    # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    # See the License for the specific language governing permissions and
+    # limitations under the License.
+    
+    # HTTP, gRPC & metrics server configuration
+    http_server:
+      host: "127.0.0.1"
+      port: 8080
+    grpc_server:
+      host: "127.0.0.1"
+      port: 8090
+    metric_server:
+      host: "127.0.0.1"
+      port: 9090
+    
+    logging:
+      level: "debug"
+      format: "json"
+      #logFile: "/var/log/minder.log"
+    
+    tracing:
+      enabled: false
+      #sample_ratio: 0.1
+    
+    metrics:
+      enabled: true
+    
+    database:
+      dbhost: "localhost"
+      dbport: 5432
+      dbuser: postgres
+      dbpass: postgres
+      dbname: minder
+      sslmode: disable
+    
+    identity:
+      cli:
+        issuer_url: http://localhost:8081
+        realm: stacklok
+        client_id: minder-cli
+      server:
+        issuer_url: http://keycloak:8080 # Use http://localhost:8081 instead for running minder outside of docker-compose
+        realm: stacklok
+        client_id: minder-server
+        client_secret: secret
+    
+    # Crypto (these should be ultimately stored in a secure vault)
+    # The token key can be generated with:
+    #   openssl rand -base64 32 > .ssh/token_key_passphrase
+    auth:
+      token_key: "./.ssh/token_key_passphrase"
+    
+    # Password Salting, these values are using argon2id
+    # https://en.wikipedia.org/wiki/Argon2
+    # Argon has resistance against side-channel timing attacks and tradeoff attacks
+    # but it is computationally expensive.
+    # If this is a problematic, we could use bcrypt instead.
+    # https://en.wikipedia.org/wiki/Bcrypt
+    salt:
+      # The amount of memory used by the algorithm (in kibibytes).
+      memory: 65536
+      # the amount of iterations
+      iterations:  50
+      # degree of parallelism (number of threads)
+      parallelism: 4
+      # the length of the salt to be used
+      salt_length: 16
+      # the desired number of returned bytes
+      key_length: 32
+    
+    # Webhook Configuration
+    # change example.com to an exposed IP / domain
+    # webhook_secret is set withing the webhook sent to github. Github then signs
+    # the payload sent to minder and minder verifies.
+    webhook-config:
+      external_webhook_url: "https://example.com/api/v1/webhook/github"
+      external_ping_url: "https://example.com/api/v1/health"
+      webhook_secret: "your-password"
+    
+    # OAuth2 Configuration (used during enrollment)
+    # These values are to be set within the GitHub OAuth2 App page
+    github:
+        client_id: "abcde....."
+        client_secret: "abcde....."
+        payload_secret: "your-password"
+        redirect_uri: "http://localhost:8080/api/v1/auth/callback/github"
+        # [*] for all events. It can also be a list such as [push,branch_protection_rule].
+        # Please check complete list on https://docs.github.com/es/webhooks-and-events/webhooks/webhook-events-and-payloads
+        events: ["*"]
+    
+    events:
+      driver: go-channel
+      router_close_timeout: 10
+      go-channel: {}
+    
+  overrides.yaml: |
+    
+    database:
+      dbuser: migrate-job
+      dbname: minder
+      sslmode: disabled
+---
+# Source: minder/templates/job.yaml
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: db-update
+  annotations:
+    helm.sh/hook-delete-policy: hook-succeeded
+    helm.sh/hook: pre-install,pre-upgrade
+    helm.sh/hook-weight: "5"
+  labels:
+    helm.sh/chart: 'minder-0.1.0'
+    app.kubernetes.io/name: minder
+    app.kubernetes.io/instance: "minder"
+    app.kubernetes.io/version: "2023-07-31"
+    app.kubernetes.io/managed-by: "Helm"
+spec:
+  template:
+    metadata:
+      labels:
+        app: db-init
+    spec:
+      serviceAccountName: migrate-job
+      restartPolicy: Never
+      containers:
+        - name: minder-dbinit
+          # restricted security context:
+          # https://kubernetes.io/docs/concepts/security/pod-security-standards/
+          securityContext:
+            allowPrivilegeEscalation: false
+            runAsNonRoot: true
+            seccompProfile:
+              type: RuntimeDefault
+            capabilities:
+              drop:
+                - ALL
+          image: ko://github.com/stacklok/minder/cmd/server
+          args:
+          - "migrate"
+          - "up"
+          - "--yes"
+          - "--db-host=postgres.postgres.svc"
+          - "--config=/config/config.yaml"
+          # We use two config files, one with all the defaults, and one with
+          # additional override values from helm.  (This is a viper feature.)
+          - "--config=/config/overrides.yaml"
+          # ko will always specify a digest, so we don't need to worry about
+          # CRI image caching
+          imagePullPolicy: IfNotPresent
+          resources:
+            limits:
+              cpu: 1
+              memory: 300Mi
+            requests:
+              cpu: 200m
+              memory: 200Mi
+          env:
+            - name: PGPASSFILE
+              value: /secrets/db/.pgpass
+          volumeMounts:
+          - name: config
+            mountPath: /config
+          - mountPath: /secrets/db
+            name: db-password
+        - args:
+          - -c
+          - while true; do kubectl get secret minder-migrate-password -o jsonpath='{.data.password}'
+            | base64 -d > /secrets/db/.pgpass; sleep 300; done
+          command:
+          - /bin/bash
+          image: bitnami/kubectl
+          name: fetch-secrets
+          volumeMounts:
+          - mountPath: /secrets/db
+            name: db-password
+      volumes:
+      - name: config
+        configMap:
+          name: db-update-config
+          items:
+          - key: config.yaml
+            path: config.yaml
+          - key: overrides.yaml
+            path: overrides.yaml
+      - emptyDir:
+          medium: Memory
+          sizeLimit: 1Mi
+        name: db-password

--- a/go.mod
+++ b/go.mod
@@ -21,6 +21,7 @@ require (
 	github.com/goccy/go-json v0.10.2
 	github.com/golang-migrate/migrate/v4 v4.16.2
 	github.com/golang/mock v1.6.0
+	github.com/google/go-cmp v0.6.0
 	github.com/google/go-containerregistry v0.16.1
 	github.com/google/go-github/v53 v53.2.0
 	github.com/google/uuid v1.4.0

--- a/internal/config/db.go
+++ b/internal/config/db.go
@@ -105,12 +105,11 @@ func (c *DatabaseConfig) GetDBConnection(ctx context.Context) (*sql.DB, string, 
 		return nil, "", err
 	}
 
-	var err error
 	for i := 0; i < 8; i++ {
 		// Ensure we actually connected to the database, per Go docs
 		err = conn.Ping()
 		if err != nil {
-			zerolog.Ctx(ctx).Warn().Err(err).Msg("Unable to initialize connection to DB, retry %d", i)
+			zerolog.Ctx(ctx).Warn().Err(err).Msgf("Unable to initialize connection to DB, retry %d", i)
 			time.Sleep(1 * time.Second)
 			continue
 		}


### PR DESCRIPTION
Since many people probably care about their helm versions, I didn't make it part of the bootstrap command, and instead rely on helm already being installed for this test.

I started with trying to use https://github.com/mittwald/go-helm-client/, but it turns out that has a bunch of out-of-date dependencies, and all the APIs changed because that's how k8s API dependencies work.
