### PR TITLE
Avoid attempting to lock other deleted resources

### DIFF
--- a/internal/eea/eea.go
+++ b/internal/eea/eea.go
@@ -76,6 +76,7 @@ func (e *EEA) AggregateMiddleware(h message.HandlerFunc) message.HandlerFunc {
 	}
 }
 
+// nolint:gocyclo // TODO: hacking in the TODO about foreign keys pushed this over the limit.
 func (e *EEA) aggregate(msg *message.Message) (*message.Message, error) {
 	ctx := msg.Context()
 	inf, err := engine.ParseEntityEvent(msg)


### PR DESCRIPTION
Followup to https://github.com/stacklok/minder/pull/1834; we made some progress, but then got stuck on a `pull_requests` that had been removed.