### PR TITLE
Point Trusty helm chart default to public instance

### DIFF
--- a/deployment/helm/README.md
+++ b/deployment/helm/README.md
@@ -78,4 +78,4 @@ installed in the namespace specified by your current Kubernetes context.
 | service.metricPort | int | `9090` | port for the metrics endpoint |
 | serviceAccounts.migrate | string, optional | `""` | If non-empty, minder will use the named ServiceAccount resources rather than creating a ServiceAccount |
 | serviceAccounts.server | string, optional | `""` | If non-empty, minder will use the named ServiceAccount resources rather than creating a ServiceAccount |
-| trusty.endpoint | string | `"http://pi.pi:8000"` | trusty host to use |
+| trusty.endpoint | string | `"https://api.trustypkg.dev"` | Trusty host to use |

--- a/deployment/helm/values.yaml
+++ b/deployment/helm/values.yaml
@@ -35,7 +35,7 @@ db:
 # trusty settings
 trusty:
   # -- (string) trusty host to use
-  endpoint: "http://pi.pi:8000"
+  endpoint: "https://api.trustypkg.dev"
 
 # AWS-specific configuration
 # NOTE: we are migrating from AWS-specific annotations to a "pre-create the service account" model.

--- a/deployment/helm_tests/basic.yaml
+++ b/deployment/helm_tests/basic.yaml
@@ -16,6 +16,9 @@ hostname: "minder-test.example.com"
 db:
   host: postgres.postgres.svc
 
+trusty:
+  endpoint: http://trusty.trusty:8080
+
 serviceAccounts:
   server: minder
   migrate: migrate-job

--- a/deployment/helm_tests/basic.yaml-out
+++ b/deployment/helm_tests/basic.yaml-out
@@ -320,7 +320,7 @@ spec:
           - name: "MINDER_IDENTITY_SERVER_CLIENT_SECRET_FILE"
             value: "/secrets/identity/identity_client_secret"
           - name: "MINDER_UNSTABLE_TRUSTY_ENDPOINT"
-            value: "http://pi.pi:8000"
+            value: "http://trusty.trusty:8080"
           - name: "SIGSTORE_NO_CACHE"
             value: "true"
           

--- a/deployment/helm_tests/sidecar.yaml-out
+++ b/deployment/helm_tests/sidecar.yaml-out
@@ -320,7 +320,7 @@ spec:
           - name: "MINDER_IDENTITY_SERVER_CLIENT_SECRET_FILE"
             value: "/secrets/identity/identity_client_secret"
           - name: "MINDER_UNSTABLE_TRUSTY_ENDPOINT"
-            value: "http://pi.pi:8000"
+            value: "https://api.trustypkg.dev"
           - name: "SIGSTORE_NO_CACHE"
             value: "true"
           - name: PGPASSFILE

--- a/internal/engine/eval/trusty/trusty_rest_handler.go
+++ b/internal/engine/eval/trusty/trusty_rest_handler.go
@@ -79,7 +79,7 @@ func newPiClient(baseUrl string) *trustyClient {
 }
 
 func (p *trustyClient) newRequest(ctx context.Context, dep *pb.Dependency) (*http.Request, error) {
-	u, err := urlFromEndpointAndPaths(p.baseUrl, "pi/v1/report", dep.Name, strings.ToLower(dep.Ecosystem.AsString()))
+	u, err := urlFromEndpointAndPaths(p.baseUrl, "v1/report", dep.Name, strings.ToLower(dep.Ecosystem.AsString()))
 	if err != nil {
 		return nil, fmt.Errorf("could not parse endpoint: %w", err)
 	}


### PR DESCRIPTION
It turns out we were encoding some internal pre-launch configuration details in the public helm chart.  This switches the defaults so they should work outside Stacklok's EKS cluster.
