### PR TITLE
README: add `ko` as a dependency for minder-server

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,10 @@ This section describes how to build and run Minder from source.
 
 You'd need the following tools available - [Go](https://golang.org/doc/install), [Docker](https://docs.docker.com/get-docker/) and [Docker Compose](https://docs.docker.com/compose/install/).
 
+To build and run `minder-server`, you will also need [ko](https://ko.build/install/).
+
+To run the test suite via `make test`, you will need [gotestfmt](https://github.com/GoTestTools/gotestfmt#installing) and [helm](https://github.com/helm/helm/releases).
+
 ### Clone the repository
 
 ```bash
@@ -156,7 +160,7 @@ git clone git@github.com:stacklok/minder.git
 
 ## Build 
 
-Run the following to build `minder` and `minder-server`(binaries will be present at `./bin/`)
+Run the following to build `minder` and `minder-server` (binaries will be present at `./bin/`)
 
 ```bash
 make build


### PR DESCRIPTION
The `make run-docker` step of the README has a dependency on [`ko`](https://ko.build/install/). Add that in the README itself.

(Note that `make` is also implicitly depended on in the "Build it from source" section of the README, but not listed in the prerequisites, nor is it installed by default on most base systems. Its omission makes a certain amount of sense to me, but I thought that I would call that out explicitly while I'm proposing changes to this section.)