### PR TITLE
Replace unpinned actions with pinned action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,10 +5,10 @@ jobs:
     name: Verify build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4 # v3.5.0
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
       - name: Extract version of Go to use
         run: echo "GOVERSION=$(sed -n 's/^go \([0-9.]*\)/\1/p' go.mod)" >> $GITHUB_ENV
-      - uses: actions/setup-go@v5 # v4.0.0
+      - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5
         with:
           go-version-file: 'go.mod'
       - name: build

--- a/.github/workflows/chart-publish.yml
+++ b/.github/workflows/chart-publish.yml
@@ -6,67 +6,54 @@ name: Publish Helm Chart
 on:
   push:
     branches:
-    -  main
-
+      - main
   schedule:
     # Weekdays at noon GMT
     - cron: '00 12 * * 1-5'
-
 jobs:
   check-helm:
     name: Build Helm chart
     runs-on: ubuntu-latest
-
     permissions:
       contents: read
       packages: write
       id-token: write # To sign the provenance.
-
     env:
       BASE_REPO: "ghcr.io/stacklok/minder"
-
-
     steps:
       - name: Install Cosign
-        uses: sigstore/cosign-installer@v3.3.0
+        uses: sigstore/cosign-installer@9614fae9e5c5eddabb09f90a270fcb487c9f7149 # v3.3.0
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5
         with:
           go-version-file: 'go.mod'
-
-      - uses: ko-build/setup-ko@v0.6
-
-      - uses: azure/setup-helm@v3
+      - uses: ko-build/setup-ko@ace48d793556083a76f1e3e6068850c1f4a369aa # v0.6
+      - uses: azure/setup-helm@5119fcb9089d432beecbf79bb2c7915207344b78 # v3
         with:
           version: v3.12.2
-
       - name: Compute version number
         id: version-string
         run: |
           DATE="$(date +%Y%m%d)"
           COMMIT="$(git rev-parse --short HEAD)"
           echo "tag=0.$DATE.$GITHUB_RUN_NUMBER+ref.$COMMIT" >> "$GITHUB_OUTPUT"
-
       - name: Build images and Helm Chart
         run: |
           KO_DOCKER_REPO=$BASE_REPO make helm
         env:
           KO_PUSH_IMAGE: "true"
           HELM_PACKAGE_VERSION: "${{ steps.version-string.outputs.tag }}"
-
       - name: Helm Login
         # ko can pick up tokens ambiently from the GitHub Actions environment, but
         # Helm needs explicit login
         run: |
           helm registry login $BASE_REPO --username ${{ github.repository_owner }} --password ${{ secrets.GITHUB_TOKEN }}
-
       - name: Push Helm Chart
         run: |
           cd deployment/helm
           helm push minder-*.tgz oci://$BASE_REPO/helm
-
       - name: Sign the published helm chart and ko image
         # This step uses the identity token to provision an ephemeral certificate
         # against the sigstore community Fulcio instance.

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -10,15 +10,13 @@
 # supported CodeQL languages.
 #
 name: "CodeQL"
-
 on:
   push:
-    branches: [ "main" ]
+    branches: ["main"]
   pull_request:
-    branches: [ "main" ]
+    branches: ["main"]
   schedule:
     - cron: '22 15 * * 1'
-
 jobs:
   analyze:
     name: Analyze
@@ -33,54 +31,46 @@ jobs:
       actions: read
       contents: read
       security-events: write
-
     strategy:
       fail-fast: false
       matrix:
-        language: [ 'go' ]
+        language: ['go']
         # CodeQL supports [ 'c-cpp', 'csharp', 'go', 'java-kotlin', 'javascript-typescript', 'python', 'ruby', 'swift' ]
         # Use only 'java-kotlin' to analyze code written in Java, Kotlin or both
         # Use only 'javascript-typescript' to analyze code written in JavaScript, TypeScript or both
         # Learn more about CodeQL language support at https://aka.ms/codeql-docs/language-support
-
     steps:
