### PR TITLE
Modify `mindev` to have `ruletype` subcommand

### DIFF
--- a/cmd/dev/app/root.go
+++ b/cmd/dev/app/root.go
@@ -22,6 +22,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 
+	"github.com/stacklok/minder/cmd/dev/app/rule_type"
 	"github.com/stacklok/minder/internal/util"
 )
 
@@ -46,6 +47,8 @@ func Execute() {
 func init() {
 	cobra.OnInitialize(initConfig)
 	RootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is $PWD/config.yaml)")
+
+	RootCmd.AddCommand(rule_type.CmdRuleType())
 }
 
 func initConfig() {

--- a/cmd/dev/app/rule_type/rttst.go
+++ b/cmd/dev/app/rule_type/rttst.go
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package rule_type provides the CLI subcommand for developing rules
-// e.g. the 'rule type test' subcommand.
 package rule_type
 
 import (
@@ -29,7 +27,6 @@ import (
 	"github.com/spf13/viper"
 	"google.golang.org/protobuf/reflect/protoreflect"
 
-	"github.com/stacklok/minder/cmd/dev/app"
 	"github.com/stacklok/minder/internal/db"
 	"github.com/stacklok/minder/internal/engine"
 	"github.com/stacklok/minder/internal/engine/errors"
@@ -40,17 +37,16 @@ import (
 	minderv1 "github.com/stacklok/minder/pkg/api/protobuf/go/minder/v1"
 )
 
-// TestCmd is the root command for the rule subcommands
-var testCmd = &cobra.Command{
-	Use:          "rule type test",
-	Short:        "test a rule type definition",
-	Long:         `The 'rule type test' subcommand allows you test a rule type definition`,
-	RunE:         testCmdRun,
-	SilenceUsage: true,
-}
+// CmdTest is the root command for the rule subcommands
+func CmdTest() *cobra.Command {
+	var testCmd = &cobra.Command{
+		Use:          "test",
+		Short:        "test a rule type definition",
+		Long:         `The 'rule type test' subcommand allows you test a rule type definition`,
+		RunE:         testCmdRun,
+		SilenceUsage: true,
+	}
 
-func init() {
-	app.RootCmd.AddCommand(testCmd)
 	testCmd.Flags().StringP("rule-type", "r", "", "file to read rule type definition from")
 	testCmd.Flags().StringP("entity", "e", "", "YAML file containing the entity to test the rule against")
 	testCmd.Flags().StringP("profile", "p", "", "YAML file containing a profile to test the rule against")
@@ -73,6 +69,7 @@ func init() {
 	}
 	// bind environment variable
 	viper.SetEnvKeyReplacer(strings.NewReplacer(".", "_"))
+	return testCmd
 }
 
 func testCmdRun(cmd *cobra.Command, _ []string) error {

--- a/cmd/dev/app/rule_type/ruletype.go
+++ b/cmd/dev/app/rule_type/ruletype.go
@@ -1,0 +1,29 @@
+// Copyright 2023 Stacklok, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package rule_type provides the root command for the ruletype subcommands
+package rule_type
+
+import "github.com/spf13/cobra"
+
+// CmdRuleType is the root command for the ruletype subcommands
+func CmdRuleType() *cobra.Command {
+	var rtCmd = &cobra.Command{
+		Use: "ruletype",
+	}
+
+	rtCmd.AddCommand(CmdTest())
+
+	return rtCmd
+}


### PR DESCRIPTION
This adds an explicit parent command for `mindev` for rule types. This will
make it easier to add more sub-commands there.
