### PR TITLE
Introduce `mindev ruletype lint` command

### DIFF
--- a/cmd/dev/app/rule_type/lint.go
+++ b/cmd/dev/app/rule_type/lint.go
@@ -1,0 +1,102 @@
+// Copyright 2023 Stacklok, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package rule_type
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/spf13/cobra"
+	"github.com/styrainc/regal/pkg/linter"
+	"github.com/styrainc/regal/pkg/rules"
+	"gopkg.in/yaml.v3"
+
+	"github.com/stacklok/minder/internal/engine/eval/rego"
+	minderv1 "github.com/stacklok/minder/pkg/api/protobuf/go/minder/v1"
+)
+
+// CmdLint is the command for linting a rule type definition
+func CmdLint() *cobra.Command {
+	var lintCmd = &cobra.Command{
+		Use:          "lint",
+		Short:        "lint a rule type definition",
+		Long:         `The 'rule type lint' subcommand allows you lint a rule type definition`,
+		RunE:         lintCmdRun,
+		SilenceUsage: true,
+	}
+	lintCmd.Flags().StringP("rule-type", "r", "", "file to read rule type definition from")
+
+	if err := lintCmd.MarkFlagRequired("rule-type"); err != nil {
+		fmt.Fprintf(os.Stderr, "Error marking flag as required: %s\n", err)
+		os.Exit(1)
+	}
+
+	return lintCmd
+}
+
+func lintCmdRun(cmd *cobra.Command, _ []string) error {
+	rtpath := cmd.Flag("rule-type")
+
+	ctx := cmd.Context()
+
+	rtpathStr := rtpath.Value.String()
+
+	rt, err := readRuleTypeFromFile(rtpathStr)
+	if err != nil {
+		return fmt.Errorf("error reading rule type from file: %w", err)
+	}
+
+	if err := rt.Validate(); err != nil {
+		return fmt.Errorf("error validating rule type: %w", err)
+	}
+
+	if rt.Def.Eval.Type == rego.RegoEvalType {
+		if err := validateRegoRule(ctx, rt.Def.Eval.Rego, rtpathStr, cmd.OutOrStdout()); err != nil {
+			return fmt.Errorf("failed validating rego rule: %w", err)
+		}
+	}
+
+	return nil
+}
+
+func validateRegoRule(ctx context.Context, r *minderv1.RuleType_Definition_Eval_Rego, path string, out io.Writer) error {
+	if r == nil {
+		return fmt.Errorf("rego rule is nil")
+	}
+
+	if r.Def == "" {
+		return fmt.Errorf("rego rule definition is empty")
+	}
+
+	inputs, err := rules.InputFromText(path, r.Def)
+	if err != nil {
+		return fmt.Errorf("failed parsing rego rule: %w", err)
+	}
+
+	lint := linter.NewLinter().WithInputModules(&inputs)
+
+	res, err := lint.Lint(ctx)
+	if err != nil {
+		return fmt.Errorf("failed linting rego rule: %w", err)
+	}
+
+	if err := yaml.NewEncoder(out).Encode(res); err != nil {
+		return fmt.Errorf("failed writing lint results: %w", err)
+	}
+
+	return nil
+}

--- a/cmd/dev/app/rule_type/ruletype.go
+++ b/cmd/dev/app/rule_type/ruletype.go
@@ -24,6 +24,7 @@ func CmdRuleType() *cobra.Command {
 	}
 
 	rtCmd.AddCommand(CmdTest())
+	rtCmd.AddCommand(CmdLint())
 
 	return rtCmd
 }

