### PR TITLE
Revert "Use variadic parameters for the table interface (#2008)"

### DIFF
--- a/cmd/cli/app/artifact/artifact_get.go
+++ b/cmd/cli/app/artifact/artifact_get.go
@@ -73,7 +73,7 @@ func getCommand(ctx context.Context, cmd *cobra.Command, conn *grpc.ClientConn) 
 	case app.Table:
 		ta := table.New(table.Simple, layouts.Default,
 			[]string{"ID", "Type", "Owner", "Name", "Repository", "Visibility", "Creation date"})
-		ta.AddRow(
+		ta.AddRow([]string{
 			art.ArtifactPk,
 			art.Type,
 			art.GetOwner(),
@@ -81,19 +81,19 @@ func getCommand(ctx context.Context, cmd *cobra.Command, conn *grpc.ClientConn) 
 			art.Repository,
 			art.Visibility,
 			art.CreatedAt.AsTime().Format(time.RFC3339),
-		)
+		})
 		ta.Render()
 
 		tv := table.New(table.Simple, layouts.Default,
 			[]string{"ID", "Tags", "Signature", "Identity", "Creation date"})
 		for _, version := range versions {
-			tv.AddRow(
+			tv.AddRow([]string{
 				fmt.Sprintf("%d", version.VersionId),
 				strings.Join(version.Tags, ","),
 				getSignatureStatusText(version.SignatureVerification),
 				version.GetSignatureVerification().GetCertIdentity(),
 				version.CreatedAt.AsTime().Format(time.RFC3339),
-			)
+			})
 		}
 		tv.Render()
 	case app.JSON:

--- a/cmd/cli/app/artifact/artifact_list.go
+++ b/cmd/cli/app/artifact/artifact_list.go
@@ -77,7 +77,7 @@ func listCommand(ctx context.Context, cmd *cobra.Command, conn *grpc.ClientConn)
 		t := table.New(table.Simple, layouts.Default,
 			[]string{"ID", "Type", "Owner", "Name", "Repository", "Visibility", "Creation date"})
 		for _, artifact := range artifactList.Results {
-			t.AddRow(
+			t.AddRow([]string{
 				artifact.ArtifactPk,
 				artifact.Type,
 				artifact.GetOwner(),
@@ -85,7 +85,7 @@ func listCommand(ctx context.Context, cmd *cobra.Command, conn *grpc.ClientConn)
 				artifact.Repository,
 				artifact.Visibility,
 				artifact.CreatedAt.AsTime().Format(time.RFC3339),
-			)
+			})
 
 		}
 		t.Render()

--- a/cmd/cli/app/auth/common.go
+++ b/cmd/cli/app/auth/common.go
@@ -41,29 +41,29 @@ func userRegistered(ctx context.Context, client minderv1.UserServiceClient) (boo
 
 func renderNewUser(conn string, newUser *minderv1.CreateUserResponse) {
 	t := table.New(table.Simple, layouts.KeyValue, nil)
-	t.AddRow("Project ID", newUser.ProjectId)
-	t.AddRow("Project Name", newUser.ProjectName)
-	t.AddRow("Minder Server", conn)
+	t.AddRow([]string{"Project ID", newUser.ProjectId})
+	t.AddRow([]string{"Project Name", newUser.ProjectName})
+	t.AddRow([]string{"Minder Server", conn})
 	t.Render()
 }
 
 func renderUserInfo(conn string, user *minderv1.GetUserResponse) {
 	t := table.New(table.Simple, layouts.KeyValue, nil)
-	t.AddRow("Minder Server", conn)
+	t.AddRow([]string{"Minder Server", conn})
 	for _, project := range getProjectTableRows(user.Projects) {
-		t.AddRow(project...)
+		t.AddRow(project)
 	}
 	t.Render()
 }
 
 func renderUserInfoWhoami(conn string, user *minderv1.GetUserResponse) {
 	t := table.New(table.Simple, layouts.KeyValue, nil)
-	t.AddRow("Subject", user.GetUser().GetIdentitySubject())
-	t.AddRow("Created At", user.GetUser().GetCreatedAt().AsTime().String())
-	t.AddRow("Updated At", user.GetUser().GetUpdatedAt().AsTime().String())
-	t.AddRow("Minder Server", conn)
+	t.AddRow([]string{"Subject", user.GetUser().GetIdentitySubject()})
+	t.AddRow([]string{"Created At", user.GetUser().GetCreatedAt().AsTime().String()})
+	t.AddRow([]string{"Updated At", user.GetUser().GetUpdatedAt().AsTime().String()})
+	t.AddRow([]string{"Minder Server", conn})
 	for _, project := range getProjectTableRows(user.Projects) {
-		t.AddRow(project...)
+		t.AddRow(project)
 	}
 	t.Render()
 }

--- a/cmd/cli/app/profile/table_render.go
+++ b/cmd/cli/app/profile/table_render.go
@@ -60,11 +60,11 @@ func NewProfileSettingsTable() table.Table {
 
 // RenderProfileSettingsTable renders the profile settings table
 func RenderProfileSettingsTable(p *minderv1.Profile, t table.Table) {
-	t.AddRow("ID", p.GetId())
-	t.AddRow("Name", p.GetName())
-	t.AddRow("Provider", p.GetContext().GetProvider())
-	t.AddRow("Alert", p.GetAlert())
-	t.AddRow("Remediate", p.GetRemediate())
+	t.AddRow([]string{"ID", p.GetId()})
+	t.AddRow([]string{"Name", p.GetName()})
+	t.AddRow([]string{"Provider", p.GetContext().GetProvider()})
+	t.AddRow([]string{"Alert", p.GetAlert()})
+	t.AddRow([]string{"Remediate", p.GetRemediate()})
 }
 
 // NewProfileTable creates a new table for rendering profiles
@@ -99,12 +99,13 @@ func renderRuleTable(entType minderv1.EntityType, rule *minderv1.Profile_Rule, t
 	params := marshalStructOrEmpty(rule.Params)
 	def := marshalStructOrEmpty(rule.Def)
 
-	t.AddRow(
+	row := []string{
 		entType.String(),
 		rule.Type,
 		params,
 		def,
-	)
+	}
+	t.AddRow(row)
 }
 
 // NewProfileStatusTable creates a new table for rendering profile status

--- a/cmd/cli/app/repo/repo_list.go
+++ b/cmd/cli/app/repo/repo_list.go
@@ -71,14 +71,14 @@ func listCommand(ctx context.Context, cmd *cobra.Command, conn *grpc.ClientConn)
 	case app.Table:
 		t := table.New(table.Simple, layouts.RepoList, nil)
 		for _, v := range resp.Results {
-			t.AddRow(
+			t.AddRow([]string{
 				*v.Id,
 				*v.Context.Project,
 				*v.Context.Provider,
 				fmt.Sprintf("%d", v.GetRepoId()),
 				v.GetOwner(),
 				v.GetName(),
-			)
+			})
 		}
 		t.Render()
 	case app.JSON:

--- a/cmd/cli/app/repo/repo_register.go
+++ b/cmd/cli/app/repo/repo_register.go
@@ -149,7 +149,7 @@ func RegisterCmd(ctx context.Context, cmd *cobra.Command, conn *grpc.ClientConn)
 		} else {
 			row = append(row, "")
 		}
-		t.AddRow(row...)
+		t.AddRow(row)
 	}
 	t.Render()
 	return nil

