### PR TITLE
Create context between steps in quickstart

### DIFF
--- a/cmd/cli/app/quickstart/quickstart.go
+++ b/cmd/cli/app/quickstart/quickstart.go
@@ -159,7 +159,10 @@ var cmd = &cobra.Command{
 			return err
 		}
 
-		// Step 2 - Confirm repository registration
+		// Step 2 - Confirm repository registration (new context, so we don't time out)
+		ctx, cancel := getQuickstartContext(cmd.Context(), viper.GetViper())
+		defer cancel()
+
 		yes = cli.PrintYesNoPrompt(cmd,
 			stepPromptMsgRegister,
 			"Proceed?",
@@ -217,7 +220,7 @@ var cmd = &cobra.Command{
 		}
 
 		// Create the rule type in minder (new context, so we don't time out)
-		ctx, cancel := cli.GetAppContext(cmd.Context(), viper.GetViper())
+		ctx, cancel = getQuickstartContext(cmd.Context(), viper.GetViper())
 		defer cancel()
 
 		_, err = client.CreateRuleType(ctx, &minderv1.CreateRuleTypeRequest{
@@ -267,7 +270,7 @@ var cmd = &cobra.Command{
 		}
 
 		// Create the profile in minder (new context, so we don't time out)
-		ctx, cancel = cli.GetAppContext(cmd.Context(), viper.GetViper())
+		ctx, cancel = getQuickstartContext(cmd.Context(), viper.GetViper())
 		defer cancel()
 
 		alreadyExists := ""
@@ -309,4 +312,8 @@ func init() {
 	cmd.Flags().StringP("provider", "p", "github", "Name of the provider")
 	cmd.Flags().StringP("token", "t", "", "Personal Access Token (PAT) to use for enrollment")
 	cmd.Flags().StringP("owner", "o", "", "Owner to filter on for provider resources")
+}
+
+func getQuickstartContext(ctx context.Context, v *viper.Viper) (context.Context, context.CancelFunc) {
+	return cli.GetAppContextWithTimeoutDuration(ctx, v, 20)
 }

--- a/internal/util/cli/cli.go
+++ b/internal/util/cli/cli.go
@@ -79,7 +79,12 @@ func GrpcForCommand(cmd *cobra.Command, v *viper.Viper) (*grpc.ClientConn, error
 
 // GetAppContext is a helper for getting the cmd app context
 func GetAppContext(ctx context.Context, v *viper.Viper) (context.Context, context.CancelFunc) {
-	v.SetDefault("cli.context_timeout", 10)
+	return GetAppContextWithTimeoutDuration(ctx, v, 10)
+}
+
+// GetAppContextWithTimeoutDuration is a helper for getting the cmd app context with a custom timeout
+func GetAppContextWithTimeoutDuration(ctx context.Context, v *viper.Viper, tout int) (context.Context, context.CancelFunc) {
+	v.SetDefault("cli.context_timeout", tout)
 	timeout := v.GetInt("cli.context_timeout")
 
 	ctx, cancel := context.WithTimeout(ctx, time.Duration(timeout)*time.Second)


### PR DESCRIPTION
I was using the quickstart command to record a demo and was frequently
hitting deadline exceeded if I wasn't quick enough.

Let's add a context around each step so that the user actually has time
to read the text we present.