-    - name: Checkout repository
-      uses: actions/checkout@v4
-
-    - name: Setup Go
-      uses: actions/setup-go@v5
-      with:
-        go-version-file: ./go.mod
-
-    # Initializes the CodeQL tools for scanning.
-    - name: Initialize CodeQL
-      uses: github/codeql-action/init@v3
-      with:
-        languages: ${{ matrix.language }}
-        # If you wish to specify custom queries, you can do so here or in a config file.
-        # By default, queries listed here will override any specified in a config file.
-        # Prefix the list here with "+" to use these queries and those in the config file.
-
+      - name: Checkout repository
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
+      - name: Setup Go
+        uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5
+        with:
+          go-version-file: ./go.mod
+      # Initializes the CodeQL tools for scanning.
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@1743d02c67be5a24134dacfe540706cbe6652208 # v3
+        with:
+          languages: ${{ matrix.language }}
+          # If you wish to specify custom queries, you can do so here or in a config file.
+          # By default, queries listed here will override any specified in a config file.
+          # Prefix the list here with "+" to use these queries and those in the config file.
+      # Autobuild attempts to build any compiled languages (C/C++, C#, Go, Java, or Swift).
+      # If this step fails, then you should remove it and run the build manually (see below)
+      - name: Autobuild
         # For more details on CodeQL's query packs, refer to: https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs
         # queries: security-extended,security-and-quality
 
+        uses: github/codeql-action/autobuild@1743d02c67be5a24134dacfe540706cbe6652208 # v3
+      # ℹ️ Command-line programs to run using the OS shell.
+      # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
 
-    # Autobuild attempts to build any compiled languages (C/C++, C#, Go, Java, or Swift).
-    # If this step fails, then you should remove it and run the build manually (see below)
-    - name: Autobuild
-      uses: github/codeql-action/autobuild@v3
+      #   If the Autobuild fails above, remove it and uncomment the following three lines.
+      #   modify them (or add more) to build your code if your project, please refer to the EXAMPLE below for guidance.
 
-    # ℹ️ Command-line programs to run using the OS shell.
-    # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
-
-    #   If the Autobuild fails above, remove it and uncomment the following three lines.
-    #   modify them (or add more) to build your code if your project, please refer to the EXAMPLE below for guidance.
-
-    # - run: |
-    #     echo "Run, Build Application using script"
-    #     ./location_of_script_within_repo/buildscript.sh
-
-    - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v3
-      with:
-        category: "/language:${{matrix.language}}"
+      # - run: |
+      #     echo "Run, Build Application using script"
+      #     ./location_of_script_within_repo/buildscript.sh
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@1743d02c67be5a24134dacfe540706cbe6652208 # v3
+        with:
+          category: "/language:${{matrix.language}}"

--- a/.github/workflows/compose-migrate.yml
+++ b/.github/workflows/compose-migrate.yml
@@ -1,46 +1,30 @@
 # This test verifies that the docker-compose.yml file is valid and that the
 # containers can be started and stopped. It also verifies the database migrations.
 name: Compose Migrate test
-
 on:
   workflow_call:
-
 jobs:
   docker:
     timeout-minutes: 10
     runs-on: ubuntu-latest
-
     steps:
-    - name: Checkout
-      uses: actions/checkout@v4
+      - name: Checkout
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
+      - name: Setup Go
+        uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5
+        with:
+          go-version-file: 'go.mod'
+      - name: Install ko
+        uses: ko-build/setup-ko@ace48d793556083a76f1e3e6068850c1f4a369aa # v0.6
+      - name: Start containers
+        run: KO_DOCKER_REPO=ko.local make run-docker services="postgres migrate"
+      - name: Wait for the migrations to complete
+        timeout-minutes: 1
+        run: |
+          set -e
 
