### PR TITLE
Show rule type details vertically in get call

### DIFF
--- a/cmd/cli/app/ruletype/common.go
+++ b/cmd/cli/app/ruletype/common.go
@@ -99,7 +99,34 @@ func shouldSkipFile(f string) bool {
 	}
 }
 
-// initializeTable initializes the table for the rule type
-func initializeTable() table.Table {
-	return table.New(table.Simple, layouts.RuleType, nil)
+// initializeTableForList initializes the table for the rule type
+func initializeTableForList() table.Table {
+	return table.New(table.Simple, layouts.RuleTypeList, nil)
+}
+
+// initializeTableForList initializes the table for the rule type
+func initializeTableForOne() table.Table {
+	return table.New(table.Simple, layouts.RuleTypeOne, nil)
+}
+
+func oneRuleTypeToRows(t table.Table, rt *minderv1.RuleType) {
+	t.AddRow("ID", *rt.Id)
+	t.AddRow("Name", rt.Name)
+	t.AddRow("Provider", *rt.Context.Provider)
+	t.AddRow("Project", *rt.Context.Project)
+	t.AddRow("Description", rt.Description)
+	t.AddRow("Ingest type", rt.Def.Ingest.Type)
+	t.AddRow("Eval type", rt.Def.Eval.Type)
+	rem := "unsupported"
+	if rt.Def.GetRemediate() != nil {
+		rem = rt.Def.GetRemediate().Type
+	}
+	t.AddRow("Remediation", rem)
+
+	alert := "unsupported"
+	if rt.Def.GetAlert() != nil {
+		alert = rt.Def.GetAlert().Type
+	}
+
+	t.AddRow("Alert", alert)
 }

--- a/cmd/cli/app/ruletype/ruletype_apply.go
+++ b/cmd/cli/app/ruletype/ruletype_apply.go
@@ -65,7 +65,7 @@ func applyCommand(_ context.Context, cmd *cobra.Command, conn *grpc.ClientConn) 
 		return cli.MessageAndError("Error expanding file args", err)
 	}
 
