### PR TITLE
Log successful event handling in watermill middleware

### DIFF
--- a/internal/events/eventer.go
+++ b/internal/events/eventer.go
@@ -290,6 +290,12 @@ func (e *Eventer) Register(
 				return err
 			}
 
+			e.router.Logger().Info("Handled message", watermill.LogFields{
+				"message_uuid": msg.UUID,
+				"topic":        topic,
+				"handler":      funcName,
+			})
+
 			return nil
 		},
 	)


### PR DESCRIPTION
This re-uses the existing watermill middleware we have in order to log
the events we've successfully processed. We already logged errors anyway.

Closes: https://github.com/stacklok/minder/issues/1923
