### PR TITLE
Replace cli utilities print functions for cobra's

### DIFF
--- a/cmd/cli/app/artifact/artifact_get.go
+++ b/cmd/cli/app/artifact/artifact_get.go
@@ -60,7 +60,7 @@ var artifact_getCmd = &cobra.Command{
 		if err != nil {
 			return cli.MessageAndError(cmd, "Error getting json from proto", err)
 		}
-		cli.Print(cmd.OutOrStdout(), out)
+		cmd.Println(out)
 		return nil
 	}),
 }

--- a/cmd/cli/app/artifact/artifact_list.go
+++ b/cmd/cli/app/artifact/artifact_list.go
@@ -88,13 +88,13 @@ var artifact_listCmd = &cobra.Command{
 			if err != nil {
 				return cli.MessageAndError(cmd, "Error getting json from proto", err)
 			}
-			cli.PrintCmd(cmd, out)
+			cmd.Println(out)
 		case "yaml":
 			out, err := util.GetYamlFromProto(artifacts)
 			if err != nil {
 				return cli.MessageAndError(cmd, "Error getting yaml from proto", err)
 			}
-			cli.PrintCmd(cmd, out)
+			cmd.Println(out)
 		}
 
 		return nil

--- a/cmd/cli/app/auth/auth_delete.go
+++ b/cmd/cli/app/auth/auth_delete.go
@@ -72,9 +72,9 @@ var auth_deleteCmd = &cobra.Command{
 		// directly related to user deletion because the token will expire after 5 minutes and cannot be refreshed
 		err = util.RemoveCredentials()
 		if err != nil {
-			cli.PrintCmd(cmd, cli.WarningBanner.Render("Failed to remove locally stored credentials."))
+			cmd.Println(cli.WarningBanner.Render("Failed to remove locally stored credentials."))
 		}
-		cli.PrintCmd(cmd, cli.SuccessBanner.Render("Successfully deleted account. It may take up to 48 hours for "+
+		cmd.Println(cli.SuccessBanner.Render("Successfully deleted account. It may take up to 48 hours for " +
 			"all data to be removed."))
 
 		return nil

--- a/cmd/cli/app/auth/auth_logout.go
+++ b/cmd/cli/app/auth/auth_logout.go
@@ -51,8 +51,8 @@ var auth_logoutCmd = &cobra.Command{
 		}
 
 		logoutUrl := parsedURL.JoinPath("realms/stacklok/protocol/openid-connect/logout")
-		cli.PrintCmd(cmd, cli.SuccessBanner.Render("You have successfully logged out of the CLI."))
-		cli.PrintCmd(cmd, "If you would like to log out of the browser, you can visit %s", logoutUrl.String())
+		cmd.Println(cli.SuccessBanner.Render("You have successfully logged out of the CLI."))
+		cmd.Printf("If you would like to log out of the browser, you can visit %s\n", logoutUrl.String())
 		return nil
 	},
 }

--- a/cmd/cli/app/auth/auth_test.go
+++ b/cmd/cli/app/auth/auth_test.go
@@ -16,7 +16,6 @@
 package auth
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/spf13/viper"
@@ -51,7 +50,6 @@ func TestCobraMain(t *testing.T) {
 			viper.AddConfigPath("../../../..")
 			viper.SetConfigType("yaml")
 			viper.AutomaticEnv()
-			fmt.Println(viper.GetViper().ConfigFileUsed())
 
 			tw := &util.TestWriter{}
 			app.RootCmd.SetOut(tw) // stub to capture eventual output

--- a/cmd/cli/app/auth/auth_whoami.go
+++ b/cmd/cli/app/auth/auth_whoami.go
@@ -39,7 +39,7 @@ var authWhoamiCmd = &cobra.Command{
 			return cli.MessageAndError(cmd, "Error getting information for user", err)
 		}
 
-		cli.PrintCmd(cmd, cli.Header.Render("Here are your details:"))
+		cmd.Println(cli.Header.Render("Here are your details:"))
 		renderUserInfoWhoami(cmd, conn, userInfo)
 		return nil
 	}),

