### PR TITLE
Surface git clone errors as failures if the branch doesn't exist

### DIFF
--- a/internal/providers/git/git.go
+++ b/internal/providers/git/git.go
@@ -17,6 +17,7 @@ package git
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/go-git/go-billy/v5/memfs"
@@ -79,6 +80,10 @@ func (g *Git) Clone(ctx context.Context, url, branch string) (*git.Repository, e
 	// where we don't have access to the underlying filesystem.
 	r, err := git.CloneContext(ctx, storer, fs, opts)
 	if err != nil {
+		var refspecerr git.NoMatchingRefSpecError
+		if errors.Is(err, git.ErrBranchNotFound) || refspecerr.Is(err) {
+			return nil, provifv1.ErrProviderGitBranchNotFound
+		}
 		return nil, fmt.Errorf("could not clone repo: %w", err)
 	}
 

--- a/pkg/providers/v1/errors.go
+++ b/pkg/providers/v1/errors.go
@@ -1,0 +1,22 @@
+// Copyright 2023 Stacklok, Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v1
+
+import "errors"
+
+var (
+	// ErrProviderGitBranchNotFound is returned when the branch is not found
+	ErrProviderGitBranchNotFound = errors.New("branch not found")
+)


### PR DESCRIPTION
This changes the logic for the git ingester to output an evaluation
failure if the branch didn't exist.

Closes: #1804
