### PR TITLE
Get default provider from those enrolled in project

### DIFF
--- a/cmd/cli/app/artifact/artifact_list.go
+++ b/cmd/cli/app/artifact/artifact_list.go
@@ -104,10 +104,6 @@ var artifact_listCmd = &cobra.Command{
 func init() {
 	ArtifactCmd.AddCommand(artifact_listCmd)
 	artifact_listCmd.Flags().StringP("output", "f", "", "Output format (json or yaml)")
-	artifact_listCmd.Flags().StringP("provider", "p", "", "Name for the provider to enroll")
+	artifact_listCmd.Flags().StringP("provider", "p", "github", "Name for the provider to enroll")
 	artifact_listCmd.Flags().StringP("project-id", "g", "", "ID of the project for repo registration")
-
-	if err := artifact_listCmd.MarkFlagRequired("provider"); err != nil {
-		fmt.Fprintf(os.Stderr, "Error marking flag as required: %s\n", err)
-	}
 }

--- a/cmd/cli/app/profile/profile_list.go
+++ b/cmd/cli/app/profile/profile_list.go
@@ -18,7 +18,6 @@ package profile
 import (
 	"context"
 	"fmt"
-	"os"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -82,15 +81,10 @@ minder control plane for an specific project.`,
 
 func init() {
 	ProfileCmd.AddCommand(profile_listCmd)
-	profile_listCmd.Flags().StringP("provider", "p", "", "Provider to list profiles for")
+	profile_listCmd.Flags().StringP("provider", "p", "github", "Provider to list profiles for")
 	profile_listCmd.Flags().StringP("output", "o", app.Table, "Output format (json, yaml or table)")
 	// TODO: Take project ID into account
 	// profile_listCmd.Flags().Int32P("project-id", "g", 0, "project id to list roles for")
-
-	if err := profile_listCmd.MarkFlagRequired("provider"); err != nil {
-		fmt.Fprintf(os.Stderr, "Error marking flag as required: %s\n", err)
-		os.Exit(1)
-	}
 }
 
 func handleListTableOutput(cmd *cobra.Command, resp *pb.ListProfilesResponse) {

--- a/cmd/cli/app/repo/repo_delete.go
+++ b/cmd/cli/app/repo/repo_delete.go
@@ -91,7 +91,7 @@ var repoDeleteCmd = &cobra.Command{
 
 func init() {
 	RepoCmd.AddCommand(repoDeleteCmd)
-	repoDeleteCmd.Flags().StringP("provider", "p", "", "Name of the enrolled provider")
+	repoDeleteCmd.Flags().StringP("provider", "p", "github", "Name of the enrolled provider")
 	repoDeleteCmd.Flags().StringP("name", "n", "", "Name of the repository (owner/name format)")
 	repoDeleteCmd.Flags().StringP("repo-id", "r", "", "ID of the repo to delete")
 	repoDeleteCmd.Flags().BoolP("status", "s", false, "Only return the status of the profiles associated to this repo")

--- a/cmd/cli/app/repo/repo_get.go
+++ b/cmd/cli/app/repo/repo_get.go
@@ -113,7 +113,7 @@ var repo_getCmd = &cobra.Command{
 func init() {
 	RepoCmd.AddCommand(repo_getCmd)
 	repo_getCmd.Flags().StringP("output", "f", "", "Output format (json or yaml)")
-	repo_getCmd.Flags().StringP("provider", "p", "", "Name for the provider to enroll")
+	repo_getCmd.Flags().StringP("provider", "p", "github", "Name for the provider to enroll")
 	repo_getCmd.Flags().StringP("name", "n", "", "Name of the repository (owner/name format)")
 	repo_getCmd.Flags().StringP("repo-id", "r", "", "ID of the repo to query")
 	repo_getCmd.Flags().BoolP("status", "s", false, "Only return the status of the profiles associated to this repo")

--- a/cmd/cli/app/repo/repo_list.go
+++ b/cmd/cli/app/repo/repo_list.go
@@ -112,9 +112,6 @@ var repo_listCmd = &cobra.Command{
 func init() {
 	RepoCmd.AddCommand(repo_listCmd)
 	repo_listCmd.Flags().StringP("output", "f", "", "Output format (json or yaml)")
-	repo_listCmd.Flags().StringP("provider", "p", "", "Name for the provider to enroll")
+	repo_listCmd.Flags().StringP("provider", "p", "github", "Name for the provider to enroll")
 	repo_listCmd.Flags().StringP("project-id", "g", "", "ID of the project for repo registration")
-	if err := repo_listCmd.MarkFlagRequired("provider"); err != nil {
-		fmt.Fprintf(os.Stderr, "Error marking flag as required: %s\n", err)
-	}
 }

--- a/cmd/cli/app/repo/repo_register.go
+++ b/cmd/cli/app/repo/repo_register.go
@@ -59,12 +59,9 @@ var repoRegisterCmd = &cobra.Command{
 
 func init() {
 	RepoCmd.AddCommand(repoRegisterCmd)
-	repoRegisterCmd.Flags().StringP("provider", "p", "", "Name for the provider to enroll")
+	repoRegisterCmd.Flags().StringP("provider", "p", "github", "Name for the provider to enroll")
 	repoRegisterCmd.Flags().StringP("project-id", "g", "", "ID of the project for repo registration")
 	repoRegisterCmd.Flags().StringVar(&cfgFlagRepos, "repo", "", "List of repositories to register, i.e owner/repo,owner/repo")
-	if err := repoRegisterCmd.MarkFlagRequired("provider"); err != nil {
-		_, _ = fmt.Fprintf(os.Stderr, "Error marking flag as required: %s\n", err)
-	}
 }
 
 func getSelectedRepositories(repoList []*pb.UpstreamRepositoryRef, flagRepos string) ([]*pb.UpstreamRepositoryRef, error) {

--- a/cmd/cli/app/ruletype/ruletype_delete.go
+++ b/cmd/cli/app/ruletype/ruletype_delete.go
@@ -135,10 +135,8 @@ minder control plane.`,
 
 func init() {
 	ruleTypeCmd.AddCommand(ruleType_deleteCmd)
-	ruleType_deleteCmd.Flags().StringP("provider", "p", "", "Provider to list rule types for")
+	ruleType_deleteCmd.Flags().StringP("provider", "p", "github", "Provider to list rule types for")
 	ruleType_deleteCmd.Flags().StringP("id", "i", "", "ID of rule type to delete")
 	ruleType_deleteCmd.Flags().BoolP("all", "a", false, "Warning: Deletes all rule types")
 	ruleType_deleteCmd.Flags().BoolP("yes", "y", false, "Bypass yes/no prompt when deleting all rule types")
-	err := ruleType_deleteCmd.MarkFlagRequired("provider")
-	util.ExitNicelyOnError(err, "Error marking flag as required")
 }

--- a/cmd/cli/app/ruletype/ruletype_list.go
+++ b/cmd/cli/app/ruletype/ruletype_list.go
@@ -81,15 +81,10 @@ minder control plane for an specific project.`,
 
 func init() {
 	ruleTypeCmd.AddCommand(ruleType_listCmd)
-	ruleType_listCmd.Flags().StringP("provider", "p", "", "Provider to list rule types for")
+	ruleType_listCmd.Flags().StringP("provider", "p", "github", "Provider to list rule types for")
 	ruleType_listCmd.Flags().StringP("output", "o", app.Table, "Output format (json, yaml or table)")
 	// TODO: Take project ID into account
 	// ruleType_listCmd.Flags().Int32P("project-id", "g", 0, "project id to list roles for")
-
-	if err := ruleType_listCmd.MarkFlagRequired("provider"); err != nil {
-		fmt.Fprintf(os.Stderr, "Error marking flag as required: %s\n", err)
-		os.Exit(1)
-	}
 }
 
 func handleListTableOutput(cmd *cobra.Command, resp *minderv1.ListRuleTypesResponse) {

--- a/internal/controlplane/common.go
+++ b/internal/controlplane/common.go
@@ -20,12 +20,14 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"slices"
 
 	"github.com/google/uuid"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
 	"github.com/stacklok/minder/internal/auth"
+	"github.com/stacklok/minder/internal/db"
 	"github.com/stacklok/minder/internal/util"
 )
 
@@ -33,6 +35,12 @@ import (
 type ProjectIDGetter interface {
 	// GetProjectId returns the project ID
 	GetProjectId() string
+}
+
+// ProviderNameGetter is an interface that can be implemented by a request
+type ProviderNameGetter interface {
+	// GetProvider returns the provider name
+	GetProvider() string
 }
 
 func providerError(err error) error {
@@ -58,4 +66,34 @@ func getProjectFromRequestOrDefault(ctx context.Context, in ProjectIDGetter) (uu
 		return uuid.UUID{}, util.UserVisibleError(codes.InvalidArgument, "malformed project ID")
 	}
 	return parsedProjectID, nil
+}
+
+func getProviderFromRequestOrDefault(
+	ctx context.Context,
+	store db.Store,
+	in ProviderNameGetter,
+	projectId uuid.UUID,
+) (db.Provider, error) {
+	providers, err := store.ListProvidersByProjectID(ctx, projectId)
+	if err != nil {
+		return db.Provider{}, status.Errorf(codes.InvalidArgument, "cannot retrieve providers: %s", err)
+	}
+	// if we do not have a provider name, check if we can infer it
+	if in.GetProvider() == "" {
+		if len(providers) == 1 {
+			return providers[0], nil
+		}
+		return db.Provider{}, util.UserVisibleError(codes.InvalidArgument, "cannot infer provider, there are %d providers available",
+			len(providers))
+	}
+
+	matchesName := func(provider db.Provider) bool {
+		return provider.Name == in.GetProvider()
+	}
+
+	i := slices.IndexFunc(providers, matchesName)
+	if i == -1 {
+		return db.Provider{}, util.UserVisibleError(codes.InvalidArgument, "invalid provider name: %s", in.GetProvider())
+	}
+	return providers[i], nil
 }

--- a/internal/controlplane/handlers_artifacts.go
+++ b/internal/controlplane/handlers_artifacts.go
@@ -44,10 +44,7 @@ func (s *Server) ListArtifacts(ctx context.Context, in *pb.ListArtifactsRequest)
 		return nil, err
 	}
 
-	provider, err := s.store.GetProviderByName(ctx, db.GetProviderByNameParams{
-		Name:      in.Provider,
-		ProjectID: projectID,
-	})
+	provider, err := getProviderFromRequestOrDefault(ctx, s.store, in, projectID)
 	if err != nil {
 		return nil, providerError(err)
 	}

--- a/internal/controlplane/handlers_oauth.go
+++ b/internal/controlplane/handlers_oauth.go
@@ -59,10 +59,7 @@ func (s *Server) GetAuthorizationURL(ctx context.Context,
 	defer span.End()
 
 	// get provider info
-	provider, err := s.store.GetProviderByName(ctx, db.GetProviderByNameParams{
-		Name:      req.Provider,
-		ProjectID: projectID,
-	})
+	provider, err := getProviderFromRequestOrDefault(ctx, s.store, req, projectID)
 	if err != nil {
 		return nil, providerError(fmt.Errorf("provider error: %w", err))
 	}
@@ -153,10 +150,7 @@ func (s *Server) ExchangeCodeForTokenCLI(ctx context.Context,
 	}
 
 	// get provider
-	provider, err := s.store.GetProviderByName(ctx, db.GetProviderByNameParams{
-		Name:      in.Provider,
-		ProjectID: stateData.ProjectID,
-	})
+	provider, err := getProviderFromRequestOrDefault(ctx, s.store, in, stateData.ProjectID)
 	if err != nil {
 		return nil, providerError(fmt.Errorf("provider error: %w", err))
 	}
@@ -294,8 +288,7 @@ func (s *Server) StoreProviderToken(ctx context.Context,
 		return nil, err
 	}
 
-	provider, err := s.store.GetProviderByName(ctx, db.GetProviderByNameParams{
-		Name: in.Provider, ProjectID: projectID})
+	provider, err := getProviderFromRequestOrDefault(ctx, s.store, in, projectID)
 	if err != nil {
 		return nil, providerError(fmt.Errorf("provider error: %w", err))
 	}
@@ -356,8 +349,7 @@ func (s *Server) VerifyProviderTokenFrom(ctx context.Context,
 		return nil, err
 	}
 
-	provider, err := s.store.GetProviderByName(ctx, db.GetProviderByNameParams{
-		Name: in.Provider, ProjectID: projectID})
+	provider, err := getProviderFromRequestOrDefault(ctx, s.store, in, projectID)
 	if err != nil {
 		return nil, providerError(fmt.Errorf("provider error: %w", err))
 	}

--- a/internal/controlplane/handlers_oauth_test.go
+++ b/internal/controlplane/handlers_oauth_test.go
@@ -105,14 +105,11 @@ func TestGetAuthorizationURL(t *testing.T) {
 			},
 			buildStubs: func(store *mockdb.MockStore) {
 				store.EXPECT().
-					GetProviderByName(gomock.Any(), db.GetProviderByNameParams{
-						Name:      "github",
-						ProjectID: projectID,
-					}).
-					Return(db.Provider{
+					ListProvidersByProjectID(gomock.Any(), projectID).
+					Return([]db.Provider{{
 						ID:   providerID,
 						Name: "github",
-					}, nil)
+					}}, nil)
 				store.EXPECT().
 					CreateSessionState(gomock.Any(), gomock.Any()).
 					Return(db.SessionStore{

--- a/internal/controlplane/handlers_repositories.go
+++ b/internal/controlplane/handlers_repositories.go
@@ -52,9 +52,7 @@ func (s *Server) RegisterRepository(ctx context.Context,
 		return nil, err
 	}
 
-	provider, err := s.store.GetProviderByName(ctx, db.GetProviderByNameParams{
-		Name:      in.GetProvider(),
-		ProjectID: projectID})
+	provider, err := getProviderFromRequestOrDefault(ctx, s.store, in, projectID)
 	if err != nil {
 		return nil, providerError(fmt.Errorf("provider error: %w", err))
 	}
@@ -155,9 +153,7 @@ func (s *Server) ListRepositories(ctx context.Context,
 		return nil, err
 	}
 
-	provider, err := s.store.GetProviderByName(ctx, db.GetProviderByNameParams{
-		Name:      in.GetProvider(),
-		ProjectID: projectID})
+	provider, err := getProviderFromRequestOrDefault(ctx, s.store, in, projectID)
 	if err != nil {
 		return nil, providerError(fmt.Errorf("provider error: %w", err))
 	}
@@ -270,10 +266,7 @@ func (s *Server) GetRepositoryByName(ctx context.Context,
 		return nil, err
 	}
 
-	provider, err := s.store.GetProviderByName(ctx, db.GetProviderByNameParams{
-		Name:      in.Provider,
-		ProjectID: projectID,
-	})
+	provider, err := getProviderFromRequestOrDefault(ctx, s.store, in, projectID)
 	if err != nil {
 		return nil, providerError(fmt.Errorf("provider error: %w", err))
 	}
@@ -366,10 +359,7 @@ func (s *Server) DeleteRepositoryByName(ctx context.Context,
 		return nil, err
 	}
 
-	provider, err := s.store.GetProviderByName(ctx, db.GetProviderByNameParams{
-		Name:      in.Provider,
-		ProjectID: projectID,
-	})
+	provider, err := getProviderFromRequestOrDefault(ctx, s.store, in, projectID)
 	if err != nil {
 		return nil, providerError(fmt.Errorf("provider error: %w", err))
 	}
@@ -418,10 +408,7 @@ func (s *Server) ListRemoteRepositoriesFromProvider(
 		Str("projectID", projectID.String()).
 		Msgf("listing repositories for provider: %s", in.Provider)
 
-	provider, err := s.store.GetProviderByName(ctx, db.GetProviderByNameParams{
-		Name:      in.Provider,
-		ProjectID: projectID,
-	})
+	provider, err := getProviderFromRequestOrDefault(ctx, s.store, in, projectID)
 	if err != nil {
 		return nil, providerError(fmt.Errorf("provider error: %w", err))
 	}


### PR DESCRIPTION
Fix #1752
Fix #1745

Also, make GitHub the default provider in the CLI, since that's the only option we allow to get past the CLI (this was initially suggested in #1745, which I had mistakenly assumed would be fixed by the server change)