### PR TITLE
Default to v1 and profile if profile type or version are not set to fix old clients

### DIFF
--- a/pkg/api/protobuf/go/minder/v1/validators.go
+++ b/pkg/api/protobuf/go/minder/v1/validators.go
@@ -118,13 +118,29 @@ func (def *RuleType_Definition) Validate() error {
 	return nil
 }
 
+func (p *Profile) getTypeWithDefault() string {
+	pt := p.GetType()
+	if pt == "" {
+		return ProfileType
+	}
+	return pt
+}
+
+func (p *Profile) getVersionWithDefault() string {
+	pv := p.GetVersion()
+	if pv == "" {
+		return ProfileTypeVersion
+	}
+	return pv
+}
+
 // Validate validates a pipeline profile
 func (p *Profile) Validate() error {
-	if p.Type != ProfileType {
+	if p.getTypeWithDefault() != ProfileType {
 		return fmt.Errorf("%w: profile type is invalid: %s. Did you parse the wrong file?",
 			ErrValidationFailed, p.Type)
 	}
-	if p.Version != ProfileTypeVersion {
+	if p.getVersionWithDefault() != ProfileTypeVersion {
 		return fmt.Errorf("%w: profile version is invalid: %s", ErrValidationFailed, p.Version)
 	}
 


### PR DESCRIPTION
We added profile type and validation recently which is great, but since
those fields are not set by older clients who didn't have those fields
in their protobuf definitions, those fields would come to the server as
empty and the validation would have failed.

This would impact e.g. an older client running quickstart against a new
server.

We should remove this workaround after a couple of releases when we can
be reasonably sure everyone has migrated to a new client.