--- a/go.mod
+++ b/go.mod
@@ -51,6 +51,7 @@ require (
 	github.com/sqlc-dev/pqtype v0.3.0
 	github.com/stacklok/frizbee v0.0.5
 	github.com/stretchr/testify v1.8.4
+	github.com/styrainc/regal v0.13.0
 	github.com/xeipuuv/gojsonschema v1.2.0
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.46.1
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.46.1

--- a/go.sum
+++ b/go.sum
@@ -356,8 +356,8 @@ github.com/erikgeiser/promptkit v0.9.0 h1:3qL1mS/ntCrXdb8sTP/ka82CJ9kEQaGuYXNrYJ
 github.com/erikgeiser/promptkit v0.9.0/go.mod h1:pU9dtogSe3Jlc2AY77EP7R4WFP/vgD4v+iImC83KsCo=
 github.com/evanphx/json-patch/v5 v5.7.0 h1:nJqP7uwL84RJInrohHfW0Fx3awjbm8qZeFv0nW9SYGc=
 github.com/evanphx/json-patch/v5 v5.7.0/go.mod h1:VNkHZ/282BpEyt/tObQO8s5CMPmYYq14uClGH4abBuQ=
-github.com/fatih/color v1.15.0 h1:kOqh6YHBtK8aywxGerMG2Eq3H6Qgoqeo13Bk2Mv/nBs=
-github.com/fatih/color v1.15.0/go.mod h1:0h5ZqXfHYED7Bhv2ZJamyIOUej9KtShiJESRwBDUSsw=
+github.com/fatih/color v1.16.0 h1:zmkK9Ngbjj+K0yRhTVONQh1p/HknKYSlNT+vZCzyokM=
+github.com/fatih/color v1.16.0/go.mod h1:fL2Sau1YI5c0pdGEVCbKQbLXB6edEj1ZgiY4NijnWvE=
 github.com/felixge/httpsnoop v1.0.4 h1:NFTV2Zj1bL4mc9sqWACXbQFVBBg2W3GPvqp8/ESS2Wg=
 github.com/felixge/httpsnoop v1.0.4/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/fergusstrange/embedded-postgres v1.25.0 h1:sa+k2Ycrtz40eCRPOzI7Ry7TtkWXXJ+YRsxpKMDhxK0=
@@ -547,8 +547,8 @@ github.com/google/btree v0.0.0-20180813153112-4030bb1f1f0c/go.mod h1:lNA+9X1NB3Z
 github.com/google/btree v1.0.0/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
 github.com/google/certificate-transparency-go v1.1.7 h1:IASD+NtgSTJLPdzkthwvAG1ZVbF2WtFg4IvoA68XGSw=
 github.com/google/certificate-transparency-go v1.1.7/go.mod h1:FSSBo8fyMVgqptbfF6j5p/XNdgQftAhSmXcIxV9iphE=
-github.com/google/flatbuffers v2.0.8+incompatible h1:ivUb1cGomAB101ZM1T0nOiWz9pSrTMoa9+EiY7igmkM=
-github.com/google/flatbuffers v2.0.8+incompatible/go.mod h1:1AeVuKshWv4vARoZatz6mlQ0JxURH0Kv5+zNeJKJCa8=
+github.com/google/flatbuffers v23.5.26+incompatible h1:M9dgRyhJemaM4Sw8+66GHBu8ioaQmyPLg1b8VwK5WJg=
+github.com/google/flatbuffers v23.5.26+incompatible/go.mod h1:1AeVuKshWv4vARoZatz6mlQ0JxURH0Kv5+zNeJKJCa8=
 github.com/google/gnostic-models v0.6.9-0.20230804172637-c7be7c783f49 h1:0VpGH+cDhbDtdcweoyCVsF3fhN8kejK6rFe/2FFX2nU=
 github.com/google/gnostic-models v0.6.9-0.20230804172637-c7be7c783f49/go.mod h1:BkkQ4L1KS1xMt2aWSPStnn55ChGC0DPOn2FQYj+f25M=
 github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
@@ -1024,6 +1024,8 @@ github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o
 github.com/stretchr/testify v1.8.2/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
 github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
+github.com/styrainc/regal v0.13.0 h1:3ZZnc+uRwaNB338kylv49Un9cgRCCz2VHHGT0zv82WE=
+github.com/styrainc/regal v0.13.0/go.mod h1:kHvKg3svuquqdj4XoMzOiSHPCYdmZN3dsnNBdGkJsSA=
 github.com/subosito/gotenv v1.6.0 h1:9NlTDc1FTs4qu0DDq7AEtTPNw6SVm7uBMsUCUjABIf8=
 github.com/subosito/gotenv v1.6.0/go.mod h1:Dk4QP5c2W3ibzajGcXpNraDfq2IrhjMIvMSWPKKo0FU=
 github.com/syndtr/goleveldb v1.0.1-0.20220721030215-126854af5e6d h1:vfofYNRScrDdvS342BElfbETmL1Aiz3i2t0zfRj16Hs=


### PR DESCRIPTION
This is a helper command to lint minder rule type definitions. The main
value it currently brings is being able to also lint rego rules.
