### PR TITLE
Run tests in a silent mode (error only output)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,4 +30,4 @@ jobs:
 
       # Run the tests
       - name: Run tests
-        run: make test
+        run: make test-silent

--- a/.mk/test.mk
+++ b/.mk/test.mk
@@ -18,8 +18,12 @@ clean: ## clean up environment
 	rm -rf dist/* & rm -rf bin/*
 
 .PHONY: test
-test: clean init-examples ## run tests
+test: clean init-examples ## run tests in verbose mode
 	go test -json -race -v ./... | gotestfmt
+
+.PHONY: test-silent
+test-silent: clean init-examples ## run tests in a silent mode (errors only output)
+	go test -json -race -v ./... | gotestfmt -hide "all"
 
 .PHONY: cover
 cover: ## display test coverage


### PR DESCRIPTION
By default, gotestfmt will output all tests and their logs. In case you want to see which test is failing it gets a bit difficult to navigate through all of them, so this simplifies that.

I've used the `-all` option out of the following.

- successful-tests: Hide successful tests.
- successful-downloads: Hide successful dependency downloads.
- successful-packages: Hide packages with only successful tests.
- empty-packages: Hide packages that have no tests.
- all: Hide all non-error items.