### PR TITLE
Rule evaluator business telemetry

### DIFF
--- a/internal/engine/actions/actions.go
+++ b/internal/engine/actions/actions.go
@@ -72,6 +72,11 @@ func NewRuleActions(p *minderv1.Profile, rt *minderv1.RuleType, pbuild *provider
 	}, nil
 }
 
+// GetOnOffState returns the on/off state of the actions
+func (rae *RuleActionsEngine) GetOnOffState() map[engif.ActionType]engif.ActionOpt {
+	return rae.actionsOnOff
+}
+
 // DoActions processes all actions i.e., remediation and alerts
 func (rae *RuleActionsEngine) DoActions(
 	ctx context.Context,

--- a/internal/engine/errors/errors.go
+++ b/internal/engine/errors/errors.go
@@ -207,3 +207,21 @@ func HTTPErrorCodeToErr(httpCode int) error {
 
 	return err
 }
+
+// EvalErrorAsString returns the evaluation error as a string
+func EvalErrorAsString(err error) string {
+	dbEvalStatus := ErrorAsEvalStatus(err)
+	return string(dbEvalStatus)
+}
+
+// RemediationErrorAsString returns the remediation error as a string
+func RemediationErrorAsString(err error) string {
+	dbRemediationStatus := ErrorAsRemediationStatus(err)
+	return string(dbRemediationStatus)
+}
+
+// AlertErrorAsString returns the alert error as a string
+func AlertErrorAsString(err error) string {
+	dbAlertStatus := ErrorAsAlertStatus(err)
+	return string(dbAlertStatus)
+}

--- a/internal/engine/executor.go
+++ b/internal/engine/executor.go
@@ -32,6 +32,7 @@ import (
 	"github.com/stacklok/minder/internal/engine/ingestcache"
 	engif "github.com/stacklok/minder/internal/engine/interfaces"
 	"github.com/stacklok/minder/internal/events"
+	minderlogger "github.com/stacklok/minder/internal/logger"
 	"github.com/stacklok/minder/internal/providers"
 	providertelemetry "github.com/stacklok/minder/internal/providers/telemetry"
 	pb "github.com/stacklok/minder/pkg/api/protobuf/go/minder/v1"
@@ -116,6 +117,8 @@ func (e *Executor) Wait() {
 // HandleEntityEvent handles events coming from webhooks/signals
 // as well as the init event.
 func (e *Executor) HandleEntityEvent(msg *message.Message) error {
+	// Grab the context before making a copy of the message
+	msgCtx := msg.Context()
 	// Let's not share memory with the caller
 	msg = msg.Copy()
 
@@ -131,6 +134,9 @@ func (e *Executor) HandleEntityEvent(msg *message.Message) error {
 		ctx, cancel := context.WithTimeout(e.terminationcontext, DefaultExecutionTimeout)
 		defer cancel()
 
+		ts := minderlogger.BusinessRecord(msgCtx)
+		ctx = ts.WithTelemetry(ctx)
+
 		if err := inf.WithExecutionIDFromMessage(msg); err != nil {
 			logger := zerolog.Ctx(ctx)
 			logger.Info().
@@ -139,7 +145,19 @@ func (e *Executor) HandleEntityEvent(msg *message.Message) error {
 			return
 		}
 
-		if err := e.prepAndEvalEntityEvent(ctx, inf); err != nil {
+		err := e.prepAndEvalEntityEvent(ctx, inf)
+
+		// record telemetry regardless of error. We explicitly record telemetry
+		// here even though we also record it in the middleware because the evaluation
+		// is done in a separate goroutine which usually still runs after the middleware
+		// had already recorded the telemetry.
+		logMsg := zerolog.Ctx(ctx).Info()
+		if err != nil {
+			logMsg = zerolog.Ctx(ctx).Error()
+		}
+		ts.Record(logMsg).Send()
+
+		if err != nil {
 			zerolog.Ctx(ctx).Info().
 				Str("project", inf.ProjectID.String()).
 				Str("provider", inf.Provider).
@@ -235,7 +253,7 @@ func (e *Executor) evalEntityEvent(
 			evalParams.SetActionsErr(ctx, rte.Actions(ctx, inf, evalParams))
 
 			// Log the evaluation
-			logEval(ctx, inf, evalParams)
+			logEval(ctx, inf, profile.Name, evalParams)
 
 			// Create or update the evaluation status
 			return e.createOrUpdateEvalStatus(ctx, evalParams)
@@ -303,6 +321,7 @@ func (e *Executor) getEvaluator(
 	rte = rte.WithIngesterCache(ingestCache)
 
 	// All okay
+	params.SetActionsOnOff(rte.GetActionsOnOff())
 	return params, rte, nil
 }
 
@@ -380,6 +399,7 @@ func (e *Executor) releaseLockAndFlush(
 func logEval(
 	ctx context.Context,
 	inf *entities.EntityInfoWrapper,
+	profileName string,
 	params *engif.EvalStatusParams) {
 	logger := zerolog.Ctx(ctx)
 	evalLog := logger.Debug().
@@ -407,6 +427,10 @@ func logEval(
 		Str("action", "alert").
 		Str("action_status", string(evalerrors.ErrorAsAlertStatus(params.GetActionsErr().AlertErr))).
 		Msg("result - action")
+
+	// log business logic
+	minderlogger.BusinessRecord(ctx).
+		AddRuleEval(params.Rule.Type, profileName, params)
 }
 
 func filterActionErrorForLogging(err error) error {

--- a/internal/engine/executor.go
+++ b/internal/engine/executor.go
@@ -253,7 +253,7 @@ func (e *Executor) evalEntityEvent(
 			evalParams.SetActionsErr(ctx, rte.Actions(ctx, inf, evalParams))
 
 			// Log the evaluation
-			logEval(ctx, inf, profile.Name, evalParams)
+			logEval(ctx, inf, evalParams)
 
 			// Create or update the evaluation status
 			return e.createOrUpdateEvalStatus(ctx, evalParams)
@@ -399,7 +399,6 @@ func (e *Executor) releaseLockAndFlush(
 func logEval(
 	ctx context.Context,
 	inf *entities.EntityInfoWrapper,
-	profileName string,
 	params *engif.EvalStatusParams) {
 	logger := zerolog.Ctx(ctx)
 	evalLog := logger.Debug().
@@ -429,8 +428,7 @@ func logEval(
 		Msg("result - action")
 
 	// log business logic
-	minderlogger.BusinessRecord(ctx).
-		AddRuleEval(params.Rule.Type, profileName, params)
+	minderlogger.BusinessRecord(ctx).AddRuleEval(params)
 }
 
 func filterActionErrorForLogging(err error) error {

--- a/internal/engine/rule_types.go
+++ b/internal/engine/rule_types.go
@@ -244,7 +244,7 @@ func (r *RuleTypeEngine) GetRuleInstanceValidator() *RuleValidator {
 }
 
 // Eval runs the rule type engine against the given entity
-func (r *RuleTypeEngine) Eval(ctx context.Context, inf *entities.EntityInfoWrapper, params engif.EvalParams) error {
+func (r *RuleTypeEngine) Eval(ctx context.Context, inf *entities.EntityInfoWrapper, params engif.EvalParamsReadWriter) error {
 	// Try looking at the ingesting cache first
 	result, ok := r.ingestCache.Get(r.rdi, inf.Entity, params.GetRule().Params)
 	if !ok {
@@ -275,6 +275,11 @@ func (r *RuleTypeEngine) Actions(
 ) enginerr.ActionsError {
 	// Process actions
 	return r.rae.DoActions(ctx, inf.Entity, params)
+}
+
+// GetActionsOnOff returns the on/off state of the actions
+func (r *RuleTypeEngine) GetActionsOnOff() map[engif.ActionType]engif.ActionOpt {
+	return r.rae.GetOnOffState()
 }
 
 // RuleDefFromDB converts a rule type definition from the database to a protobuf

--- a/internal/logger/telemetry_store.go
+++ b/internal/logger/telemetry_store.go
@@ -76,8 +76,6 @@ type TelemetryStore struct {
 
 // AddRuleEval is a convenience method to add a rule evaluation result to the telemetry store.
 func (ts *TelemetryStore) AddRuleEval(
-	ruleName string,
-	profileName string,
 	evalInfo interfaces.ActionsParams,
 ) {
 	if ts == nil {
@@ -85,8 +83,8 @@ func (ts *TelemetryStore) AddRuleEval(
 	}
 
 	red := RuleEvalData{
-		RuleName:    ruleName,
-		ProfileName: profileName,
+		RuleName:    evalInfo.GetRule().GetType(),
+		ProfileName: evalInfo.GetProfile().GetName(),
 		EvalResult:  errors.EvalErrorAsString(evalInfo.GetEvalErr()),
 		Actions: map[interfaces.ActionType]ActionEvalData{
 			remediate.ActionType: {

--- a/internal/logger/telemetry_store_test.go
+++ b/internal/logger/telemetry_store_test.go
@@ -28,6 +28,7 @@ import (
 	enginerr "github.com/stacklok/minder/internal/engine/errors"
 	engif "github.com/stacklok/minder/internal/engine/interfaces"
 	"github.com/stacklok/minder/internal/logger"
+	minderv1 "github.com/stacklok/minder/pkg/api/protobuf/go/minder/v1"
 )
 
 func TestTelemetryStore_Record(t *testing.T) {
@@ -44,6 +45,12 @@ func TestTelemetryStore_Record(t *testing.T) {
 		evalParamsFunc: func() *engif.EvalStatusParams {
 			ep := &engif.EvalStatusParams{}
 
+			ep.Rule = &minderv1.Profile_Rule{
+				Type: "artifact_signature",
+			}
+			ep.Profile = &minderv1.Profile{
+				Name: "artifact_profile",
+			}
 			ep.SetEvalErr(enginerr.NewErrEvaluationFailed("evaluation failure reason"))
 			ep.SetActionsOnOff(map[engif.ActionType]engif.ActionOpt{
 				alert.ActionType:     engif.ActionOptOn,
@@ -59,8 +66,7 @@ func TestTelemetryStore_Record(t *testing.T) {
 			logger.BusinessRecord(ctx).Project = "bar"
 
 			logger.BusinessRecord(ctx).Resource = "foo/repo"
-			logger.BusinessRecord(ctx).AddRuleEval(
-				"artifact_signature", "artifact_profile", evalParams)
+			logger.BusinessRecord(ctx).AddRuleEval(evalParams)
 		},
 	}, {
 		name:      "standard telemetry",
@@ -68,6 +74,12 @@ func TestTelemetryStore_Record(t *testing.T) {
 		evalParamsFunc: func() *engif.EvalStatusParams {
 			ep := &engif.EvalStatusParams{}
 
+			ep.Rule = &minderv1.Profile_Rule{
+				Type: "artifact_signature",
+			}
+			ep.Profile = &minderv1.Profile{
+				Name: "artifact_profile",
+			}
 			ep.SetEvalErr(enginerr.NewErrEvaluationFailed("evaluation failure reason"))
 			ep.SetActionsOnOff(map[engif.ActionType]engif.ActionOpt{
 				alert.ActionType:     engif.ActionOptOff,
@@ -83,7 +95,7 @@ func TestTelemetryStore_Record(t *testing.T) {
 			logger.BusinessRecord(ctx).Project = "bar"
 
 			logger.BusinessRecord(ctx).Resource = "foo/repo"
-			logger.BusinessRecord(ctx).AddRuleEval("artifact_signature", "artifact_profile", evalParams)
+			logger.BusinessRecord(ctx).AddRuleEval(evalParams)
 		},
 		expected: `{
     "project": "bar",

--- a/internal/logger/telemetry_store_test.go
+++ b/internal/logger/telemetry_store_test.go
@@ -23,40 +23,96 @@ import (
 
 	"github.com/rs/zerolog"
 
-	"github.com/stacklok/minder/internal/engine/interfaces"
+	"github.com/stacklok/minder/internal/engine/actions/alert"
+	"github.com/stacklok/minder/internal/engine/actions/remediate"
+	enginerr "github.com/stacklok/minder/internal/engine/errors"
+	engif "github.com/stacklok/minder/internal/engine/interfaces"
 	"github.com/stacklok/minder/internal/logger"
 )
 
 func TestTelemetryStore_Record(t *testing.T) {
 	t.Parallel()
 	cases := []struct {
-		name       string
-		telemetry  *logger.TelemetryStore
-		recordFunc func(context.Context)
-		expected   string
-		notPresent []string
+		name           string
+		telemetry      *logger.TelemetryStore
+		evalParamsFunc func() *engif.EvalStatusParams
+		recordFunc     func(context.Context, engif.ActionsParams)
+		expected       string
+		notPresent     []string
 	}{{
 		name: "nil telemetry",
-		recordFunc: func(ctx context.Context) {
+		evalParamsFunc: func() *engif.EvalStatusParams {
+			ep := &engif.EvalStatusParams{}
+
+			ep.SetEvalErr(enginerr.NewErrEvaluationFailed("evaluation failure reason"))
+			ep.SetActionsOnOff(map[engif.ActionType]engif.ActionOpt{
+				alert.ActionType:     engif.ActionOptOn,
+				remediate.ActionType: engif.ActionOptOff,
+			})
+			ep.SetActionsErr(context.Background(), enginerr.ActionsError{
+				RemediateErr: nil,
+				AlertErr:     enginerr.ErrActionSkipped,
+			})
+			return ep
+		},
+		recordFunc: func(ctx context.Context, evalParams engif.ActionsParams) {
 			logger.BusinessRecord(ctx).Project = "bar"
 
 			logger.BusinessRecord(ctx).Resource = "foo/repo"
-			logger.BusinessRecord(ctx).AddRuleEval("artifact_signature", interfaces.ActionOptDryRun)
+			logger.BusinessRecord(ctx).AddRuleEval(
+				"artifact_signature", "artifact_profile", evalParams)
 		},
 	}, {
 		name:      "standard telemetry",
 		telemetry: &logger.TelemetryStore{},
-		recordFunc: func(ctx context.Context) {
+		evalParamsFunc: func() *engif.EvalStatusParams {
+			ep := &engif.EvalStatusParams{}
+
+			ep.SetEvalErr(enginerr.NewErrEvaluationFailed("evaluation failure reason"))
+			ep.SetActionsOnOff(map[engif.ActionType]engif.ActionOpt{
+				alert.ActionType:     engif.ActionOptOff,
+				remediate.ActionType: engif.ActionOptOn,
+			})
+			ep.SetActionsErr(context.Background(), enginerr.ActionsError{
+				RemediateErr: nil,
+				AlertErr:     enginerr.ErrActionSkipped,
+			})
+			return ep
+		},
+		recordFunc: func(ctx context.Context, evalParams engif.ActionsParams) {
 			logger.BusinessRecord(ctx).Project = "bar"
 
 			logger.BusinessRecord(ctx).Resource = "foo/repo"
-			logger.BusinessRecord(ctx).AddRuleEval("artifact_signature", interfaces.ActionOptDryRun)
+			logger.BusinessRecord(ctx).AddRuleEval("artifact_signature", "artifact_profile", evalParams)
 		},
-		expected: `{"project":"bar","resource":"foo/repo","rules":[{"name":"artifact_signature","action":2}]}`,
+		expected: `{
+    "project": "bar",
+    "resource": "foo/repo",
+    "rules": [
+        {
+            "rule_name": "artifact_signature",
+            "profile_name": "artifact_profile",
+            "eval_result": "failure",
+            "actions": {
+                "alert": {
+                    "state": "off",
+                    "result": "skipped"
+                },
+                "remediate": {
+                    "state": "on",
+                    "result": "success"
+                }
+            }
+        }
+    ]
+    }`,
 	}, {
 		name:      "empty telemetry",
 		telemetry: &logger.TelemetryStore{},
-		recordFunc: func(ctx context.Context) {
+		evalParamsFunc: func() *engif.EvalStatusParams {
+			return nil
+		},
+		recordFunc: func(_ context.Context, _ engif.ActionsParams) {
 		},
 		expected:   `{"telemetry": true}`,
 		notPresent: []string{"project", "resource", "rules", "login_sha"},
@@ -75,7 +131,7 @@ func TestTelemetryStore_Record(t *testing.T) {
 			// Create a new TelemetryStore instance
 			ctx := tc.telemetry.WithTelemetry(context.Background())
 
-			tc.recordFunc(ctx)
+			tc.recordFunc(ctx, tc.evalParamsFunc())
 
 			tc.telemetry.Record(zlog.Info()).Send()
 


### PR DESCRIPTION
Extends the telemetry store so that all the rules being evaluated are stored in the telemetry store for sending later.

Fixes: #1881