### PR TITLE
Do database queue connection initialization on eventer

### DIFF
--- a/cmd/server/app/serve.go
+++ b/cmd/server/app/serve.go
@@ -75,27 +75,9 @@ var serveCmd = &cobra.Command{
 
 		store := db.NewStore(dbConn)
 
-		// Get a separate database connection for eventing. This is done to separate concerns from the main database.
-		// It is used for the lifetime of the application, hence it is initialised here.
-		// This is not ideal from a Clean Code perspective, but it is the simplest way to
-		// ensure that the connection is closed when the application exits.
-		var dbConnEvents *sql.DB
-		if cfg.Events.Driver == events.SQLDriver {
-			dbConnEvents, _, err = cfg.Events.SQLPubSub.GetDBConnection(ctx)
-			if err != nil {
-				return fmt.Errorf("unable to connect to events database: %w", err)
-			}
-			defer func(dbConnEvents *sql.DB) {
-				err := dbConnEvents.Close()
-				if err != nil {
-					log.Printf("error closing events database connection: %v", err)
-				}
-			}(dbConnEvents)
-		}
-
 		errg, ctx := errgroup.WithContext(ctx)
 
-		evt, err := events.Setup(ctx, &cfg.Events, dbConnEvents)
+		evt, err := events.Setup(ctx, &cfg.Events)
 		if err != nil {
 			log.Printf("Failed to set up eventer: %v", err)
 			return err

--- a/internal/config/events.go
+++ b/internal/config/events.go
@@ -24,7 +24,7 @@ type EventConfig struct {
 	// GoChannel is the configuration for the go channel event driver
 	GoChannel GoChannelEventConfig `mapstructure:"go-channel" default:"{}"`
 	// SQLPubSub is the configuration for the database event driver
-	SQLPubSub DatabaseConfig `mapstructure:"sql" default:"{}"`
+	SQLPubSub SQLEventConfig `mapstructure:"sql" default:"{}"`
 	// Aggregator is the configuration for the event aggregator middleware
 	Aggregator AggregatorConfig `mapstructure:"aggregator" default:"{}"`
 }
@@ -39,6 +39,13 @@ type GoChannelEventConfig struct {
 	// BlockPublishUntilSubscriberAck is whether or not to block publishing until
 	// the subscriber acks the message. This is useful for testing.
 	BlockPublishUntilSubscriberAck bool `mapstructure:"block_publish_until_subscriber_ack" default:"false"`
+}
+
+// SQLEventConfig is the configuration for the database event driver
+type SQLEventConfig struct {
+	// InitSchema is whether or not to initialize the schema
+	InitSchema bool           `mapstructure:"init_schema" default:"true"`
+	Connection DatabaseConfig `mapstructure:"connection" default:"{}"`
 }
 
 // AggregatorConfig is the configuration for the event aggregator middleware

--- a/internal/controlplane/handlers_user_test.go
+++ b/internal/controlplane/handlers_user_test.go
@@ -261,7 +261,7 @@ func TestCreateUser_gRPC(t *testing.T) {
 			evt, err := events.Setup(context.Background(), &config.EventConfig{
 				Driver:    "go-channel",
 				GoChannel: config.GoChannelEventConfig{},
-			}, nil)
+			})
 			require.NoError(t, err, "failed to setup eventer")
 			server, err := NewServer(mockStore, evt, NewMetrics(), &config.Config{
 				Salt: config.DefaultConfigForTest().Salt,
@@ -468,7 +468,7 @@ func TestDeleteUser_gRPC(t *testing.T) {
 			evt, err := events.Setup(context.Background(), &config.EventConfig{
 				Driver:    "go-channel",
 				GoChannel: config.GoChannelEventConfig{},
-			}, nil)
+			})
 			require.NoError(t, err, "failed to setup eventer")
 			server, err := NewServer(mockStore, evt, NewMetrics(), &config.Config{
 				Salt: config.DefaultConfigForTest().Salt,

--- a/internal/controlplane/server_test.go
+++ b/internal/controlplane/server_test.go
@@ -73,7 +73,7 @@ func newDefaultServer(t *testing.T, mockStore *mockdb.MockStore) *Server {
 	evt, err := events.Setup(context.Background(), &config.EventConfig{
 		Driver:    "go-channel",
 		GoChannel: config.GoChannelEventConfig{},
-	}, nil)
+	})
 	require.NoError(t, err, "failed to setup eventer")
 
 	var c *config.Config

--- a/internal/eea/eea_test.go
+++ b/internal/eea/eea_test.go
@@ -56,7 +56,7 @@ func TestAggregator(t *testing.T) {
 			BufferSize:                     concurrentEvents,
 			BlockPublishUntilSubscriberAck: true,
 		},
-	}, nil)
+	})
 	require.NoError(t, err)
 
 	// we'll wait 2 seconds for the lock to be available

--- a/internal/engine/executor_test.go
+++ b/internal/engine/executor_test.go
@@ -265,7 +265,7 @@ default allow = true`,
 		GoChannel: config.GoChannelEventConfig{
 			BlockPublishUntilSubscriberAck: true,
 		},
-	}, nil)
+	})
 	require.NoError(t, err, "failed to setup eventer")
 
 	go func() {

--- a/internal/events/eventer_test.go
+++ b/internal/events/eventer_test.go
@@ -126,7 +126,7 @@ func TestEventer(t *testing.T) {
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()
 
-			eventer, err := events.Setup(ctx, driverConfig(), nil)
+			eventer, err := events.Setup(ctx, driverConfig())
 			if err != nil {
 				t.Errorf("Setup() error = %v", err)
 				return


### PR DESCRIPTION
This removes the boilerplate on other parts of the code and instead moves
the responsibility to eventer.