--- a/cmd/cli/app/profile/profile_delete.go
+++ b/cmd/cli/app/profile/profile_delete.go
@@ -17,7 +17,6 @@ package profile
 
 import (
 	"context"
-	"fmt"
 	"os"
 
 	"github.com/spf13/cobra"
@@ -61,7 +60,7 @@ func init() {
 	profile_deleteCmd.Flags().StringP("id", "i", "", "ID of profile to delete")
 	profile_deleteCmd.Flags().StringP("provider", "p", "github", "Provider for the profile")
 	if err := profile_deleteCmd.MarkFlagRequired("id"); err != nil {
-		fmt.Printf("Error marking flag as required: %s", err)
+		profile_deleteCmd.Printf("Error marking flag as required: %s", err)
 		os.Exit(1)
 	}
 	// TODO: add a flag for the profile name

--- a/cmd/cli/app/profile/profile_get.go
+++ b/cmd/cli/app/profile/profile_get.go
@@ -64,13 +64,13 @@ minder control plane.`,
 			if err != nil {
 				return cli.MessageAndError(cmd, "Error getting yaml from proto", err)
 			}
-			fmt.Println(out)
+			cmd.Println(out)
 		case app.JSON:
 			out, err := util.GetJsonFromProto(profile)
 			if err != nil {
 				return cli.MessageAndError(cmd, "Error getting json from proto", err)
 			}
-			fmt.Println(out)
+			cmd.Println(out)
 		case app.Table:
 			p := profile.GetProfile()
 			handleGetTableOutput(cmd, p)

--- a/cmd/cli/app/profile/status/profile_status_get.go
+++ b/cmd/cli/app/profile/status/profile_status_get.go
@@ -82,13 +82,13 @@ minder control plane for an specific provider/project or profile id, entity type
 			if err != nil {
 				return cli.MessageAndError(cmd, "Error getting json from proto", err)
 			}
-			cli.PrintCmd(cmd, out)
+			cmd.Println(out)
 		case app.YAML:
 			out, err := util.GetYamlFromProto(resp)
 			if err != nil {
 				return cli.MessageAndError(cmd, "Error getting yaml from proto", err)
 			}
-			cli.PrintCmd(cmd, out)
+			cmd.Println(out)
 		case app.Table:
 			handleProfileStatusListTable(cmd, resp)
 		}
@@ -109,11 +109,11 @@ func init() {
 
 	// mark as required
 	if err := profilestatus_getCmd.MarkFlagRequired("profile"); err != nil {
-		fmt.Printf("Error marking flag as required: %s", err)
+		profilestatus_getCmd.Printf("Error marking flag as required: %s", err)
 		os.Exit(1)
 	}
 	if err := profilestatus_getCmd.MarkFlagRequired("entity"); err != nil {
-		fmt.Printf("Error marking flag as required: %s", err)
+		profilestatus_getCmd.Printf("Error marking flag as required: %s", err)
 		os.Exit(1)
 	}
 }

--- a/cmd/cli/app/profile/status/profile_status_list.go
+++ b/cmd/cli/app/profile/status/profile_status_list.go
@@ -79,13 +79,13 @@ minder control plane for an specific provider/project or profile id.`,
 			if err != nil {
 				return cli.MessageAndError(cmd, "Error getting json from proto", err)
 			}
-			cli.PrintCmd(cmd, out)
+			cmd.Println(out)
 		case app.YAML:
 			out, err := util.GetYamlFromProto(resp)
 			if err != nil {
 				return cli.MessageAndError(cmd, "Error getting yaml from proto", err)
 			}
-			cli.PrintCmd(cmd, out)
+			cmd.Println(out)
 		case app.Table:
 			handleProfileStatusListTable(cmd, resp)
 

--- a/cmd/cli/app/quickstart/quickstart.go
+++ b/cmd/cli/app/quickstart/quickstart.go
@@ -287,11 +287,11 @@ var cmd = &cobra.Command{
 		}
 
 		// Finish - Confirm profile creation
-		cli.PrintCmd(cmd, cli.WarningBanner.Render(stepPromptMsgFinish))
+		cmd.Println(cli.WarningBanner.Render(stepPromptMsgFinish))
 
 		// Print the "profile already exists" message, if needed
 		if alreadyExists != "" {
-			cli.PrintCmd(cmd, cli.WarningBanner.Render(alreadyExists))
+			cmd.Println(cli.WarningBanner.Render(alreadyExists))
 		} else {
 			// Print the profile create result table
 			cmd.Println("Profile details (minder profile list -p github):")

--- a/cmd/cli/app/repo/repo_get.go
+++ b/cmd/cli/app/repo/repo_get.go
@@ -105,13 +105,13 @@ var repo_getCmd = &cobra.Command{
 				if err != nil {
 					return cli.MessageAndError(cmd, "Error getting json from proto", err)
 				}
-				cli.PrintCmd(cmd, out)
+				cmd.Println(out)
 			} else {
 				out, err := util.GetYamlFromProto(repository)
 				if err != nil {
 					return cli.MessageAndError(cmd, "Error getting yaml from proto", err)
 				}
-				cli.PrintCmd(cmd, out)
+				cmd.Println(out)
 			}
 		}
 		return nil

--- a/cmd/cli/app/repo/repo_list.go
+++ b/cmd/cli/app/repo/repo_list.go
@@ -89,19 +89,19 @@ var repo_listCmd = &cobra.Command{
 				table.WithStyles(cli.TableHiddenSelectStyles),
 			)
 
-			cli.PrintCmd(cmd, cli.TableRender(t))
+			cmd.Println(cli.TableRender(t))
 		case "json":
 			out, err := util.GetJsonFromProto(resp)
 			if err != nil {
 				return cli.MessageAndError(cmd, "Error getting json from proto", err)
 			}
-			cli.PrintCmd(cmd, out)
+			cmd.Println(out)
 		case "yaml":
 			out, err := util.GetYamlFromProto(resp)
 			if err != nil {
 				return cli.MessageAndError(cmd, "Error getting yaml from proto", err)
 			}
-			cli.PrintCmd(cmd, out)
+			cmd.Println(out)
 		}
 		return nil
 	}),

