### PR TITLE
Allow tools to depend on targets in the rest of the minder repo

### DIFF
--- a/tools/go.mod
+++ b/tools/go.mod
@@ -287,3 +287,5 @@ require (
 	mvdan.cc/lint v0.0.0-20170908181259-adc824a0674b // indirect
 	mvdan.cc/unparam v0.0.0-20221223090309-7455f1af531d // indirect
 )
+
+replace github.com/stacklok/minder => ../.


### PR DESCRIPTION
Separating out this change from #1790
