### PR TITLE
Increase entropy of repo ID generation for tests

### DIFF
--- a/internal/db/repositories_test.go
+++ b/internal/db/repositories_test.go
@@ -44,7 +44,7 @@ func createRandomRepository(t *testing.T, project uuid.UUID, prov string, opts .
 		ProjectID:  project,
 		RepoOwner:  rand.RandomName(seed),
 		RepoName:   rand.RandomName(seed),
-		RepoID:     int32(rand.RandomInt(0, 2000, seed)),
+		RepoID:     int32(rand.RandomInt(0, 5000, seed)),
 		IsPrivate:  false,
 		IsFork:     false,
 		WebhookID:  sql.NullInt32{Int32: int32(rand.RandomInt(0, 1000, seed)), Valid: true},
@@ -62,7 +62,7 @@ func createRandomRepository(t *testing.T, project uuid.UUID, prov string, opts .
 		_, err := testQueries.GetRepositoryByRepoID(context.Background(), arg.RepoID)
 		if err != sql.ErrNoRows {
 			seed++
-			arg.RepoID = int32(rand.RandomInt(0, 2000, seed))
+			arg.RepoID = int32(rand.RandomInt(0, 5000, seed))
 		} else {
 			break
 		}


### PR DESCRIPTION
This aims to avoid issues such as:

```
       repositories_test.go:166:
          	Error Trace:	/home/runner/work/minder/minder/internal/db/repositories_test.go:72
          	            				/home/runner/work/minder/minder/internal/db/repositories_test.go:166
          	Error:      	Received unexpected error:
          	            	pq: duplicate key value violates unique constraint "unique_repo_id"
          	Test:       	TestListRepositoriesByProjectID
```