-	table := initializeTable()
+	table := initializeTableForList()
 
 	applyFunc := func(ctx context.Context, fileName string, rt *minderv1.RuleType) (*minderv1.RuleType, error) {
 		createResp, err := client.CreateRuleType(ctx, &minderv1.CreateRuleTypeRequest{

--- a/cmd/cli/app/ruletype/ruletype_create.go
+++ b/cmd/cli/app/ruletype/ruletype_create.go
@@ -64,7 +64,7 @@ func createCommand(_ context.Context, cmd *cobra.Command, conn *grpc.ClientConn)
 		return cli.MessageAndError("Error expanding file args", err)
 	}
 
-	table := initializeTable()
+	table := initializeTableForList()
 
 	createFunc := func(ctx context.Context, fileName string, rt *minderv1.RuleType) (*minderv1.RuleType, error) {
 		resprt, err := client.CreateRuleType(ctx, &minderv1.CreateRuleTypeRequest{

--- a/cmd/cli/app/ruletype/ruletype_get.go
+++ b/cmd/cli/app/ruletype/ruletype_get.go
@@ -80,16 +80,10 @@ func getCommand(ctx context.Context, cmd *cobra.Command, conn *grpc.ClientConn) 
 		cmd.Println(out)
 	case app.Table:
 		// Initialize the table
-		table := initializeTable()
+		table := initializeTableForOne()
 		rt := rtype.GetRuleType()
+		oneRuleTypeToRows(table, rt)
 		// add the rule type to the table rows
-		table.AddRow(
-			*rt.Context.Provider,
-			*rt.Context.Project,
-			*rt.Id,
-			rt.Name,
-			rt.Description,
-		)
 		table.Render()
 	}
 	return nil

--- a/cmd/cli/app/ruletype/ruletype_list.go
+++ b/cmd/cli/app/ruletype/ruletype_list.go
@@ -76,7 +76,7 @@ func listCommand(ctx context.Context, cmd *cobra.Command, conn *grpc.ClientConn)
 		}
 		cmd.Println(out)
 	case app.Table:
-		table := initializeTable()
+		table := initializeTableForList()
 		for _, rt := range resp.RuleTypes {
 			table.AddRow(
 				*rt.Context.Provider,

--- a/internal/util/cli/table/layouts/layouts.go
+++ b/internal/util/cli/table/layouts/layouts.go
@@ -23,8 +23,10 @@ type TableLayout string
 const (
 	// KeyValue is the key value table layout
 	KeyValue TableLayout = "keyvalue"
-	// RuleType is the rule type table layout
-	RuleType TableLayout = "ruletype"
+	// RuleTypeOne is the rule type table layout
+	RuleTypeOne TableLayout = "ruletype"
+	// RuleTypeList is the rule type table layout
+	RuleTypeList TableLayout = "ruletype_list"
 	// ProfileSettings is the profile settings table layout
 	ProfileSettings TableLayout = "profile_settings"
 	// Profile is the profile table layout

--- a/internal/util/cli/table/simple/simple.go
+++ b/internal/util/cli/table/simple/simple.go
@@ -34,8 +34,10 @@ func New(layout layouts.TableLayout, header []string) *Table {
 	switch layout {
 	case layouts.KeyValue:
 		keyValueLayout(table)
-	case layouts.RuleType:
+	case layouts.RuleTypeOne:
 		ruleTypeLayout(table)
+	case layouts.RuleTypeList:
+		ruleTypeListLayout(table)
 	case layouts.ProfileSettings:
 		profileSettingsLayout(table)
 	case layouts.Profile:
@@ -120,11 +122,17 @@ func repoListLayout(table *tablewriter.Table) {
 	table.SetHeader([]string{"ID", "Project", "Provider", "Upstream ID", "Owner", "Name"})
 }
 
-func ruleTypeLayout(table *tablewriter.Table) {
+func ruleTypeListLayout(table *tablewriter.Table) {
 	defaultLayout(table)
 	table.SetHeader([]string{"Provider", "Project Name", "ID", "Name", "Description"})
 	table.SetAutoMergeCellsByColumnIndex([]int{0, 1, 2, 3})
 	// This is needed for the rule definition and rule parameters
 	table.SetAutoWrapText(false)
+}
 
+func ruleTypeLayout(table *tablewriter.Table) {
+	defaultLayout(table)
+	table.SetHeader([]string{"Rule Type"})
+	// This is needed for the rule definition and rule parameters
+	table.SetAutoWrapText(false)
 }


### PR DESCRIPTION
This shows more details for the rule type in a vertical table.

e.g.

```bash
$ minder ruletype get -i 7f1bbee6-a27a-4318-95f5-7408f2fcb106
No config file present, using default values.
+-------------+-----------------------------------------------------------+
|  RULE TYPE  |                                                           |
+-------------+-----------------------------------------------------------+
| ID          | 7f1bbee6-a27a-4318-95f5-7408f2fcb106                      |
+-------------+-----------------------------------------------------------+
| Name        | dependabot_configured                                     |
+-------------+-----------------------------------------------------------+
| Provider    | github                                                    |
+-------------+-----------------------------------------------------------+
| Project     | jaormx                                                    |
+-------------+-----------------------------------------------------------+
| Description | Verifies that Dependabot is configured for the repository |
+-------------+-----------------------------------------------------------+
| Ingest type | git                                                       |
+-------------+-----------------------------------------------------------+
| Eval type   | rego                                                      |
+-------------+-----------------------------------------------------------+
| Remediation | pull_request                                              |
+-------------+-----------------------------------------------------------+
| Alert       | security_advisory                                         |
+-------------+-----------------------------------------------------------+
```

```bash
$ minder ruletype get -i 7361c508-f954-414b-a103-589c2cb4bbc5
No config file present, using default values.
+-------------+---------------------------------------------------------------------------------------+
|  RULE TYPE  |                                                                                       |
+-------------+---------------------------------------------------------------------------------------+
| ID          | 7361c508-f954-414b-a103-589c2cb4bbc5                                                  |
+-------------+---------------------------------------------------------------------------------------+
| Name        | repo_action_allow_list                                                                |
+-------------+---------------------------------------------------------------------------------------+
| Provider    | github                                                                                |
+-------------+---------------------------------------------------------------------------------------+
| Project     | jaormx                                                                                |
+-------------+---------------------------------------------------------------------------------------+
| Description | Verifies that the github workflows in a repo only use actions enumerated in the rule. |
|             |                                                                                       |
+-------------+---------------------------------------------------------------------------------------+
| Ingest type | git                                                                                   |
+-------------+---------------------------------------------------------------------------------------+
| Eval type   | rego                                                                                  |
+-------------+---------------------------------------------------------------------------------------+
| Remediation | unsupported                                                                           |
+-------------+---------------------------------------------------------------------------------------+
| Alert       | security_advisory                                                                     |
+-------------+---------------------------------------------------------------------------------------+
```

```bash
$ minder ruletype get -i 9ae5a1d0-df12-402b-861c-797d4217bdfb
No config file present, using default values.
+-------------+--------------------------------------------------------------------------------+
|  RULE TYPE  |                                                                                |
+-------------+--------------------------------------------------------------------------------+
| ID          | 9ae5a1d0-df12-402b-861c-797d4217bdfb                                           |
+-------------+--------------------------------------------------------------------------------+
| Name        | pr_trusty_check                                                                |
+-------------+--------------------------------------------------------------------------------+
| Provider    | github                                                                         |
+-------------+--------------------------------------------------------------------------------+
| Project     | jaormx                                                                         |
+-------------+--------------------------------------------------------------------------------+
| Description | Verifies that pull requests do not add any dependencies with low Trusty scores |
+-------------+--------------------------------------------------------------------------------+
| Ingest type | diff                                                                           |
+-------------+--------------------------------------------------------------------------------+
| Eval type   | trusty                                                                         |
+-------------+--------------------------------------------------------------------------------+
| Remediation | unsupported                                                                    |
+-------------+--------------------------------------------------------------------------------+
| Alert       | unsupported                                                                    |
+-------------+--------------------------------------------------------------------------------+
```

Closes: https://github.com/stacklok/minder/issues/1062
