### PR TITLE
Add newline to `No config file present, using default values.`

### DIFF
--- a/cmd/cli/app/root.go
+++ b/cmd/cli/app/root.go
@@ -104,7 +104,7 @@ func initConfig() {
 	if err := viper.ReadInConfig(); err != nil {
 		if _, ok := err.(viper.ConfigFileNotFoundError); ok {
 			// Config file not found; use default values
-			RootCmd.PrintErr("No config file present, using default values.")
+			RootCmd.PrintErrln("No config file present, using default values.")
 		} else {
 			// Some other error occurred
 			RootCmd.Printf("Error reading config file: %s", err)


### PR DESCRIPTION
The newline was missing which was messing with the output.
