### PR TITLE
Re-enable proto compatibility checks

### DIFF
--- a/.github/workflows/generation.yml
+++ b/.github/workflows/generation.yml
@@ -34,17 +34,16 @@ jobs:
       # Lint your Protobuf sources
       - uses: bufbuild/buf-lint-action@v1
 
-  # TODO(jaosorior): Re-enable this once we have a stable API.
-  # proto-breaking-changes:
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - uses: actions/checkout@v4
-  #     - uses: bufbuild/buf-setup-action@v1
-  #       with:
-  #         github_token: ${{ secrets.GITHUB_TOKEN }}
-  #     - uses: bufbuild/buf-breaking-action@v1
-  #       with:
-  #         against: "https://github.com/stacklok/minder.git#branch=main"
+  proto-breaking-changes:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: bufbuild/buf-setup-action@v1
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+      - uses: bufbuild/buf-breaking-action@v1
+        with:
+          against: "https://github.com/stacklok/minder.git#branch=main"
 
   sqlc-generation:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This should have caught the error I made in #1831 declaring the removal of the `Context` message safe.  Let's rely on the automation, instead.
