### PR TITLE
Add CLI wrapper that passes in a default context and GRPC client

### DIFF
--- a/cmd/cli/app/auth/auth.go
+++ b/cmd/cli/app/auth/auth.go
@@ -34,6 +34,7 @@ var AuthCmd = &cobra.Command{
 	Short: "Authorize and manage accounts within a minder control plane",
 	Long: `The minder auth command project lets you create accounts and grant or revoke
 authorization to existing accounts within a minder control plane.`,
+
 	RunE: func(cmd *cobra.Command, args []string) error {
 		return cmd.Usage()
 	},

--- a/cmd/cli/app/auth/auth_login.go
+++ b/cmd/cli/app/auth/auth_login.go
@@ -169,7 +169,7 @@ will be saved to $XDG_CONFIG_HOME/minder/credentials.json`,
 			fmt.Println(err)
 		}
 
-		conn, err := util.GrpcForCommand(cmd, viper.GetViper())
+		conn, err := cli.GrpcForCommand(cmd, viper.GetViper())
 		util.ExitNicelyOnError(err, "Error getting grpc connection")
 		defer conn.Close()
 		client := pb.NewUserServiceClient(conn)

--- a/cmd/cli/app/profile_status/profile_status_get.go
+++ b/cmd/cli/app/profile_status/profile_status_get.go
@@ -16,15 +16,18 @@
 package profile_status
 
 import (
+	"context"
 	"fmt"
 	"os"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
+	"google.golang.org/grpc"
 
 	"github.com/stacklok/minder/cmd/cli/app"
 	"github.com/stacklok/minder/internal/entities"
 	"github.com/stacklok/minder/internal/util"
+	"github.com/stacklok/minder/internal/util/cli"
 	minderv1 "github.com/stacklok/minder/pkg/api/protobuf/go/minder/v1"
 )
 
@@ -38,16 +41,8 @@ minder control plane for an specific provider/project or profile id, entity type
 			fmt.Fprintf(os.Stderr, "Error binding flags: %s\n", err)
 		}
 	},
-	RunE: func(cmd *cobra.Command, args []string) error {
-		conn, err := util.GrpcForCommand(cmd, viper.GetViper())
-		if err != nil {
-			return fmt.Errorf("error getting grpc connection: %w", err)
-		}
-		defer conn.Close()
-
+	RunE: cli.GRPCClientWrapRunE(func(ctx context.Context, cmd *cobra.Command, conn *grpc.ClientConn) error {
 		client := minderv1.NewProfileServiceClient(conn)
-		ctx, cancel := util.GetAppContext()
-		defer cancel()
 
 		provider := viper.GetString("provider")
 		project := viper.GetString("project")
@@ -100,7 +95,7 @@ minder control plane for an specific provider/project or profile id, entity type
 		}
 
 		return nil
-	},
+	}),
 }
 
 func init() {

--- a/cmd/cli/app/repo/repo_get.go
+++ b/cmd/cli/app/repo/repo_get.go
@@ -16,15 +16,18 @@
 package repo
 
 import (
+	"context"
 	"fmt"
 	"os"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
+	"google.golang.org/grpc"
 
 	"github.com/stacklok/minder/cmd/cli/app"
 	github "github.com/stacklok/minder/internal/providers/github"
 	"github.com/stacklok/minder/internal/util"
+	"github.com/stacklok/minder/internal/util/cli"
 	pb "github.com/stacklok/minder/pkg/api/protobuf/go/minder/v1"
 )
 
@@ -44,8 +47,7 @@ var repo_getCmd = &cobra.Command{
 			fmt.Fprintf(os.Stderr, "error binding flags: %s", err)
 		}
 	},
-	RunE: func(cmd *cobra.Command, args []string) error {
-
+	RunE: cli.GRPCClientWrapRunE(func(ctx context.Context, cmd *cobra.Command, conn *grpc.ClientConn) error {
 		provider := util.GetConfigValue(viper.GetViper(), "provider", "provider", cmd, "").(string)
 		repoid := viper.GetString("repo-id")
 		format := viper.GetString("output")
@@ -74,13 +76,7 @@ var repo_getCmd = &cobra.Command{
 			return fmt.Errorf("invalid output format: %s", format)
 		}
 
-		conn, err := util.GrpcForCommand(cmd, viper.GetViper())
-		util.ExitNicelyOnError(err, "Error getting grpc connection")
-		defer conn.Close()
-
 		client := pb.NewRepositoryServiceClient(conn)
-		ctx, cancel := util.GetAppContext()
-		defer cancel()
 
 		// check repo by id
 		var repository *pb.Repository
@@ -117,7 +113,7 @@ var repo_getCmd = &cobra.Command{
 			}
 		}
 		return nil
-	},
+	}),
 }
 
 func init() {

--- a/cmd/cli/app/ruletype/rule_type_apply.go
+++ b/cmd/cli/app/ruletype/rule_type_apply.go
@@ -16,15 +16,18 @@
 package ruletype
 
 import (
+	"context"
 	"fmt"
 	"os"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
+	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
 	"github.com/stacklok/minder/internal/util"
+	"github.com/stacklok/minder/internal/util/cli"
 	minderv1 "github.com/stacklok/minder/pkg/api/protobuf/go/minder/v1"
 )
 
@@ -39,7 +42,7 @@ within a minder control plane.`,
 			fmt.Fprintf(os.Stderr, "Error binding flags: %s\n", err)
 		}
 	},
