### PR TITLE
Fix pull_request remediation from branch

### DIFF
--- a/internal/engine/actions/remediate/pull_request/pull_request.go
+++ b/internal/engine/actions/remediate/pull_request/pull_request.go
@@ -479,7 +479,7 @@ func prFromBranchAlreadyExists(
 ) (bool, error) {
 	// TODO(jakub): pagination
 	opts := &github.PullRequestListOptions{
-		Head: branchName,
+		Head: fmt.Sprintf("%s:%s", repo.GetOwner(), branchName),
 	}
 
 	openPrs, err := cli.ListPullRequests(ctx, repo.GetOwner(), repo.GetName(), opts)


### PR DESCRIPTION
Turns out that the `Head` parameter of the `PullRequestListOptions`
structure doesn't just take the branch name but `owner:branch`.

The tricky thing is that if you just use the branch name, then the list
operation would just return all the currently open PRs. I think this might be
a bug in the GH API, but what do I know. 

This bug would manifest as minder pushing some code into a branch, but then
not opening a PR if any other PR was opened against an enrolled repository.

I didn't notice this in my initial testing beacuse I would either have 0
PRs or just 1 with the tag-to-sha patch.

To try this, you can use a curl request against one of my test repos:
```
curl -L -v \
  -H "Accept: application/vnd.github+json" \
  -H "Authorization: Bearer $TOKEN" \
  -H "X-GitHub-Api-Version: 2022-11-28" \
  https://api.github.com/repos/jakubtestorg/bad-python/pulls\?head\=minder_add_dependabot_configuration_for_pip
```
This is what the code used to do earlier and returns all PRs.

Compare to:
```
curl -L -v \
  -H "Accept: application/vnd.github+json" \
  -H "Authorization: Bearer $TOKEN" \
  -H "X-GitHub-Api-Version: 2022-11-28" \
  https://api.github.com/repos/jakubtestorg/bad-python/pulls\?head\=jakubtestorg:minder_add_dependabot_configuration_for_pip
```

which just returns 0 or 1.

Sorry about the inconvenience.