--- a/cmd/cli/app/ruletype/common.go
+++ b/cmd/cli/app/ruletype/common.go
@@ -60,13 +60,13 @@ func execOnOneRuleType(
 	}
 
 	// add the rule type to the table rows
-	t.AddRow(
+	t.AddRow([]string{
 		*rt.Context.Provider,
 		*rt.Context.Project,
 		*rt.Id,
 		rt.Name,
 		rt.Description,
-	)
+	})
 	return nil
 }
 

--- a/cmd/cli/app/ruletype/ruletype_get.go
+++ b/cmd/cli/app/ruletype/ruletype_get.go
@@ -83,13 +83,13 @@ func getCommand(ctx context.Context, cmd *cobra.Command, conn *grpc.ClientConn) 
 		table := initializeTable()
 		rt := rtype.GetRuleType()
 		// add the rule type to the table rows
-		table.AddRow(
+		table.AddRow([]string{
 			*rt.Context.Provider,
 			*rt.Context.Project,
 			*rt.Id,
 			rt.Name,
 			rt.Description,
-		)
+		})
 		table.Render()
 	}
 	return nil

--- a/cmd/cli/app/ruletype/ruletype_list.go
+++ b/cmd/cli/app/ruletype/ruletype_list.go
@@ -78,13 +78,13 @@ func listCommand(ctx context.Context, cmd *cobra.Command, conn *grpc.ClientConn)
 	case app.Table:
 		table := initializeTable()
 		for _, rt := range resp.RuleTypes {
-			table.AddRow(
+			table.AddRow([]string{
 				*rt.Context.Provider,
 				*rt.Context.Project,
 				*rt.Id,
 				rt.Name,
 				rt.Description,
-			)
+			})
 		}
 		table.Render()
 	}

--- a/internal/util/cli/table/simple/simple.go
+++ b/internal/util/cli/table/simple/simple.go
@@ -59,7 +59,7 @@ func New(layout layouts.TableLayout, header []string) *Table {
 }
 
 // AddRow adds a row
-func (t *Table) AddRow(row ...string) {
+func (t *Table) AddRow(row []string) {
 	t.table.Append(row)
 }
 

--- a/internal/util/cli/table/table.go
+++ b/internal/util/cli/table/table.go
@@ -35,7 +35,7 @@ const (
 
 // Table is an interface for rendering tables
 type Table interface {
-	AddRow(row ...string)
+	AddRow(row []string)
 	AddRowWithColor(row []string, rowColors []string)
 	Render()
 }


### PR DESCRIPTION
After talking with Ozz we decided to revert the commit for now because making the other method use the same layout ended up being unnecessarily more code than we save here. Once we revisit our choice of table framework the whole interface will probably be removed too so we can fix this then.

This reverts commit ec8dff906ee59bd1ee5d63341bbf4c98e4a4e5db. 

Closes https://github.com/stacklok/minder/pull/2009