-	RunE: func(cmd *cobra.Command, args []string) error {
+	RunE: cli.GRPCClientWrapRunE(func(ctx context.Context, cmd *cobra.Command, conn *grpc.ClientConn) error {
 		files, err := cmd.Flags().GetStringArray("file")
 		if err != nil {
 			return fmt.Errorf("error getting file flag: %w", err)
@@ -49,12 +52,6 @@ within a minder control plane.`,
 			return fmt.Errorf("error validating file arg: %w", err)
 		}
 
-		conn, err := util.GrpcForCommand(cmd, viper.GetViper())
-		if err != nil {
-			return fmt.Errorf("error getting grpc connection: %w", err)
-		}
-		defer conn.Close()
-
 		client := minderv1.NewProfileServiceClient(conn)
 
 		expfiles, err := util.ExpandFileArgs(files)
@@ -63,9 +60,6 @@ within a minder control plane.`,
 		}
 
 		table := initializeTable(cmd)
-
-		ctx, cancel := util.GetAppContext()
-		defer cancel()
 
 		applyFunc := func(fileName string, rt *minderv1.RuleType) (*minderv1.RuleType, error) {
 			createResp, err := client.CreateRuleType(ctx, &minderv1.CreateRuleTypeRequest{
@@ -110,7 +104,7 @@ within a minder control plane.`,
 		table.Render()
 
 		return nil
-	},
+	}),
 }
 
 func init() {

--- a/cmd/cli/app/ruletype/rule_type_delete.go
+++ b/cmd/cli/app/ruletype/rule_type_delete.go
@@ -16,11 +16,14 @@
 package ruletype
 
 import (
+	"context"
+	"errors"
 	"fmt"
 	"os"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
+	"google.golang.org/grpc"
 
 	"github.com/stacklok/minder/internal/util"
 	"github.com/stacklok/minder/internal/util/cli"
@@ -37,7 +40,7 @@ minder control plane.`,
 			fmt.Fprintf(os.Stderr, "Error binding flags: %s\n", err)
 		}
 	},
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: cli.GRPCClientWrapRunE(func(ctx context.Context, cmd *cobra.Command, conn *grpc.ClientConn) error {
 		// Delete the rule type via GRPC
 		id := viper.GetString("id")
 		deleteAll := viper.GetBool("all")
@@ -45,14 +48,12 @@ minder control plane.`,
 
 		// If id is set, deleteAll cannot be set
 		if id != "" && deleteAll {
-			fmt.Fprintf(os.Stderr, "Cannot set both id and deleteAll")
-			return
+			return errors.New("cannot set both id and deleteAll")
 		}
 
 		// Either name or deleteAll needs to be set
 		if id == "" && !deleteAll {
-			fmt.Fprintf(os.Stderr, "Either id or deleteAll needs to be set")
-			return
+			return errors.New("Either id or deleteAll needs to be set")
 		}
 
 		if deleteAll && !yesFlag {
@@ -63,17 +64,10 @@ minder control plane.`,
 				"Delete all rule types operation cancelled.",
 				false)
 			if !yes {
-				return
+				return nil
 			}
 		}
-		// Create GRPC connection
-		conn, err := util.GrpcForCommand(cmd, viper.GetViper())
-		util.ExitNicelyOnError(err, "Error getting grpc connection")
-		defer conn.Close()
-
 		client := minderv1.NewProfileServiceClient(conn)
-		ctx, cancel := util.GetAppContext()
-		defer cancel()
 
 		// List of rule types to delete
 		rulesToDelete := []*minderv1.RuleType{}
@@ -88,8 +82,7 @@ minder control plane.`,
 				Id: id,
 			})
 			if err != nil {
-				cmd.Println("Error getting rule type")
-				return
+				return fmt.Errorf("Error getting rule type: %w", err)
 			}
 			// Add the rule type for deletion
 			rulesToDelete = append(rulesToDelete, rtype.RuleType)
@@ -103,8 +96,7 @@ minder control plane.`,
 				},
 			})
 			if err != nil {
-				cmd.Println("Error getting rule types")
-				return
+				return fmt.Errorf("Error listing rule types: %w", err)
 			}
 			rulesToDelete = append(rulesToDelete, resp.RuleTypes...)
 		}
