### PR TITLE
Parse GitHub Action exclusion from rule def

### DIFF
--- a/internal/engine/actions/remediate/pull_request/pull_request.go
+++ b/internal/engine/actions/remediate/pull_request/pull_request.go
@@ -183,6 +183,7 @@ func (r *Remediator) Do(
 		prCfg: r.prCfg,
 		ghCli: r.ghCli,
 		bfs:   ingested.Fs,
+		def:   params.GetRule().Def.AsMap(),
 	})
 	if err != nil {
 		return nil, fmt.Errorf("cannot get modification: %w", err)

--- a/internal/engine/actions/remediate/pull_request/types_actions_replace_tags.go
+++ b/internal/engine/actions/remediate/pull_request/types_actions_replace_tags.go
@@ -44,7 +44,9 @@ func newFrizbeeTagResolveModification(
 	params *modificationConstructorParams,
 ) (fsModifier, error) {
 	exclude := []string{}
-	if ex := params.prCfg.GetActionsReplaceTagsWithSha().GetExclude(); ex != nil {
+	if ex := parseExcludeFromDef(params.def); ex != nil {
+		exclude = ex
+	} else if ex := params.prCfg.GetActionsReplaceTagsWithSha().GetExclude(); ex != nil {
 		exclude = ex
 	}
 	return &frizbeeTagResolveModification{
@@ -98,4 +100,32 @@ func (ftr *frizbeeTagResolveModification) modifyFs() ([]*fsEntry, error) {
 		return nil, fmt.Errorf("cannot write entries: %w", err)
 	}
 	return ftr.entries, nil
+}
+
+func parseExcludeFromDef(def map[string]any) []string {
+	if def == nil {
+		return nil
+	}
+
+	exclude, ok := def["exclude"]
+	if !ok {
+		return nil
+	}
+
+	excludeSlice, ok := exclude.([]interface{})
+	if !ok {
+		return nil
+	}
+
+	excludeStrings := []string{}
+	for _, ex := range excludeSlice {
+		excludeStr, ok := ex.(string)
+		if !ok {
+			return nil
+		}
+
+		excludeStrings = append(excludeStrings, excludeStr)
+	}
+
+	return excludeStrings
 }

--- a/internal/engine/actions/remediate/pull_request/types_registry.go
+++ b/internal/engine/actions/remediate/pull_request/types_registry.go
@@ -37,6 +37,7 @@ type modificationConstructorParams struct {
 	prCfg *pb.RuleType_Definition_Remediate_PullRequestRemediation
 	ghCli v1.GitHub
 	bfs   billy.Filesystem
+	def   map[string]any
 }
 
 type modificationConstructor func(*modificationConstructorParams) (fsModifier, error)


### PR DESCRIPTION
In the PR remediation that replaces tags for checksums, we need a way to
pass in an exclusion list from the user input in the profile.

This implements that by parsing an `exclude` key from the `def` section
of the rule.
