### PR TITLE
Pass through error messages from AuthFromMD for debugging

### DIFF
--- a/deployment/helm/Chart.lock
+++ b/deployment/helm/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 2.13.3
-digest: sha256:6fbdc8a525f6f9f98ec4ac5d11b049993f2e5800fd2f44b3abb3b00b74936ee0
-generated: "2023-10-27T10:44:53.947903137+03:00"
+  version: 2.13.4
+digest: sha256:3d041bf804861d1b205322f51bbf39745e1437de236c1fc0e74f6e5031a70e73
+generated: "2023-12-18T13:06:30.589568-08:00"

--- a/internal/controlplane/handlers_authz.go
+++ b/internal/controlplane/handlers_authz.go
@@ -169,6 +169,9 @@ func AuthUnaryInterceptor(ctx context.Context, req interface{}, info *grpc.Unary
 
 	token, err := gauth.AuthFromMD(ctx, "bearer")
 	if err != nil {
+		if statusErr, ok := status.FromError(err); ok {
+			return nil, util.FromRpcError(statusErr)
+		}
 		return nil, status.Errorf(codes.Unauthenticated, "no auth token: %v", err)
 	}
 


### PR DESCRIPTION
See https://github.com/stacklok/minder/discussions/1957 -- requests though the GRPC gateway don't seem to have proper auth (returning `codes.Unauthenticated`, but we're not providing anything more useful in terms of error message to distinguish different cases.

I'd really love it if I'd written tests for `UnaryAuthorizationInterceptor` earlier, but I compounded the technical debt here to get the quick fix in.
