### PR TITLE
Don't `ExitNicelyOnError` on the sub-commands

### DIFF
--- a/cmd/cli/app/artifact/artifact_list.go
+++ b/cmd/cli/app/artifact/artifact_list.go
@@ -26,7 +26,6 @@ import (
 	"github.com/spf13/viper"
 	"google.golang.org/grpc"
 
-	"github.com/stacklok/minder/internal/auth"
 	"github.com/stacklok/minder/internal/util"
 	"github.com/stacklok/minder/internal/util/cli"
 	pb "github.com/stacklok/minder/pkg/api/protobuf/go/minder/v1"
@@ -40,9 +39,6 @@ var artifact_listCmd = &cobra.Command{
 		format := viper.GetString("output")
 
 		provider := util.GetConfigValue(viper.GetViper(), "provider", "provider", cmd, "").(string)
-		if provider != auth.Github {
-			return fmt.Errorf("only %s is supported at this time", auth.Github)
-		}
 		projectID := viper.GetString("project-id")
 
 		switch format {
@@ -65,7 +61,7 @@ var artifact_listCmd = &cobra.Command{
 		)
 
 		if err != nil {
-			return fmt.Errorf("error getting artifacts: %s", err)
+			return cli.MessageAndError(cmd, "Couldn't list artifacts", err)
 		}
 
 		switch format {
@@ -89,12 +85,16 @@ var artifact_listCmd = &cobra.Command{
 			table.Render()
 		case "json":
 			out, err := util.GetJsonFromProto(artifacts)
-			util.ExitNicelyOnError(err, "Error getting json from proto")
-			fmt.Println(out)
+			if err != nil {
+				return cli.MessageAndError(cmd, "Error getting json from proto", err)
+			}
+			cli.PrintCmd(cmd, out)
 		case "yaml":
 			out, err := util.GetYamlFromProto(artifacts)
-			util.ExitNicelyOnError(err, "Error getting yaml from proto")
-			fmt.Println(out)
+			if err != nil {
+				return cli.MessageAndError(cmd, "Error getting yaml from proto", err)
+			}
+			cli.PrintCmd(cmd, out)
 		}
 
 		return nil

--- a/cmd/cli/app/auth/auth_delete.go
+++ b/cmd/cli/app/auth/auth_delete.go
@@ -39,11 +39,15 @@ var auth_deleteCmd = &cobra.Command{
 
 		// Ensure the user already exists in the local database
 		_, _, err := userRegistered(ctx, client)
-		util.ExitNicelyOnError(err, "Error fetching user")
+		if err != nil {
+			return cli.MessageAndError(cmd, "Error checking if user exists", err)
+		}
 
 		// Get user details - name, email from the jwt token
 		userDetails, err := auth.GetUserDetails(ctx, cmd, viper.GetViper())
-		util.ExitNicelyOnError(err, "Error fetching user details")
+		if err != nil {
+			return cli.MessageAndError(cmd, "Error fetching user details", err)
+		}
 
 		// Confirm user wants to delete their account
 		yes := cli.PrintYesNoPrompt(cmd,
@@ -60,7 +64,9 @@ var auth_deleteCmd = &cobra.Command{
 		}
 
 		_, err = client.DeleteUser(ctx, &pb.DeleteUserRequest{})
-		util.ExitNicelyOnError(err, "Error registering user")
+		if err != nil {
+			return cli.MessageAndError(cmd, "Error deleting user", err)
+		}
 
 		// This step is added to avoid confusing the users by seeing their credentials locally, however it is not
 		// directly related to user deletion because the token will expire after 5 minutes and cannot be refreshed

--- a/cmd/cli/app/auth/auth_login.go
+++ b/cmd/cli/app/auth/auth_login.go
@@ -27,6 +27,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"os"
 	"time"
 
 	"github.com/charmbracelet/bubbles/table"
@@ -60,7 +61,7 @@ func userRegistered(ctx context.Context, client pb.UserServiceClient) (bool, *pb
 				return false, nil, nil
 			}
 		}
-		return false, nil, fmt.Errorf("error retrieving user %v", err)
+		return false, nil, fmt.Errorf("error retrieving user %w", err)
 	}
 	return true, res, nil
 }
@@ -76,7 +77,7 @@ will be saved to $XDG_CONFIG_HOME/minder/credentials.json`,
 			cli.Print(cmd.ErrOrStderr(), "Error binding flags: %s\n", err)
 		}
 	},
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		ctx := context.Background()
 
 		issuerUrlStr := util.GetConfigValue(viper.GetViper(), "identity.cli.issuer_url", "identity-url", cmd,
@@ -84,7 +85,10 @@ will be saved to $XDG_CONFIG_HOME/minder/credentials.json`,
 		clientID := util.GetConfigValue(viper.GetViper(), "identity.cli.client_id", "identity-client", cmd, "minder-cli").(string)
 
 		parsedURL, err := url.Parse(issuerUrlStr)
-		util.ExitNicelyOnError(err, "Error parsing issuer URL")
+		if err != nil {
+			return cli.MessageAndError(cmd, "Error parsing issuer URL", err)
+		}
+
 		issuerUrl := parsedURL.JoinPath("realms/stacklok")
 		scopes := []string{"openid"}
 		callbackPath := "/auth/callback"
@@ -102,18 +106,27 @@ will be saved to $XDG_CONFIG_HOME/minder/credentials.json`,
 
 		// Get random port
 		port, err := rand.GetRandomPort()
-		util.ExitNicelyOnError(err, "Error getting random port")
+		if err != nil {
+			return cli.MessageAndError(cmd, "Error getting random port", err)
+		}
 
 		parsedURL, err = url.Parse(fmt.Sprintf("http://localhost:%v", port))
-		util.ExitNicelyOnError(err, "Error creating callback server")
+		if err != nil {
+			return cli.MessageAndError(cmd, "Error parsing callback URL", err)
+		}
 		redirectURI := parsedURL.JoinPath(callbackPath)
 
 		provider, err := rp.NewRelyingPartyOIDC(issuerUrl.String(), clientID, "", redirectURI.String(), scopes, options...)
-		util.ExitNicelyOnError(err, "error creating identity provider reference")
+		if err != nil {
+			return cli.MessageAndError(cmd, "Error creating relying party", err)
+		}
 
 		stateFn := func() string {
 			state, err := mcrypto.GenerateNonce()
-			util.ExitNicelyOnError(err, "error generating state for login")
+			if err != nil {
+				cmd.PrintErrln("error generating state for login")
+				os.Exit(1)
+			}
 			return state
 		}
 
@@ -166,22 +179,28 @@ will be saved to $XDG_CONFIG_HOME/minder/credentials.json`,
 			AccessTokenExpiresAt: token.Expiry,
 		})
 		if err != nil {
-			fmt.Println(err)
+			cli.Print(cmd.ErrOrStderr(), "couldn't save credentials: %s\n", err)
 		}
 
 		conn, err := cli.GrpcForCommand(cmd, viper.GetViper())
-		util.ExitNicelyOnError(err, "Error getting grpc connection")
+		if err != nil {
+			return cli.MessageAndError(cmd, "Error getting grpc connection", err)
+		}
 		defer conn.Close()
 		client := pb.NewUserServiceClient(conn)
 
 		// check if the user already exists in the local database
 		registered, userInfo, err := userRegistered(ctx, client)
-		util.ExitNicelyOnError(err, "Error fetching user")
+		if err != nil {
+			return cli.MessageAndError(cmd, "Error checking if user exists", err)
+		}
 
 		if !registered {
 			cli.PrintCmd(cmd, "First login, registering user...\n")
 			newUser, err := client.CreateUser(ctx, &pb.CreateUserRequest{})
-			util.ExitNicelyOnError(err, "Error registering user")
+			if err != nil {
+				return cli.MessageAndError(cmd, "Error registering user", err)
+			}
 
 			cli.PrintCmd(cmd, cli.SuccessBanner.Render(
 				"You have been successfully registered. Welcome!"))
@@ -203,8 +222,8 @@ will be saved to $XDG_CONFIG_HOME/minder/credentials.json`,
 		cli.PrintCmd(cmd, "Your access credentials have been saved to %s", filePath)
 
 		// shut down the HTTP server
-		err = server.Shutdown(context.Background())
-		util.ExitNicelyOnError(err, "Failed to shut down server")
+		// TODO: should this use the app context?
+		return server.Shutdown(context.Background())
 	},
 }
 

--- a/cmd/cli/app/auth/auth_whoami.go
+++ b/cmd/cli/app/auth/auth_whoami.go
@@ -22,7 +22,6 @@ import (
 	"github.com/spf13/cobra"
 	"google.golang.org/grpc"
 
-	"github.com/stacklok/minder/internal/util"
 	"github.com/stacklok/minder/internal/util/cli"
 	pb "github.com/stacklok/minder/pkg/api/protobuf/go/minder/v1"
 )
@@ -36,7 +35,9 @@ var authWhoamiCmd = &cobra.Command{
 		client := pb.NewUserServiceClient(conn)
 
 		userInfo, err := client.GetUser(ctx, &pb.GetUserRequest{})
-		util.ExitNicelyOnError(err, "Error getting information for user")
+		if err != nil {
+			return cli.MessageAndError(cmd, "Error getting information for user", err)
+		}
 
 		cli.PrintCmd(cmd, cli.Header.Render("Here are your details:"))
 		renderUserInfoWhoami(cmd, conn, userInfo)

--- a/cmd/cli/app/profile/profile_apply.go
+++ b/cmd/cli/app/profile/profile_apply.go
@@ -57,18 +57,18 @@ within a minder control plane.`,
 			st, ok := status.FromError(err)
 			if !ok {
 				// We can't parse the error, so just return it
-				return nil, fmt.Errorf("error creating rule type from %s: %w", f, err)
+				return nil, cli.MessageAndError(cmd, fmt.Sprintf("error creating rule type from %s", f), err)
 			}
 
 			if st.Code() != codes.AlreadyExists {
-				return nil, fmt.Errorf("error creating rule type from %s: %w", f, err)
+				return nil, cli.MessageAndError(cmd, fmt.Sprintf("error creating rule type from %s", f), err)
 			}
 
 			updateResp, err := client.UpdateProfile(ctx, &pb.UpdateProfileRequest{
 				Profile: p,
 			})
 			if err != nil {
-				return nil, fmt.Errorf("error updating rule type from %s: %w", f, err)
+				return nil, cli.MessageAndError(cmd, fmt.Sprintf("error updating rule type from %s", f), err)
 			}
 
 			return updateResp.GetProfile(), nil

--- a/cmd/cli/app/profile/profile_delete.go
+++ b/cmd/cli/app/profile/profile_delete.go
@@ -17,12 +17,13 @@ package profile
 
 import (
 	"context"
+	"fmt"
+	"os"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	"google.golang.org/grpc"
 
-	"github.com/stacklok/minder/internal/util"
 	"github.com/stacklok/minder/internal/util/cli"
 	pb "github.com/stacklok/minder/pkg/api/protobuf/go/minder/v1"
 )
@@ -45,8 +46,10 @@ minder control plane.`,
 			},
 			Id: id,
 		})
+		if err != nil {
+			return cli.MessageAndError(cmd, "Error deleting profile", err)
+		}
 
-		util.ExitNicelyOnError(err, "Error deleting profile")
 		cmd.Println("Successfully deleted profile with id:", id)
 
 		return nil
@@ -57,7 +60,9 @@ func init() {
 	ProfileCmd.AddCommand(profile_deleteCmd)
 	profile_deleteCmd.Flags().StringP("id", "i", "", "ID of profile to delete")
 	profile_deleteCmd.Flags().StringP("provider", "p", "github", "Provider for the profile")
-	err := profile_deleteCmd.MarkFlagRequired("id")
-	util.ExitNicelyOnError(err, "Error marking flag as required")
+	if err := profile_deleteCmd.MarkFlagRequired("id"); err != nil {
+		fmt.Printf("Error marking flag as required: %s", err)
+		os.Exit(1)
+	}
 	// TODO: add a flag for the profile name
 }

--- a/cmd/cli/app/profile/profile_get.go
+++ b/cmd/cli/app/profile/profile_get.go
@@ -54,16 +54,22 @@ minder control plane.`,
 			},
 			Id: id,
 		})
