### PR TITLE
Handle null values in config file to prevent incorrect data retrieval from viper store

### DIFF
--- a/internal/config/client/config_test.go
+++ b/internal/config/client/config_test.go
@@ -59,16 +59,7 @@ identity:
 func TestReadClientConfigWithDefaults(t *testing.T) {
 	t.Parallel()
 
-	clientCfgString := `---
-grpc_server:
-identity:
-`
-	cfgbuf := bytes.NewBufferString(clientCfgString)
-
 	v := viper.New()
-
-	v.SetConfigType("yaml")
-	require.NoError(t, v.ReadConfig(cfgbuf), "Unexpected error")
 
 	flags := pflag.NewFlagSet("test", pflag.ContinueOnError)
 	require.NoError(t, clientconfig.RegisterMinderClientFlags(v, flags), "Unexpected error")
@@ -144,36 +135,6 @@ grpc_server:
 identity:
   cli:
     issuer_url: http://localhost:4567
-`
-	cfgbuf := bytes.NewBufferString(clientCfgString)
-
-	v := viper.New()
-
-	v.SetConfigType("yaml")
-	require.NoError(t, v.ReadConfig(cfgbuf), "Unexpected error")
-
-	flags := pflag.NewFlagSet("test", pflag.ContinueOnError)
-	require.NoError(t, clientconfig.RegisterMinderClientFlags(v, flags), "Unexpected error")
-
-	require.NoError(t, flags.Parse([]string{"--grpc-host=192.168.1.7", "--grpc-port=1234", "--identity-url=http://localhost:1654"}))
-
-	cfg, err := clientconfig.ReadConfigFromViper(v)
-	require.NoError(t, err, "Unexpected error")
-
-	require.Equal(t, "192.168.1.7", cfg.GRPCClientConfig.Host)
-	require.Equal(t, 1234, cfg.GRPCClientConfig.Port)
-	require.Equal(t, false, cfg.GRPCClientConfig.Insecure)
-	require.Equal(t, "http://localhost:1654", cfg.Identity.CLI.IssuerUrl)
-	require.Equal(t, "minder-cli", cfg.Identity.CLI.ClientId)
-}
-
-func TestReadClientConfigWithCmdLineArgsAndEmptyInputConfig(t *testing.T) {
-	t.Parallel()
-	t.Skip("This test is randomly failing. Skipping until we can figure out why. See https://github.com/stacklok/minder/issues/2067")
-
-	clientCfgString := `---
-grpc_server:
-identity:
 `
 	cfgbuf := bytes.NewBufferString(clientCfgString)
 

--- a/internal/config/utils_test.go
+++ b/internal/config/utils_test.go
@@ -1,0 +1,150 @@
+//
+// Copyright 2024 Stacklok, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"gopkg.in/yaml.v3"
+)
+
+func TestGetKeysWithNullValueFromYAML(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		yamlInput string
+		want      []string
+	}{
+		{
+			name: "Test with null values",
+			yamlInput: `
+key1: null
+key2:
+  subkey1: null
+  subkey2: value
+key3: [null, value]
+`,
+			want: []string{
+				".key1",
+				".key2.subkey1",
+				".key3[0]",
+			},
+		},
+		{
+			name: "Test without null values",
+			yamlInput: `
+key1: value1
+key2:
+  subkey1: subvalue1
+  subkey2: subvalue2
+key3: [value1, value2]
+`,
+			want: []string{},
+		},
+		{
+			name: "Test with highly nested null values",
+			yamlInput: `
+key1: value1
+key2:
+  subkey1: null
+  subkey2: value2
+  subkey3:
+    subsubkey1: null
+    subsubkey2: [value1, null, value2]
+    subsubkey3:
+      subsubsubkey1: [value1, value2, null]
+      subsubsubkey2: null
+key3: [value1, null, value2]
+key4:
+  subkey1: [value1, value2, null]
+  subkey2:
+    subsubkey1: null
+    subsubkey2: [null, value1, value2]
+    subsubkey3:
+      subsubsubkey1: [value1, null, value2]
+      subsubsubkey2: null
+`,
+			want: []string{
+				".key2.subkey1",
+				".key2.subkey3.subsubkey1",
+				".key2.subkey3.subsubkey2[1]",
+				".key2.subkey3.subsubkey3.subsubsubkey1[2]",
+				".key2.subkey3.subsubkey3.subsubsubkey2",
+				".key3[1]",
+				".key4.subkey1[2]",
+				".key4.subkey2.subsubkey1",
+				".key4.subkey2.subsubkey2[0]",
+				".key4.subkey2.subsubkey3.subsubsubkey1[1]",
+				".key4.subkey2.subsubkey3.subsubsubkey2",
+			},
+		},
+		{
+			name: "Test with null values with integer, boolean, and null keys",
+			yamlInput: `
+key1: value1
+true:
+  null: null
+  1: value2
+  2:
+    false: null
+    3: [value1, null, value2]
+    4:
+      true: [value1, value2, null]
+      5: null
+key3: [value1, null, value2]
+6:
+  true: [value1, value2, null]
+  7:
+    false: null
+    8: [null, value1, value2]
+    9:
+      true: [value1, null, value2]
+      10: null
+`,
+			want: []string{
+				".true.null",
+				".true.2.false",
+				".true.2.3[1]",
+				".true.2.4.true[2]",
+				".true.2.4.5",
+				".key3[1]",
+				".6.true[2]",
+				".6.7.false",
+				".6.7.8[0]",
+				".6.7.9.true[1]",
+				".6.7.9.10",
+			},
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			var data interface{}
+			err := yaml.Unmarshal([]byte(test.yamlInput), &data)
+			if err != nil {
+				t.Fatalf("Error parsing YAML: %v", err)
+			}
+
+			got := GetKeysWithNullValueFromYAML(data, "")
+			assert.ElementsMatchf(t, got, test.want, "GetKeysWithNullValueFromYAML() = %v, want %v", got, test.want)
+		})
+	}
+}


### PR DESCRIPTION
Fixes #2067

---

For rationale see https://github.com/stacklok/minder/issues/2067#issuecomment-1877102081

Major Changes:

- Check config file contents before adding it to the viper store
- UT for `GetKeysWithNullValueFromYAML`