### PR TITLE
Add a yes flag to skip prompts for CLI commands

### DIFF
--- a/cmd/cli/app/auth/auth_revoke_provider.go
+++ b/cmd/cli/app/auth/auth_revoke_provider.go
@@ -46,6 +46,7 @@ var Auth_revokeproviderCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		// check if we need to revoke all tokens or the user one
 		all := util.GetConfigValue(viper.GetViper(), "all", "all", cmd, false).(bool)
+		yesFlag := util.GetConfigValue(viper.GetViper(), "yes", "yes", cmd, false).(bool)
 		project := viper.GetString("project-id")
 		provider := util.GetConfigValue(viper.GetViper(), "provider", "provider", cmd, "").(string)
 
@@ -54,7 +55,7 @@ var Auth_revokeproviderCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
-		if all {
+		if all && !yesFlag {
 			yes := cli.PrintYesNoPrompt(cmd,
 				"You are about to revoke the access tokens for your provider.",
 				"Are you sure?",
@@ -64,6 +65,7 @@ var Auth_revokeproviderCmd = &cobra.Command{
 				return
 			}
 		}
+
 		conn, err := util.GrpcForCommand(cmd, viper.GetViper())
 		util.ExitNicelyOnError(err, "Error getting grpc connection")
 		defer conn.Close()
@@ -92,4 +94,5 @@ func init() {
 	Auth_revokeproviderCmd.Flags().StringP("provider", "p", "", "Name for the provider to revoke tokens for")
 	Auth_revokeproviderCmd.Flags().StringP("project-id", "g", "", "ID of the project for repo registration")
 	Auth_revokeproviderCmd.Flags().BoolP("all", "a", false, "Revoke all tokens")
+	Auth_revokeproviderCmd.Flags().BoolP("yes", "y", false, "Bypass yes/no prompt when revoking all tokens")
 }

--- a/cmd/cli/app/provider/provider_enroll.go
+++ b/cmd/cli/app/provider/provider_enroll.go
@@ -135,19 +135,23 @@ func EnrollProviderCmd(cmd *cobra.Command, _ []string) (string, error) {
 	project := viper.GetString("project")
 	pat := util.GetConfigValue(viper.GetViper(), "token", "token", cmd, "").(string)
 	owner := util.GetConfigValue(viper.GetViper(), "owner", "owner", cmd, "").(string)
+	yesFlag := util.GetConfigValue(viper.GetViper(), "yes", "yes", cmd, false).(bool)
 
 	// Ask for confirmation if an owner is set on purpose
 	ownerPromptStr := "your personal account"
 	if owner != "" {
 		ownerPromptStr = fmt.Sprintf("the %s organisation", owner)
 	}
-	yes := cli.PrintYesNoPrompt(cmd,
-		fmt.Sprintf("You are about to enroll repositories from %s.", ownerPromptStr),
-		"Do you confirm?",
-		"Enroll operation cancelled.",
-		true)
-	if !yes {
-		return "", nil
+
+	if !yesFlag {
+		yes := cli.PrintYesNoPrompt(cmd,
+			fmt.Sprintf("You are about to enroll repositories from %s.", ownerPromptStr),
+			"Do you confirm?",
+			"Enroll operation cancelled.",
+			true)
+		if !yes {
+			return "", nil
+		}
 	}
 
 	conn, err := util.GrpcForCommand(cmd, viper.GetViper())
@@ -218,6 +222,7 @@ func init() {
 	enrollProviderCmd.Flags().StringP("project", "r", "", "ID of the project for enrolling the provider")
 	enrollProviderCmd.Flags().StringP("token", "t", "", "Personal Access Token (PAT) to use for enrollment")
 	enrollProviderCmd.Flags().StringP("owner", "o", "", "Owner to filter on for provider resources")
+	enrollProviderCmd.Flags().BoolP("yes", "y", false, "Bypass yes/no prompt when enrolling new provider")
 	if err := enrollProviderCmd.MarkFlagRequired("provider"); err != nil {
 		fmt.Fprintf(os.Stderr, "Error marking flag as required: %s\n", err)
 	}

--- a/cmd/cli/app/rule_type/rule_type_delete.go
+++ b/cmd/cli/app/rule_type/rule_type_delete.go
@@ -41,6 +41,7 @@ minder control plane.`,
 		// Delete the rule type via GRPC
 		id := viper.GetString("id")
 		deleteAll := viper.GetBool("all")
+		yesFlag := util.GetConfigValue(viper.GetViper(), "yes", "yes", cmd, false).(bool)
 
 		// If id is set, deleteAll cannot be set
 		if id != "" && deleteAll {
@@ -53,7 +54,8 @@ minder control plane.`,
 			fmt.Fprintf(os.Stderr, "Either id or deleteAll needs to be set")
 			return
 		}
-		if deleteAll {
+
+		if deleteAll && !yesFlag {
 			// Ask for confirmation if deleteAll is set on purpose
 			yes := cli.PrintYesNoPrompt(cmd,
 				"You are about to permanently delete all of your rule types.",
@@ -146,6 +148,7 @@ func init() {
 	ruleType_deleteCmd.Flags().StringP("provider", "p", "", "Provider to list rule types for")
 	ruleType_deleteCmd.Flags().StringP("id", "i", "", "ID of rule type to delete")
 	ruleType_deleteCmd.Flags().BoolP("all", "a", false, "Warning: Deletes all rule types")
+	ruleType_deleteCmd.Flags().BoolP("yes", "y", false, "Bypass yes/no prompt when deleting all rule types")
 	err := ruleType_deleteCmd.MarkFlagRequired("provider")
 	util.ExitNicelyOnError(err, "Error marking flag as required")
 }


### PR DESCRIPTION
Adds an optional `--yes/-y` flag for bypassing the yes/no prompt.

There are four commands that have this prompt currently, 
1. `minder auth revoke_provider`
2. `minder auth delete`
3. `minder rule_type delete`
4. `minder provider enroll`

I have added to all the above except `minder auth delete` as I feel this one should always ask for a confirmation. Let me know if we should add to this one too.


_Updated(by @rdimitrov):_
Fixes #1519