-    - name: Setup Go
-      uses: actions/setup-go@v5
-      with:
-        go-version-file: 'go.mod'
-
-    - name: Install ko
-      uses: ko-build/setup-ko@v0.6
-
-    - name: Start containers
-      run: KO_DOCKER_REPO=ko.local make run-docker services="postgres migrate"
-    
-    - name: Wait for the migrations to complete
-      timeout-minutes: 1
-      run: |
-        set -e
-
-        while [ "$(docker logs minder_migrate_1 | grep 'Database migration completed successfully')" = "" ]; do
-          sleep 1
-        done
-        
-    
-    - name: Check that the database contains the tables found in the migrations folder
-      run: |
-        set -e
-
-        tables=$(grep -Ri 'CREATE TABLE' database/migrations | sed -E 's/.*CREATE TABLE (IF NOT EXISTS )?(.*) \(/\2/i')
-        for table in $tables; do
-          docker exec $(docker ps -a | grep postgres | awk '{print $1}') psql -U postgres -d minder -c "SELECT * FROM $table"
-        done 
-
+          while [ "$(docker logs minder_migrate_1 | grep 'Database migration completed successfully')" = "" ]; do
+            sleep 1
+          done
+      - name: Check that the database contains the tables found in the migrations folder
+        run: "set -e\n\ntables=$(grep -Ri 'CREATE TABLE' database/migrations | sed -E 's/.*CREATE TABLE (IF NOT EXISTS )?(.*) \\(/\\2/i')\nfor table in $tables; do\n  docker exec $(docker ps -a | grep postgres | awk '{print $1}') psql -U postgres -d minder -c \"SELECT * FROM $table\"\ndone \n"

--- a/.github/workflows/deploy-doc.yml
+++ b/.github/workflows/deploy-doc.yml
@@ -1,13 +1,10 @@
 name: Deploy docs to GitHub Pages
-
 on:
   workflow_dispatch:
   release:
     types: [created]
-
 permissions:
   contents: write
-
 jobs:
   deploy:
     name: Deploy to GitHub Pages
@@ -16,20 +13,18 @@ jobs:
       run:
         working-directory: docs
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
+      - uses: actions/setup-node@b39b52d1213e96004bfcb1c61a8a6fa8ab84f3e8 # v4
         with:
           node-version: 18
-
       - name: Install dependencies
         run: yarn install --frozen-lockfile
       - name: Build website
         run: yarn build
-
       # Popular action to deploy to GitHub Pages:
       # Docs: https://github.com/peaceiris/actions-gh-pages#%EF%B8%8F-docusaurus
       - name: Deploy to GitHub Pages
-        uses: peaceiris/actions-gh-pages@v3
+        uses: peaceiris/actions-gh-pages@4a2e02b36f31d8974a0d09d3bb9f3172aa2d0d0d # v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           # Build output to publish to the `gh-pages` branch:

--- a/.github/workflows/generation.yml
+++ b/.github/workflows/generation.yml
@@ -1,5 +1,4 @@
 name: Code Generation
-
 on:
   push:
     branches:
@@ -20,52 +19,44 @@ on:
       - "**.txt"
       - "images/**"
       - "LICENSE"
-
 jobs:
   lint-protos:
     runs-on: ubuntu-latest
     steps:
       # Run `git checkout`
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
       # Install the `buf` CLI
-      - uses: bufbuild/buf-setup-action@v1
+      - uses: bufbuild/buf-setup-action@382440cdb8ec7bc25a68d7b4711163d95f7cc3aa # v1
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
       # Lint your Protobuf sources
-      - uses: bufbuild/buf-lint-action@v1
-
+      - uses: bufbuild/buf-lint-action@044d13acb1f155179c606aaa2e53aea304d22058 # v1
   proto-breaking-changes:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: bufbuild/buf-setup-action@v1
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
+      - uses: bufbuild/buf-setup-action@382440cdb8ec7bc25a68d7b4711163d95f7cc3aa # v1
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-      - uses: bufbuild/buf-breaking-action@v1
+      - uses: bufbuild/buf-breaking-action@a074e988ee34efcd4927079e79c611f428354c01 # v1
         with:
           against: "https://github.com/stacklok/minder.git#branch=main"
