### PR TITLE
Print profiles in one table instead of several

### DIFF
--- a/cmd/cli/app/profile/list.go
+++ b/cmd/cli/app/profile/list.go
@@ -76,16 +76,11 @@ func listCommand(ctx context.Context, cmd *cobra.Command, conn *grpc.ClientConn)
 		}
 		cmd.Println(out)
 	case app.Table:
-		if len(resp.Profiles) == 0 {
-			settable := NewProfileSettingsTable()
-			settable.Render()
-		}
-
+		settable := NewProfileSettingsTable()
 		for _, v := range resp.Profiles {
-			settable := NewProfileSettingsTable()
 			RenderProfileSettingsTable(v, settable)
-			settable.Render()
 		}
+		settable.Render()
 		return nil
 	}
 	// this is unreachable


### PR DESCRIPTION
Instead of having several tables as so:

```
$ minder profile list
No config file present, using default values.
+--------------------------------------+----------------------------------------------------+----------+-------+-----------+
|                  ID                  |                        NAME                        | PROVIDER | ALERT | REMEDIATE |
+--------------------------------------+----------------------------------------------------+----------+-------+-----------+
| 6fec2b7b-6489-487c-8fe3-f611efdf5d53 | demo-profile                                       | github   | on    | on        |
+--------------------------------------+----------------------------------------------------+----------+-------+-----------+
+--------------------------------------+----------------------------------------------------+----------+-------+-----------+
|                  ID                  |                        NAME                        | PROVIDER | ALERT | REMEDIATE |
+--------------------------------------+----------------------------------------------------+----------+-------+-----------+
| 4d5c4952-5e30-4b9b-b694-c133279508c4 | acme-github-profile                                | github   | on    | off       |
+--------------------------------------+----------------------------------------------------+----------+-------+-----------+
```

This changes the output to be only one:

```
$ minder profile list
No config file present, using default values.
+--------------------------------------+----------------------------------------------------+----------+-------+-----------+
|                  ID                  |                        NAME                        | PROVIDER | ALERT | REMEDIATE |
+--------------------------------------+----------------------------------------------------+----------+-------+-----------+
| 6fec2b7b-6489-487c-8fe3-f611efdf5d53 | demo-profile                                       | github   | on    | on        |
+--------------------------------------+----------------------------------------------------+----------+-------+-----------+
| 4d5c4952-5e30-4b9b-b694-c133279508c4 | acme-github-profile                                | github   | on    | off       |
+--------------------------------------+----------------------------------------------------+----------+-------+-----------+
```