-		util.ExitNicelyOnError(err, "Error getting profile")
+		if err != nil {
+			return cli.MessageAndError(cmd, "Error getting profile", err)
+		}
 
 		switch format {
 		case app.YAML:
 			out, err := util.GetYamlFromProto(profile)
-			util.ExitNicelyOnError(err, "Error getting yaml from proto")
+			if err != nil {
+				return cli.MessageAndError(cmd, "Error getting yaml from proto", err)
+			}
 			fmt.Println(out)
 		case app.JSON:
 			out, err := util.GetJsonFromProto(profile)
-			util.ExitNicelyOnError(err, "Error getting json from proto")
+			if err != nil {
+				return cli.MessageAndError(cmd, "Error getting json from proto", err)
+			}
 			fmt.Println(out)
 		case app.Table:
 			p := profile.GetProfile()

--- a/cmd/cli/app/profile/profile_list.go
+++ b/cmd/cli/app/profile/profile_list.go
@@ -57,18 +57,22 @@ minder control plane for an specific project.`,
 			},
 		})
 		if err != nil {
-			return fmt.Errorf("error getting profiles: %w", err)
+			return cli.MessageAndError(cmd, "Error getting profiles", err)
 		}
 
 		switch format {
 		case app.JSON:
 			out, err := util.GetJsonFromProto(resp)
-			util.ExitNicelyOnError(err, "Error getting json from proto")
-			fmt.Println(out)
+			if err != nil {
+				return fmt.Errorf("error getting json from proto: %w", err)
+			}
+			cmd.Println(out)
 		case app.YAML:
 			out, err := util.GetYamlFromProto(resp)
-			util.ExitNicelyOnError(err, "Error getting json from proto")
-			fmt.Println(out)
+			if err != nil {
+				return fmt.Errorf("error getting yaml from proto: %w", err)
+			}
+			cmd.Println(out)
 		case app.Table:
 			handleListTableOutput(cmd, resp)
 			return nil

--- a/cmd/cli/app/profile/status/profile_status_get.go
+++ b/cmd/cli/app/profile/status/profile_status_get.go
@@ -18,6 +18,7 @@ package status
 import (
 	"context"
 	"fmt"
+	"os"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -78,12 +79,16 @@ minder control plane for an specific provider/project or profile id, entity type
 		switch format {
 		case app.JSON:
 			out, err := util.GetJsonFromProto(resp)
-			util.ExitNicelyOnError(err, "Error getting json from proto")
-			fmt.Println(out)
+			if err != nil {
+				return cli.MessageAndError(cmd, "Error getting json from proto", err)
+			}
+			cli.PrintCmd(cmd, out)
 		case app.YAML:
 			out, err := util.GetYamlFromProto(resp)
-			util.ExitNicelyOnError(err, "Error getting yaml from proto")
-			fmt.Println(out)
+			if err != nil {
+				return cli.MessageAndError(cmd, "Error getting yaml from proto", err)
+			}
+			cli.PrintCmd(cmd, out)
 		case app.Table:
 			handleProfileStatusListTable(cmd, resp)
 		}
@@ -104,9 +109,11 @@ func init() {
 
 	// mark as required
 	if err := profilestatus_getCmd.MarkFlagRequired("profile"); err != nil {
-		util.ExitNicelyOnError(err, "error marking flag as required")
+		fmt.Printf("Error marking flag as required: %s", err)
+		os.Exit(1)
 	}
 	if err := profilestatus_getCmd.MarkFlagRequired("entity"); err != nil {
-		util.ExitNicelyOnError(err, "error marking flag as required")
+		fmt.Printf("Error marking flag as required: %s", err)
+		os.Exit(1)
 	}
 }

--- a/cmd/cli/app/profile/status/profile_status_list.go
+++ b/cmd/cli/app/profile/status/profile_status_list.go
@@ -76,12 +76,16 @@ minder control plane for an specific provider/project or profile id.`,
 		switch format {
 		case app.JSON:
 			out, err := util.GetJsonFromProto(resp)
-			util.ExitNicelyOnError(err, "Error getting json from proto")
-			fmt.Println(out)
+			if err != nil {
+				return cli.MessageAndError(cmd, "Error getting json from proto", err)
+			}
+			cli.PrintCmd(cmd, out)
 		case app.YAML:
 			out, err := util.GetYamlFromProto(resp)
-			util.ExitNicelyOnError(err, "Error getting yaml from proto")
-			fmt.Println(out)
+			if err != nil {
+				return cli.MessageAndError(cmd, "Error getting yaml from proto", err)
+			}
+			cli.PrintCmd(cmd, out)
 		case app.Table:
 			handleProfileStatusListTable(cmd, resp)
 

--- a/cmd/cli/app/provider/provider_enroll.go
+++ b/cmd/cli/app/provider/provider_enroll.go
@@ -122,8 +122,7 @@ actions such as adding repositories.`,
 func EnrollProviderCmd(ctx context.Context, cmd *cobra.Command, conn *grpc.ClientConn) error {
 	provider := util.GetConfigValue(viper.GetViper(), "provider", "provider", cmd, "").(string)
 	if provider != ghclient.Github {
-		msg := fmt.Sprintf("Only %s is supported at this time", ghclient.Github)
-		return fmt.Errorf(msg)
+		return fmt.Errorf("Only %s is supported at this time", ghclient.Github)
 	}
 	project := viper.GetString("project")
 	pat := util.GetConfigValue(viper.GetViper(), "token", "token", cmd, "").(string)
@@ -156,7 +155,7 @@ func EnrollProviderCmd(ctx context.Context, cmd *cobra.Command, conn *grpc.Clien
 		_, err := client.StoreProviderToken(context.Background(),
 			&pb.StoreProviderTokenRequest{Provider: provider, ProjectId: project, AccessToken: pat, Owner: &owner})
 		if err != nil {
-			return fmt.Errorf("error storing token: %w", err)
+			return cli.MessageAndError(cmd, "Error storing token", err)
 		}
 
 		cli.PrintCmd(cmd, "Provider enrolled successfully")
@@ -177,7 +176,7 @@ func EnrollProviderCmd(ctx context.Context, cmd *cobra.Command, conn *grpc.Clien
 		Owner:     &owner,
 	})
 	if err != nil {
-		return fmt.Errorf("error getting authorization URL: %w", err)
+		return cli.MessageAndError(cmd, "error getting authorization URL", err)
 	}
 
 	fmt.Printf("Your browser will now be opened to: %s\n", resp.GetUrl())

--- a/cmd/cli/app/quickstart/quickstart.go
+++ b/cmd/cli/app/quickstart/quickstart.go
@@ -34,7 +34,6 @@ import (
 	minderprov "github.com/stacklok/minder/cmd/cli/app/provider"
 	"github.com/stacklok/minder/cmd/cli/app/repo"
 	"github.com/stacklok/minder/internal/engine"
-	"github.com/stacklok/minder/internal/util"
 	"github.com/stacklok/minder/internal/util/cli"
 	minderv1 "github.com/stacklok/minder/pkg/api/protobuf/go/minder/v1"
 )
@@ -172,7 +171,9 @@ var cmd = &cobra.Command{
 
 		// Prompt to register repositories
 		results, msg, err := repo.RegisterCmd(ctx, cmd, conn)
-		util.ExitNicelyOnError(err, msg)
+		if err != nil {
+			return cli.MessageAndError(cmd, msg, err)
+		}
 
 		var registeredRepos []string
 		for _, result := range results {

--- a/cmd/cli/app/repo/repo_delete.go
+++ b/cmd/cli/app/repo/repo_delete.go
@@ -23,7 +23,6 @@ import (
 	"github.com/spf13/viper"
 	"google.golang.org/grpc"
 
-	github "github.com/stacklok/minder/internal/providers/github"
 	"github.com/stacklok/minder/internal/util"
 	"github.com/stacklok/minder/internal/util/cli"
 	pb "github.com/stacklok/minder/pkg/api/protobuf/go/minder/v1"
@@ -62,16 +61,16 @@ var repoDeleteCmd = &cobra.Command{
 			resp, err := client.DeleteRepositoryById(ctx, &pb.DeleteRepositoryByIdRequest{
 				RepositoryId: repoid,
 			})
-			util.ExitNicelyOnError(err, "Error deleting repo by id")
+			if err != nil {
+				return cli.MessageAndError(cmd, "Error deleting repo by id", err)
+			}
 			deletedRepoID = resp
 		} else {
-			if provider != github.Github {
-				return fmt.Errorf("only %s is supported at this time", github.Github)
-			}
-
 			// delete repo by name
 			resp, err := client.DeleteRepositoryByName(ctx, &pb.DeleteRepositoryByNameRequest{Provider: provider, Name: name})
-			util.ExitNicelyOnError(err, "Error deleting repo by name")
+			if err != nil {
+				return cli.MessageAndError(cmd, "Error deleting repo by name", err)
+			}
 			deletedRepoName = resp
 		}
 

--- a/cmd/cli/app/repo/repo_get.go
+++ b/cmd/cli/app/repo/repo_get.go
@@ -78,7 +78,9 @@ var repo_getCmd = &cobra.Command{
 			resp, err := client.GetRepositoryById(ctx, &pb.GetRepositoryByIdRequest{
 				RepositoryId: repoid,
 			})
-			util.ExitNicelyOnError(err, "Error getting repo by id")
+			if err != nil {
+				return cli.MessageAndError(cmd, "Error getting repo by id", err)
+			}
 			repository = resp.Repository
 		} else {
 			if provider != github.Github {
@@ -87,7 +89,9 @@ var repo_getCmd = &cobra.Command{
 
 			// check repo by name
 			resp, err := client.GetRepositoryByName(ctx, &pb.GetRepositoryByNameRequest{Provider: provider, Name: name})
-			util.ExitNicelyOnError(err, "Error getting repo by id")
+			if err != nil {
+				return cli.MessageAndError(cmd, "Error getting repo by name", err)
+			}
 			repository = resp.Repository
 		}
 
@@ -98,12 +102,16 @@ var repo_getCmd = &cobra.Command{
 			// print result just in JSON or YAML
 			if format == "" || format == formatJSON {
 				out, err := util.GetJsonFromProto(repository)
-				util.ExitNicelyOnError(err, "Error getting json from proto")
-				fmt.Println(out)
+				if err != nil {
+					return cli.MessageAndError(cmd, "Error getting json from proto", err)
+				}
+				cli.PrintCmd(cmd, out)
 			} else {
 				out, err := util.GetYamlFromProto(repository)
-				util.ExitNicelyOnError(err, "Error getting json from proto")
-				fmt.Println(out)
+				if err != nil {
+					return cli.MessageAndError(cmd, "Error getting yaml from proto", err)
+				}
+				cli.PrintCmd(cmd, out)
 			}
 		}
 		return nil

--- a/cmd/cli/app/repo/repo_list.go
+++ b/cmd/cli/app/repo/repo_list.go
@@ -18,14 +18,12 @@ package repo
 import (
 	"context"
 	"fmt"
-	"os"
 
 	"github.com/charmbracelet/bubbles/table"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	"google.golang.org/grpc"
 
-	github "github.com/stacklok/minder/internal/providers/github"
 	"github.com/stacklok/minder/internal/util"
 	"github.com/stacklok/minder/internal/util/cli"
 	pb "github.com/stacklok/minder/pkg/api/protobuf/go/minder/v1"
@@ -37,9 +35,6 @@ var repo_listCmd = &cobra.Command{
 	Long:  `Repo list is used to register a repo with the minder control plane`,
 	RunE: cli.GRPCClientWrapRunE(func(ctx context.Context, cmd *cobra.Command, conn *grpc.ClientConn) error {
 		provider := util.GetConfigValue(viper.GetViper(), "provider", "provider", cmd, "").(string)
-		if provider != github.Github {
-			return fmt.Errorf("only %s is supported at this time", github.Github)
-		}
 		projectID := viper.GetString("project-id")
 		format := viper.GetString("output")
 
@@ -59,8 +54,7 @@ var repo_listCmd = &cobra.Command{
 			ProjectId: projectID,
 		})
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "Error getting repo of repos: %s\n", err)
-			os.Exit(1)
+			return cli.MessageAndError(cmd, "Error getting repo of repos", err)
 		}
 
 		switch format {
@@ -98,12 +92,16 @@ var repo_listCmd = &cobra.Command{
 			cli.PrintCmd(cmd, cli.TableRender(t))
 		case "json":
 			out, err := util.GetJsonFromProto(resp)
-			util.ExitNicelyOnError(err, "Error getting json from proto")
-			fmt.Println(out)
+			if err != nil {
+				return cli.MessageAndError(cmd, "Error getting json from proto", err)
+			}
+			cli.PrintCmd(cmd, out)
 		case "yaml":
 			out, err := util.GetYamlFromProto(resp)
-			util.ExitNicelyOnError(err, "Error getting yaml from proto")
-			fmt.Println(out)
+			if err != nil {
+				return cli.MessageAndError(cmd, "Error getting yaml from proto", err)
+			}
+			cli.PrintCmd(cmd, out)
 		}
 		return nil
 	}),

--- a/cmd/cli/app/repo/repo_register.go
+++ b/cmd/cli/app/repo/repo_register.go
@@ -51,8 +51,9 @@ var repoRegisterCmd = &cobra.Command{
 	Short: "Register a repo with the minder control plane",
 	Long:  `Repo register is used to register a repo with the minder control plane`,
 	RunE: cli.GRPCClientWrapRunE(func(ctx context.Context, cmd *cobra.Command, conn *grpc.ClientConn) error {
-		_, msg, err := RegisterCmd(ctx, cmd, conn)
-		util.ExitNicelyOnError(err, msg)
+		if _, msg, err := RegisterCmd(ctx, cmd, conn); err != nil {
+			return cli.MessageAndError(cmd, msg, err)
+		}
 		return nil
 	}),
 }

--- a/cmd/cli/app/root.go
+++ b/cmd/cli/app/root.go
@@ -51,7 +51,7 @@ const Table = "table"
 // Execute adds all child commands to the root command and sets flags appropriately.
 func Execute() {
 	err := RootCmd.Execute()
-	util.ExitNicelyOnError(err, "Error on execute")
+	util.ExitNicelyOnError(err, "")
 }
 
 func init() {

--- a/cmd/cli/app/ruletype/ruletype_create.go
+++ b/cmd/cli/app/ruletype/ruletype_create.go
@@ -58,7 +58,7 @@ within a minder control plane.`,
 				RuleType: rt,
 			})
 			if err != nil {
-				return nil, fmt.Errorf("error creating rule type from %s: %w", fileName, err)
+				return nil, cli.MessageAndError(cmd, fmt.Sprintf("Error creating rule type from %s", fileName), err)
 			}
 
 			return resprt.RuleType, nil
