### PR TITLE
Add a gauge to count the quickstart profiles

### DIFF
--- a/database/mock/store.go
+++ b/database/mock/store.go
@@ -126,6 +126,21 @@ func (mr *MockStoreMockRecorder) CountProfilesByEntityType(arg0 interface{}) *go
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CountProfilesByEntityType", reflect.TypeOf((*MockStore)(nil).CountProfilesByEntityType), arg0)
 }
 
+// CountProfilesByName mocks base method.
+func (m *MockStore) CountProfilesByName(arg0 context.Context, arg1 string) (int64, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CountProfilesByName", arg0, arg1)
+	ret0, _ := ret[0].(int64)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// CountProfilesByName indicates an expected call of CountProfilesByName.
+func (mr *MockStoreMockRecorder) CountProfilesByName(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CountProfilesByName", reflect.TypeOf((*MockStore)(nil).CountProfilesByName), arg0, arg1)
+}
+
 // CountRepositories mocks base method.
 func (m *MockStore) CountRepositories(arg0 context.Context) (int64, error) {
 	m.ctrl.T.Helper()

--- a/database/query/profiles.sql
+++ b/database/query/profiles.sql
@@ -83,3 +83,6 @@ SELECT COUNT(p.id) AS num_profiles, ep.entity AS profile_entity
 FROM profiles AS p
          JOIN entity_profiles AS ep ON p.id = ep.profile_id
 GROUP BY ep.entity;
+
+-- name: CountProfilesByName :one
+SELECT COUNT(*) AS num_named_profiles FROM profiles WHERE name = $1;

--- a/internal/db/profiles.sql.go
+++ b/internal/db/profiles.sql.go
@@ -48,6 +48,17 @@ func (q *Queries) CountProfilesByEntityType(ctx context.Context) ([]CountProfile
 	return items, nil
 }
 
+const countProfilesByName = `-- name: CountProfilesByName :one
+SELECT COUNT(*) AS num_named_profiles FROM profiles WHERE name = $1
+`
+
+func (q *Queries) CountProfilesByName(ctx context.Context, name string) (int64, error) {
+	row := q.db.QueryRowContext(ctx, countProfilesByName, name)
+	var num_named_profiles int64
+	err := row.Scan(&num_named_profiles)
+	return num_named_profiles, err
+}
+
 const createProfile = `-- name: CreateProfile :one
 INSERT INTO profiles (  
     provider,

--- a/internal/db/querier.go
+++ b/internal/db/querier.go
@@ -15,6 +15,7 @@ type Querier interface {
 	AddUserProject(ctx context.Context, arg AddUserProjectParams) (UserProject, error)
 	AddUserRole(ctx context.Context, arg AddUserRoleParams) (UserRole, error)
 	CountProfilesByEntityType(ctx context.Context) ([]CountProfilesByEntityTypeRow, error)
+	CountProfilesByName(ctx context.Context, name string) (int64, error)
 	CountRepositories(ctx context.Context) (int64, error)
 	CountUsers(ctx context.Context) (int64, error)
 	CreateAccessToken(ctx context.Context, arg CreateAccessTokenParams) (ProviderAccessToken, error)


### PR DESCRIPTION
The quickstart profile are a bit of a special case, with a special name
(that's not enforced, but I don't think the number of false positives
would be very high). We don't have another way to see if a profile was
created by the quickstart tool and while we could add one, it's not
worth the effort.

This PR adds a gauge that counts the profiles with the quickstart name
so that we can get metrics on their usage.
