### PR TITLE
Rename Rule Type sub-commands to `ruletype`

### DIFF
--- a/cmd/cli/app/ruletype/common.go
+++ b/cmd/cli/app/ruletype/common.go
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package rule_type
+package ruletype
 
 import (
 	"fmt"

--- a/cmd/cli/app/ruletype/rule_type.go
+++ b/cmd/cli/app/ruletype/rule_type.go
@@ -13,8 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package rule_type provides the CLI subcommand for managing rules
-package rule_type
+// Package ruletype provides the CLI subcommand for managing rules
+package ruletype
 
 import (
 	"github.com/spf13/cobra"
@@ -24,9 +24,9 @@ import (
 
 // ruleTypeCmd is the root command for the rule subcommands
 var ruleTypeCmd = &cobra.Command{
-	Use:   "rule_type",
+	Use:   "ruletype",
 	Short: "Manage rule types within a minder control plane",
-	Long: `The minder rule_type subcommands allows the management of rule types within
+	Long: `The minder ruletype subcommands allows the management of rule types within
 a minder control plane.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		return cmd.Usage()

--- a/cmd/cli/app/ruletype/rule_type_apply.go
+++ b/cmd/cli/app/ruletype/rule_type_apply.go
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package rule_type
+package ruletype
 
 import (
 	"fmt"
@@ -21,16 +21,18 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 
 	"github.com/stacklok/minder/internal/util"
 	minderv1 "github.com/stacklok/minder/pkg/api/protobuf/go/minder/v1"
 )
 
-// RuleType_createCmd represents the profile create command
-var RuleType_createCmd = &cobra.Command{
-	Use:   "create",
-	Short: "Create a rule type within a minder control plane",
-	Long: `The minder rule type create subcommand lets you create new rule types for a project
+// RuleType_applyCmd represents the profile create command
+var RuleType_applyCmd = &cobra.Command{
+	Use:   "apply",
+	Short: "Apply a rule type within a minder control plane",
+	Long: `The minder rule type apply subcommand lets you create or update rule types for a project
 within a minder control plane.`,
 	PreRun: func(cmd *cobra.Command, args []string) {
 		if err := viper.BindPFlags(cmd.Flags()); err != nil {
@@ -65,15 +67,34 @@ within a minder control plane.`,
 		ctx, cancel := util.GetAppContext()
 		defer cancel()
 
-		createFunc := func(fileName string, rt *minderv1.RuleType) (*minderv1.RuleType, error) {
-			resprt, err := client.CreateRuleType(ctx, &minderv1.CreateRuleTypeRequest{
+		applyFunc := func(fileName string, rt *minderv1.RuleType) (*minderv1.RuleType, error) {
+			createResp, err := client.CreateRuleType(ctx, &minderv1.CreateRuleTypeRequest{
 				RuleType: rt,
 			})
-			if err != nil {
+
+			if err == nil {
+				return createResp.RuleType, nil
+			}
+
+			st, ok := status.FromError(err)
+			if !ok {
+				// We can't parse the error, so just return it
 				return nil, fmt.Errorf("error creating rule type from %s: %w", fileName, err)
 			}
 
-			return resprt.RuleType, nil
+			if st.Code() != codes.AlreadyExists {
+				return nil, fmt.Errorf("error creating rule type from %s: %w", fileName, err)
+			}
+
+			updateResp, err := client.UpdateRuleType(ctx, &minderv1.UpdateRuleTypeRequest{
+				RuleType: rt,
+			})
+
+			if err != nil {
+				return nil, fmt.Errorf("error updating rule type from %s: %w", fileName, err)
+			}
+
+			return updateResp.RuleType, nil
 		}
 
 		for _, f := range expfiles {
@@ -81,7 +102,7 @@ within a minder control plane.`,
 				continue
 			}
 
-			if err := execOnOneRuleType(table, f, os.Stdin, createFunc); err != nil {
+			if err := execOnOneRuleType(table, f, os.Stdin, applyFunc); err != nil {
 				return fmt.Errorf("error creating rule type %s: %w", f, err)
 			}
 		}
@@ -93,7 +114,7 @@ within a minder control plane.`,
 }
 
 func init() {
-	ruleTypeCmd.AddCommand(RuleType_createCmd)
-	RuleType_createCmd.Flags().StringArrayP("file", "f", []string{},
+	ruleTypeCmd.AddCommand(RuleType_applyCmd)
+	RuleType_applyCmd.Flags().StringArrayP("file", "f", []string{},
 		"Path to the YAML defining the rule type (or - for stdin). Can be specified multiple times. Can be a directory.")
 }

--- a/cmd/cli/app/ruletype/rule_type_delete.go
+++ b/cmd/cli/app/ruletype/rule_type_delete.go
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package rule_type
+package ruletype
 
 import (
 	"fmt"

--- a/cmd/cli/app/ruletype/rule_type_get.go
+++ b/cmd/cli/app/ruletype/rule_type_get.go
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package rule_type
+package ruletype
 
 import (
 	"fmt"
@@ -30,7 +30,7 @@ import (
 var ruleType_getCmd = &cobra.Command{
 	Use:   "get",
 	Short: "Get details for a rule type within a minder control plane",
-	Long: `The minder rule_type get subcommand lets you retrieve details for a rule type within a
+	Long: `The minder ruletype get subcommand lets you retrieve details for a rule type within a
 minder control plane.`,
 	PreRun: func(cmd *cobra.Command, args []string) {
 		if err := viper.BindPFlags(cmd.Flags()); err != nil {

--- a/cmd/cli/app/ruletype/rule_type_list.go
+++ b/cmd/cli/app/ruletype/rule_type_list.go
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package rule_type
+package ruletype
 
 import (
 	"fmt"
@@ -30,7 +30,7 @@ import (
 var ruleType_listCmd = &cobra.Command{
 	Use:   "list",
 	Short: "List rule types within a minder control plane",
-	Long: `The minder rule_type list subcommand lets you list rule type within a
+	Long: `The minder ruletype list subcommand lets you list rule type within a
 minder control plane for an specific project.`,
 	PreRun: func(cmd *cobra.Command, args []string) {
 		if err := viper.BindPFlags(cmd.Flags()); err != nil {

--- a/cmd/cli/app/ruletype/rule_type_update.go
+++ b/cmd/cli/app/ruletype/rule_type_update.go
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package rule_type
+package ruletype
 
 import (
 	"fmt"

--- a/cmd/cli/app/ruletype/table_render.go
+++ b/cmd/cli/app/ruletype/table_render.go
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package rule_type
+package ruletype
 
 import (
 	"github.com/olekukonko/tablewriter"

--- a/cmd/cli/main.go
+++ b/cmd/cli/main.go
@@ -26,7 +26,7 @@ import (
 	_ "github.com/stacklok/minder/cmd/cli/app/provider"
 	_ "github.com/stacklok/minder/cmd/cli/app/quickstart"
 	_ "github.com/stacklok/minder/cmd/cli/app/repo"
-	_ "github.com/stacklok/minder/cmd/cli/app/rule_type"
+	_ "github.com/stacklok/minder/cmd/cli/app/ruletype"
 	_ "github.com/stacklok/minder/cmd/cli/app/version"
 )
 


### PR DESCRIPTION
This even renamed the package. Cause, why not!?

Closes: #1755
