### PR TITLE
Print Details, not Description when a rpc error is caught

### DIFF
--- a/internal/util/cli/cli.go
+++ b/internal/util/cli/cli.go
@@ -148,7 +148,7 @@ func ExitNicelyOnError(err error, message string) {
 		// Check if the error is a grpc status
 		if rpcStatus, ok := status.FromError(err); ok {
 			nice := util.FromRpcError(rpcStatus)
-			fmt.Fprintf(os.Stderr, "Details: %s\n", nice.Description)
+			fmt.Fprintf(os.Stderr, "Details: %s\n", nice.Details)
 			os.Exit(int(nice.Code))
 		} else {
 			fmt.Fprintf(os.Stderr, "Details: %s\n", err)


### PR DESCRIPTION
We used to just print the stringified error code, e.g. Invalid Argument, but not the actual reason.

Fixes: #2012