--- a/cmd/cli/app/repo/repo_register.go
+++ b/cmd/cli/app/repo/repo_register.go
@@ -191,7 +191,7 @@ func RegisterCmd(ctx context.Context, cmd *cobra.Command, conn *grpc.ClientConn)
 		}
 	}
 
-	cli.PrintCmd(cmd, "Found %d remote repositories: %d registered and %d unregistered.\n",
+	cmd.Printf("Found %d remote repositories: %d registered and %d unregistered.\n",
 		len(remoteListResp.Results), len(listResp.Results), len(unregisteredRepos))
 
 	// Get the selected repos
@@ -257,6 +257,6 @@ func RegisterCmd(ctx context.Context, cmd *cobra.Command, conn *grpc.ClientConn)
 		table.WithStyles(cli.TableHiddenSelectStyles),
 	)
 
-	cli.PrintCmd(cmd, cli.TableRender(t))
+	cmd.Println(cli.TableRender(t))
 	return registeredRepos, "", nil
 }

--- a/cmd/cli/app/root.go
+++ b/cmd/cli/app/root.go
@@ -50,6 +50,8 @@ const Table = "table"
 
 // Execute adds all child commands to the root command and sets flags appropriately.
 func Execute() {
+	RootCmd.SetOut(os.Stdout)
+	RootCmd.SetErr(os.Stderr)
 	err := RootCmd.Execute()
 	util.ExitNicelyOnError(err, "")
 }

--- a/cmd/cli/app/ruletype/ruletype_get.go
+++ b/cmd/cli/app/ruletype/ruletype_get.go
@@ -69,13 +69,13 @@ minder control plane.`,
 			if err != nil {
 				return fmt.Errorf("error getting yaml from proto: %w", err)
 			}
-			cli.PrintCmd(cmd, out)
+			cmd.Println(out)
 		case app.JSON:
 			out, err := util.GetJsonFromProto(rtype)
 			if err != nil {
 				return fmt.Errorf("error getting json from proto: %w", err)
 			}
-			cli.PrintCmd(cmd, out)
+			cmd.Println(out)
 		case app.Table:
 			handleGetTableOutput(cmd, rtype.GetRuleType())
 		}

--- a/cmd/cli/app/version/version.go
+++ b/cmd/cli/app/version/version.go
@@ -21,7 +21,6 @@ import (
 
 	"github.com/stacklok/minder/cmd/cli/app"
 	"github.com/stacklok/minder/internal/constants"
-	"github.com/stacklok/minder/internal/util/cli"
 	"github.com/stacklok/minder/internal/util/cli/useragent"
 )
 
@@ -31,8 +30,8 @@ var VersionCmd = &cobra.Command{
 	Short: "Print the version of the minder CLI",
 	Long:  `The minder version command prints the version of the minder CLI.`,
 	Run: func(cmd *cobra.Command, _ []string) {
-		cli.PrintCmd(cmd, constants.VerboseCLIVersion)
-		cli.PrintCmd(cmd, "User Agent: %s", useragent.GetUserAgent())
+		cmd.Println(constants.VerboseCLIVersion)
+		cmd.Printf("User Agent: %s\n", useragent.GetUserAgent())
 	},
 }
 

--- a/cmd/dev/app/root.go
+++ b/cmd/dev/app/root.go
@@ -18,6 +18,7 @@ package app
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -40,6 +41,8 @@ https://docs.stacklok.com/minder`,
 
 // Execute adds all child commands to the root command and sets flags appropriately.
 func Execute() {
+	RootCmd.SetOut(os.Stdout)
+	RootCmd.SetErr(os.Stderr)
 	err := RootCmd.Execute()
 	util.ExitNicelyOnError(err, "Error on execute")
 }

