### PR TITLE
Refactor DLQ eventer observability func

### DIFF
--- a/internal/events/eventer.go
+++ b/internal/events/eventer.go
@@ -204,19 +204,19 @@ func recordMetrics(instruments *messageInstruments) func(h message.HandlerFunc) 
 				}
 			}
 
+			res, err := h(msg)
+
 			// Defer the DLQ tracking logic to after the message has been processed by other middlewares,
 			// including the deferred PoisonQueue middleware functionality,
 			// so that we can check if it has been poisoned or not.
-			defer func() {
-				isPoisoned := msg.Metadata.Get(middleware.ReasonForPoisonedKey) != ""
-				instruments.messageProcessingTimeHistogram.Record(
-					msg.Context(),
-					processingTime.Milliseconds(),
-					metric.WithAttributes(attribute.Bool("poison", isPoisoned)),
-				)
-			}()
+			isPoisoned := msg.Metadata.Get(middleware.ReasonForPoisonedKey) != ""
+			instruments.messageProcessingTimeHistogram.Record(
+				msg.Context(),
+				processingTime.Milliseconds(),
+				metric.WithAttributes(attribute.Bool("poison", isPoisoned)),
+			)
 
-			return h(msg)
+			return res, err
 		}
 	}
 	return metricsFunc


### PR DESCRIPTION
This PR is a follow-up on the following suggestion: https://github.com/stacklok/minder/pull/2052#discussion_r1440992647


Also, we can now see the metrics being exported as expected in Grafana (in Staging) (+ the "poison" attribute):

`minder_messages_processing_delay_milliseconds_count{app="minder",instance="10.0.2.229:9090",job="kubernetes-pods",namespace="mediator",node="ip-10-0-2-241.ec2.internal",otel_scope_name="eventer",pod="minder-7fc6d89469-qfhxr",pod_template_hash="7fc6d89469",poison="false"}`