@@ -70,7 +70,7 @@ within a minder control plane.`,
 			}
 
 			if err := execOnOneRuleType(table, f, os.Stdin, createFunc); err != nil {
-				return fmt.Errorf("error creating rule type %s: %w", f, err)
+				return err
 			}
 		}
 

--- a/cmd/cli/app/ruletype/ruletype_delete.go
+++ b/cmd/cli/app/ruletype/ruletype_delete.go
@@ -18,7 +18,6 @@ package ruletype
 import (
 	"context"
 	"errors"
-	"fmt"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -77,7 +76,7 @@ minder control plane.`,
 				Id: id,
 			})
 			if err != nil {
-				return fmt.Errorf("Error getting rule type: %w", err)
+				return cli.MessageAndError(cmd, "Error getting rule type", err)
 			}
 			// Add the rule type for deletion
 			rulesToDelete = append(rulesToDelete, rtype.RuleType)
@@ -92,7 +91,7 @@ minder control plane.`,
 				},
 			})
 			if err != nil {
-				return fmt.Errorf("Error listing rule types: %w", err)
+				return cli.MessageAndError(cmd, "Error listing rule types", err)
 			}
 			rulesToDelete = append(rulesToDelete, resp.RuleTypes...)
 		}

--- a/cmd/cli/app/ruletype/ruletype_get.go
+++ b/cmd/cli/app/ruletype/ruletype_get.go
@@ -66,12 +66,16 @@ minder control plane.`,
 		switch format {
 		case app.YAML:
 			out, err := util.GetYamlFromProto(rtype)
-			util.ExitNicelyOnError(err, "Error getting json from proto")
-			fmt.Println(out)
+			if err != nil {
+				return fmt.Errorf("error getting yaml from proto: %w", err)
+			}
+			cli.PrintCmd(cmd, out)
 		case app.JSON:
 			out, err := util.GetJsonFromProto(rtype)
-			util.ExitNicelyOnError(err, "Error getting json from proto")
-			fmt.Println(out)
+			if err != nil {
+				return fmt.Errorf("error getting json from proto: %w", err)
+			}
+			cli.PrintCmd(cmd, out)
 		case app.Table:
 			handleGetTableOutput(cmd, rtype.GetRuleType())
 		}

