### PR TITLE
Fix: Docs - Update quickstart.md

### DIFF
--- a/docs/docs/getting_started/quickstart.md
+++ b/docs/docs/getting_started/quickstart.md
@@ -32,7 +32,7 @@ rule type and create a profile which enables secret scanning for the selected re
 To see the status of your profile, run:
 
 ```bash
-minder profile status list --profile quickstart-profile --detailed
+minder profile status list --name quickstart-profile --detailed
 ```
 
 You should see the overall profile status and a detailed view of the rule evaluation statuses for each of your registered repositories.


### PR DESCRIPTION
--profile is now --name

I was attempting the quickstart guide and came across this one small issue.