### PR TITLE
Warn users when the target environment for the CLI is staging

### DIFF
--- a/cmd/cli/app/root.go
+++ b/cmd/cli/app/root.go
@@ -23,6 +23,7 @@ import (
 	"github.com/spf13/viper"
 
 	clientconfig "github.com/stacklok/minder/internal/config/client"
+	"github.com/stacklok/minder/internal/constants"
 	ghclient "github.com/stacklok/minder/internal/providers/github"
 	"github.com/stacklok/minder/internal/util/cli"
 )
@@ -37,6 +38,12 @@ var (
 		Long: `For more information about minder, please visit:
 https://docs.stacklok.com/minder`,
 		SilenceErrors: true, // don't print errors twice, we handle them in cli.ExitNicelyOnError
+		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+			if constants.TargetEnv == "staging" {
+				cmd.Print("WARNING: This build uses a test environment and may not be stable \n")
+			}
+			return nil
+		},
 	}
 )
 

--- a/internal/constants/prod.go
+++ b/internal/constants/prod.go
@@ -18,6 +18,8 @@
 package constants
 
 const (
+	// TargetEnv is the environment the build will point to
+	TargetEnv = "prod"
 	// IdentitySeverURL is the URL of the identity server
 	IdentitySeverURL = "https://auth.stacklok.com"
 	// MinderGRPCHost is the host of the minder gRPC server

--- a/internal/constants/staging.go
+++ b/internal/constants/staging.go
@@ -18,6 +18,8 @@
 package constants
 
 const (
+	// TargetEnv is the environment the build will point to
+	TargetEnv = "staging"
 	// IdentitySeverURL is the URL of the identity server
 	IdentitySeverURL = "https://auth.staging.stacklok.dev"
 	// MinderGRPCHost is the host of the minder gRPC server


### PR DESCRIPTION
Staging can sometimes be unstable and there's need to warn users about this