### PR TITLE
Remove extra empty string from color list of remediation status

### DIFF
--- a/cmd/cli/app/profile/table_render.go
+++ b/cmd/cli/app/profile/table_render.go
@@ -170,7 +170,6 @@ func RenderRuleEvaluationStatusTable(
 			"",
 			"",
 			"",
-			"",
 			getEvalStatusColor(eval.Status),
 			getRemediateStatusColor(eval.RemediationStatus),
 			"",


### PR DESCRIPTION
This was causing the colors to be rendered incorrectly.

Closes: https://github.com/stacklok/minder/issues/2018