-
   sqlc-generation:
     runs-on: ubuntu-latest
-
     steps:
       - name: Check out code
-        uses: actions/checkout@v4
-
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5
         with:
           go-version-file: "go.mod"
-
       - name: Make bootstrap
         run: |
           make bootstrap
-
       - name: Generate Go code from SQL and check for syntax errors
         shell: bash
         run: |
           make sqlc
-
       - name: Check for uncommitted SQLC changes
         run: |
           git diff --exit-code || (echo "Error: Uncommitted changes detected after running 'sqlc generate'. Please commit the changes and try again." && exit 1)

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -10,12 +10,12 @@ jobs:
     name: Go Lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
+      - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5
         with:
           go-version-file: 'go.mod'
           cache: false
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v3
+        uses: golangci/golangci-lint-action@3a919529898de77ec3da873e3063ca4b10e7f5cc # v3
         with:
           version: v1.55.2

--- a/.github/workflows/image-build.yml
+++ b/.github/workflows/image-build.yml
@@ -1,74 +1,58 @@
 on:
   workflow_call: {}
-
 jobs:
   image:
     name: Image build
     runs-on: ubuntu-latest
-
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
-
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5
         with:
           go-version-file: 'go.mod'
-
-      - uses: ko-build/setup-ko@v0.6
-
+      - uses: ko-build/setup-ko@ace48d793556083a76f1e3e6068850c1f4a369aa # v0.6
       - run: |
           ko build --platform=linux/amd64,linux/arm64 --push=false ./cmd/server \
             --image-label=org.opencontainers.image.source=https://github.com/stacklok/minder,org.opencontainers.image.title="Stacklok Minder",org.opencontainers.image.licenses=Apache-2.0,org.opencontainers.image.vendor=Stacklok
         env:
           KO_DOCKER_REPO: "ko.local"
-
   check-helm:
     name: Build Helm chart
     # TODO: remove the 'image' build once helm build is stable, because ko resolve will build the image
     runs-on: ubuntu-latest
-
     permissions:
       contents: read
       packages: none
-
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
-
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5
         with:
           go-version-file: 'go.mod'
-
-      - uses: ko-build/setup-ko@v0.6
-
-      - uses: azure/setup-helm@v3
+      - uses: ko-build/setup-ko@ace48d793556083a76f1e3e6068850c1f4a369aa # v0.6
+      - uses: azure/setup-helm@5119fcb9089d432beecbf79bb2c7915207344b78 # v3
         with:
           version: v3.12.2
-
       - run: |
           make helm
         env:
           KO_DOCKER_REPO: "ko.local"
           KO_PUSH_IMAGE: "false"
-
   docker-image:
     name: Check docker image build
     runs-on: ubuntu-latest
-
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
-
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
+        uses: docker/setup-buildx-action@f95db51fddba0c2d1ec667646a06c2ce06100226 # v3
       - name: Test build on x86
         id: docker_build
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@4a13e500e55cf31b7a5d59a38ab2040ab0f42f56 # v5
         with:
           context: .
           file: Dockerfile
           platforms: linux/amd64
-          push: false  # Only attempt to build, to verify the Dockerfile is working
+          push: false # Only attempt to build, to verify the Dockerfile is working

--- a/.github/workflows/license-check.yml
+++ b/.github/workflows/license-check.yml
@@ -5,9 +5,8 @@ jobs:
     name: License boilerplate check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4 # v3.5.0
-
-      - uses: actions/setup-go@v5 # v4.0.0
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
+      - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5
         with:
           go-version-file: "go.mod"
       - name: Install addlicense

--- a/.github/workflows/migrate-touch.yml
+++ b/.github/workflows/migrate-touch.yml
@@ -1,43 +1,38 @@
----
 # This test verifies that Pull Requests don't touch the merged database migrations.
 # Folks should now only be adding new migrations to the `database/migrations/` directory.
 name: Database Migrations Untouched
-
 on:
   pull_request:
     paths:
       - 'database/migrations/*'
       - '.github/workflows/migrate-touch.yml'
