### PR TITLE
Remove invalid validation for projects in reconcilers

### DIFF
--- a/internal/reconcilers/artifacts.go
+++ b/internal/reconcilers/artifacts.go
@@ -47,7 +47,7 @@ var (
 // RepoReconcilerEvent is an event that is sent to the reconciler topic
 type RepoReconcilerEvent struct {
 	// Project is the project that the event is relevant to
-	Project uuid.UUID `json:"group" validate:"gte=0"`
+	Project uuid.UUID `json:"project"`
 	// Repository is the repository to be reconciled
 	Repository int32 `json:"repository" validate:"gte=0"`
 }

--- a/internal/reconcilers/run_profile.go
+++ b/internal/reconcilers/run_profile.go
@@ -39,7 +39,7 @@ import (
 // and sending a profile evaluation event for each one.
 type ProfileInitEvent struct {
 	// Project is the project that the event is relevant to
-	Project uuid.UUID `json:"project" validate:"gte=0"`
+	Project uuid.UUID `json:"project"`
 }
 
 // NewProfileInitMessage creates a new repos init event


### PR DESCRIPTION
These were still validating integers while they're not UUIDs. This also
moved one event reference to be `project` instead of `group`.
