### PR TITLE
Add new env var for db queue pass

### DIFF
--- a/deployment/helm/README.md
+++ b/deployment/helm/README.md
@@ -58,6 +58,7 @@ installed in the namespace specified by your current Kubernetes context.
 | deploymentSettings.resources | object | `{"limits":{"cpu":4,"memory":"1.5Gi"},"requests":{"cpu":1,"memory":"1Gi"}}` | resources to use for the main deployment |
 | deploymentSettings.secrets.appSecretName | string | `"minder-github-secrets"` | name of the secret containing the github configuration |
 | deploymentSettings.secrets.authSecretName | string | `"minder-auth-secrets"` | name of the secret containing the auth configuration |
+| deploymentSettings.secrets.dbQueueSecretName | string | `"minder-db-queue-secrets"` | name of the secret containing the database queue configuration |
 | deploymentSettings.secrets.identitySecretName | string | `"minder-identity-secrets"` | name of the secret containing the identity configuration |
 | deploymentSettings.sidecarContainers | array, optional | `nil` | Additional configuration for sidecar containers |
 | extra_config | string | `"# Add content here\n"` | Additional configuration yaml beyond what's in config.yaml.example |

--- a/deployment/helm/templates/deployment.yaml
+++ b/deployment/helm/templates/deployment.yaml
@@ -126,6 +126,9 @@ spec:
       - name: identity-secrets
         secret:
           secretName: {{ .Values.deploymentSettings.secrets.identitySecretName }}
+      - name: db-queue-secrets
+        secret:
+          secretName: {{ .Values.deploymentSettings.secrets.dbQueueSecretName }}
       {{- if .Values.deploymentSettings.extraVolumes }}
       {{- toYaml .Values.deploymentSettings.extraVolumes | nindent 6 }}
       {{- end }}

--- a/deployment/helm/values.yaml
+++ b/deployment/helm/values.yaml
@@ -120,6 +120,8 @@ deploymentSettings:
     appSecretName: "minder-github-secrets"
     # -- (string) name of the secret containing the identity configuration
     identitySecretName: "minder-identity-secrets"
+    # -- (string) name of the secret containing the database queue configuration
+    dbQueueSecretName: "minder-db-queue-secrets"
   # -- (array, optional) Additional configuration for sidecar containers
   sidecarContainers: null
 

--- a/deployment/helm_tests/basic.yaml
+++ b/deployment/helm_tests/basic.yaml
@@ -43,6 +43,7 @@ deploymentSettings:
     authSecretName: "minder-auth-secrets"
     appSecretName: "minder-github-api-secrets"
     identitySecretName: "minder-identity-secrets"
+    dbQueueSecretName: "minder-db-queue-secrets"
 
 extra_config: |
   database:

--- a/deployment/helm_tests/basic.yaml-out
+++ b/deployment/helm_tests/basic.yaml-out
@@ -382,6 +382,9 @@ spec:
       - name: identity-secrets
         secret:
           secretName: minder-identity-secrets
+      - name: db-queue-secrets
+        secret:
+          secretName: minder-db-queue-secrets
 ---
 # Source: minder/templates/hpa.yaml
 # Copyright 2023 Stacklok, Inc

--- a/deployment/helm_tests/sidecar.yaml
+++ b/deployment/helm_tests/sidecar.yaml
@@ -43,6 +43,7 @@ deploymentSettings:
     authSecretName: "minder-auth-secrets"
     appSecretName: "minder-github-api-secrets"
     identitySecretName: "minder-identity-secrets"
+    dbQueueSecretName: "minder-db-queue-secrets"
   extraEnv:
   - name: "PGPASSFILE"
     value: "/secrets/db/.pgpass"

--- a/deployment/helm_tests/sidecar.yaml-out
+++ b/deployment/helm_tests/sidecar.yaml-out
@@ -397,6 +397,9 @@ spec:
       - name: identity-secrets
         secret:
           secretName: minder-identity-secrets
+      - name: db-queue-secrets
+        secret:
+          secretName: minder-db-queue-secrets
       - emptyDir:
           medium: Memory
           sizeLimit: 1Mi