-
 jobs:
   verify-migrations:
     name: Don't touch existing migrations
     runs-on: ubuntu-latest
-
     steps:
-    - name: Checkout code
-      uses: actions/checkout@v4
-      with:
-        fetch-depth: 0
+      - name: Checkout code
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
+        with:
+          fetch-depth: 0
+      - name: Verify Migration Files
+        run: |
+          # Check out the base branch
+          git checkout $GITHUB_BASE_REF
+          # Get files in migration directory before our changes
+          BEFORE=$(find database/migrations/ -type f | sort)
+          echo "Files before: $BEFORE"
 
-    - name: Verify Migration Files
-      run: |
-        # Check out the base branch
-        git checkout $GITHUB_BASE_REF
-        # Get files in migration directory before our changes
-        BEFORE=$(find database/migrations/ -type f | sort)
-        echo "Files before: $BEFORE"
+          # Check out our changes
+          git checkout $GITHUB_SHA -- database/migrations/
 
-        # Check out our changes
-        git checkout $GITHUB_SHA -- database/migrations/
-
-        # Verify that the existing migration files were not touched by the new changes
-        modified=$(git diff --name-only origin/$GITHUB_BASE_REF $GITHUB_SHA -- database/migrations/)
-        echo "Files modified: $modified"
-        for file in $modified; do
-          if [[ $BEFORE == *"$file"* ]]; then
-            echo "ERROR: $file was modified by this PR. Please only add new migrations to the database/migrations/ directory."
-            exit 1
-          fi
-        done
-      shell: bash
+          # Verify that the existing migration files were not touched by the new changes
+          modified=$(git diff --name-only origin/$GITHUB_BASE_REF $GITHUB_SHA -- database/migrations/)
+          echo "Files modified: $modified"
+          for file in $modified; do
+            if [[ $BEFORE == *"$file"* ]]; then
+              echo "ERROR: $file was modified by this PR. Please only add new migrations to the database/migrations/ directory."
+              exit 1
+            fi
+          done
+        shell: bash

--- a/.github/workflows/releaser.yml
+++ b/.github/workflows/releaser.yml
@@ -25,10 +25,8 @@ on:
   workflow_dispatch:
   release:
     types: [created]
-
 permissions:
   contents: write
-
 jobs:
   ldflags_args:
     runs-on: ubuntu-latest
@@ -39,7 +37,7 @@ jobs:
       tree-state: ${{ steps.ldflags.outputs.tree-state }}
     steps:
       - id: checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
         with:
           fetch-depth: 0
       - id: ldflags
@@ -60,21 +58,21 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
         with:
           fetch-depth: 0
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5
         with:
           go-version-file: 'go.mod'
           cache: true
       - name: Install Syft
         uses: anchore/sbom-action/download-syft@5ecf649a417b8ae17dc8383dc32d46c03f2312df # v0.15.1
       - name: Install Cosign
-        uses: sigstore/cosign-installer@v3.3.0
+        uses: sigstore/cosign-installer@9614fae9e5c5eddabb09f90a270fcb487c9f7149 # v3.3.0
       - name: Run GoReleaser
         id: run-goreleaser
-        uses: goreleaser/goreleaser-action@v5
+        uses: goreleaser/goreleaser-action@7ec5c2b0c6cdda6e8bbb49444bc797dd33d74dd8 # v5
         with:
           distribution: goreleaser
           version: latest
@@ -87,7 +85,6 @@ jobs:
           COMMIT: ${{ needs.ldflags_args.outputs.commit }}
           COMMIT_DATE: ${{ needs.ldflags_args.outputs.commit-date }}
           TREE_STATE: ${{ needs.ldflags_args.outputs.tree-state }}
-
       - name: Generate subject
         id: hash
         env:
@@ -121,7 +118,7 @@ jobs:
     permissions: read-all
     steps:
       - name: Install the SLSA verifier
