### PR TITLE
Move common `PreRun` calls to cli wrapper

### DIFF
--- a/cmd/cli/app/artifact/artifact_get.go
+++ b/cmd/cli/app/artifact/artifact_get.go
@@ -33,11 +33,6 @@ var artifact_getCmd = &cobra.Command{
 	Use:   "get",
 	Short: "Get artifact details",
 	Long:  `Artifact get will get artifact details from an artifact, for a given ID`,
-	PreRun: func(cmd *cobra.Command, args []string) {
-		if err := viper.BindPFlags(cmd.Flags()); err != nil {
-			fmt.Fprintf(os.Stderr, "error binding flags: %s", err)
-		}
-	},
 	RunE: cli.GRPCClientWrapRunE(func(ctx context.Context, cmd *cobra.Command, conn *grpc.ClientConn) error {
 		tag := util.GetConfigValue(viper.GetViper(), "tag", "tag", cmd, "").(string)
 		artifactID := viper.GetString("id")

--- a/cmd/cli/app/artifact/artifact_list.go
+++ b/cmd/cli/app/artifact/artifact_list.go
@@ -36,11 +36,6 @@ var artifact_listCmd = &cobra.Command{
 	Use:   "list",
 	Short: "List artifacts from a provider",
 	Long:  `Artifact list will list artifacts from a provider`,
-	PreRun: func(cmd *cobra.Command, args []string) {
-		if err := viper.BindPFlags(cmd.Flags()); err != nil {
-			fmt.Fprintf(os.Stderr, "error binding flags: %s", err)
-		}
-	},
 	RunE: cli.GRPCClientWrapRunE(func(ctx context.Context, cmd *cobra.Command, conn *grpc.ClientConn) error {
 		format := viper.GetString("output")
 

--- a/cmd/cli/app/auth/auth_delete.go
+++ b/cmd/cli/app/auth/auth_delete.go
@@ -34,13 +34,6 @@ var auth_deleteCmd = &cobra.Command{
 	Use:   "delete",
 	Short: "Permanently delete account",
 	Long:  `Permanently delete account. All associated user data will be permanently removed.`,
-	PreRunE: func(cmd *cobra.Command, args []string) error {
-		if err := viper.BindPFlags(cmd.Flags()); err != nil {
-			return fmt.Errorf("Error binding flags: %s", err)
-		}
-
-		return nil
-	},
 	RunE: cli.GRPCClientWrapRunE(func(ctx context.Context, cmd *cobra.Command, conn *grpc.ClientConn) error {
 		client := pb.NewUserServiceClient(conn)
 

--- a/cmd/cli/app/auth/auth_logout.go
+++ b/cmd/cli/app/auth/auth_logout.go
@@ -22,9 +22,7 @@
 package auth
 
 import (
-	"fmt"
 	"net/url"
-	"os"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -39,11 +37,6 @@ var auth_logoutCmd = &cobra.Command{
 	Use:   "logout",
 	Short: "Logout from minder control plane.",
 	Long:  `Logout from minder control plane. Credentials will be removed from $XDG_CONFIG_HOME/minder/credentials.json`,
-	PreRun: func(cmd *cobra.Command, args []string) {
-		if err := viper.BindPFlags(cmd.Flags()); err != nil {
-			fmt.Fprintf(os.Stderr, "Error binding flags: %s\n", err)
-		}
-	},
 	Run: func(cmd *cobra.Command, args []string) {
 		err := util.RemoveCredentials()
 		util.ExitNicelyOnError(err, "Error removing credentials")

--- a/cmd/cli/app/auth/auth_whoami.go
+++ b/cmd/cli/app/auth/auth_whoami.go
@@ -17,12 +17,9 @@ package auth
 
 import (
 	"context"
-	"fmt"
-	"os"
 
 	"github.com/charmbracelet/bubbles/table"
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
 	"google.golang.org/grpc"
 
 	"github.com/stacklok/minder/internal/util"
@@ -35,11 +32,6 @@ var authWhoamiCmd = &cobra.Command{
 	Use:   "whoami",
 	Short: "whoami for current user",
 	Long:  `whoami gets information about the current user from the minder server`,
-	PreRun: func(cmd *cobra.Command, args []string) {
-		if err := viper.BindPFlags(cmd.Flags()); err != nil {
-			fmt.Fprintf(os.Stderr, "Error binding flags: %s\n", err)
-		}
-	},
 	RunE: cli.GRPCClientWrapRunE(func(ctx context.Context, cmd *cobra.Command, conn *grpc.ClientConn) error {
 		client := pb.NewUserServiceClient(conn)
 

--- a/cmd/cli/app/profile/profile_apply.go
+++ b/cmd/cli/app/profile/profile_apply.go
@@ -37,13 +37,6 @@ var Profile_applyCmd = &cobra.Command{
 	Short: "Create or update a profile within a minder control plane",
 	Long: `The minder profile apply subcommand lets you create or update new profiles for a project
 within a minder control plane.`,
-	PreRunE: func(cmd *cobra.Command, args []string) error {
-		if err := viper.BindPFlags(cmd.Flags()); err != nil {
-			return fmt.Errorf("Error binding flags: %s", err)
-		}
-
-		return nil
-	},
 	RunE: cli.GRPCClientWrapRunE(func(ctx context.Context, cmd *cobra.Command, conn *grpc.ClientConn) error {
 		f := util.GetConfigValue(viper.GetViper(), "file", "file", cmd, "").(string)
 		proj := viper.GetString("project")

--- a/cmd/cli/app/profile/profile_create.go
+++ b/cmd/cli/app/profile/profile_create.go
@@ -35,11 +35,6 @@ var Profile_createCmd = &cobra.Command{
 	Short: "Create a profile within a minder control plane",
 	Long: `The minder profile create subcommand lets you create new profiles for a project
 within a minder control plane.`,
-	PreRun: func(cmd *cobra.Command, args []string) {
-		if err := viper.BindPFlags(cmd.Flags()); err != nil {
-			fmt.Fprintf(os.Stderr, "Error binding flags: %s\n", err)
-		}
-	},
 	RunE: cli.GRPCClientWrapRunE(func(ctx context.Context, cmd *cobra.Command, conn *grpc.ClientConn) error {
 		f := util.GetConfigValue(viper.GetViper(), "file", "file", cmd, "").(string)
 		proj := viper.GetString("project")

--- a/cmd/cli/app/profile/profile_delete.go
+++ b/cmd/cli/app/profile/profile_delete.go
@@ -17,8 +17,6 @@ package profile
 
 import (
 	"context"
-	"fmt"
-	"os"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -34,11 +32,6 @@ var profile_deleteCmd = &cobra.Command{
 	Short: "Delete a profile within a minder control plane",
 	Long: `The minder profile delete subcommand lets you delete profiles within a
 minder control plane.`,
-	PreRun: func(cmd *cobra.Command, args []string) {
-		if err := viper.BindPFlags(cmd.Flags()); err != nil {
-			fmt.Fprintf(os.Stderr, "Error binding flags: %s\n", err)
-		}
-	},
 	RunE: cli.GRPCClientWrapRunE(func(ctx context.Context, cmd *cobra.Command, conn *grpc.ClientConn) error {
 		// delete the profile via GRPC
 		id := viper.GetString("id")

--- a/cmd/cli/app/profile/profile_get.go
+++ b/cmd/cli/app/profile/profile_get.go
@@ -35,11 +35,6 @@ var profile_getCmd = &cobra.Command{
 	Short: "Get details for a profile within a minder control plane",
 	Long: `The minder profile get subcommand lets you retrieve details for a profile within a
 minder control plane.`,
-	PreRun: func(cmd *cobra.Command, args []string) {
-		if err := viper.BindPFlags(cmd.Flags()); err != nil {
-			fmt.Fprintf(os.Stderr, "Error binding flags: %s\n", err)
-		}
-	},
 	RunE: cli.GRPCClientWrapRunE(func(ctx context.Context, cmd *cobra.Command, conn *grpc.ClientConn) error {
 		provider := viper.GetString("provider")
 		format := viper.GetString("output")

--- a/cmd/cli/app/profile/profile_list.go
+++ b/cmd/cli/app/profile/profile_list.go
@@ -35,11 +35,6 @@ var profile_listCmd = &cobra.Command{
 	Short: "List profiles within a minder control plane",
 	Long: `The minder profile list subcommand lets you list profiles within a
 minder control plane for an specific project.`,
-	PreRun: func(cmd *cobra.Command, args []string) {
-		if err := viper.BindPFlags(cmd.Flags()); err != nil {
-			fmt.Fprintf(os.Stderr, "Error binding flags: %s\n", err)
-		}
-	},
 	RunE: cli.GRPCClientWrapRunE(func(ctx context.Context, cmd *cobra.Command, conn *grpc.ClientConn) error {
 		format := viper.GetString("output")
 

--- a/cmd/cli/app/profile/profile_update.go
+++ b/cmd/cli/app/profile/profile_update.go
@@ -38,11 +38,6 @@ var Profile_updateCmd = &cobra.Command{
 	Short: "Update a profile within a minder control plane",
 	Long: `The minder profile update subcommand lets you update profiles for a project
 within a minder control plane.`,
-	PreRun: func(cmd *cobra.Command, args []string) {
-		if err := viper.BindPFlags(cmd.Flags()); err != nil {
-			fmt.Fprintf(os.Stderr, "Error binding flags: %s\n", err)
-		}
-	},
 	RunE: cli.GRPCClientWrapRunE(func(ctx context.Context, cmd *cobra.Command, conn *grpc.ClientConn) error {
 		f := util.GetConfigValue(viper.GetViper(), "file", "file", cmd, "").(string)
 		proj := viper.GetString("project")

--- a/cmd/cli/app/profile_status/profile_status_get.go
+++ b/cmd/cli/app/profile_status/profile_status_get.go
@@ -18,7 +18,6 @@ package profile_status
 import (
 	"context"
 	"fmt"
-	"os"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -36,11 +35,6 @@ var profilestatus_getCmd = &cobra.Command{
 	Short: "Get profile status within a minder control plane",
 	Long: `The minder profile_status get subcommand lets you get profile status within a
 minder control plane for an specific provider/project or profile id, entity type and entity id.`,
-	PreRun: func(cmd *cobra.Command, args []string) {
-		if err := viper.BindPFlags(cmd.Flags()); err != nil {
-			fmt.Fprintf(os.Stderr, "Error binding flags: %s\n", err)
-		}
-	},
 	RunE: cli.GRPCClientWrapRunE(func(ctx context.Context, cmd *cobra.Command, conn *grpc.ClientConn) error {
 		client := minderv1.NewProfileServiceClient(conn)
 

--- a/cmd/cli/app/profile_status/profile_status_list.go
+++ b/cmd/cli/app/profile_status/profile_status_list.go
@@ -35,11 +35,6 @@ var profilestatus_listCmd = &cobra.Command{
 	Short: "List profile status within a minder control plane",
 	Long: `The minder profile_status list subcommand lets you list profile status within a
 minder control plane for an specific provider/project or profile id.`,
-	PreRun: func(cmd *cobra.Command, args []string) {
-		if err := viper.BindPFlags(cmd.Flags()); err != nil {
-			fmt.Fprintf(os.Stderr, "Error binding flags: %s\n", err)
-		}
-	},
 	RunE: cli.GRPCClientWrapRunE(func(ctx context.Context, cmd *cobra.Command, conn *grpc.ClientConn) error {
 		client := pb.NewProfileServiceClient(conn)
 

--- a/cmd/cli/app/provider/provider_enroll.go
+++ b/cmd/cli/app/provider/provider_enroll.go
@@ -115,11 +115,6 @@ var enrollProviderCmd = &cobra.Command{
 	Long: `The minder provider enroll command allows a user to enroll a provider
 such as GitHub into the minder control plane. Once enrolled, users can perform
 actions such as adding repositories.`,
-	PreRun: func(cmd *cobra.Command, args []string) {
-		if err := viper.BindPFlags(cmd.Flags()); err != nil {
-			fmt.Fprintf(os.Stderr, "Error binding flags: %s\n", err)
-		}
-	},
 	RunE: cli.GRPCClientWrapRunE(EnrollProviderCmd),
 }
 

--- a/cmd/cli/app/quickstart/quickstart.go
+++ b/cmd/cli/app/quickstart/quickstart.go
@@ -21,7 +21,6 @@ import (
 	"context"
 	"embed"
 	"fmt"
-	"os"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -131,11 +130,6 @@ var cmd = &cobra.Command{
 	Use:   "quickstart",
 	Short: "Quickstart minder",
 	Long:  "The quickstart command provide the means to quickly get started with minder",
-	PreRun: func(cmd *cobra.Command, args []string) {
-		if err := viper.BindPFlags(cmd.Flags()); err != nil {
-			fmt.Fprintf(os.Stderr, "Error binding flags: %s\n", err)
-		}
-	},
 	RunE: cli.GRPCClientWrapRunE(func(ctx context.Context, cmd *cobra.Command, conn *grpc.ClientConn) error {
 		proj := viper.GetString("project")
 		provider := viper.GetString("provider")

--- a/cmd/cli/app/repo/repo_delete.go
+++ b/cmd/cli/app/repo/repo_delete.go
@@ -18,7 +18,6 @@ package repo
 import (
 	"context"
 	"fmt"
-	"os"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -34,11 +33,6 @@ var repoDeleteCmd = &cobra.Command{
 	Use:   "delete",
 	Short: "delete repository",
 	Long:  `Repo delete is used to delete a repository within the minder control plane`,
-	PreRun: func(cmd *cobra.Command, args []string) {
-		if err := viper.BindPFlags(cmd.Flags()); err != nil {
-			fmt.Fprintf(os.Stderr, "error binding flags: %s", err)
-		}
-	},
 	RunE: cli.GRPCClientWrapRunE(func(ctx context.Context, cmd *cobra.Command, conn *grpc.ClientConn) error {
 		provider := util.GetConfigValue(viper.GetViper(), "provider", "provider", cmd, "").(string)
 		repoid := viper.GetString("repo-id")

--- a/cmd/cli/app/repo/repo_get.go
+++ b/cmd/cli/app/repo/repo_get.go
@@ -18,7 +18,6 @@ package repo
 import (
 	"context"
 	"fmt"
-	"os"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -42,11 +41,6 @@ var repo_getCmd = &cobra.Command{
 	Use:   "get",
 	Short: "Get repository in the minder control plane",
 	Long:  `Repo get is used to get a repo with the minder control plane`,
-	PreRun: func(cmd *cobra.Command, args []string) {
-		if err := viper.BindPFlags(cmd.Flags()); err != nil {
-			fmt.Fprintf(os.Stderr, "error binding flags: %s", err)
-		}
-	},
 	RunE: cli.GRPCClientWrapRunE(func(ctx context.Context, cmd *cobra.Command, conn *grpc.ClientConn) error {
 		provider := util.GetConfigValue(viper.GetViper(), "provider", "provider", cmd, "").(string)
 		repoid := viper.GetString("repo-id")

--- a/cmd/cli/app/repo/repo_list.go
+++ b/cmd/cli/app/repo/repo_list.go
@@ -35,11 +35,6 @@ var repo_listCmd = &cobra.Command{
 	Use:   "list",
 	Short: "List repositories in the minder control plane",
 	Long:  `Repo list is used to register a repo with the minder control plane`,
-	PreRun: func(cmd *cobra.Command, args []string) {
-		if err := viper.BindPFlags(cmd.Flags()); err != nil {
-			fmt.Fprintf(os.Stderr, "error binding flags: %s", err)
-		}
-	},
 	RunE: cli.GRPCClientWrapRunE(func(ctx context.Context, cmd *cobra.Command, conn *grpc.ClientConn) error {
 		provider := util.GetConfigValue(viper.GetViper(), "provider", "provider", cmd, "").(string)
 		if provider != github.Github {

--- a/cmd/cli/app/repo/repo_register.go
+++ b/cmd/cli/app/repo/repo_register.go
@@ -50,11 +50,6 @@ var repoRegisterCmd = &cobra.Command{
 	Use:   "register",
 	Short: "Register a repo with the minder control plane",
 	Long:  `Repo register is used to register a repo with the minder control plane`,
-	PreRun: func(cmd *cobra.Command, args []string) {
-		if err := viper.BindPFlags(cmd.Flags()); err != nil {
-			fmt.Fprintf(os.Stderr, "Error binding flags: %s\n", err)
-		}
-	},
 	RunE: cli.GRPCClientWrapRunE(func(ctx context.Context, cmd *cobra.Command, conn *grpc.ClientConn) error {
 		_, msg, err := RegisterCmd(ctx, cmd, conn)
 		util.ExitNicelyOnError(err, msg)

--- a/cmd/cli/app/ruletype/rule_type_apply.go
+++ b/cmd/cli/app/ruletype/rule_type_apply.go
@@ -21,7 +21,6 @@ import (
 	"os"
 
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -37,11 +36,6 @@ var RuleType_applyCmd = &cobra.Command{
 	Short: "Apply a rule type within a minder control plane",
 	Long: `The minder rule type apply subcommand lets you create or update rule types for a project
 within a minder control plane.`,
-	PreRun: func(cmd *cobra.Command, args []string) {
-		if err := viper.BindPFlags(cmd.Flags()); err != nil {
-			fmt.Fprintf(os.Stderr, "Error binding flags: %s\n", err)
-		}
-	},
 	RunE: cli.GRPCClientWrapRunE(func(ctx context.Context, cmd *cobra.Command, conn *grpc.ClientConn) error {
 		files, err := cmd.Flags().GetStringArray("file")
 		if err != nil {

--- a/cmd/cli/app/ruletype/rule_type_create.go
+++ b/cmd/cli/app/ruletype/rule_type_create.go
@@ -21,7 +21,6 @@ import (
 	"os"
 
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
 	"google.golang.org/grpc"
 
 	"github.com/stacklok/minder/internal/util"
@@ -35,11 +34,6 @@ var RuleType_createCmd = &cobra.Command{
 	Short: "Create a rule type within a minder control plane",
 	Long: `The minder rule type create subcommand lets you create new rule types for a project
 within a minder control plane.`,
-	PreRun: func(cmd *cobra.Command, args []string) {
-		if err := viper.BindPFlags(cmd.Flags()); err != nil {
-			fmt.Fprintf(os.Stderr, "Error binding flags: %s\n", err)
-		}
-	},
 	RunE: cli.GRPCClientWrapRunE(func(ctx context.Context, cmd *cobra.Command, conn *grpc.ClientConn) error {
 		files, err := cmd.Flags().GetStringArray("file")
 		if err != nil {

--- a/cmd/cli/app/ruletype/rule_type_delete.go
+++ b/cmd/cli/app/ruletype/rule_type_delete.go
@@ -19,7 +19,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"os"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -35,11 +34,6 @@ var ruleType_deleteCmd = &cobra.Command{
 	Short: "Delete a rule type",
 	Long: `The minder rule type delete subcommand lets you delete rule types within a
 minder control plane.`,
-	PreRun: func(cmd *cobra.Command, args []string) {
-		if err := viper.BindPFlags(cmd.Flags()); err != nil {
-			fmt.Fprintf(os.Stderr, "Error binding flags: %s\n", err)
-		}
-	},
 	RunE: cli.GRPCClientWrapRunE(func(ctx context.Context, cmd *cobra.Command, conn *grpc.ClientConn) error {
 		// Delete the rule type via GRPC
 		id := viper.GetString("id")

--- a/cmd/cli/app/ruletype/rule_type_get.go
+++ b/cmd/cli/app/ruletype/rule_type_get.go
@@ -35,11 +35,6 @@ var ruleType_getCmd = &cobra.Command{
 	Short: "Get details for a rule type within a minder control plane",
 	Long: `The minder ruletype get subcommand lets you retrieve details for a rule type within a
 minder control plane.`,
-	PreRun: func(cmd *cobra.Command, args []string) {
-		if err := viper.BindPFlags(cmd.Flags()); err != nil {
-			fmt.Fprintf(os.Stderr, "Error binding flags: %s\n", err)
-		}
-	},
 	RunE: cli.GRPCClientWrapRunE(func(ctx context.Context, cmd *cobra.Command, conn *grpc.ClientConn) error {
 		provider := viper.GetString("provider")
 		format := viper.GetString("output")

--- a/cmd/cli/app/ruletype/rule_type_list.go
+++ b/cmd/cli/app/ruletype/rule_type_list.go
@@ -35,11 +35,6 @@ var ruleType_listCmd = &cobra.Command{
 	Short: "List rule types within a minder control plane",
 	Long: `The minder ruletype list subcommand lets you list rule type within a
 minder control plane for an specific project.`,
-	PreRun: func(cmd *cobra.Command, args []string) {
-		if err := viper.BindPFlags(cmd.Flags()); err != nil {
-			fmt.Fprintf(os.Stderr, "Error binding flags: %s\n", err)
-		}
-	},
 	RunE: cli.GRPCClientWrapRunE(func(ctx context.Context, cmd *cobra.Command, conn *grpc.ClientConn) error {
 		format := viper.GetString("output")
 

--- a/cmd/cli/app/ruletype/rule_type_update.go
+++ b/cmd/cli/app/ruletype/rule_type_update.go
@@ -21,7 +21,6 @@ import (
 	"os"
 
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
 	"google.golang.org/grpc"
 
 	"github.com/stacklok/minder/internal/util"
@@ -35,11 +34,6 @@ var RuleType_updateCmd = &cobra.Command{
 	Short: "Update a rule type within a minder control plane",
 	Long: `The minder rule type update subcommand lets you update rule types for a project
 within a minder control plane.`,
-	PreRun: func(cmd *cobra.Command, args []string) {
-		if err := viper.BindPFlags(cmd.Flags()); err != nil {
-			fmt.Fprintf(os.Stderr, "Error binding flags: %s\n", err)
-		}
-	},
 	RunE: cli.GRPCClientWrapRunE(func(ctx context.Context, cmd *cobra.Command, conn *grpc.ClientConn) error {
 		files, err := cmd.Flags().GetStringArray("file")
 		if err != nil {

--- a/internal/util/cli/cli.go
+++ b/internal/util/cli/cli.go
@@ -102,6 +102,10 @@ func GRPCClientWrapRunE(
 	runEFunc func(ctx context.Context, cmd *cobra.Command, c *grpc.ClientConn) error,
 ) func(cmd *cobra.Command, args []string) error {
 	return func(cmd *cobra.Command, args []string) error {
+		if err := viper.BindPFlags(cmd.Flags()); err != nil {
+			return fmt.Errorf("error binding flags: %s", err)
+		}
+
 		ctx, cancel := GetAppContext(cmd.Context(), viper.GetViper())
 		defer cancel()
 


### PR DESCRIPTION
This removes the repetition we had by calling the viper flag binding
inside of the common wrapper we're now using for our CLI commands.