--- a/docs/docs/run_minder_server/installing_minder.md
+++ b/docs/docs/run_minder_server/installing_minder.md
@@ -64,28 +64,38 @@ Deploy Minder on Kubernetes
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| aws.accountID | string | `"123456789012"` | AWS account ID where the service will be deployed |
-| aws.migrate.iamRole | string | `"minder_migrate_role"` | IAM role for the migration operations in AWS |
-| aws.server.iamRole | string | `"minder_server_role"` | IAM role for the server operations in AWS |
-| db.host | string | `"postgres.postgres"` | Hostname for the database where Minder will store its data |
-| deploymentSettings.extraVolumeMounts | string | `nil` | Additional volume mounts for the deployment |
-| deploymentSettings.extraVolumes | string | `nil` | Additional volumes to mount into the deployment |
-| deploymentSettings.image | string | `"ko://github.com/stacklok/minder/cmd/server"` | Image to use for the main Minder deployment |
-| deploymentSettings.imagePullPolicy | string | `"IfNotPresent"` | Image pull policy for the main deployment |
-| deploymentSettings.resources | object | `{"limits":{"cpu":4,"memory":"1.5Gi"},"requests":{"cpu":1,"memory":"1Gi"}}` | Compute resource requests and limits for the main deployment |
-| deploymentSettings.secrets | object | `{"appSecretName":"minder-github-secrets","authSecretName":"minder-auth-secrets","identitySecretName":"minder-identity-secrets"}` | Names of the secrets for various Minder components |
-| hostname | string | `"minder.example.com"` | The hostname for the Minder service |
-| hpaSettings.maxReplicas | int | `1` | Maximum number of replicas for HPA |
-| hpaSettings.metrics | object | `{"cpu":{"targetAverageUtilization":60}}` | Target CPU utilization percentage for HPA to scale |
-| hpaSettings.minReplicas | int | `1` | Minimum number of replicas for HPA |
-| ingress.annotations | object | `{}` | Ingress annotations |
-| migrationSettings.image | string | `"ko://github.com/stacklok/minder/cmd/server"` | Image to use for the migration jobs |
-| migrationSettings.imagePullPolicy | string | `"IfNotPresent"` | Image pull policy for the migration jobs |
-| migrationSettings.resources | object | `{"limits":{"cpu":1,"memory":"300Mi"},"requests":{"cpu":"200m","memory":"200Mi"}}` | Compute resource requests and limits for the migration jobs |
-| service.grpcPort | int | `8090` | GRPC port for the service to listen on |
-| service.httpPort | int | `8080` | HTTP port for the service to listen on |
-| service.metricPort | int | `9090` | Metrics port for the service to expose metrics on |
-| serviceAccounts.migrate | string | `""` | ServiceAccount to be used for migration. If set, Minder will use this named ServiceAccount. |
-| serviceAccounts.server | string | `""` | ServiceAccount to be used by the server. If set, Minder will use this named ServiceAccount. |
-| trusty.endpoint | string | `"http://pi.pi:8000"` | Endpoint for the trusty service which Minder communicates with |
-
+| aws.accountID | string | `"123456789012"` |  |
+| aws.migrate | object, optional | `{"iamRole":"minder_migrate_role"}` | AWS IAM migration settings |
+| aws.migrate.iamRole | string | `"minder_migrate_role"` | IAM role to use for the migration job |
+| aws.server | object, optional | `{"iamRole":"minder_server_role"}` | AWS IAM server settings |
+| aws.server.iamRole | string | `"minder_server_role"` | IAM role to use for the server |
+| db.host | string | `"postgres.postgres"` | database host to use |
+| deploymentSettings.extraVolumeMounts | array, optional | `nil` | Additional volume mounts |
+| deploymentSettings.extraVolumes | array, optional | `nil` | Additional volumes to mount |
+| deploymentSettings.image | string | `"ko://github.com/stacklok/minder/cmd/server"` | image to use for the main deployment |
+| deploymentSettings.imagePullPolicy | string | `"IfNotPresent"` | image pull policy to use for the main deployment |
+| deploymentSettings.resources | object | `{"limits":{"cpu":4,"memory":"1.5Gi"},"requests":{"cpu":1,"memory":"1Gi"}}` | resources to use for the main deployment |
+| deploymentSettings.secrets.appSecretName | string | `"minder-github-secrets"` | name of the secret containing the github configuration |
+| deploymentSettings.secrets.authSecretName | string | `"minder-auth-secrets"` | name of the secret containing the auth configuration |
+| deploymentSettings.secrets.dbQueueSecretName | string | `"minder-db-queue-secrets"` | name of the secret containing the database queue configuration |
+| deploymentSettings.secrets.identitySecretName | string | `"minder-identity-secrets"` | name of the secret containing the identity configuration |
+| deploymentSettings.sidecarContainers | array, optional | `nil` | Additional configuration for sidecar containers |
+| extra_config | string | `"# Add content here\n"` | Additional configuration yaml beyond what's in config.yaml.example |
+| extra_config_migrate | string | `"# Add even more content here\n"` | Additional configuration yaml that's applied to the migration job |
+| hostname | string | `"minder.example.com"` | hostname to ue for the ingress configuration |
+| hpaSettings.maxReplicas | int | `1` | maximum number of replicas for the HPA |
+| hpaSettings.metrics | object | `{"cpu":{"targetAverageUtilization":60}}` | metrics to use for the HPA |
+| hpaSettings.minReplicas | int | `1` | minimum number of replicas for the HPA |
+| ingress.annotations | object, optional | `{}` | annotations to use for the ingress |
+| migrationSettings.extraVolumeMounts | array, optional | `nil` | Additional volume mounts |
+| migrationSettings.extraVolumes | array, optional | `nil` | Additional volumes to mount |
+| migrationSettings.image | string | `"ko://github.com/stacklok/minder/cmd/server"` | image to use for the migration job |
+| migrationSettings.imagePullPolicy | string | `"IfNotPresent"` | image pull policy to use for the migration job |
+| migrationSettings.resources | object | `{"limits":{"cpu":1,"memory":"300Mi"},"requests":{"cpu":"200m","memory":"200Mi"}}` | resources to use for the migration job |
+| migrationSettings.sidecarContainers | array, optional | `nil` | Additional configuration for sidecar containers |
+| service.grpcPort | int | `8090` | port for the gRPC API |
+| service.httpPort | int | `8080` | port for the HTTP API |
+| service.metricPort | int | `9090` | port for the metrics endpoint |
+| serviceAccounts.migrate | string, optional | `""` | If non-empty, minder will use the named ServiceAccount resources rather than creating a ServiceAccount |
+| serviceAccounts.server | string, optional | `""` | If non-empty, minder will use the named ServiceAccount resources rather than creating a ServiceAccount |
+| trusty.endpoint | string | `"http://pi.pi:8000"` | trusty host to use |


### PR DESCRIPTION
Add a new env var to the minder helm template to separate concerns and use a dedicated external secret (in incoming infra PRs).