### PR TITLE
Add CODEOWNERS to minder

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @stacklok/minder-maintainers


### PR DESCRIPTION
This adds the maintenance team as CODEOWNERS
