### PR TITLE
Make sure each call to NewRand is initialized with a unique seed

### DIFF
--- a/internal/util/rand/random.go
+++ b/internal/util/rand/random.go
@@ -33,11 +33,16 @@ import (
 	"net"
 	"os"
 	"path/filepath"
+	"sync/atomic"
 )
+
+// seedGuard makes sure each call to NewRand is initialized with a unique seed.
+var seedGuard atomic.Int64
 
 // NewRand returns a new instance of rand.Rand with a fixed source.
 func NewRand(seed int64) *rand.Rand {
-	return rand.New(rand.NewSource(seed))
+	seedGuard.Add(1)
+	return rand.New(rand.NewSource(seed + seedGuard.Load()))
 }
 
 // RandomInt returns a random integer between min and max.


### PR DESCRIPTION
Fixes #1352.

There are several potential locations to fix this, but I think this proposed change helps to remedy other tests that rely on random values.

I tested on the main branch to reproduce the flakiness as follows:

```console
for i in {1..10} ; do go test -count 1 ./internal/db/... ; done
```

I consistently get an error similar to the following (but mostly not at the first run):

```console
2023-11-30 23:28:49.938 WIB [11553] ERROR:  duplicate key value violates unique constraint "projects_name_idx"
2023-11-30 23:28:49.938 WIB [11553] DETAIL:  Key (name)=(dZGJGaiAlN) already exists.
```

Hence resulting `STATEMENT:  -- name: CreateOrganization :one` and `STATEMENT:  -- name: CreateProject :one` to fail, similar to https://github.com/stacklok/minder/issues/1352.

```console
2023-11-30 23:28:49.938 WIB [11553] STATEMENT:  -- name: CreateOrganization :one
        INSERT INTO projects (
            name,
            is_organization,
            metadata 
        ) VALUES (
            $1, TRUE, $2::jsonb
        ) RETURNING id, name, is_organization, metadata, parent_id, created_at, updated_at

2023-11-30 23:28:49.940 WIB [11557] ERROR:  invalid input syntax for type json
2023-11-30 23:28:49.940 WIB [11557] DETAIL:  The input string ended unexpectedly.
2023-11-30 23:28:49.940 WIB [11557] CONTEXT:  JSON data, line 1: 
        unnamed portal parameter $3 = ''
2023-11-30 23:28:49.940 WIB [11557] STATEMENT:  -- name: CreateProject :one
        INSERT INTO projects (
            name,
            parent_id,
            metadata
        ) VALUES (
            $1, $2, $3::jsonb
        ) RETURNING id, name, is_organization, metadata, parent_id, created_at, updated_at
```

With this change, run the above test (with or without -race) is successful: 

```console
for i in {1..100} ; do go test -count 1 ./internal/db/... ; done
for i in {1..100} ; do go test -count 1 -race ./internal/db/... ; done
```