--- a/cmd/server/app/migrate_down.go
+++ b/cmd/server/app/migrate_down.go
@@ -51,10 +51,10 @@ var downCmd = &cobra.Command{
 
 		yes, err := cmd.Flags().GetBool("yes")
 		if err != nil {
-			fmt.Printf("Error getting flag yes: %v", err)
+			cmd.Printf("Error getting flag yes: %v", err)
 		}
 		if !yes {
-			fmt.Print("WARNING: Running this command will change the database structure. Are you want to continue? (y/n): ")
+			cmd.Print("WARNING: Running this command will change the database structure. Are you want to continue? (y/n): ")
 			var response string
 			_, err := fmt.Scanln(&response)
 			if err != nil {
@@ -62,7 +62,7 @@ var downCmd = &cobra.Command{
 			}
 
 			if response == "n" {
-				fmt.Println("Exiting...")
+				cmd.Println("Exiting...")
 				return nil
 			}
 		}
@@ -70,14 +70,14 @@ var downCmd = &cobra.Command{
 		configPath := getMigrateConfigPath()
 		m, err := migrate.New(configPath, connString)
 		if err != nil {
-			fmt.Printf("Error while creating migration instance (%s): %v\n", configPath, err)
+			cmd.Printf("Error while creating migration instance (%s): %v\n", configPath, err)
 			os.Exit(1)
 		}
 
 		var usteps uint
 		usteps, err = cmd.Flags().GetUint("num-steps")
 		if err != nil {
-			fmt.Printf("Error while getting num-steps flag: %v", err)
+			cmd.Printf("Error while getting num-steps flag: %v", err)
 		}
 
 		if usteps == 0 {
@@ -87,11 +87,11 @@ var downCmd = &cobra.Command{
 		}
 
 		if err != nil {
-			fmt.Printf("Error while migrating database: %v\n", err)
+			cmd.Printf("Error while migrating database: %v\n", err)
 			os.Exit(1)
 		}
 
-		fmt.Println("Database migration down done with success")
+		cmd.Println("Database migration down done with success")
 		return nil
 	},
 }

--- a/cmd/server/app/migrate_up.go
+++ b/cmd/server/app/migrate_up.go
@@ -54,10 +54,10 @@ var upCmd = &cobra.Command{
 
 		yes, err := cmd.Flags().GetBool("yes")
 		if err != nil {
-			fmt.Printf("Error while getting yes flag: %v", err)
+			cmd.Printf("Error while getting yes flag: %v", err)
 		}
 		if !yes {
-			fmt.Print("WARNING: Running this command will change the database structure. Are you want to continue? (y/n): ")
+			cmd.Print("WARNING: Running this command will change the database structure. Are you want to continue? (y/n): ")
 			var response string
 			_, err := fmt.Scanln(&response)
 			if err != nil {
@@ -65,7 +65,7 @@ var upCmd = &cobra.Command{
 			}
 
 			if response == "n" {
-				fmt.Printf("Exiting...")
+				cmd.Printf("Exiting...")
 				return nil
 			}
 		}
@@ -73,14 +73,14 @@ var upCmd = &cobra.Command{
 		configPath := getMigrateConfigPath()
 		m, err := migrate.New(configPath, connString)
 		if err != nil {
-			fmt.Printf("Error while creating migration instance (%s): %v\n", configPath, err)
+			cmd.Printf("Error while creating migration instance (%s): %v\n", configPath, err)
 			os.Exit(1)
 		}
 
 		var usteps uint
 		usteps, err = cmd.Flags().GetUint("num-steps")
 		if err != nil {
-			fmt.Printf("Error while getting num-steps flag: %v", err)
+			cmd.Printf("Error while getting num-steps flag: %v", err)
 		}
 
 		if usteps == 0 {
@@ -91,14 +91,14 @@ var upCmd = &cobra.Command{
 
 		if err != nil {
 			if !errors.Is(err, migrate.ErrNoChange) {
-				fmt.Printf("Error while migrating database: %v\n", err)
+				cmd.Printf("Error while migrating database: %v\n", err)
 				os.Exit(1)
 			} else {
-				fmt.Println("Database already up-to-date")
+				cmd.Println("Database already up-to-date")
 			}
 		}
 
-		fmt.Println("Database migration completed successfully")
+		cmd.Println("Database migration completed successfully")
 		return nil
 	},
 }

--- a/cmd/server/app/migrate_version.go
+++ b/cmd/server/app/migrate_version.go
@@ -54,17 +54,17 @@ var versionCmd = &cobra.Command{
 		configPath := getMigrateConfigPath()
 		m, err := migrate.New(configPath, connString)
 		if err != nil {
-			fmt.Printf("Error while creating migration instance (%s): %v\n", configPath, err)
+			cmd.Printf("Error while creating migration instance (%s): %v\n", configPath, err)
 			os.Exit(1)
 		}
 
 		version, dirty, err := m.Version()
 		if err != nil {
-			fmt.Printf("Error while getting migration version: %v\n", err)
+			cmd.Printf("Error while getting migration version: %v\n", err)
 			os.Exit(1)
 		}
 
-		fmt.Printf("Version=%v dirty=%v\n", version, dirty)
+		cmd.Printf("Version=%v dirty=%v\n", version, dirty)
 		return nil
 	},
 }

--- a/cmd/server/app/root.go
+++ b/cmd/server/app/root.go
@@ -19,6 +19,7 @@ package app
 import (
 	"fmt"
 	"log"
+	"os"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -41,6 +42,8 @@ var (
 // Execute adds all child commands to the root command and sets flags appropriately.
 // This is called by main.main(). It only needs to happen once to the rootCmd.
 func Execute() {
+	RootCmd.SetOut(os.Stdout)
+	RootCmd.SetErr(os.Stderr)
 	err := RootCmd.Execute()
 	util.ExitNicelyOnError(err, "Error executing root command")
 }

--- a/internal/util/cli/cli.go
+++ b/internal/util/cli/cli.go
@@ -25,7 +25,6 @@ package cli
 import (
 	"context"
 	"fmt"
-	"io"
 	"time"
 
 	"github.com/erikgeiser/promptkit/confirmation"
@@ -38,20 +37,10 @@ import (
 	"github.com/stacklok/minder/internal/util/cli/useragent"
 )
 
-// PrintCmd prints a message using the output defined in the cobra Command
-func PrintCmd(cmd *cobra.Command, msg string, args ...interface{}) {
-	Print(cmd.OutOrStdout(), msg, args...)
-}
-
-// Print prints a message using the given io.Writer
-func Print(out io.Writer, msg string, args ...interface{}) {
-	fmt.Fprintf(out, msg+"\n", args...)
-}
-
 // PrintYesNoPrompt prints a yes/no prompt to the user and returns false if the user did not respond with yes or y
 func PrintYesNoPrompt(cmd *cobra.Command, promptMsg, confirmMsg, fallbackMsg string, defaultYes bool) bool {
 	// Print the warning banner with the prompt message
-	PrintCmd(cmd, WarningBanner.Render(promptMsg))
+	cmd.Println(WarningBanner.Render(promptMsg))
 
 	// Determine the default confirmation value
 	defConf := confirmation.No
@@ -63,13 +52,13 @@ func PrintYesNoPrompt(cmd *cobra.Command, promptMsg, confirmMsg, fallbackMsg str
 	input := confirmation.New(confirmMsg, defConf)
 	ok, err := input.RunPrompt()
 	if err != nil {
-		PrintCmd(cmd, WarningBanner.Render(fmt.Sprintf("Error reading input: %v", err)))
+		cmd.Println(WarningBanner.Render(fmt.Sprintf("Error reading input: %v", err)))
 		ok = false
 	}
 
 	// If the user did not confirm, print the fallback message
 	if !ok {
-		PrintCmd(cmd, Header.Render(fallbackMsg))
+		cmd.Println(Header.Render(fallbackMsg))
 	}
 	return ok
 }
@@ -122,6 +111,6 @@ func GRPCClientWrapRunE(
 
 // MessageAndError prints a message and returns an error.
 func MessageAndError(cmd *cobra.Command, msg string, err error) error {
-	Print(cmd.ErrOrStderr(), msg)
+	cmd.PrintErrln(msg)
 	return err
 }


### PR DESCRIPTION
cobra already had printing utilities, this replaces our home-cooked ones
for those. This also replaces the `fmt.Print*` usages for the aforementioned
functions.
