### PR TITLE
Switch events configuration reference to English

### DIFF
--- a/config/config.yaml.example
+++ b/config/config.yaml.example
@@ -96,7 +96,7 @@ github:
     payload_secret: "your-password"
     redirect_uri: "http://localhost:8080/api/v1/auth/callback/github"
     # [*] for all events. It can also be a list such as [push,branch_protection_rule].
-    # Please check complete list on https://docs.github.com/es/webhooks-and-events/webhooks/webhook-events-and-payloads
+    # Please check complete list on https://docs.github.com/en/webhooks-and-events/webhooks/webhook-events-and-payloads
     events: ["*"]
 
 events:

--- a/deployment/helm_tests/basic.yaml-out
+++ b/deployment/helm_tests/basic.yaml-out
@@ -126,7 +126,7 @@ data:
         payload_secret: "your-password"
         redirect_uri: "http://localhost:8080/api/v1/auth/callback/github"
         # [*] for all events. It can also be a list such as [push,branch_protection_rule].
-        # Please check complete list on https://docs.github.com/es/webhooks-and-events/webhooks/webhook-events-and-payloads
+        # Please check complete list on https://docs.github.com/en/webhooks-and-events/webhooks/webhook-events-and-payloads
         events: ["*"]
     
     events:
@@ -734,7 +734,7 @@ data:
         payload_secret: "your-password"
         redirect_uri: "http://localhost:8080/api/v1/auth/callback/github"
         # [*] for all events. It can also be a list such as [push,branch_protection_rule].
-        # Please check complete list on https://docs.github.com/es/webhooks-and-events/webhooks/webhook-events-and-payloads
+        # Please check complete list on https://docs.github.com/en/webhooks-and-events/webhooks/webhook-events-and-payloads
         events: ["*"]
     
     events:

--- a/deployment/helm_tests/sidecar.yaml-out
+++ b/deployment/helm_tests/sidecar.yaml-out
@@ -126,7 +126,7 @@ data:
         payload_secret: "your-password"
         redirect_uri: "http://localhost:8080/api/v1/auth/callback/github"
         # [*] for all events. It can also be a list such as [push,branch_protection_rule].
-        # Please check complete list on https://docs.github.com/es/webhooks-and-events/webhooks/webhook-events-and-payloads
+        # Please check complete list on https://docs.github.com/en/webhooks-and-events/webhooks/webhook-events-and-payloads
         events: ["*"]
     
     events:
@@ -753,7 +753,7 @@ data:
         payload_secret: "your-password"
         redirect_uri: "http://localhost:8080/api/v1/auth/callback/github"
         # [*] for all events. It can also be a list such as [push,branch_protection_rule].
-        # Please check complete list on https://docs.github.com/es/webhooks-and-events/webhooks/webhook-events-and-payloads
+        # Please check complete list on https://docs.github.com/en/webhooks-and-events/webhooks/webhook-events-and-payloads
         events: ["*"]
     
     events:


### PR DESCRIPTION
We accidentally persisted the documentation reference for events
in Spanish instead of English in the configuration example. This
changes that.
