### PR TITLE
Fix alert docs and update key value column width

### DIFF
--- a/docs/docs/understand/alerts.md
+++ b/docs/docs/understand/alerts.md
@@ -43,18 +43,20 @@ def:
 Alerts are configured in the `alert` section of the profile yaml file. The following example shows how to configure
 alerts for a profile:
 
-    ```yaml
-    ---
-    version: v1
-    type: profile
-    name: github-profile
-    context:
-      provider: github
-    alert: "on"
-    repository:
-      - type: secret_scanning
-        def:
-          enabled: true
-    ```
+```yaml
+---
+version: v1
+type: profile
+name: github-profile
+context:
+  provider: github
+alert: "on"
+repository:
+  - type: secret_scanning
+    def:
+      enabled: true
+```
 
-The `alert` section can be configured with the following values: `on`, `off` and `dry_run`. The default value is `on`.
+The `alert` section can be configured with the following values: `on` (default), `off` and `dry_run`. Dry run would be
+useful for testing. In `dry_run` Minder will process the alert conditions and output the resulted REST call, but it
+won't execute it.

--- a/internal/util/cli/table/simple/simple.go
+++ b/internal/util/cli/table/simple/simple.go
@@ -88,12 +88,13 @@ func defaultLayout(table *tablewriter.Table) {
 func keyValueLayout(table *tablewriter.Table) {
 	defaultLayout(table)
 	table.SetHeader([]string{"Key", "Value"})
-	table.SetColMinWidth(0, 25)
+	table.SetColMinWidth(0, 50)
+	table.SetColMinWidth(1, 50)
 }
 
 func profileLayout(table *tablewriter.Table) {
 	defaultLayout(table)
-	table.SetHeader([]string{"Id", "Name", "Provider", "Entity", "Rule", "Rule Params", "Rule Definition"})
+	table.SetHeader([]string{"ID", "Name", "Provider", "Entity", "Rule", "Rule Params", "Rule Definition"})
 	table.SetAutoMergeCellsByColumnIndex([]int{0, 1, 2, 3, 4})
 	// This is needed for the rule definition and rule parameters
 	table.SetAutoWrapText(false)
@@ -101,7 +102,7 @@ func profileLayout(table *tablewriter.Table) {
 
 func profileStatusLayout(table *tablewriter.Table) {
 	defaultLayout(table)
-	table.SetHeader([]string{"Id", "Name", "Overall Status", "Last Updated"})
+	table.SetHeader([]string{"ID", "Name", "Overall Status", "Last Updated"})
 	table.SetReflowDuringAutoWrap(true)
 }
 
@@ -121,7 +122,7 @@ func repoListLayout(table *tablewriter.Table) {
 
 func ruleTypeLayout(table *tablewriter.Table) {
 	defaultLayout(table)
-	table.SetHeader([]string{"Provider", "Project Name", "Id", "Name", "Description"})
+	table.SetHeader([]string{"Provider", "Project Name", "ID", "Name", "Description"})
 	table.SetAutoMergeCellsByColumnIndex([]int{0, 1, 2, 3})
 	// This is needed for the rule definition and rule parameters
 	table.SetAutoWrapText(false)


### PR DESCRIPTION
Details:
1. Changes the width for the key value columns to 50
2. Noticed the alert documentation had a code snippet that was not rendering properly
3. Noticed the ID headers were inconsistent  