### PR TITLE
Create a config structure for the minder CLI

### DIFF
--- a/cmd/cli/app/auth/auth_delete.go
+++ b/cmd/cli/app/auth/auth_delete.go
@@ -24,6 +24,7 @@ import (
 	"google.golang.org/grpc"
 
 	"github.com/stacklok/minder/internal/auth"
+	clientconfig "github.com/stacklok/minder/internal/config/client"
 	"github.com/stacklok/minder/internal/util"
 	"github.com/stacklok/minder/internal/util/cli"
 	minderv1 "github.com/stacklok/minder/pkg/api/protobuf/go/minder/v1"
@@ -41,12 +42,17 @@ var deleteCmd = &cobra.Command{
 func deleteCommand(ctx context.Context, cmd *cobra.Command, conn *grpc.ClientConn) error {
 	client := minderv1.NewUserServiceClient(conn)
 
-	issuerUrl := viper.GetString("identity.cli.issuer_url")
-	clientId := viper.GetString("identity.cli.client_id")
+	clientConfig, err := clientconfig.ReadConfigFromViper(viper.GetViper())
+	if err != nil {
+		return cli.MessageAndError("Unable to read config", err)
+	}
+
+	issuerUrl := clientConfig.Identity.CLI.IssuerUrl
+	clientId := clientConfig.Identity.CLI.ClientId
 	yesFlag := viper.GetBool("yes-delete-my-account")
 
 	// Ensure the user already exists in the local database
-	_, _, err := userRegistered(ctx, client)
+	_, _, err = userRegistered(ctx, client)
 	if err != nil {
 		return cli.MessageAndError("Error checking if user exists", err)
 	}

--- a/cmd/cli/app/auth/auth_login.go
+++ b/cmd/cli/app/auth/auth_login.go
@@ -32,6 +32,7 @@ import (
 	httphelper "github.com/zitadel/oidc/v2/pkg/http"
 	"github.com/zitadel/oidc/v2/pkg/oidc"
 
+	clientconfig "github.com/stacklok/minder/internal/config/client"
 	mcrypto "github.com/stacklok/minder/internal/crypto"
 	"github.com/stacklok/minder/internal/util"
 	"github.com/stacklok/minder/internal/util/cli"
@@ -55,8 +56,13 @@ $XDG_CONFIG_HOME/minder/credentials.json`,
 func loginCommand(cmd *cobra.Command, _ []string) error {
 	ctx := context.Background()
 
-	issuerUrlStr := viper.GetString("identity.cli.issuer_url")
-	clientID := viper.GetString("identity.cli.client_id")
+	clientConfig, err := clientconfig.ReadConfigFromViper(viper.GetViper())
+	if err != nil {
+		return cli.MessageAndError("Unable to read config", err)
+	}
+
+	issuerUrlStr := clientConfig.Identity.CLI.IssuerUrl
+	clientID := clientConfig.Identity.CLI.ClientId
 
 	parsedURL, err := url.Parse(issuerUrlStr)
 	if err != nil {

--- a/cmd/cli/app/auth/auth_logout.go
+++ b/cmd/cli/app/auth/auth_logout.go
@@ -21,6 +21,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 
+	clientconfig "github.com/stacklok/minder/internal/config/client"
 	"github.com/stacklok/minder/internal/util"
 	"github.com/stacklok/minder/internal/util/cli"
 )
@@ -35,7 +36,11 @@ var logoutCmd = &cobra.Command{
 			return cli.MessageAndError("Error removing credentials", err)
 		}
 
-		issuerUrlStr := viper.GetString("identity.cli.issuer_url")
+		clientConfig, err := clientconfig.ReadConfigFromViper(viper.GetViper())
+		if err != nil {
+			return cli.MessageAndError("Unable to read config", err)
+		}
+		issuerUrlStr := clientConfig.Identity.CLI.IssuerUrl
 
 		parsedURL, err := url.Parse(issuerUrlStr)
 		if err != nil {

--- a/cmd/cli/app/root.go
+++ b/cmd/cli/app/root.go
@@ -22,7 +22,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 
-	"github.com/stacklok/minder/internal/constants"
+	clientconfig "github.com/stacklok/minder/internal/config/client"
 	ghclient "github.com/stacklok/minder/internal/providers/github"
 	"github.com/stacklok/minder/internal/util/cli"
 )
@@ -59,35 +59,14 @@ func Execute() {
 
 func init() {
 	cobra.OnInitialize(initConfig)
-	// Global flags
-	RootCmd.PersistentFlags().String("grpc-host", constants.MinderGRPCHost, "Server host")
-	RootCmd.PersistentFlags().Int("grpc-port", 443, "Server port")
-	RootCmd.PersistentFlags().Bool("grpc-insecure", false, "Allow establishing insecure connections")
-	RootCmd.PersistentFlags().String("identity-url", constants.IdentitySeverURL, "Identity server issuer URL")
-	RootCmd.PersistentFlags().String("identity-client", "minder-cli", "Identity server client ID")
-	RootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "Config file (default is $PWD/config.yaml)")
 
-	// Bind viper config to cobra flags
-	if err := viper.BindPFlag("grpc_server.host", RootCmd.PersistentFlags().Lookup("grpc-host")); err != nil {
+	// Register minder cli flags - gRPC client config and identity config
+	if err := clientconfig.RegisterMinderClientFlags(viper.GetViper(), RootCmd.PersistentFlags()); err != nil {
 		RootCmd.Printf("error: %s", err)
 		os.Exit(1)
 	}
-	if err := viper.BindPFlag("grpc_server.port", RootCmd.PersistentFlags().Lookup("grpc-port")); err != nil {
-		RootCmd.Printf("error: %s", err)
-		os.Exit(1)
-	}
-	if err := viper.BindPFlag("grpc_server.insecure", RootCmd.PersistentFlags().Lookup("grpc-insecure")); err != nil {
-		RootCmd.Printf("error: %s", err)
-		os.Exit(1)
-	}
-	if err := viper.BindPFlag("identity.cli.issuer_url", RootCmd.PersistentFlags().Lookup("identity-url")); err != nil {
-		RootCmd.Printf("error: %s", err)
-		os.Exit(1)
-	}
-	if err := viper.BindPFlag("identity.cli.client_id", RootCmd.PersistentFlags().Lookup("identity-client")); err != nil {
-		RootCmd.Printf("error: %s", err)
-		os.Exit(1)
-	}
+
+	RootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "Config file (default is $PWD/config.yaml)")
 }
 
 func initConfig() {

--- a/cmd/server/app/migrate_down.go
+++ b/cmd/server/app/migrate_down.go
@@ -26,7 +26,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 
-	"github.com/stacklok/minder/internal/config"
+	serverconfig "github.com/stacklok/minder/internal/config/server"
 	"github.com/stacklok/minder/internal/logger"
 )
 
@@ -35,7 +35,7 @@ var downCmd = &cobra.Command{
 	Short: "migrate a down a database version",
 	Long:  `Command to downgrade database`,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		cfg, err := config.ReadConfigFromViper(viper.GetViper())
+		cfg, err := serverconfig.ReadConfigFromViper(viper.GetViper())
 		if err != nil {
 			return fmt.Errorf("unable to read config: %w", err)
 		}

--- a/cmd/server/app/migrate_up.go
+++ b/cmd/server/app/migrate_up.go
@@ -28,7 +28,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 
-	"github.com/stacklok/minder/internal/config"
+	serverconfig "github.com/stacklok/minder/internal/config/server"
 	"github.com/stacklok/minder/internal/logger"
 )
 
@@ -38,7 +38,7 @@ var upCmd = &cobra.Command{
 	Short: "migrate the database to the latest version",
 	Long:  `Command to upgrade database`,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		cfg, err := config.ReadConfigFromViper(viper.GetViper())
+		cfg, err := serverconfig.ReadConfigFromViper(viper.GetViper())
 		if err != nil {
 			return fmt.Errorf("unable to read config: %w", err)
 		}

--- a/cmd/server/app/migrate_version.go
+++ b/cmd/server/app/migrate_version.go
@@ -27,7 +27,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 
-	"github.com/stacklok/minder/internal/config"
+	serverconfig "github.com/stacklok/minder/internal/config/server"
 	"github.com/stacklok/minder/internal/logger"
 )
 
@@ -37,7 +37,7 @@ var versionCmd = &cobra.Command{
 	Short: "get the db version",
 	Long:  `Command to get the database version`,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		cfg, err := config.ReadConfigFromViper(viper.GetViper())
+		cfg, err := serverconfig.ReadConfigFromViper(viper.GetViper())
 		if err != nil {
 			return fmt.Errorf("unable to read config: %w", err)
 		}

--- a/cmd/server/app/root.go
+++ b/cmd/server/app/root.go
@@ -25,7 +25,7 @@ import (
 	"github.com/spf13/viper"
 
 	"github.com/stacklok/minder/internal/auth"
-	"github.com/stacklok/minder/internal/config"
+	serverconfig "github.com/stacklok/minder/internal/config/server"
 	"github.com/stacklok/minder/internal/util/cli"
 )
 
@@ -51,19 +51,19 @@ func Execute() {
 func init() {
 	cobra.OnInitialize(initConfig)
 	RootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is $PWD/server-config.yaml)")
-	if err := config.RegisterDatabaseFlags(viper.GetViper(), RootCmd.PersistentFlags()); err != nil {
+	if err := serverconfig.RegisterDatabaseFlags(viper.GetViper(), RootCmd.PersistentFlags()); err != nil {
 		log.Fatal().Err(err).Msg("Error registering database flags")
 	}
 	if err := auth.RegisterOAuthFlags(viper.GetViper(), RootCmd.PersistentFlags()); err != nil {
 		log.Fatal().Err(err).Msg("Error registering oauth flags")
 	}
-	if err := config.RegisterIdentityFlags(viper.GetViper(), RootCmd.PersistentFlags()); err != nil {
+	if err := serverconfig.RegisterIdentityFlags(viper.GetViper(), RootCmd.PersistentFlags()); err != nil {
 		log.Fatal().Err(err).Msg("Error registering identity flags")
 	}
 }
 
 func initConfig() {
-	config.SetViperDefaults(viper.GetViper())
+	serverconfig.SetViperDefaults(viper.GetViper())
 
 	if cfgFile != "" {
 		viper.SetConfigFile(cfgFile)

--- a/cmd/server/app/serve.go
+++ b/cmd/server/app/serve.go
@@ -29,7 +29,7 @@ import (
 	"golang.org/x/sync/errgroup"
 
 	"github.com/stacklok/minder/internal/auth"
-	"github.com/stacklok/minder/internal/config"
+	serverconfig "github.com/stacklok/minder/internal/config/server"
 	"github.com/stacklok/minder/internal/controlplane"
 	"github.com/stacklok/minder/internal/db"
 	"github.com/stacklok/minder/internal/eea"
@@ -49,7 +49,7 @@ var serveCmd = &cobra.Command{
 		ctx, cancel := signal.NotifyContext(cmd.Context(), os.Interrupt)
 		defer cancel()
 
-		cfg, err := config.ReadConfigFromViper(viper.GetViper())
+		cfg, err := serverconfig.ReadConfigFromViper(viper.GetViper())
 		if err != nil {
 			return fmt.Errorf("unable to read config: %w", err)
 		}
@@ -164,7 +164,7 @@ func init() {
 	v := viper.GetViper()
 
 	// Register flags for the server - http, grpc, metrics
-	if err := config.RegisterServerFlags(v, serveCmd.Flags()); err != nil {
+	if err := serverconfig.RegisterServerFlags(v, serveCmd.Flags()); err != nil {
 		log.Fatal().Err(err).Msg("Error registering server flags")
 	}
 

--- a/internal/config/client/config.go
+++ b/internal/config/client/config.go
@@ -1,0 +1,92 @@
+//
+// Copyright 2024 Stacklok, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package client contains the configuration for the minder cli
+package client
+
+import (
+	"github.com/spf13/pflag"
+	"github.com/spf13/viper"
+
+	"github.com/stacklok/minder/internal/config"
+	"github.com/stacklok/minder/internal/constants"
+)
+
+// Config is the configuration for the minder cli
+type Config struct {
+	GRPCClientConfig GRPCClientConfig      `mapstructure:"grpc_server"`
+	Identity         IdentityConfigWrapper `mapstructure:"identity"`
+}
+
+// GRPCClientConfig is the configuration for the minder cli to connect to gRPC server
+type GRPCClientConfig struct {
+	// Host is the host to connect to
+	Host string `mapstructure:"host" default:"api.stacklok.com"`
+
+	// Port is the port to connect to
+	Port int `mapstructure:"port" default:"443"`
+
+	// Insecure is whether to allow establishing insecure connections
+	Insecure bool `mapstructure:"insecure" default:"false"`
+}
+
+// ReadConfigFromViper reads the client configuration from the given Viper instance.
+// Client Configuration is set while initializing minder-cli by binding PFlags to Viper.
+func ReadConfigFromViper(v *viper.Viper) (*Config, error) {
+	var cfg Config
+	if err := v.Unmarshal(&cfg); err != nil {
+		return nil, err
+	}
+	return &cfg, nil
+}
+
+// RegisterMinderClientFlags registers the flags for the minder cli
+func RegisterMinderClientFlags(v *viper.Viper, flags *pflag.FlagSet) error {
+	if err := registerGRPCClientConfigFlags(v, flags); err != nil {
+		return err
+	}
+
+	return registerClientIdentityConfigFlags(v, flags)
+}
+
+// registerGRPCClientConfigFlags registers the flags for the gRPC client
+func registerGRPCClientConfigFlags(v *viper.Viper, flags *pflag.FlagSet) error {
+	err := config.BindConfigFlag(v, flags, "grpc_server.host", "grpc-host", constants.MinderGRPCHost,
+		"Server host", flags.String)
+	if err != nil {
+		return err
+	}
+
+	err = config.BindConfigFlag(v, flags, "grpc_server.port", "grpc-port", 443,
+		"Server port", flags.Int)
+	if err != nil {
+		return err
+	}
+
+	return config.BindConfigFlag(v, flags, "grpc_server.insecure", "grpc-insecure", false,
+		"Allow establishing insecure connections", flags.Bool)
+}
+
+// registerClientIdentityConfigFlags registers the flags for the client identity
+func registerClientIdentityConfigFlags(v *viper.Viper, flags *pflag.FlagSet) error {
+	err := config.BindConfigFlag(v, flags, "identity.cli.issuer_url", "identity-url", constants.IdentitySeverURL,
+		"Identity server issuer URL", flags.String)
+	if err != nil {
+		return err
+	}
+
+	return config.BindConfigFlag(v, flags, "identity.cli.client_id", "identity-client", "minder-cli",
+		"Identity server client ID", flags.String)
+}

--- a/internal/config/client/config_test.go
+++ b/internal/config/client/config_test.go
@@ -1,0 +1,176 @@
+//
+// Copyright 2024 Stacklok, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package client_test
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/spf13/pflag"
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/require"
+
+	clientconfig "github.com/stacklok/minder/internal/config/client"
+)
+
+func TestReadClientConfig(t *testing.T) {
+	t.Parallel()
+
+	clientCfgString := `---
+grpc_server:
+  host: "127.0.0.1"
+  port: 8090
+
+identity:
+  cli:
+    issuer_url: http://localhost:8081
+    client_id: minder-cli
+`
+	cfgbuf := bytes.NewBufferString(clientCfgString)
+
+	v := viper.New()
+
+	v.SetConfigType("yaml")
+	require.NoError(t, v.ReadConfig(cfgbuf), "Unexpected error")
+
+	cfg, err := clientconfig.ReadConfigFromViper(v)
+	require.NoError(t, err, "Unexpected error")
+
+	require.Equal(t, "127.0.0.1", cfg.GRPCClientConfig.Host)
+	require.Equal(t, 8090, cfg.GRPCClientConfig.Port)
+	require.Equal(t, false, cfg.GRPCClientConfig.Insecure)
+	require.Equal(t, "http://localhost:8081", cfg.Identity.CLI.IssuerUrl)
+	require.Equal(t, "minder-cli", cfg.Identity.CLI.ClientId)
+}
+
+func TestReadClientConfigWithDefaults(t *testing.T) {
+	t.Parallel()
+
+	clientCfgString := `---
+grpc_server:
+identity:
+`
+	cfgbuf := bytes.NewBufferString(clientCfgString)
+
+	v := viper.New()
+
+	v.SetConfigType("yaml")
+	require.NoError(t, v.ReadConfig(cfgbuf), "Unexpected error")
+
+	flags := pflag.NewFlagSet("test", pflag.ContinueOnError)
+	require.NoError(t, clientconfig.RegisterMinderClientFlags(v, flags), "Unexpected error")
+
+	cfg, err := clientconfig.ReadConfigFromViper(v)
+	require.NoError(t, err, "Unexpected error")
+
+	require.Equal(t, "api.stacklok.com", cfg.GRPCClientConfig.Host)
+	require.Equal(t, 443, cfg.GRPCClientConfig.Port)
+	require.Equal(t, false, cfg.GRPCClientConfig.Insecure)
+	require.Equal(t, "https://auth.stacklok.com", cfg.Identity.CLI.IssuerUrl)
+	require.Equal(t, "minder-cli", cfg.Identity.CLI.ClientId)
+}
+
+func TestReadClientConfigWithConfigFileOverride(t *testing.T) {
+	t.Parallel()
+
+	clientCfgString := `---
+grpc_server:
+  host: "192.168.1.7"
+identity:
+  cli:
+    issuer_url: http://localhost:1234
+`
+	cfgbuf := bytes.NewBufferString(clientCfgString)
+
+	v := viper.New()
+
+	v.SetConfigType("yaml")
+	require.NoError(t, v.ReadConfig(cfgbuf), "Unexpected error")
+
+	flags := pflag.NewFlagSet("test", pflag.ContinueOnError)
+	require.NoError(t, clientconfig.RegisterMinderClientFlags(v, flags), "Unexpected error")
+
+	cfg, err := clientconfig.ReadConfigFromViper(v)
+	require.NoError(t, err, "Unexpected error")
+
+	require.Equal(t, "192.168.1.7", cfg.GRPCClientConfig.Host)
+	require.Equal(t, 443, cfg.GRPCClientConfig.Port)
+	require.Equal(t, false, cfg.GRPCClientConfig.Insecure)
+	require.Equal(t, "http://localhost:1234", cfg.Identity.CLI.IssuerUrl)
+	require.Equal(t, "minder-cli", cfg.Identity.CLI.ClientId)
+}
+
+func TestReadClientConfigWithCmdLineArgs(t *testing.T) {
+	t.Parallel()
+
+	clientCfgString := `---
+grpc_server:
+identity:
+`
+	cfgbuf := bytes.NewBufferString(clientCfgString)
+
+	v := viper.New()
+
+	v.SetConfigType("yaml")
+	require.NoError(t, v.ReadConfig(cfgbuf), "Unexpected error")
+
+	flags := pflag.NewFlagSet("test", pflag.ContinueOnError)
+	require.NoError(t, clientconfig.RegisterMinderClientFlags(v, flags), "Unexpected error")
+
+	require.NoError(t, flags.Parse([]string{"--grpc-host=192.168.1.7", "--grpc-port=1234", "--identity-url=http://localhost:1654"}))
+	t.Logf("Viper Configuration: %+v", v.AllSettings())
+
+	cfg, err := clientconfig.ReadConfigFromViper(v)
+	require.NoError(t, err, "Unexpected error")
+
+	require.Equal(t, "192.168.1.7", cfg.GRPCClientConfig.Host)
+	require.Equal(t, 1234, cfg.GRPCClientConfig.Port)
+	require.Equal(t, false, cfg.GRPCClientConfig.Insecure)
+	require.Equal(t, "http://localhost:1654", cfg.Identity.CLI.IssuerUrl)
+	require.Equal(t, "minder-cli", cfg.Identity.CLI.ClientId)
+}
+
+func TestReadClientConfigWithCmdLineArgsAndInputConfig(t *testing.T) {
+	t.Parallel()
+
+	clientCfgString := `---
+grpc_server:
+  host: "196.167.2.5"
+identity:
+  cli:
+    issuer_url: http://localhost:4567
+`
+	cfgbuf := bytes.NewBufferString(clientCfgString)
+
+	v := viper.New()
+
+	v.SetConfigType("yaml")
+	require.NoError(t, v.ReadConfig(cfgbuf), "Unexpected error")
+
+	flags := pflag.NewFlagSet("test", pflag.ContinueOnError)
+	require.NoError(t, clientconfig.RegisterMinderClientFlags(v, flags), "Unexpected error")
+
+	require.NoError(t, flags.Parse([]string{"--grpc-host=192.168.1.7", "--grpc-port=1234", "--identity-url=http://localhost:1654"}))
+
+	cfg, err := clientconfig.ReadConfigFromViper(v)
+	require.NoError(t, err, "Unexpected error")
+
+	require.Equal(t, "192.168.1.7", cfg.GRPCClientConfig.Host)
+	require.Equal(t, 1234, cfg.GRPCClientConfig.Port)
+	require.Equal(t, false, cfg.GRPCClientConfig.Insecure)
+	require.Equal(t, "http://localhost:1654", cfg.Identity.CLI.IssuerUrl)
+	require.Equal(t, "minder-cli", cfg.Identity.CLI.ClientId)
+}

--- a/internal/config/client/identity.go
+++ b/internal/config/client/identity.go
@@ -1,0 +1,30 @@
+//
+// Copyright 2024 Stacklok, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package client
+
+// IdentityConfigWrapper is the configuration wrapper for the identity provider used by minder-cli
+type IdentityConfigWrapper struct {
+	CLI IdentityConfig `mapstructure:"cli"`
+}
+
+// IdentityConfig is the configuration for the identity provider used by minder-cli
+type IdentityConfig struct {
+	// IssuerUrl is the base URL where the identity server is running
+	IssuerUrl string `mapstructure:"issuer_url" default:"https://auth.stacklok.com"`
+
+	// ClientId is the client ID that identifies the server client ID
+	ClientId string `mapstructure:"client_id" default:"minder-cli"`
+}

--- a/internal/config/server/auth.go
+++ b/internal/config/server/auth.go
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package config
+package server
 
 import (
 	"fmt"

--- a/internal/config/server/config.go
+++ b/internal/config/server/config.go
@@ -13,9 +13,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package config contains a centralized structure for all configuration
+// Package server contains a centralized structure for all configuration
 // options.
-package config
+package server
 
 import (
 	"fmt"
@@ -24,23 +24,22 @@ import (
 	"strings"
 	"unicode"
 
-	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
 )
 
 // Config is the top-level configuration structure.
 type Config struct {
-	HTTPServer    HTTPServerConfig   `mapstructure:"http_server"`
-	GRPCServer    GRPCServerConfig   `mapstructure:"grpc_server"`
-	MetricServer  MetricServerConfig `mapstructure:"metric_server"`
-	LoggingConfig LoggingConfig      `mapstructure:"logging"`
-	Tracing       TracingConfig      `mapstructure:"tracing"`
-	Metrics       MetricsConfig      `mapstructure:"metrics"`
-	Database      DatabaseConfig     `mapstructure:"database"`
-	Identity      IdentityConfig     `mapstructure:"identity"`
-	Auth          AuthConfig         `mapstructure:"auth"`
-	WebhookConfig WebhookConfig      `mapstructure:"webhook-config"`
-	Events        EventConfig        `mapstructure:"events"`
+	HTTPServer    HTTPServerConfig      `mapstructure:"http_server"`
+	GRPCServer    GRPCServerConfig      `mapstructure:"grpc_server"`
+	MetricServer  MetricServerConfig    `mapstructure:"metric_server"`
+	LoggingConfig LoggingConfig         `mapstructure:"logging"`
+	Tracing       TracingConfig         `mapstructure:"tracing"`
+	Metrics       MetricsConfig         `mapstructure:"metrics"`
+	Database      DatabaseConfig        `mapstructure:"database"`
+	Identity      IdentityConfigWrapper `mapstructure:"identity"`
+	Auth          AuthConfig            `mapstructure:"auth"`
+	WebhookConfig WebhookConfig         `mapstructure:"webhook-config"`
+	Events        EventConfig           `mapstructure:"events"`
 }
 
 // DefaultConfigForTest returns a configuration with all the struct defaults set,
@@ -129,73 +128,4 @@ func setViperStructDefaults(v *viper.Viper, prefix string, s any) {
 		}
 		v.SetDefault(valueName, defaultValue)
 	}
-}
-
-// FlagInst is a function that creates a flag and returns a pointer to the value
-type FlagInst[V any] func(name string, value V, usage string) *V
-
-// FlagInstShort is a function that creates a flag and returns a pointer to the value
-type FlagInstShort[V any] func(name, shorthand string, value V, usage string) *V
-
-// BindConfigFlag is a helper function that binds a configuration value to a flag.
-//
-// Parameters:
-// - v: The viper.Viper object used to retrieve the configuration value.
-// - flags: The pflag.FlagSet object used to retrieve the flag value.
-// - viperPath: The path used to retrieve the configuration value from Viper.
-// - cmdLineArg: The flag name used to check if the flag has been set and to retrieve its value.
-// - help: The help text for the flag.
-// - defaultValue: A default value used to determine the type of the flag (string, int, etc.).
-// - binder: A function that creates a flag and returns a pointer to the value.
-func BindConfigFlag[V any](
-	v *viper.Viper,
-	flags *pflag.FlagSet,
-	viperPath string,
-	cmdLineArg string,
-	defaultValue V,
-	help string,
-	binder FlagInst[V],
-) error {
-	binder(cmdLineArg, defaultValue, help)
-	return doViperBind[V](v, flags, viperPath, cmdLineArg, defaultValue)
-}
-
-// BindConfigFlagWithShort is a helper function that binds a configuration value to a flag.
-//
-// Parameters:
-// - v: The viper.Viper object used to retrieve the configuration value.
-// - flags: The pflag.FlagSet object used to retrieve the flag value.
-// - viperPath: The path used to retrieve the configuration value from Viper.
-// - cmdLineArg: The flag name used to check if the flag has been set and to retrieve its value.
-// - short: The short name for the flag.
-// - help: The help text for the flag.
-// - defaultValue: A default value used to determine the type of the flag (string, int, etc.).
-// - binder: A function that creates a flag and returns a pointer to the value.
-func BindConfigFlagWithShort[V any](
-	v *viper.Viper,
-	flags *pflag.FlagSet,
-	viperPath string,
-	cmdLineArg string,
-	short string,
-	defaultValue V,
-	help string,
-	binder FlagInstShort[V],
-) error {
-	binder(cmdLineArg, short, defaultValue, help)
-	return doViperBind[V](v, flags, viperPath, cmdLineArg, defaultValue)
-}
-
-func doViperBind[V any](
-	v *viper.Viper,
-	flags *pflag.FlagSet,
-	viperPath string,
-	cmdLineArg string,
-	defaultValue V,
-) error {
-	v.SetDefault(viperPath, defaultValue)
-	if err := v.BindPFlag(viperPath, flags.Lookup(cmdLineArg)); err != nil {
-		return fmt.Errorf("failed to bind flag %s to viper path %s: %w", cmdLineArg, viperPath, err)
-	}
-
-	return nil
 }

--- a/internal/config/server/config_test.go
+++ b/internal/config/server/config_test.go
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package config_test
+package server_test
 
 import (
 	"bytes"
@@ -27,6 +27,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/stacklok/minder/internal/config"
+	serverconfig "github.com/stacklok/minder/internal/config/server"
 )
 
 func TestReadValidConfig(t *testing.T) {
@@ -51,7 +52,7 @@ metric_server:
 	v.SetConfigType("yaml")
 	require.NoError(t, v.ReadConfig(cfgbuf), "Unexpected error")
 
-	cfg, err := config.ReadConfigFromViper(v)
+	cfg, err := serverconfig.ReadConfigFromViper(v)
 	require.NoError(t, err, "Unexpected error")
 
 	require.Equal(t, "myhost", cfg.HTTPServer.Host)
@@ -76,12 +77,12 @@ metric_server:
 	v := viper.New()
 	flags := pflag.NewFlagSet("test", pflag.ContinueOnError)
 
-	require.NoError(t, config.RegisterServerFlags(v, flags), "Unexpected error")
+	require.NoError(t, serverconfig.RegisterServerFlags(v, flags), "Unexpected error")
 
 	v.SetConfigType("yaml")
 	require.NoError(t, v.ReadConfig(cfgbuf), "Unexpected error")
 
-	cfg, err := config.ReadConfigFromViper(v)
+	cfg, err := serverconfig.ReadConfigFromViper(v)
 	require.NoError(t, err, "Unexpected error")
 
 	require.Equal(t, "", cfg.HTTPServer.Host)
@@ -112,14 +113,14 @@ metric_server:
 	v := viper.New()
 	flags := pflag.NewFlagSet("test", pflag.ContinueOnError)
 
-	require.NoError(t, config.RegisterServerFlags(v, flags), "Unexpected error")
+	require.NoError(t, serverconfig.RegisterServerFlags(v, flags), "Unexpected error")
 
 	require.NoError(t, flags.Parse([]string{"--http-host=foo", "--http-port=1234", "--grpc-host=bar", "--grpc-port=5678", "--metric-host=var", "--metric-port=6679"}))
 
 	v.SetConfigType("yaml")
 	require.NoError(t, v.ReadConfig(cfgbuf), "Unexpected error")
 
-	cfg, err := config.ReadConfigFromViper(v)
+	cfg, err := serverconfig.ReadConfigFromViper(v)
 	require.NoError(t, err, "Unexpected error")
 
 	require.Equal(t, "foo", cfg.HTTPServer.Host)
@@ -133,7 +134,7 @@ metric_server:
 func TestReadDefaultConfig(t *testing.T) {
 	t.Parallel()
 
-	cfg := config.DefaultConfigForTest()
+	cfg := serverconfig.DefaultConfigForTest()
 	require.Equal(t, "debug", cfg.LoggingConfig.Level)
 	require.Equal(t, "minder", cfg.Database.Name)
 	require.Equal(t, "./.ssh/token_key_passphrase", cfg.Auth.TokenKey)
@@ -144,7 +145,7 @@ func TestReadAuthConfig(t *testing.T) {
 
 	testCases := []struct {
 		name     string
-		mutate   func(*testing.T, *config.AuthConfig)
+		mutate   func(*testing.T, *serverconfig.AuthConfig)
 		keyError string
 	}{
 		{
@@ -152,7 +153,7 @@ func TestReadAuthConfig(t *testing.T) {
 		},
 		{
 			name: "missing keys",
-			mutate: func(t *testing.T, cfg *config.AuthConfig) {
+			mutate: func(t *testing.T, cfg *serverconfig.AuthConfig) {
 				t.Helper()
 				require.NoError(t, os.Remove(cfg.TokenKey))
 			},
@@ -165,7 +166,7 @@ func TestReadAuthConfig(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			tmpdir := t.TempDir()
-			cfg := config.AuthConfig{
+			cfg := serverconfig.AuthConfig{
 				TokenKey: filepath.Join(tmpdir, "token_key"),
 			}
 			if err := os.WriteFile(cfg.TokenKey, []byte("test"), 0600); err != nil {

--- a/internal/config/server/db.go
+++ b/internal/config/server/db.go
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package config
+package server
 
 import (
 	"context"
@@ -26,6 +26,8 @@ import (
 	"github.com/signalfx/splunk-otel-go/instrumentation/database/sql/splunksql"
 	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
+
+	"github.com/stacklok/minder/internal/config"
 )
 
 // DatabaseConfig is the configuration for the database
@@ -67,36 +69,36 @@ func (c *DatabaseConfig) GetDBConnection(ctx context.Context) (*sql.DB, string, 
 
 // RegisterDatabaseFlags registers the flags for the database configuration
 func RegisterDatabaseFlags(v *viper.Viper, flags *pflag.FlagSet) error {
-	err := BindConfigFlagWithShort(
+	err := config.BindConfigFlagWithShort(
 		v, flags, "database.dbhost", "db-host", "H", "localhost", "Database host", flags.StringP)
 	if err != nil {
 		return err
 	}
 
-	err = BindConfigFlag(
+	err = config.BindConfigFlag(
 		v, flags, "database.dbport", "db-port", 5432, "Database port", flags.Int)
 	if err != nil {
 		return err
 	}
 
-	err = BindConfigFlagWithShort(
+	err = config.BindConfigFlagWithShort(
 		v, flags, "database.dbuser", "db-user", "u", "postgres", "Database user", flags.StringP)
 	if err != nil {
 		return err
 	}
 
-	err = BindConfigFlagWithShort(
+	err = config.BindConfigFlagWithShort(
 		v, flags, "database.dbpass", "db-pass", "P", "postgres", "Database password", flags.StringP)
 	if err != nil {
 		return err
 	}
 
-	err = BindConfigFlagWithShort(
+	err = config.BindConfigFlagWithShort(
 		v, flags, "database.dbname", "db-name", "d", "minder", "Database name", flags.StringP)
 	if err != nil {
 		return err
 	}
 
-	return BindConfigFlagWithShort(
+	return config.BindConfigFlagWithShort(
 		v, flags, "database.sslmode", "db-sslmode", "s", "disable", "Database sslmode", flags.StringP)
 }

--- a/internal/config/server/events.go
+++ b/internal/config/server/events.go
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package config
+package server
 
 // EventConfig is the configuration for minder's eventing system.
 type EventConfig struct {

--- a/internal/config/server/identity.go
+++ b/internal/config/server/identity.go
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package config
+package server
 
 import (
 	"fmt"
@@ -22,15 +22,17 @@ import (
 
 	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
+
+	"github.com/stacklok/minder/internal/config"
 )
 
-// IdentityConfig is the configuration for the identity provider
-type IdentityConfig struct {
-	Server ServerIdentityConfig `mapstructure:"server"`
+// IdentityConfigWrapper is the configuration for the identity provider
+type IdentityConfigWrapper struct {
+	Server IdentityConfig `mapstructure:"server"`
 }
 
-// ServerIdentityConfig is the configuration for the identity provider in minder server
-type ServerIdentityConfig struct {
+// IdentityConfig is the configuration for the identity provider in minder server
+type IdentityConfig struct {
 	// IssuerUrl is the base URL where the identity server is running
 	IssuerUrl string `mapstructure:"issuer_url" default:"http://localhost:8081"`
 	// ClientId is the client ID that identifies the minder server
@@ -42,7 +44,7 @@ type ServerIdentityConfig struct {
 }
 
 // GetClientSecret returns the minder-server client secret
-func (sic *ServerIdentityConfig) GetClientSecret() (string, error) {
+func (sic *IdentityConfig) GetClientSecret() (string, error) {
 	if sic.ClientSecretFile != "" {
 		data, err := os.ReadFile(filepath.Clean(sic.ClientSecretFile))
 		if err != nil {
@@ -55,6 +57,6 @@ func (sic *ServerIdentityConfig) GetClientSecret() (string, error) {
 
 // RegisterIdentityFlags registers the flags for the identity server
 func RegisterIdentityFlags(v *viper.Viper, flags *pflag.FlagSet) error {
-	return BindConfigFlag(v, flags, "identity.server.issuer_url", "issuer-url", "",
+	return config.BindConfigFlag(v, flags, "identity.server.issuer_url", "issuer-url", "",
 		"The base URL where the identity server is running", flags.String)
 }

--- a/internal/config/server/logging.go
+++ b/internal/config/server/logging.go
@@ -13,15 +13,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package config
+package server
 
-// WebhookConfig is the configuration for our webhook capabilities
-type WebhookConfig struct {
-	// ExternalWebhookURL is the URL that we will send our webhook to
-	ExternalWebhookURL string `mapstructure:"external_webhook_url"`
-	// ExternalPingURL is the URL that we will send our ping to
-	ExternalPingURL string `mapstructure:"external_ping_url"`
-	// WebhookSecret is the secret that we will use to sign our webhook
-	// TODO: Check if this is actually used and needed
-	WebhookSecret string `mapstructure:"webhook_secret"`
+// LoggingConfig is the configuration for the logging package
+type LoggingConfig struct {
+	Level   string `mapstructure:"level" default:"debug"`
+	Format  string `mapstructure:"format" default:"json"`
+	LogFile string `mapstructure:"logFile" default:""`
 }

--- a/internal/config/server/metrics.go
+++ b/internal/config/server/metrics.go
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package config
+package server
 
 // MetricsConfig is the configuration for the metrics
 type MetricsConfig struct {

--- a/internal/config/server/server.go
+++ b/internal/config/server/server.go
@@ -13,13 +13,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package config
+package server
 
 import (
 	"fmt"
 
 	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
+
+	"github.com/stacklok/minder/internal/config"
 )
 
 // HTTPServerConfig is the configuration for the HTTP server
@@ -79,36 +81,36 @@ func RegisterServerFlags(v *viper.Viper, flags *pflag.FlagSet) error {
 
 // registerHTTPServerFlags registers the flags for the HTTP server
 func registerHTTPServerFlags(v *viper.Viper, flags *pflag.FlagSet) error {
-	err := BindConfigFlag(v, flags, "http_server.host", "http-host", "",
+	err := config.BindConfigFlag(v, flags, "http_server.host", "http-host", "",
 		"The host to bind to for the HTTP server", flags.String)
 	if err != nil {
 		return err
 	}
 
-	return BindConfigFlag(v, flags, "http_server.port", "http-port", 8080,
+	return config.BindConfigFlag(v, flags, "http_server.port", "http-port", 8080,
 		"The port to bind to for the HTTP server", flags.Int)
 }
 
 // registerGRPCServerFlags registers the flags for the gRPC server
 func registerGRPCServerFlags(v *viper.Viper, flags *pflag.FlagSet) error {
-	err := BindConfigFlag(v, flags, "grpc_server.host", "grpc-host", "",
+	err := config.BindConfigFlag(v, flags, "grpc_server.host", "grpc-host", "",
 		"The host to bind to for the gRPC server", flags.String)
 	if err != nil {
 		return err
 	}
 
-	return BindConfigFlag(v, flags, "grpc_server.port", "grpc-port", 8090,
+	return config.BindConfigFlag(v, flags, "grpc_server.port", "grpc-port", 8090,
 		"The port to bind to for the gRPC server", flags.Int)
 }
 
 // registerMetricServerFlags registers the flags for the metric server
 func registerMetricServerFlags(v *viper.Viper, flags *pflag.FlagSet) error {
-	err := BindConfigFlag(v, flags, "metric_server.host", "metric-host", "",
+	err := config.BindConfigFlag(v, flags, "metric_server.host", "metric-host", "",
 		"The host to bind to for the metric server", flags.String)
 	if err != nil {
 		return err
 	}
 
-	return BindConfigFlag(v, flags, "metric_server.port", "metric-port", 9090,
+	return config.BindConfigFlag(v, flags, "metric_server.port", "metric-port", 9090,
 		"The port to bind to for the metric server", flags.Int)
 }

--- a/internal/config/server/tracing.go
+++ b/internal/config/server/tracing.go
@@ -13,11 +13,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package config
+package server
 
-// LoggingConfig is the configuration for the logging package
-type LoggingConfig struct {
-	Level   string `mapstructure:"level" default:"debug"`
-	Format  string `mapstructure:"format" default:"json"`
-	LogFile string `mapstructure:"logFile" default:""`
+// TracingConfig is the configuration for our tracing capabilities
+type TracingConfig struct {
+	Enabled bool `mapstructure:"enabled" default:"false"`
+	// for the demonstration, we use AlwaysSmaple sampler to take all spans.
+	// do not use this option in production.
+	SampleRatio float64 `mapstructure:"sample_ratio" default:"0.1"`
 }

--- a/internal/config/server/webhook.go
+++ b/internal/config/server/webhook.go
@@ -13,12 +13,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package config
+package server
 
-// TracingConfig is the configuration for our tracing capabilities
-type TracingConfig struct {
-	Enabled bool `mapstructure:"enabled" default:"false"`
-	// for the demonstration, we use AlwaysSmaple sampler to take all spans.
-	// do not use this option in production.
-	SampleRatio float64 `mapstructure:"sample_ratio" default:"0.1"`
+// WebhookConfig is the configuration for our webhook capabilities
+type WebhookConfig struct {
+	// ExternalWebhookURL is the URL that we will send our webhook to
+	ExternalWebhookURL string `mapstructure:"external_webhook_url"`
+	// ExternalPingURL is the URL that we will send our ping to
+	ExternalPingURL string `mapstructure:"external_ping_url"`
+	// WebhookSecret is the secret that we will use to sign our webhook
+	// TODO: Check if this is actually used and needed
+	WebhookSecret string `mapstructure:"webhook_secret"`
 }

--- a/internal/config/utils.go
+++ b/internal/config/utils.go
@@ -1,0 +1,93 @@
+//
+// Copyright 2023 Stacklok, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package config contains the configuration for the minder cli and server
+package config
+
+import (
+	"fmt"
+
+	"github.com/spf13/pflag"
+	"github.com/spf13/viper"
+)
+
+// FlagInst is a function that creates a flag and returns a pointer to the value
+type FlagInst[V any] func(name string, value V, usage string) *V
+
+// FlagInstShort is a function that creates a flag and returns a pointer to the value
+type FlagInstShort[V any] func(name, shorthand string, value V, usage string) *V
+
+// BindConfigFlag is a helper function that binds a configuration value to a flag.
+//
+// Parameters:
+// - v: The viper.Viper object used to retrieve the configuration value.
+// - flags: The pflag.FlagSet object used to retrieve the flag value.
+// - viperPath: The path used to retrieve the configuration value from Viper.
+// - cmdLineArg: The flag name used to check if the flag has been set and to retrieve its value.
+// - help: The help text for the flag.
+// - defaultValue: A default value used to determine the type of the flag (string, int, etc.).
+// - binder: A function that creates a flag and returns a pointer to the value.
+func BindConfigFlag[V any](
+	v *viper.Viper,
+	flags *pflag.FlagSet,
+	viperPath string,
+	cmdLineArg string,
+	defaultValue V,
+	help string,
+	binder FlagInst[V],
+) error {
+	binder(cmdLineArg, defaultValue, help)
+	return doViperBind[V](v, flags, viperPath, cmdLineArg, defaultValue)
+}
+
+// BindConfigFlagWithShort is a helper function that binds a configuration value to a flag.
+//
+// Parameters:
+// - v: The viper.Viper object used to retrieve the configuration value.
+// - flags: The pflag.FlagSet object used to retrieve the flag value.
+// - viperPath: The path used to retrieve the configuration value from Viper.
+// - cmdLineArg: The flag name used to check if the flag has been set and to retrieve its value.
+// - short: The short name for the flag.
+// - help: The help text for the flag.
+// - defaultValue: A default value used to determine the type of the flag (string, int, etc.).
+// - binder: A function that creates a flag and returns a pointer to the value.
+func BindConfigFlagWithShort[V any](
+	v *viper.Viper,
+	flags *pflag.FlagSet,
+	viperPath string,
+	cmdLineArg string,
+	short string,
+	defaultValue V,
+	help string,
+	binder FlagInstShort[V],
+) error {
+	binder(cmdLineArg, short, defaultValue, help)
+	return doViperBind[V](v, flags, viperPath, cmdLineArg, defaultValue)
+}
+
+func doViperBind[V any](
+	v *viper.Viper,
+	flags *pflag.FlagSet,
+	viperPath string,
+	cmdLineArg string,
+	defaultValue V,
+) error {
+	v.SetDefault(viperPath, defaultValue)
+	if err := v.BindPFlag(viperPath, flags.Lookup(cmdLineArg)); err != nil {
+		return fmt.Errorf("failed to bind flag %s to viper path %s: %w", cmdLineArg, viperPath, err)
+	}
+
+	return nil
+}

--- a/internal/controlplane/handlers_user_test.go
+++ b/internal/controlplane/handlers_user_test.go
@@ -35,7 +35,7 @@ import (
 	mockdb "github.com/stacklok/minder/database/mock"
 	"github.com/stacklok/minder/internal/auth"
 	mockjwt "github.com/stacklok/minder/internal/auth/mock"
-	"github.com/stacklok/minder/internal/config"
+	serverconfig "github.com/stacklok/minder/internal/config/server"
 	"github.com/stacklok/minder/internal/crypto"
 	"github.com/stacklok/minder/internal/db"
 	"github.com/stacklok/minder/internal/events"
@@ -148,7 +148,7 @@ func TestCreateUserDBMock(t *testing.T) {
 
 			server := &Server{
 				store:        mockStore,
-				cfg:          &config.Config{},
+				cfg:          &serverconfig.Config{},
 				cryptoEngine: crypeng,
 				vldtr:        mockJwtValidator,
 			}
@@ -256,13 +256,13 @@ func TestCreateUser_gRPC(t *testing.T) {
 			mockStore := mockdb.NewMockStore(ctrl)
 			mockJwtValidator := mockjwt.NewMockJwtValidator(ctrl)
 			tc.buildStubs(mockStore, mockJwtValidator)
-			evt, err := events.Setup(context.Background(), &config.EventConfig{
+			evt, err := events.Setup(context.Background(), &serverconfig.EventConfig{
 				Driver:    "go-channel",
-				GoChannel: config.GoChannelEventConfig{},
+				GoChannel: serverconfig.GoChannelEventConfig{},
 			})
 			require.NoError(t, err, "failed to setup eventer")
-			server, err := NewServer(mockStore, evt, NewMetrics(), &config.Config{
-				Auth: config.AuthConfig{
+			server, err := NewServer(mockStore, evt, NewMetrics(), &serverconfig.Config{
+				Auth: serverconfig.AuthConfig{
 					TokenKey: generateTokenKey(t),
 				},
 			}, mockJwtValidator)
@@ -347,9 +347,9 @@ func TestDeleteUserDBMock(t *testing.T) {
 
 	server := &Server{
 		store: mockStore,
-		cfg: &config.Config{
-			Identity: config.IdentityConfig{
-				Server: config.ServerIdentityConfig{
+		cfg: &serverconfig.Config{
+			Identity: serverconfig.IdentityConfigWrapper{
+				Server: serverconfig.IdentityConfig{
 					IssuerUrl:    testServer.URL,
 					ClientId:     "client-id",
 					ClientSecret: "client-secret",
@@ -460,17 +460,17 @@ func TestDeleteUser_gRPC(t *testing.T) {
 			}))
 			defer testServer.Close()
 
-			evt, err := events.Setup(context.Background(), &config.EventConfig{
+			evt, err := events.Setup(context.Background(), &serverconfig.EventConfig{
 				Driver:    "go-channel",
-				GoChannel: config.GoChannelEventConfig{},
+				GoChannel: serverconfig.GoChannelEventConfig{},
 			})
 			require.NoError(t, err, "failed to setup eventer")
-			server, err := NewServer(mockStore, evt, NewMetrics(), &config.Config{
-				Auth: config.AuthConfig{
+			server, err := NewServer(mockStore, evt, NewMetrics(), &serverconfig.Config{
+				Auth: serverconfig.AuthConfig{
 					TokenKey: generateTokenKey(t),
 				},
-				Identity: config.IdentityConfig{
-					Server: config.ServerIdentityConfig{
+				Identity: serverconfig.IdentityConfigWrapper{
+					Server: serverconfig.IdentityConfig{
 						IssuerUrl:    testServer.URL,
 						ClientId:     "client-id",
 						ClientSecret: "client-secret",

--- a/internal/controlplane/identity_events.go
+++ b/internal/controlplane/identity_events.go
@@ -30,7 +30,7 @@ import (
 	"golang.org/x/oauth2"
 	"golang.org/x/oauth2/clientcredentials"
 
-	"github.com/stacklok/minder/internal/config"
+	serverconfig "github.com/stacklok/minder/internal/config/server"
 	"github.com/stacklok/minder/internal/db"
 )
 
@@ -49,7 +49,7 @@ type AccountEvent struct {
 }
 
 // SubscribeToIdentityEvents starts a cron job that periodically fetches events from the identity provider
-func SubscribeToIdentityEvents(ctx context.Context, store db.Store, cfg *config.Config) error {
+func SubscribeToIdentityEvents(ctx context.Context, store db.Store, cfg *serverconfig.Config) error {
 	c := cron.New()
 	_, err := c.AddFunc(eventFetchInterval, func() {
 		HandleEvents(ctx, store, cfg)
@@ -62,7 +62,7 @@ func SubscribeToIdentityEvents(ctx context.Context, store db.Store, cfg *config.
 }
 
 // HandleEvents fetches events from the identity provider and performs any related changes to the minder database
-func HandleEvents(ctx context.Context, store db.Store, cfg *config.Config) {
+func HandleEvents(ctx context.Context, store db.Store, cfg *serverconfig.Config) {
 	d := time.Now().Add(time.Duration(10) * time.Minute)
 	ctx, cancel := context.WithDeadline(ctx, d)
 	defer cancel()

--- a/internal/controlplane/identity_events_test.go
+++ b/internal/controlplane/identity_events_test.go
@@ -27,7 +27,7 @@ import (
 	"golang.org/x/oauth2"
 
 	mockdb "github.com/stacklok/minder/database/mock"
-	"github.com/stacklok/minder/internal/config"
+	serverconfig "github.com/stacklok/minder/internal/config/server"
 	"github.com/stacklok/minder/internal/db"
 )
 
@@ -74,9 +74,9 @@ func TestHandleEvents(t *testing.T) {
 		Return(db.User{}, sql.ErrNoRows)
 	mockStore.EXPECT().Rollback(gomock.Any())
 
-	c := config.Config{
-		Identity: config.IdentityConfig{
-			Server: config.ServerIdentityConfig{
+	c := serverconfig.Config{
+		Identity: serverconfig.IdentityConfigWrapper{
+			Server: serverconfig.IdentityConfig{
 				IssuerUrl:    server.URL,
 				ClientId:     "client-id",
 				ClientSecret: "client-secret",

--- a/internal/controlplane/server.go
+++ b/internal/controlplane/server.go
@@ -46,7 +46,7 @@ import (
 
 	"github.com/stacklok/minder/internal/assets"
 	"github.com/stacklok/minder/internal/auth"
-	"github.com/stacklok/minder/internal/config"
+	serverconfig "github.com/stacklok/minder/internal/config/server"
 	"github.com/stacklok/minder/internal/crypto"
 	"github.com/stacklok/minder/internal/db"
 	"github.com/stacklok/minder/internal/events"
@@ -65,7 +65,7 @@ var (
 // Server represents the controlplane server
 type Server struct {
 	store      db.Store
-	cfg        *config.Config
+	cfg        *serverconfig.Config
 	evt        *events.Eventer
 	mt         *metrics
 	provMt     provtelemetry.ProviderMetrics
@@ -98,7 +98,7 @@ func NewServer(
 	store db.Store,
 	evt *events.Eventer,
 	cpm *metrics,
-	cfg *config.Config,
+	cfg *serverconfig.Config,
 	vldtr auth.JwtValidator,
 	opts ...ServerOption,
 ) (*Server, error) {

--- a/internal/controlplane/server_test.go
+++ b/internal/controlplane/server_test.go
@@ -32,7 +32,7 @@ import (
 
 	mockdb "github.com/stacklok/minder/database/mock"
 	mockjwt "github.com/stacklok/minder/internal/auth/mock"
-	"github.com/stacklok/minder/internal/config"
+	serverconfig "github.com/stacklok/minder/internal/config/server"
 	"github.com/stacklok/minder/internal/events"
 	pb "github.com/stacklok/minder/pkg/api/protobuf/go/minder/v1"
 )
@@ -70,16 +70,16 @@ func init() {
 func newDefaultServer(t *testing.T, mockStore *mockdb.MockStore) *Server {
 	t.Helper()
 
-	evt, err := events.Setup(context.Background(), &config.EventConfig{
+	evt, err := events.Setup(context.Background(), &serverconfig.EventConfig{
 		Driver:    "go-channel",
-		GoChannel: config.GoChannelEventConfig{},
+		GoChannel: serverconfig.GoChannelEventConfig{},
 	})
 	require.NoError(t, err, "failed to setup eventer")
 
-	var c *config.Config
+	var c *serverconfig.Config
 	tokenKeyPath := generateTokenKey(t)
-	c = &config.Config{
-		Auth: config.AuthConfig{
+	c = &serverconfig.Config{
+		Auth: serverconfig.AuthConfig{
 			TokenKey: tokenKeyPath,
 		},
 	}

--- a/internal/crypto/crypto.go
+++ b/internal/crypto/crypto.go
@@ -33,7 +33,7 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
-	"github.com/stacklok/minder/internal/config"
+	serverconfig "github.com/stacklok/minder/internal/config/server"
 )
 
 // Engine is a structure that allows controller access to cryptographic functions.
@@ -44,7 +44,7 @@ type Engine struct {
 }
 
 // EngineFromAuthConfig creates a new crypto engine from an auth config
-func EngineFromAuthConfig(authConfig *config.AuthConfig) (*Engine, error) {
+func EngineFromAuthConfig(authConfig *serverconfig.AuthConfig) (*Engine, error) {
 	if authConfig == nil {
 		return nil, errors.New("auth config is nil")
 	}

--- a/internal/eea/eea.go
+++ b/internal/eea/eea.go
@@ -29,7 +29,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/rs/zerolog"
 
-	"github.com/stacklok/minder/internal/config"
+	serverconfig "github.com/stacklok/minder/internal/config/server"
 	"github.com/stacklok/minder/internal/db"
 	"github.com/stacklok/minder/internal/engine"
 	"github.com/stacklok/minder/internal/entities"
@@ -41,11 +41,11 @@ import (
 type EEA struct {
 	querier db.Store
 	evt     *events.Eventer
-	cfg     *config.AggregatorConfig
+	cfg     *serverconfig.AggregatorConfig
 }
 
 // NewEEA creates a new EEA
-func NewEEA(querier db.Store, evt *events.Eventer, cfg *config.AggregatorConfig) *EEA {
+func NewEEA(querier db.Store, evt *events.Eventer, cfg *serverconfig.AggregatorConfig) *EEA {
 	return &EEA{
 		querier: querier,
 		evt:     evt,

--- a/internal/eea/eea_test.go
+++ b/internal/eea/eea_test.go
@@ -28,7 +28,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/stacklok/minder/internal/config"
+	serverconfig "github.com/stacklok/minder/internal/config/server"
 	"github.com/stacklok/minder/internal/db"
 	"github.com/stacklok/minder/internal/eea"
 	"github.com/stacklok/minder/internal/engine"
@@ -50,9 +50,9 @@ func TestAggregator(t *testing.T) {
 
 	projectID, repoID := createNeededEntities(ctx, t)
 
-	evt, err := events.Setup(ctx, &config.EventConfig{
+	evt, err := events.Setup(ctx, &serverconfig.EventConfig{
 		Driver: "go-channel",
-		GoChannel: config.GoChannelEventConfig{
+		GoChannel: serverconfig.GoChannelEventConfig{
 			BufferSize:                     concurrentEvents,
 			BlockPublishUntilSubscriberAck: true,
 		},
@@ -62,7 +62,7 @@ func TestAggregator(t *testing.T) {
 	// we'll wait 2 seconds for the lock to be available
 	var eventThreshold int64 = 2
 
-	aggr := eea.NewEEA(testQueries, evt, &config.AggregatorConfig{
+	aggr := eea.NewEEA(testQueries, evt, &serverconfig.AggregatorConfig{
 		LockInterval: eventThreshold,
 	})
 

--- a/internal/engine/executor.go
+++ b/internal/engine/executor.go
@@ -24,7 +24,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/rs/zerolog"
 
-	"github.com/stacklok/minder/internal/config"
+	serverconfig "github.com/stacklok/minder/internal/config/server"
 	"github.com/stacklok/minder/internal/crypto"
 	"github.com/stacklok/minder/internal/db"
 	evalerrors "github.com/stacklok/minder/internal/engine/errors"
@@ -84,7 +84,7 @@ func WithAggregatorMiddleware(mdw events.AggregatorMiddleware) ExecutorOption {
 func NewExecutor(
 	ctx context.Context,
 	querier db.Store,
-	authCfg *config.AuthConfig,
+	authCfg *serverconfig.AuthConfig,
 	evt *events.Eventer,
 	opts ...ExecutorOption,
 ) (*Executor, error) {

--- a/internal/engine/executor_test.go
+++ b/internal/engine/executor_test.go
@@ -29,7 +29,7 @@ import (
 	"google.golang.org/protobuf/types/known/structpb"
 
 	mockdb "github.com/stacklok/minder/database/mock"
-	"github.com/stacklok/minder/internal/config"
+	serverconfig "github.com/stacklok/minder/internal/config/server"
 	"github.com/stacklok/minder/internal/crypto"
 	"github.com/stacklok/minder/internal/db"
 	"github.com/stacklok/minder/internal/engine"
@@ -260,9 +260,9 @@ default allow = true`,
 	err = os.WriteFile(tokenKeyPath, []byte(fakeTokenKey), 0600)
 	require.NoError(t, err, "expected no error")
 
-	evt, err := events.Setup(context.Background(), &config.EventConfig{
+	evt, err := events.Setup(context.Background(), &serverconfig.EventConfig{
 		Driver: "go-channel",
-		GoChannel: config.GoChannelEventConfig{
+		GoChannel: serverconfig.GoChannelEventConfig{
 			BlockPublishUntilSubscriberAck: true,
 		},
 	})
@@ -282,7 +282,7 @@ default allow = true`,
 	ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
 	defer cancel()
 
-	e, err := engine.NewExecutor(ctx, mockStore, &config.AuthConfig{
+	e, err := engine.NewExecutor(ctx, mockStore, &serverconfig.AuthConfig{
 		TokenKey: tokenKeyPath,
 	}, evt)
 	require.NoError(t, err, "expected no error")

--- a/internal/events/eventer.go
+++ b/internal/events/eventer.go
@@ -38,7 +38,7 @@ import (
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/metric"
 
-	"github.com/stacklok/minder/internal/config"
+	serverconfig "github.com/stacklok/minder/internal/config/server"
 )
 
 // Metadata added to Messages
@@ -118,7 +118,7 @@ var _ message.Publisher = (*Eventer)(nil)
 
 // Setup creates an Eventer object which isolates the watermill setup code
 // TODO: pass in logger
-func Setup(ctx context.Context, cfg *config.EventConfig) (*Eventer, error) {
+func Setup(ctx context.Context, cfg *serverconfig.EventConfig) (*Eventer, error) {
 	if cfg == nil {
 		return nil, errors.New("event config is nil")
 	}
@@ -229,7 +229,7 @@ func recordMetrics(m messageInstruments) func(h message.HandlerFunc) message.Han
 func instantiateDriver(
 	ctx context.Context,
 	driver string,
-	cfg *config.EventConfig,
+	cfg *serverconfig.EventConfig,
 ) (message.Publisher, message.Subscriber, driverCloser, error) {
 	switch driver {
 	case GoChannelDriver:
@@ -241,7 +241,7 @@ func instantiateDriver(
 	}
 }
 
-func buildGoChannelDriver(cfg *config.EventConfig) (message.Publisher, message.Subscriber, driverCloser, error) {
+func buildGoChannelDriver(cfg *serverconfig.EventConfig) (message.Publisher, message.Subscriber, driverCloser, error) {
 	pubsub := gochannel.NewGoChannel(gochannel.Config{
 		OutputChannelBuffer: cfg.GoChannel.BufferSize,
 		Persistent:          cfg.GoChannel.PersistEvents,
@@ -252,7 +252,7 @@ func buildGoChannelDriver(cfg *config.EventConfig) (message.Publisher, message.S
 
 func buildPostgreSQLDriver(
 	ctx context.Context,
-	cfg *config.EventConfig,
+	cfg *serverconfig.EventConfig,
 ) (message.Publisher, message.Subscriber, driverCloser, error) {
 	db, _, err := cfg.SQLPubSub.Connection.GetDBConnection(ctx)
 	if err != nil {

--- a/internal/events/eventer_test.go
+++ b/internal/events/eventer_test.go
@@ -22,7 +22,7 @@ import (
 
 	"github.com/ThreeDotsLabs/watermill/message"
 
-	"github.com/stacklok/minder/internal/config"
+	serverconfig "github.com/stacklok/minder/internal/config/server"
 	"github.com/stacklok/minder/internal/events"
 )
 
@@ -39,10 +39,10 @@ type eventPair struct {
 	msg   *message.Message
 }
 
-func driverConfig() *config.EventConfig {
-	return &config.EventConfig{
+func driverConfig() *serverconfig.EventConfig {
+	return &serverconfig.EventConfig{
 		Driver:    "go-channel",
-		GoChannel: config.GoChannelEventConfig{},
+		GoChannel: serverconfig.GoChannelEventConfig{},
 	}
 }
 

--- a/internal/logger/logger_setup.go
+++ b/internal/logger/logger_setup.go
@@ -22,13 +22,13 @@ import (
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
 
-	"github.com/stacklok/minder/internal/config"
+	serverconfig "github.com/stacklok/minder/internal/config/server"
 )
 
 // FromFlags configures logging and returns a logger with settings matching
 // the supplied cfg.  It also performs some global initialization, because
 // that's how zerolog works.
-func FromFlags(cfg config.LoggingConfig) zerolog.Logger {
+func FromFlags(cfg serverconfig.LoggingConfig) zerolog.Logger {
 	zlevel := viperLogLevelToZerologLevel(cfg.Level)
 	zerolog.SetGlobalLevel(zlevel)
 

--- a/internal/reconcilers/reconcilers.go
+++ b/internal/reconcilers/reconcilers.go
@@ -17,7 +17,7 @@
 package reconcilers
 
 import (
-	"github.com/stacklok/minder/internal/config"
+	serverconfig "github.com/stacklok/minder/internal/config/server"
 	"github.com/stacklok/minder/internal/crypto"
 	"github.com/stacklok/minder/internal/db"
 	"github.com/stacklok/minder/internal/events"
@@ -53,7 +53,7 @@ func WithProviderMetrics(mt providertelemetry.ProviderMetrics) ReconcilerOption 
 func NewReconciler(
 	store db.Store,
 	evt *events.Eventer,
-	authCfg *config.AuthConfig,
+	authCfg *serverconfig.AuthConfig,
 	opts ...ReconcilerOption,
 ) (*Reconciler, error) {
 	crypteng, err := crypto.EngineFromAuthConfig(authCfg)


### PR DESCRIPTION
Fixes #1920 

---

Major Changes:

- Migrated options in the config file to a dedicated struct
- Eliminated direct access to viper store for config file options
- Added unit tests for testing various CLI configurations
- Refactored server config code to be present in `config/server`