### PR TITLE
Don't execute actions when running `mindev ruletype test`

### DIFF
--- a/cmd/dev/app/rule_type/rttst.go
+++ b/cmd/dev/app/rule_type/rttst.go
@@ -106,6 +106,11 @@ func testCmdRun(cmd *cobra.Command, _ []string) error {
 		return fmt.Errorf("error reading fragment from file: %w", err)
 	}
 
+	// Disable actions
+	off := "off"
+	p.Alert = &off
+	p.Remediate = &off
+
 	rules, err := engine.GetRulesFromProfileOfType(p, rt)
 	if err != nil {
 		return fmt.Errorf("error getting relevant fragment: %w", err)

--- a/cmd/dev/app/rule_type/rttst.go
+++ b/cmd/dev/app/rule_type/rttst.go
@@ -109,7 +109,6 @@ func testCmdRun(cmd *cobra.Command, _ []string) error {
 	// Disable actions
 	off := "off"
 	p.Alert = &off
-	p.Remediate = &off
 
 	rules, err := engine.GetRulesFromProfileOfType(p, rt)
 	if err != nil {


### PR DESCRIPTION
This overwrites the remediation and alert to be `off` since we don't want to
execute actions when testing. This is not _yet_ supported and causes a segfault.

So, let's turn it off for now. If the need comes to test the actions themselves
with `mindev` we can work on turning it on later. But, for now, no segfault
is better.

Closes: https://github.com/stacklok/minder/issues/1858