-        uses: slsa-framework/slsa-verifier/actions/installer@v2.4.1
+        uses: slsa-framework/slsa-verifier/actions/installer@7e1e47d7d793930ab0082c15c2b971fdb53a3c95 # v2.4.1
       - name: Download assets
         env:
           GH_TOKEN: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -6,26 +6,23 @@ jobs:
     name: Code Security Scan
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
-
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
       - name: Security Scan
-        uses: aquasecurity/trivy-action@master  # Trivy Action doesn't have a stable release yet
+        uses: aquasecurity/trivy-action@91713af97dc80187565512baba96e4364e983601 # master
         with:
           scan-type: 'fs'
           scanners: vuln,secret
           trivy-config: .trivy.yml
           exit-code: 1
           ignore-unfixed: true
-
   helm-security-scan:
     runs-on: ubuntu-latest
     name: Helm Security Scan
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
-
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
       - name: Security Scan
-        uses: aquasecurity/trivy-action@master  # Trivy Action doesn't have a stable release yet
+        uses: aquasecurity/trivy-action@91713af97dc80187565512baba96e4364e983601 # master
         with:
           scan-type: 'config'
           trivy-config: .trivy.yml

--- a/.github/workflows/stalebot.yml
+++ b/.github/workflows/stalebot.yml
@@ -31,7 +31,7 @@ jobs:
   stale:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/stale@v9
+      - uses: actions/stale@28ca1036281a5e5922ead5184a1bbf96e5fc984e # v9
         with:
           stale-issue-message: 'This issue needs additional information before we can continue. It is now marked as stale because it has been open for 30 days with no activity. Please provide the necessary details to continue or it will be closed in 30 days.'
           stale-pr-message: 'This PR needs additional information before we can continue. It is now marked as stale because it has been open for 30 days with no activity. Please provide the necessary details to continue or it will be closed in 30 days.'

--- a/.github/workflows/test-deploy-doc.yml
+++ b/.github/workflows/test-deploy-doc.yml
@@ -1,5 +1,4 @@
 name: Test deployment
-
 on:
   workflow_call:
   pull_request:
@@ -7,17 +6,15 @@ on:
       - main
     paths:
       - "docs/**"
-
 jobs:
   test-deploy:
     name: Test deployment
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
+      - uses: actions/setup-node@b39b52d1213e96004bfcb1c61a8a6fa8ab84f3e8 # v4
         with:
           node-version: 18
-
       - name: Install dependencies
         run: yarn install --frozen-lockfile
         working-directory: ./docs

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,27 +7,22 @@ jobs:
     steps:
       # Checkout your project with git
       - name: Checkout
-        uses: actions/checkout@v4
-
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
       # Install Go on the VM running the action.
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5
         with:
           go-version-file: 'go.mod'
-
       - name: Set up helm (test dependency)
-        uses: azure/setup-helm@v3
-
+        uses: azure/setup-helm@5119fcb9089d432beecbf79bb2c7915207344b78 # v3
       # Install gotestfmt on the VM running the action.
       - name: Set up gotestfmt
-        uses: GoTestTools/gotestfmt-action@v2
+        uses: GoTestTools/gotestfmt-action@02b936e80bd5b0e515b98eb8f7d998a60ccca462 # v2
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-
       # copy config file into place
       - name: Copy config file
         run: cp config/server-config.yaml.example ./server-config.yaml
-
       # Run the tests
       - name: Run tests
         run: make test-silent

--- a/.github/workflows/update-docs-cli.yml
+++ b/.github/workflows/update-docs-cli.yml
@@ -9,22 +9,18 @@ jobs:
   update-docs-cli:
     runs-on: ubuntu-latest
     permissions: write-all
-
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
-
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5
         with:
           go-version-file: "go.mod"
-
       - name: Update documentation
         shell: bash
         run: |
           cp config/config.yaml.example config.yaml
           TARGET_ENV=prod make cli-docs
-
       - name: Extract Commit SHA and Details
         id: extract_commit_details
         run: |