@@ -112,7 +104,7 @@ minder control plane.`,
 		remainingRuleTypes := []string{}
 		// Delete the rule types set for deletion
 		for _, ruleType := range rulesToDelete {
-			_, err = client.DeleteRuleType(ctx, &minderv1.DeleteRuleTypeRequest{
+			_, err := client.DeleteRuleType(ctx, &minderv1.DeleteRuleTypeRequest{
 				Context: &minderv1.Context{},
 				Id:      ruleType.GetId(),
 			})
@@ -126,7 +118,7 @@ minder control plane.`,
 		// Print the results
 		if len(deletedRuleTypes) == 0 && len(remainingRuleTypes) == 0 {
 			cmd.Println("There are no rule types to delete")
-			return
+			return nil
 		}
 		if len(deletedRuleTypes) > 0 {
 			cmd.Println("\nThe following rule type(s) were successfully deleted:")
@@ -140,7 +132,9 @@ minder control plane.`,
 				cmd.Println(ruleType)
 			}
 		}
-	},
+
+		return nil
+	}),
 }
 
 func init() {

--- a/cmd/cli/app/ruletype/rule_type_get.go
+++ b/cmd/cli/app/ruletype/rule_type_get.go
@@ -16,14 +16,17 @@
 package ruletype
 
 import (
+	"context"
 	"fmt"
 	"os"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
+	"google.golang.org/grpc"
 
 	"github.com/stacklok/minder/cmd/cli/app"
 	"github.com/stacklok/minder/internal/util"
+	"github.com/stacklok/minder/internal/util/cli"
 	minderv1 "github.com/stacklok/minder/pkg/api/protobuf/go/minder/v1"
 )
 
@@ -37,7 +40,7 @@ minder control plane.`,
 			fmt.Fprintf(os.Stderr, "Error binding flags: %s\n", err)
 		}
 	},
-	RunE: func(cmd *cobra.Command, args []string) error {
+	RunE: cli.GRPCClientWrapRunE(func(ctx context.Context, cmd *cobra.Command, conn *grpc.ClientConn) error {
 		provider := viper.GetString("provider")
 		format := viper.GetString("output")
 
@@ -49,13 +52,7 @@ minder control plane.`,
 			return fmt.Errorf("error: invalid format: %s", format)
 		}
 
-		conn, err := util.GrpcForCommand(cmd, viper.GetViper())
-		util.ExitNicelyOnError(err, "Error getting grpc connection")
-		defer conn.Close()
-
 		client := minderv1.NewProfileServiceClient(conn)
-		ctx, cancel := util.GetAppContext()
-		defer cancel()
 
 		id := viper.GetString("id")
 
@@ -84,7 +81,7 @@ minder control plane.`,
 			handleGetTableOutput(cmd, rtype.GetRuleType())
 		}
 		return nil
-	},
+	}),
 }
 
 func init() {

--- a/cmd/cli/app/ruletype/rule_type_list.go
+++ b/cmd/cli/app/ruletype/rule_type_list.go
@@ -16,14 +16,17 @@
 package ruletype
 
 import (
+	"context"
 	"fmt"
 	"os"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
+	"google.golang.org/grpc"
 
 	"github.com/stacklok/minder/cmd/cli/app"
 	"github.com/stacklok/minder/internal/util"
+	"github.com/stacklok/minder/internal/util/cli"
 	minderv1 "github.com/stacklok/minder/pkg/api/protobuf/go/minder/v1"
 )
 
@@ -37,18 +40,10 @@ minder control plane for an specific project.`,
 			fmt.Fprintf(os.Stderr, "Error binding flags: %s\n", err)
 		}
 	},
-	RunE: func(cmd *cobra.Command, args []string) error {
+	RunE: cli.GRPCClientWrapRunE(func(ctx context.Context, cmd *cobra.Command, conn *grpc.ClientConn) error {
 		format := viper.GetString("output")
 
-		conn, err := util.GrpcForCommand(cmd, viper.GetViper())
-		if err != nil {
-			return fmt.Errorf("error getting grpc connection: %w", err)
-		}
-		defer conn.Close()
-
 		client := minderv1.NewProfileServiceClient(conn)
-		ctx, cancel := util.GetAppContext()
-		defer cancel()
 
 		provider := viper.GetString("provider")
 
@@ -86,7 +81,7 @@ minder control plane for an specific project.`,
 
 		// this is unreachable
 		return nil
-	},
+	}),
 }
 
 func init() {

--- a/cmd/cli/app/ruletype/rule_type_update.go
+++ b/cmd/cli/app/ruletype/rule_type_update.go
@@ -16,13 +16,16 @@
 package ruletype
 
 import (
+	"context"
 	"fmt"
 	"os"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
+	"google.golang.org/grpc"
 
 	"github.com/stacklok/minder/internal/util"
+	"github.com/stacklok/minder/internal/util/cli"
 	minderv1 "github.com/stacklok/minder/pkg/api/protobuf/go/minder/v1"
 )
 
@@ -37,7 +40,7 @@ within a minder control plane.`,
 			fmt.Fprintf(os.Stderr, "Error binding flags: %s\n", err)
 		}
 	},
-	RunE: func(cmd *cobra.Command, args []string) error {
+	RunE: cli.GRPCClientWrapRunE(func(ctx context.Context, cmd *cobra.Command, conn *grpc.ClientConn) error {
 		files, err := cmd.Flags().GetStringArray("file")
 		if err != nil {
 			return fmt.Errorf("error getting file flag: %w", err)
@@ -47,12 +50,6 @@ within a minder control plane.`,
 			return fmt.Errorf("error validating file arg: %w", err)
 		}
 
