### PR TITLE
Remove `combined.yml` from gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,7 +56,6 @@ docs/build
 docs/.docusaurus
 
 # Generated helm configuration
-/deployment/helm/templates/combined.yml
 /deployment/helm/charts
 /deployment/helm/*.tgz
 


### PR DESCRIPTION
This was previously used by our helm generation but fell out of use.

We shouldn't be ignoring this file anymore as it's no longer generated.
