### PR TITLE
Add DLQ metrics

### DIFF
--- a/internal/events/eventer.go
+++ b/internal/events/eventer.go
@@ -216,7 +216,7 @@ func recordMetrics(m *messageInstruments) func(h message.HandlerFunc) message.Ha
 	return metricsFunc
 }
 
-func poisonQueueTracking(ctx context.Context, msgInstruments *messageInstruments) func(h message.HandlerFunc) message.HandlerFunc {
+func poisonQueueTracking(ctx context.Context, instr *messageInstruments) func(h message.HandlerFunc) message.HandlerFunc {
 	metricsFunc := func(h message.HandlerFunc) message.HandlerFunc {
 		return func(msg *message.Message) ([]*message.Message, error) {
 			// Defer the tracking logic to after the message has been processed by other middlewares,
@@ -224,7 +224,7 @@ func poisonQueueTracking(ctx context.Context, msgInstruments *messageInstruments
 			// so that we can check if it has been poisoned or not.
 			defer func() {
 				if poisoned := msg.Metadata.Get(middleware.ReasonForPoisonedKey); poisoned != "" {
-					msgInstruments.poisonQueueCounter.Add(ctx, 1)
+					instr.poisonQueueCounter.Add(ctx, 1)
 				}
 			}()
 

--- a/internal/events/eventer.go
+++ b/internal/events/eventer.go
@@ -159,8 +159,8 @@ func Setup(ctx context.Context, cfg *config.EventConfig) (*Eventer, error) {
 	// Router level middleware are executed for every message sent to the router
 	router.AddMiddleware(
 		recordMetrics(metricInstruments),
-		poisonQueueMiddleware,
 		poisonQueueTracking(ctx, metricInstruments),
+		poisonQueueMiddleware,
 		middleware.Retry{
 			MaxRetries:      3,
 			InitialInterval: time.Millisecond * 100,

--- a/internal/events/eventer.go
+++ b/internal/events/eventer.go
@@ -158,9 +158,9 @@ func Setup(ctx context.Context, cfg *config.EventConfig) (*Eventer, error) {
 	}
 	// Router level middleware are executed for every message sent to the router
 	router.AddMiddleware(
-		recordMetricsMiddleware(metricInstruments),
+		recordMetrics(metricInstruments),
 		poisonQueueMiddleware,
-		poisonQueueTrackingMiddleware(ctx, metricInstruments),
+		poisonQueueTracking(ctx, metricInstruments),
 		middleware.Retry{
 			MaxRetries:      3,
 			InitialInterval: time.Millisecond * 100,
@@ -196,7 +196,7 @@ func Setup(ctx context.Context, cfg *config.EventConfig) (*Eventer, error) {
 	}, nil
 }
 
-func recordMetricsMiddleware(m *messageInstruments) func(h message.HandlerFunc) message.HandlerFunc {
+func recordMetrics(m *messageInstruments) func(h message.HandlerFunc) message.HandlerFunc {
 	metricsFunc := func(h message.HandlerFunc) message.HandlerFunc {
 		return func(message *message.Message) ([]*message.Message, error) {
 			producedMessages, err := h(message)
@@ -216,7 +216,7 @@ func recordMetricsMiddleware(m *messageInstruments) func(h message.HandlerFunc) 
 	return metricsFunc
 }
 
-func poisonQueueTrackingMiddleware(ctx context.Context, metrics *messageInstruments) func(h message.HandlerFunc) message.HandlerFunc {
+func poisonQueueTracking(ctx context.Context, metrics *messageInstruments) func(h message.HandlerFunc) message.HandlerFunc {
 	metricsFunc := func(h message.HandlerFunc) message.HandlerFunc {
 		return func(msg *message.Message) ([]*message.Message, error) {
 			// Defer the tracking logic to after the message has been processed by other middlewares,

--- a/internal/events/eventer.go
+++ b/internal/events/eventer.go
@@ -385,7 +385,7 @@ func (e *Eventer) ConsumeEvents(consumers ...Consumer) {
 }
 
 func initMetricsInstruments(meter metric.Meter) (*messageInstruments, error) {
-	histogram, err := createHistogram(meter)
+	histogram, err := createProcessingLatencyHistogram(meter)
 	if err != nil {
 		return nil, err
 	}
@@ -400,15 +400,15 @@ func initMetricsInstruments(meter metric.Meter) (*messageInstruments, error) {
 	}, nil
 }
 
-func createHistogram(meter metric.Meter) (metric.Int64Histogram, error) {
-	histogram, err := meter.Int64Histogram("messages.processing_delay",
+func createProcessingLatencyHistogram(meter metric.Meter) (metric.Int64Histogram, error) {
+	processingLatencyHistogram, err := meter.Int64Histogram("messages.processing_delay",
 		metric.WithDescription("Duration between a message being enqueued and dequeued for processing"),
 		metric.WithUnit("ms"),
 	)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create message processing histogram: %w", err)
+		return nil, fmt.Errorf("failed to create message processing processingLatencyHistogram: %w", err)
 	}
-	return histogram, nil
+	return processingLatencyHistogram, nil
 }
 
 func createPoisonQueueCounter(meter metric.Meter) (metric.Int64Counter, error) {

--- a/internal/events/eventer.go
+++ b/internal/events/eventer.go
@@ -204,7 +204,7 @@ func recordMetrics(instruments *messageInstruments) func(h message.HandlerFunc) 
 				}
 			}
 
-			// Defer the DLQ tracking logic to after the instruments has been processed by other middlewares,
+			// Defer the DLQ tracking logic to after the message has been processed by other middlewares,
 			// including the deferred PoisonQueue middleware functionality,
 			// so that we can check if it has been poisoned or not.
 			defer func() {

--- a/internal/events/eventer.go
+++ b/internal/events/eventer.go
@@ -212,7 +212,7 @@ func recordMetrics(instruments *messageInstruments) func(h message.HandlerFunc) 
 				instruments.messageProcessingTimeHistogram.Record(
 					msg.Context(),
 					processingTime.Milliseconds(),
-					metric.WithAttributes(attribute.Bool("is_poisoned", isPoisoned)),
+					metric.WithAttributes(attribute.Bool("poison", isPoisoned)),
 				)
 			}()
 


### PR DESCRIPTION
Closes: https://github.com/stacklok/minder/issues/1922

This PR adds functionality for emitting metrics when a message is added to the dead-letter queue. This is done by adding a "tracking" middleware that checks for the "posion" metadata added by the Watermill library.

Also, this change fixes the "recordMetrics" function which wasn't emitting any histogram-related metrics - we should be operating on `msg`, rather than on the result of `h()`.
