### PR TITLE
Fix "Get Hacking" page service name

### DIFF
--- a/docs/docs/developer_guide/get-hacking.md
+++ b/docs/docs/developer_guide/get-hacking.md
@@ -29,7 +29,7 @@ Note that the application requires a database to be running. This can be achieve
 using docker-compose:
 
 ```bash
-services="postgres keycloak migrateup" make run-docker
+services="postgres keycloak migrate" make run-docker
 ```
 
 Then run the application


### PR DESCRIPTION
The proper service name in 'docker-compose' is 'migrate'.

Ref: https://minder-docs.stacklok.dev/developer_guide/get-hacking#run-the-application