-		conn, err := util.GrpcForCommand(cmd, viper.GetViper())
-		if err != nil {
-			return fmt.Errorf("error getting grpc connection: %w", err)
-		}
-		defer conn.Close()
-
 		client := minderv1.NewProfileServiceClient(conn)
 
 		expfiles, err := util.ExpandFileArgs(files)
@@ -61,9 +58,6 @@ within a minder control plane.`,
 		}
 
 		table := initializeTable(cmd)
-
-		ctx, cancel := util.GetAppContext()
-		defer cancel()
 
 		updateFunc := func(fileName string, rt *minderv1.RuleType) (*minderv1.RuleType, error) {
 			resprt, err := client.UpdateRuleType(ctx, &minderv1.UpdateRuleTypeRequest{
@@ -89,7 +83,7 @@ within a minder control plane.`,
 		table.Render()
 
 		return nil
-	},
+	}),
 }
 
 func init() {

--- a/internal/util/helpers.go
+++ b/internal/util/helpers.go
@@ -54,9 +54,7 @@ import (
 	"google.golang.org/protobuf/reflect/protoreflect"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
-	"github.com/stacklok/minder/internal/constants"
 	"github.com/stacklok/minder/internal/db"
-	"github.com/stacklok/minder/internal/util/cli/useragent"
 	"github.com/stacklok/minder/internal/util/jsonyaml"
 	minderv1 "github.com/stacklok/minder/pkg/api/protobuf/go/minder/v1"
 )
@@ -140,20 +138,6 @@ func (jwt JWTTokenCredentials) GetRequestMetadata(_ context.Context, _ ...string
 // RequireTransportSecurity implements the PerRPCCredentials interface.
 func (JWTTokenCredentials) RequireTransportSecurity() bool {
 	return false
-}
-
-// GrpcForCommand is a helper for getting a testing connection from cobra flags
-func GrpcForCommand(cmd *cobra.Command, v *viper.Viper) (*grpc.ClientConn, error) {
-	grpc_host := GetConfigValue(v, "grpc_server.host", "grpc-host", cmd, constants.MinderGRPCHost).(string)
-	grpc_port := GetConfigValue(v, "grpc_server.port", "grpc-port", cmd, 443).(int)
-	insecureDefault := grpc_host == "localhost" || grpc_host == "127.0.0.1" || grpc_host == "::1"
-	allowInsecure := GetConfigValue(v, "grpc_server.insecure", "grpc-insecure", cmd, insecureDefault).(bool)
-
-	issuerUrl := GetConfigValue(v, "identity.cli.issuer_url", "identity-url", cmd, constants.IdentitySeverURL).(string)
-	clientId := GetConfigValue(v, "identity.cli.client_id", "identity-client", cmd, "minder-cli").(string)
-
-	return GetGrpcConnection(
-		grpc_host, grpc_port, allowInsecure, issuerUrl, clientId, grpc.WithUserAgent(useragent.GetUserAgent()))
 }
 
 // GetGrpcConnection is a helper for getting a testing connection for grpc
@@ -341,15 +325,6 @@ func LoadCredentials() (OpenIdCredentials, error) {
 		return OpenIdCredentials{}, fmt.Errorf("error unmarshaling credentials: %v", err)
 	}
 	return creds, nil
-}
-
-// GetAppContext is a helper for getting the cmd app context
-func GetAppContext() (context.Context, context.CancelFunc) {
-	viper.SetDefault("cli.context_timeout", 10)
-	timeout := viper.GetInt("cli.context_timeout")
-
-	ctx, cancel := context.WithTimeout(context.Background(), time.Duration(timeout)*time.Second)
-	return ctx, cancel
 }
 
 // WriteToFile writes the content to a file if the out parameter is not empty.


### PR DESCRIPTION
This wrapper makes it easier for us to build sub-commands, since it
wraps the `RunE` function and avoids the boilerplate we used to have.

Closes #1746