@@ -34,9 +30,8 @@ jobs:
           echo "commit_sha=$COMMIT_SHA" >> $GITHUB_OUTPUT
           echo "commit_date=$COMMIT_DATE" >> $GITHUB_OUTPUT
           echo "commit_author=$COMMIT_AUTHOR" >> $GITHUB_OUTPUT
-
       - name: Commit and push changes
-        uses: peter-evans/create-pull-request@v5
+        uses: peter-evans/create-pull-request@153407881ec5c347639a548ade7d8ad1d6740e38 # v5
         with:
           commit-message: Update documentation
           committer: GitHub <noreply@github.com>

--- a/.github/workflows/update-docs-dbschema.yml
+++ b/.github/workflows/update-docs-dbschema.yml
@@ -6,21 +6,17 @@ on:
       - main
     paths:
       - "database/migrations/**"
-
 jobs:
   update-docs-dbschema:
     runs-on: ubuntu-latest
     permissions: write-all
-
     steps:
       # Checkout your project with git
       - name: Checkout
-        uses: actions/checkout@v4
-
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
       # generate db schema
       - name: Generate db schema
         run: make dbschema
-
       - name: Extract Commit SHA and Details
         id: extract_commit_details
         run: |
@@ -30,9 +26,8 @@ jobs:
           echo "commit_sha=$COMMIT_SHA" >> $GITHUB_OUTPUT
           echo "commit_date=$COMMIT_DATE" >> $GITHUB_OUTPUT
           echo "commit_author=$COMMIT_AUTHOR" >> $GITHUB_OUTPUT
-
       - name: Commit and push changes
-        uses: peter-evans/create-pull-request@v5
+        uses: peter-evans/create-pull-request@153407881ec5c347639a548ade7d8ad1d6740e38 # v5
         with:
           commit-message: Update DB schema
           committer: GitHub <noreply@github.com>

--- a/.github/workflows/update-docs-helm.yml
+++ b/.github/workflows/update-docs-helm.yml
@@ -15,24 +15,20 @@ jobs:
       HELM_DOCS_VERSION: 1.11.3
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
-
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5
         with:
           go-version-file: "go.mod"
-
       - name: install helm-docs
         run: |
           cd /tmp
           wget https://github.com/norwoodj/helm-docs/releases/download/v${{env.HELM_DOCS_VERSION}}/helm-docs_${{env.HELM_DOCS_VERSION}}_Linux_x86_64.tar.gz
           tar -xvf helm-docs_${{env.HELM_DOCS_VERSION}}_Linux_x86_64.tar.gz
           sudo mv helm-docs /usr/local/sbin
-
       - name: run helm-docs
         run: |
           make helm-docs
-
       - name: Extract Commit SHA and Details
         id: extract_commit_details
         run: |
@@ -42,9 +38,8 @@ jobs:
           echo "commit_sha=$COMMIT_SHA" >> $GITHUB_OUTPUT
           echo "commit_date=$COMMIT_DATE" >> $GITHUB_OUTPUT
           echo "commit_author=$COMMIT_AUTHOR" >> $GITHUB_OUTPUT
-
       - name: Commit and push changes
-        uses: peter-evans/create-pull-request@v5
+        uses: peter-evans/create-pull-request@153407881ec5c347639a548ade7d8ad1d6740e38 # v5
         with:
           commit-message: Update helm documentation
           committer: GitHub <noreply@github.com>


### PR DESCRIPTION
<!-- minder: pr-remediation-body: { "ContentSha": "e4569d045a38bb55103bedb953853945cd74e716" } -->

This is a Minder automated pull request.

This pull request replaces references to actions by tag to references to actions by SHA.

Verifies that any actions use pinned tags
Pinning an action to a full length commit SHA is currently the only way to use
an action as an immutable release. Pinning to a particular SHA helps mitigate
the risk of a bad actor adding a backdoor to the action's repository, as they
would need to generate a SHA-1 collision for a valid Git object payload.
When selecting a SHA, you should verify it is from the action's repository
and not a repository fork.

For more information, see
https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions
