### PR TITLE
Ignore /dist directory generated by goreleaser

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,3 +61,6 @@ docs/.docusaurus
 
 # Ignore examples cloned repo
 examples/rules-and-profiles
+
+# Generated goreleaser artifacts
+/dist


### PR DESCRIPTION
Fix https://github.com/stacklok/minder/issues/1664.

This makes sure we have `Dirty: false` for `minder version` output.

I tested this locally, by simulating running `goreleaser release --clean` in a simulated clean directory with a dummy tag (while the publishing will fail, but the `/dist` directory is created). Before this change, running `minder version` gave me:

```console
...
Dirty: true
...
```

With this change:

```console
...
Dirty: false
...
```