### PR TITLE
Deploy docs on merges to `main`

### DIFF
--- a/.github/workflows/deploy-doc.yml
+++ b/.github/workflows/deploy-doc.yml
@@ -1,8 +1,9 @@
 name: Deploy docs to GitHub Pages
 on:
   workflow_dispatch:
-  release:
-    types: [created]
+  push:
+    branches:
+      - main
 permissions:
   contents: write
 jobs:


### PR DESCRIPTION
The minder docs are mean to be bleeding edge. This changes the deploy
trigger to build on merges to `main` instead of on every release.
