### PR TITLE
Don't print informational message on stdout

### DIFF
--- a/cmd/cli/app/root.go
+++ b/cmd/cli/app/root.go
@@ -104,7 +104,7 @@ func initConfig() {
 	if err := viper.ReadInConfig(); err != nil {
 		if _, ok := err.(viper.ConfigFileNotFoundError); ok {
 			// Config file not found; use default values
-			RootCmd.Println("No config file present, using default values.")
+			RootCmd.PrintErr("No config file present, using default values.")
 		} else {
 			// Some other error occurred
 			RootCmd.Printf("Error reading config file: %s", err)


### PR DESCRIPTION
The message that the config file is not present and that default are
about to be used should not be printed on stdout as it breaks json
output - you can't then just pipe the rest of the command to jq.

I would honestly prefer to remove the message altogether as asking users
to redirect stderr to /dev/null seems like a nuisance, but let's start
with not printing the message to stdout.