--- a/cmd/cli/app/ruletype/ruletype_list.go
+++ b/cmd/cli/app/ruletype/ruletype_list.go
@@ -64,12 +64,16 @@ minder control plane for an specific project.`,
 		switch format {
 		case app.JSON:
 			out, err := util.GetJsonFromProto(resp)
-			util.ExitNicelyOnError(err, "Error getting json from proto")
-			fmt.Println(out)
+			if err != nil {
+				return fmt.Errorf("error getting json from proto: %w", err)
+			}
+			cmd.Println(out)
 		case app.YAML:
 			out, err := util.GetYamlFromProto(resp)
-			util.ExitNicelyOnError(err, "Error getting yaml from proto")
-			fmt.Println(out)
+			if err != nil {
+				return fmt.Errorf("error getting yaml from proto: %w", err)
+			}
+			cmd.Println(out)
 		case app.Table:
 			handleListTableOutput(cmd, resp)
 		}

--- a/internal/util/cli/cli.go
+++ b/internal/util/cli/cli.go
@@ -119,3 +119,9 @@ func GRPCClientWrapRunE(
 		return runEFunc(ctx, cmd, c)
 	}
 }
+
+// MessageAndError prints a message and returns an error.
+func MessageAndError(cmd *cobra.Command, msg string, err error) error {
+	Print(cmd.ErrOrStderr(), msg)
+	return err
+}


### PR DESCRIPTION
Explicit is better than implicit.

We already handled the output rendering in the cobra CLI root, which does
the explicit `Execute` function. This was already even done with the
`ExitNicelyOnError` construct. So, instead of handling the logic in several
places, this moves returns the error everywhere.

The caveat is that we would miss the caller's context. That is, we would miss
a message of what was going on when the error happened. To address this,
I introduced a function called `MessageAndError` which allows us
to print a message to the right stream in cobra and then return the error.

Closes: https://github.com/stacklok/minder/issues/1747