### PR TITLE
Always return response from github_rest's Do()

### DIFF
--- a/internal/providers/github/github_rest.go
+++ b/internal/providers/github/github_rest.go
@@ -456,13 +456,14 @@ func (c *RestClient) Do(ctx context.Context, req *http.Request) (*http.Response,
 	// The GitHub client closes the response body, so we need to capture it
 	// in a buffer so that we can return it to the caller
 	resp, err := c.client.Do(ctx, req, &buf)
-	if err != nil {
+	if err != nil && resp == nil {
 		return nil, err
 	}
 
-	resp.Response.Body = io.NopCloser(&buf)
-
-	return resp.Response, nil
+	if resp.Response != nil {
+		resp.Response.Body = io.NopCloser(&buf)
+	}
+	return resp.Response, err
 }
 
 // GetToken returns the token used to authenticate with the GitHub API


### PR DESCRIPTION
The Do method in our github_rest wrapper behaved a bit differently from
the go-github method it was wrapping - instead of always returning the
result so that the caller might check it, it would always return nil on
error.

This made checking for specific error codes (like 404) awkward
especially if we pass this interface to a library as you'd have to cast
the error to go-github's error codes and then grab the reply from there
anyway.

Passing the body always would enable us to use this interface (or a
variant of it) in frizbee instead of directly passing in the go-github
instance.
