### PR TITLE
Remove duplicate top level context

### DIFF
--- a/cmd/cli/app/profile/apply.go
+++ b/cmd/cli/app/profile/apply.go
@@ -61,7 +61,6 @@ func applyCommand(_ context.Context, cmd *cobra.Command, conn *grpc.ClientConn) 
 	applyFunc := func(ctx context.Context, f string, p *minderv1.Profile) (*minderv1.Profile, error) {
 		// create a profile
 		resp, err := client.CreateProfile(ctx, &minderv1.CreateProfileRequest{
-			Context: &minderv1.Context{Provider: &provider, Project: &project},
 			Profile: p,
 		})
 		if err == nil {
@@ -79,7 +78,6 @@ func applyCommand(_ context.Context, cmd *cobra.Command, conn *grpc.ClientConn) 
 		}
 		// The profile already exists, so update it
 		updateResp, err := client.UpdateProfile(ctx, &minderv1.UpdateProfileRequest{
-			Context: &minderv1.Context{Provider: &provider, Project: &project},
 			Profile: p,
 		})
 		if err != nil {
@@ -90,7 +88,7 @@ func applyCommand(_ context.Context, cmd *cobra.Command, conn *grpc.ClientConn) 
 	}
 	// cmd.Context() is the root context. We need to create a new context for each file
 	// so we can avoid the timeout.
-	if err := ExecOnOneProfile(cmd.Context(), table, f, cmd.InOrStdin(), project, applyFunc); err != nil {
+	if err := ExecOnOneProfile(cmd.Context(), table, f, cmd.InOrStdin(), project, provider, applyFunc); err != nil {
 		return cli.MessageAndError(fmt.Sprintf("error applying profile from %s", f), err)
 	}
 

--- a/cmd/cli/app/profile/create.go
+++ b/cmd/cli/app/profile/create.go
@@ -59,7 +59,6 @@ func createCommand(_ context.Context, cmd *cobra.Command, conn *grpc.ClientConn)
 	createFunc := func(ctx context.Context, f string, p *minderv1.Profile) (*minderv1.Profile, error) {
 		// create a profile
 		resp, err := client.CreateProfile(ctx, &minderv1.CreateProfileRequest{
-			Context: &minderv1.Context{Provider: &provider, Project: &project},
 			Profile: p,
 		})
 		if err != nil {
@@ -69,7 +68,7 @@ func createCommand(_ context.Context, cmd *cobra.Command, conn *grpc.ClientConn)
 	}
 	// cmd.Context() is the root context. We need to create a new context for each file
 	// so we can avoid the timeout.
-	if err := ExecOnOneProfile(cmd.Context(), table, f, cmd.InOrStdin(), project, createFunc); err != nil {
+	if err := ExecOnOneProfile(cmd.Context(), table, f, cmd.InOrStdin(), project, provider, createFunc); err != nil {
 		return cli.MessageAndError(fmt.Sprintf("error creating profile from %s", f), err)
 	}
 

--- a/cmd/cli/app/quickstart/quickstart.go
+++ b/cmd/cli/app/quickstart/quickstart.go
@@ -260,7 +260,6 @@ func quickstartCommand(_ context.Context, cmd *cobra.Command, conn *grpc.ClientC
 
 	// Create the rule type in minder
 	_, err = client.CreateRuleType(ctx, &minderv1.CreateRuleTypeRequest{
-		Context:  &minderv1.Context{Provider: &provider, Project: &project},
 		RuleType: rt,
 	})
 	if err != nil {
@@ -313,7 +312,6 @@ func quickstartCommand(_ context.Context, cmd *cobra.Command, conn *grpc.ClientC
 	alreadyExists := ""
 	// Create the profile in minder
 	resp, err := client.CreateProfile(ctx, &minderv1.CreateProfileRequest{
-		Context: &minderv1.Context{Provider: &provider, Project: &project},
 		Profile: p,
 	})
 	if err != nil {

--- a/cmd/cli/app/ruletype/common.go
+++ b/cmd/cli/app/ruletype/common.go
@@ -37,6 +37,8 @@ func execOnOneRuleType(
 	t table.Table,
 	f string,
 	dashOpen io.Reader,
+	proj string,
+	provider string,
 	exec func(context.Context, string, *minderv1.RuleType) (*minderv1.RuleType, error),
 ) error {
 	ctx, cancel := cli.GetAppContext(ctx, viper.GetViper())
@@ -51,6 +53,24 @@ func execOnOneRuleType(
 	r, err := minderv1.ParseRuleType(reader)
 	if err != nil {
 		return fmt.Errorf("error parsing rule type: %w", err)
+	}
+
+	// Override the YAML specified project with the command line argument
+	if proj != "" {
+		if r.Context == nil {
+			r.Context = &minderv1.Context{}
+		}
+
+		r.Context.Project = &proj
+	}
+
+	// Override the YAML specified provider with the command line argument
+	if provider != "" {
+		if r.Context == nil {
+			r.Context = &minderv1.Context{}
+		}
+
+		r.Context.Provider = &provider
 	}
 
 	// create a rule

--- a/cmd/cli/app/ruletype/ruletype_apply.go
+++ b/cmd/cli/app/ruletype/ruletype_apply.go
@@ -73,7 +73,6 @@ func applyCommand(_ context.Context, cmd *cobra.Command, conn *grpc.ClientConn) 
 
 	applyFunc := func(ctx context.Context, fileName string, rt *minderv1.RuleType) (*minderv1.RuleType, error) {
 		createResp, err := client.CreateRuleType(ctx, &minderv1.CreateRuleTypeRequest{
-			Context:  &minderv1.Context{Provider: &provider, Project: &project},
 			RuleType: rt,
 		})
 
@@ -92,7 +91,6 @@ func applyCommand(_ context.Context, cmd *cobra.Command, conn *grpc.ClientConn) 
 		}
 
 		updateResp, err := client.UpdateRuleType(ctx, &minderv1.UpdateRuleTypeRequest{
-			Context:  &minderv1.Context{Provider: &provider, Project: &project},
 			RuleType: rt,
 		})
 
@@ -109,7 +107,7 @@ func applyCommand(_ context.Context, cmd *cobra.Command, conn *grpc.ClientConn) 
 		}
 		// cmd.Context() is the root context. We need to create a new context for each file
 		// so we can avoid the timeout.
-		if err = execOnOneRuleType(cmd.Context(), table, f, os.Stdin, applyFunc); err != nil {
+		if err = execOnOneRuleType(cmd.Context(), table, f, os.Stdin, project, provider, applyFunc); err != nil {
 			return cli.MessageAndError(fmt.Sprintf("error applying rule type from %s", f), err)
 		}
 	}

--- a/cmd/cli/app/ruletype/ruletype_create.go
+++ b/cmd/cli/app/ruletype/ruletype_create.go
@@ -72,7 +72,6 @@ func createCommand(_ context.Context, cmd *cobra.Command, conn *grpc.ClientConn)
 
 	createFunc := func(ctx context.Context, fileName string, rt *minderv1.RuleType) (*minderv1.RuleType, error) {
 		resprt, err := client.CreateRuleType(ctx, &minderv1.CreateRuleTypeRequest{
-			Context:  &minderv1.Context{Provider: &provider, Project: &project},
 			RuleType: rt,
 		})
 		if err != nil {
@@ -88,7 +87,7 @@ func createCommand(_ context.Context, cmd *cobra.Command, conn *grpc.ClientConn)
 		}
 		// cmd.Context() is the root context. We need to create a new context for each file
 		// so we can avoid the timeout.
-		if err = execOnOneRuleType(cmd.Context(), table, f, os.Stdin, createFunc); err != nil {
+		if err = execOnOneRuleType(cmd.Context(), table, f, os.Stdin, project, provider, createFunc); err != nil {
 			return cli.MessageAndError(fmt.Sprintf("Error creating rule type from %s", f), err)
 		}
 	}

--- a/docs/docs/ref/proto.md
+++ b/docs/docs/ref/proto.md
@@ -208,7 +208,6 @@ Profile service
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
 | profile | [Profile](#minder-v1-Profile) |  |  |
-| context | [Context](#minder-v1-Context) |  |  |
 
 
 <a name="minder-v1-CreateProfileResponse"></a>
@@ -231,7 +230,6 @@ CreateRuleTypeRequest is the request to create a rule type.
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
 | rule_type | [RuleType](#minder-v1-RuleType) |  | rule_type is the rule type to be created. |
-| context | [Context](#minder-v1-Context) |  |  |
 
 
 <a name="minder-v1-CreateRuleTypeResponse"></a>
@@ -1386,7 +1384,6 @@ the name stutters a bit but we already use a PullRequest message for handling PR
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
 | profile | [Profile](#minder-v1-Profile) |  |  |
-| context | [Context](#minder-v1-Context) |  |  |
 
 
 <a name="minder-v1-UpdateProfileResponse"></a>
@@ -1409,7 +1406,6 @@ UpdateRuleTypeRequest is the request to update a rule type.
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
 | rule_type | [RuleType](#minder-v1-RuleType) |  | rule_type is the rule type to be updated. |
-| context | [Context](#minder-v1-Context) |  |  |
 
 
 <a name="minder-v1-UpdateRuleTypeResponse"></a>

--- a/internal/controlplane/handlers_profile.go
+++ b/internal/controlplane/handlers_profile.go
@@ -122,7 +122,7 @@ func (s *Server) CreateProfile(ctx context.Context,
 	cpr *minderv1.CreateProfileRequest) (*minderv1.CreateProfileResponse, error) {
 	in := cpr.GetProfile()
 
-	ctx, err := s.authAndContextValidation(ctx, in.GetContext())
+	ctx, err := s.authAndContextValidation(ctx, cpr.GetContext())
 	if err != nil {
 		return nil, status.Errorf(codes.InvalidArgument, "error ensuring default project: %v", err)
 	}
@@ -315,7 +315,7 @@ func (s *Server) ListProfiles(ctx context.Context,
 
 	var resp minderv1.ListProfilesResponse
 	resp.Profiles = make([]*minderv1.Profile, 0, len(profiles))
-	for _, profile := range engine.MergeDatabaseListIntoProfiles(profiles, entityCtx) {
+	for _, profile := range engine.MergeDatabaseListIntoProfiles(profiles) {
 		resp.Profiles = append(resp.Profiles, profile)
 	}
 
@@ -365,7 +365,7 @@ func getProfilePBFromDB(
 		return nil, err
 	}
 
-	pols := engine.MergeDatabaseGetIntoProfiles(profiles, entityCtx)
+	pols := engine.MergeDatabaseGetIntoProfiles(profiles)
 	if len(pols) == 0 {
 		return nil, fmt.Errorf("profile not found")
 	} else if len(pols) > 1 {
@@ -575,7 +575,7 @@ func (s *Server) UpdateProfile(ctx context.Context,
 	cpr *minderv1.UpdateProfileRequest) (*minderv1.UpdateProfileResponse, error) {
 	in := cpr.GetProfile()
 
-	ctx, err := s.authAndContextValidation(ctx, in.GetContext())
+	ctx, err := s.authAndContextValidation(ctx, cpr.GetContext())
 	if err != nil {
 		return nil, status.Errorf(codes.InvalidArgument, "error ensuring default project: %v", err)
 	}
@@ -725,7 +725,7 @@ func (s *Server) getAndValidateRulesFromProfile(
 			return fmt.Errorf("error getting rule type %s: %w", r.GetType(), err)
 		}
 
-		rtyppb, err := engine.RuleTypePBFromDB(&rtdb, entityCtx)
+		rtyppb, err := engine.RuleTypePBFromDB(&rtdb)
 		if err != nil {
 			return fmt.Errorf("cannot convert rule type %s to pb: %w", rtdb.Name, err)
 		}
@@ -779,7 +779,7 @@ func (s *Server) getRulesFromProfile(
 			return fmt.Errorf("error getting rule type %s: %w", r.GetType(), err)
 		}
 
-		rtyppb, err := engine.RuleTypePBFromDB(&rtdb, entityCtx)
+		rtyppb, err := engine.RuleTypePBFromDB(&rtdb)
 		if err != nil {
 			return fmt.Errorf("cannot convert rule type %s to pb: %w", rtdb.Name, err)
 		}

--- a/internal/controlplane/handlers_ruletype.go
+++ b/internal/controlplane/handlers_ruletype.go
@@ -56,7 +56,7 @@ func (s *Server) ListRuleTypes(
 
 	for idx := range lrt {
 		rt := lrt[idx]
-		rtpb, err := engine.RuleTypePBFromDB(&rt, entityCtx)
+		rtpb, err := engine.RuleTypePBFromDB(&rt)
 		if err != nil {
 			return nil, fmt.Errorf("cannot convert rule type %s to pb: %v", rt.Name, err)
 		}
@@ -90,7 +90,7 @@ func (s *Server) GetRuleTypeByName(
 		return nil, status.Errorf(codes.Unknown, "failed to get rule type: %s", err)
 	}
 
-	rt, err := engine.RuleTypePBFromDB(&rtdb, entityCtx)
+	rt, err := engine.RuleTypePBFromDB(&rtdb)
 	if err != nil {
 		return nil, fmt.Errorf("cannot convert rule type %s to pb: %v", rtdb.Name, err)
 	}
@@ -110,8 +110,6 @@ func (s *Server) GetRuleTypeById(
 		return nil, status.Errorf(codes.InvalidArgument, "error ensuring default project: %v", err)
 	}
 
-	entityCtx := engine.EntityFromContext(ctx)
-
 	resp := &minderv1.GetRuleTypeByIdResponse{}
 
 	parsedRuleTypeID, err := uuid.Parse(in.GetId())
@@ -124,7 +122,7 @@ func (s *Server) GetRuleTypeById(
 		return nil, status.Errorf(codes.Unknown, "failed to get rule type: %s", err)
 	}
 
-	rt, err := engine.RuleTypePBFromDB(&rtdb, entityCtx)
+	rt, err := engine.RuleTypePBFromDB(&rtdb)
 	if err != nil {
 		return nil, fmt.Errorf("cannot convert rule type %s to pb: %v", rtdb.Name, err)
 	}
@@ -141,7 +139,7 @@ func (s *Server) CreateRuleType(
 ) (*minderv1.CreateRuleTypeResponse, error) {
 	in := crt.GetRuleType()
 
-	ctx, err := s.authAndContextValidation(ctx, in.GetContext())
+	ctx, err := s.authAndContextValidation(ctx, crt.GetContext())
 	if err != nil {
 		return nil, status.Errorf(codes.InvalidArgument, "error ensuring default project: %v", err)
 	}
@@ -199,7 +197,7 @@ func (s *Server) UpdateRuleType(
 ) (*minderv1.UpdateRuleTypeResponse, error) {
 	in := urt.GetRuleType()
 
-	ctx, err := s.authAndContextValidation(ctx, in.GetContext())
+	ctx, err := s.authAndContextValidation(ctx, urt.GetContext())
 	if err != nil {
 		return nil, status.Errorf(codes.InvalidArgument, "error ensuring default project: %v", err)
 	}
@@ -218,7 +216,7 @@ func (s *Server) UpdateRuleType(
 		return nil, status.Errorf(codes.Internal, "failed to get rule type: %s", err)
 	}
 
-	oldrt, err := engine.RuleTypePBFromDB(&rtdb, entityCtx)
+	oldrt, err := engine.RuleTypePBFromDB(&rtdb)
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "cannot convert rule type %s to pb: %v", in.GetName(), err)
 	}

--- a/internal/engine/executor.go
+++ b/internal/engine/executor.go
@@ -221,7 +221,7 @@ func (e *Executor) evalEntityEvent(
 		return fmt.Errorf("error getting profiles: %w", err)
 	}
 
-	for _, profile := range MergeDatabaseListIntoProfiles(dbpols, ectx) {
+	for _, profile := range MergeDatabaseListIntoProfiles(dbpols) {
 		// Get only these rules that are relevant for this entity type
 		relevant, err := GetRulesForEntity(profile, inf.Type)
 		if err != nil {
@@ -292,7 +292,7 @@ func (e *Executor) getEvaluator(
 	}
 
 	// Parse the rule type
-	rt, err := RuleTypePBFromDB(&dbrt, ectx)
+	rt, err := RuleTypePBFromDB(&dbrt)
 	if err != nil {
 		return nil, nil, fmt.Errorf("error parsing rule type when traversing profile %s: %w", params.ProfileID, err)
 	}

--- a/internal/engine/profile.go
+++ b/internal/engine/profile.go
@@ -153,7 +153,7 @@ func TraverseRules(rules []*pb.Profile_Rule, fn func(*pb.Profile_Rule) error) er
 // profiles map. This assumes that the profiles belong to the same project.
 //
 // TODO(jaosorior): This will have to consider the project tree once we	migrate to that
-func MergeDatabaseListIntoProfiles(ppl []db.ListProfilesByProjectIDRow, ectx *EntityContext) map[string]*pb.Profile {
+func MergeDatabaseListIntoProfiles(ppl []db.ListProfilesByProjectIDRow) map[string]*pb.Profile {
 	profiles := map[string]*pb.Profile{}
 
 	for idx := range ppl {
@@ -162,15 +162,15 @@ func MergeDatabaseListIntoProfiles(ppl []db.ListProfilesByProjectIDRow, ectx *En
 		// NOTE: names are unique within a given Provider & Project ID (Unique index),
 		// so we don't need to worry about collisions.
 		// first we check if profile already exists, if not we create a new one
-		// first we check if profile already exists, if not we create a new one
 		if _, ok := profiles[p.Name]; !ok {
 			profileID := p.ID.String()
+			project := p.ProjectID.String()
 			profiles[p.Name] = &pb.Profile{
 				Id:   &profileID,
 				Name: p.Name,
 				Context: &pb.Context{
-					Provider: &ectx.Provider.Name,
-					Project:  &ectx.Project.Name,
+					Provider: &p.Provider,
+					Project:  &project,
 				},
 			}
 
@@ -196,7 +196,7 @@ func MergeDatabaseListIntoProfiles(ppl []db.ListProfilesByProjectIDRow, ectx *En
 // profiles map. This assumes that the profiles belong to the same project.
 //
 // TODO(jaosorior): This will have to consider the project tree once we migrate to that
-func MergeDatabaseGetIntoProfiles(ppl []db.GetProfileByProjectAndIDRow, ectx *EntityContext) map[string]*pb.Profile {
+func MergeDatabaseGetIntoProfiles(ppl []db.GetProfileByProjectAndIDRow) map[string]*pb.Profile {
 	profiles := map[string]*pb.Profile{}
 
 	for idx := range ppl {
@@ -208,12 +208,13 @@ func MergeDatabaseGetIntoProfiles(ppl []db.GetProfileByProjectAndIDRow, ectx *En
 		// first we check if profile already exists, if not we create a new one
 		if _, ok := profiles[p.Name]; !ok {
 			profileID := p.ID.String()
+			project := p.ProjectID.String()
 			profiles[p.Name] = &pb.Profile{
 				Id:   &profileID,
 				Name: p.Name,
 				Context: &pb.Context{
-					Provider: &ectx.Provider.Name,
-					Project:  &ectx.Project.Name,
+					Provider: &p.Provider,
+					Project:  &project,
 				},
 			}
 

--- a/internal/engine/profile_test.go
+++ b/internal/engine/profile_test.go
@@ -122,7 +122,6 @@ version: v1
 type: profile
 name: acme-github-profile
 context:
-  organization: ACME
   provider: github
 repository:
   - type: secret_scanning
@@ -217,7 +216,6 @@ version: v1
 type: profile
 name: acme-github-profile
 context:
-  organization: ACME
   provider: github
 repository:
   - type: secret_scanning
@@ -253,7 +251,6 @@ version: v1
 type: profile
 name: acme-github-profile
 context:
-  organization: ACME
   provider: github
 repository:
   - type: secret_scanning
@@ -269,7 +266,6 @@ version: v1
 type: profile
 name: acme-github-profile
 context:
-  organization: ACME
   provider: github
 repository:
   - type: secret_scanning
@@ -285,7 +281,6 @@ version: v1
 type: profile
 name: acme-github-profile
 context:
-  organization: ACME
   provider: github
 repository:
   - null

--- a/internal/engine/rule_types.go
+++ b/internal/engine/rule_types.go
@@ -289,23 +289,21 @@ func RuleDefFromDB(r *db.RuleType) (*minderv1.RuleType_Definition, error) {
 
 // RuleTypePBFromDB converts a rule type from the database to a protobuf
 // rule type
-func RuleTypePBFromDB(rt *db.RuleType, ectx *EntityContext) (*minderv1.RuleType, error) {
-	gname := ectx.GetProject().GetName()
-
+func RuleTypePBFromDB(rt *db.RuleType) (*minderv1.RuleType, error) {
 	def, err := RuleDefFromDB(rt)
 	if err != nil {
 		return nil, fmt.Errorf("cannot get rule type definition: %w", err)
 	}
 
 	id := rt.ID.String()
-	name := ectx.GetProvider().Name
+	project := rt.ProjectID.String()
 
 	return &minderv1.RuleType{
 		Id:   &id,
 		Name: rt.Name,
 		Context: &minderv1.Context{
-			Provider: &name,
-			Project:  &gname,
+			Provider: &rt.Provider,
+			Project:  &project,
 		},
 		Description: rt.Description,
 		Guidance:    rt.Guidance,

--- a/pkg/api/openapi/minder/v1/minder.swagger.json
+++ b/pkg/api/openapi/minder/v1/minder.swagger.json
@@ -2520,9 +2520,6 @@
       "properties": {
         "profile": {
           "$ref": "#/definitions/v1Profile"
-        },
-        "context": {
-          "$ref": "#/definitions/v1Context"
         }
       },
       "title": "Profile service"
@@ -2541,9 +2538,6 @@
         "ruleType": {
           "$ref": "#/definitions/v1RuleType",
           "description": "rule_type is the rule type to be created."
-        },
-        "context": {
-          "$ref": "#/definitions/v1Context"
         }
       },
       "description": "CreateRuleTypeRequest is the request to create a rule type."
@@ -3237,9 +3231,6 @@
       "properties": {
         "profile": {
           "$ref": "#/definitions/v1Profile"
-        },
-        "context": {
-          "$ref": "#/definitions/v1Context"
         }
       }
     },
@@ -3257,9 +3248,6 @@
         "ruleType": {
           "$ref": "#/definitions/v1RuleType",
           "description": "rule_type is the rule type to be updated."
-        },
-        "context": {
-          "$ref": "#/definitions/v1Context"
         }
       },
       "description": "UpdateRuleTypeRequest is the request to update a rule type."

--- a/pkg/api/protobuf/go/minder/v1/minder.pb.go
+++ b/pkg/api/protobuf/go/minder/v1/minder.pb.go
@@ -3325,7 +3325,6 @@ type CreateProfileRequest struct {
 	unknownFields protoimpl.UnknownFields
 
 	Profile *Profile `protobuf:"bytes,1,opt,name=profile,proto3" json:"profile,omitempty"`
-	Context *Context `protobuf:"bytes,2,opt,name=context,proto3" json:"context,omitempty"`
 }
 
 func (x *CreateProfileRequest) Reset() {
@@ -3363,13 +3362,6 @@ func (*CreateProfileRequest) Descriptor() ([]byte, []int) {
 func (x *CreateProfileRequest) GetProfile() *Profile {
 	if x != nil {
 		return x.Profile
-	}
-	return nil
-}
-
-func (x *CreateProfileRequest) GetContext() *Context {
-	if x != nil {
-		return x.Context
 	}
 	return nil
 }
@@ -3427,7 +3419,6 @@ type UpdateProfileRequest struct {
 	unknownFields protoimpl.UnknownFields
 
 	Profile *Profile `protobuf:"bytes,1,opt,name=profile,proto3" json:"profile,omitempty"`
-	Context *Context `protobuf:"bytes,2,opt,name=context,proto3" json:"context,omitempty"`
 }
 
 func (x *UpdateProfileRequest) Reset() {
@@ -3465,13 +3456,6 @@ func (*UpdateProfileRequest) Descriptor() ([]byte, []int) {
 func (x *UpdateProfileRequest) GetProfile() *Profile {
 	if x != nil {
 		return x.Profile
-	}
-	return nil
-}
-
-func (x *UpdateProfileRequest) GetContext() *Context {
-	if x != nil {
-		return x.Context
 	}
 	return nil
 }
@@ -4768,7 +4752,6 @@ type CreateRuleTypeRequest struct {
 
 	// rule_type is the rule type to be created.
 	RuleType *RuleType `protobuf:"bytes,1,opt,name=rule_type,json=ruleType,proto3" json:"rule_type,omitempty"`
-	Context  *Context  `protobuf:"bytes,2,opt,name=context,proto3" json:"context,omitempty"`
 }
 
 func (x *CreateRuleTypeRequest) Reset() {
@@ -4806,13 +4789,6 @@ func (*CreateRuleTypeRequest) Descriptor() ([]byte, []int) {
 func (x *CreateRuleTypeRequest) GetRuleType() *RuleType {
 	if x != nil {
 		return x.RuleType
-	}
-	return nil
-}
-
-func (x *CreateRuleTypeRequest) GetContext() *Context {
-	if x != nil {
-		return x.Context
 	}
 	return nil
 }
@@ -4874,7 +4850,6 @@ type UpdateRuleTypeRequest struct {
 
 	// rule_type is the rule type to be updated.
 	RuleType *RuleType `protobuf:"bytes,2,opt,name=rule_type,json=ruleType,proto3" json:"rule_type,omitempty"`
-	Context  *Context  `protobuf:"bytes,3,opt,name=context,proto3" json:"context,omitempty"`
 }
 
 func (x *UpdateRuleTypeRequest) Reset() {
@@ -4912,13 +4887,6 @@ func (*UpdateRuleTypeRequest) Descriptor() ([]byte, []int) {
 func (x *UpdateRuleTypeRequest) GetRuleType() *RuleType {
 	if x != nil {
 		return x.RuleType
-	}
-	return nil
-}
-
-func (x *UpdateRuleTypeRequest) GetContext() *Context {
-	if x != nil {
-		return x.Context
 	}
 	return nil
 }
@@ -7496,26 +7464,21 @@ var file_minder_v1_minder_proto_rawDesc = []byte{
 	0x0a, 0x08, 0x70, 0x72, 0x6f, 0x6a, 0x65, 0x63, 0x74, 0x73, 0x18, 0x02, 0x20, 0x03, 0x28, 0x0b,
 	0x32, 0x12, 0x2e, 0x6d, 0x69, 0x6e, 0x64, 0x65, 0x72, 0x2e, 0x76, 0x31, 0x2e, 0x50, 0x72, 0x6f,
 	0x6a, 0x65, 0x63, 0x74, 0x52, 0x08, 0x70, 0x72, 0x6f, 0x6a, 0x65, 0x63, 0x74, 0x73, 0x42, 0x07,
-	0x0a, 0x05, 0x5f, 0x75, 0x73, 0x65, 0x72, 0x22, 0x72, 0x0a, 0x14, 0x43, 0x72, 0x65, 0x61, 0x74,
+	0x0a, 0x05, 0x5f, 0x75, 0x73, 0x65, 0x72, 0x22, 0x4a, 0x0a, 0x14, 0x43, 0x72, 0x65, 0x61, 0x74,
 	0x65, 0x50, 0x72, 0x6f, 0x66, 0x69, 0x6c, 0x65, 0x52, 0x65, 0x71, 0x75, 0x65, 0x73, 0x74, 0x12,
 	0x2c, 0x0a, 0x07, 0x70, 0x72, 0x6f, 0x66, 0x69, 0x6c, 0x65, 0x18, 0x01, 0x20, 0x01, 0x28, 0x0b,
 	0x32, 0x12, 0x2e, 0x6d, 0x69, 0x6e, 0x64, 0x65, 0x72, 0x2e, 0x76, 0x31, 0x2e, 0x50, 0x72, 0x6f,
-	0x66, 0x69, 0x6c, 0x65, 0x52, 0x07, 0x70, 0x72, 0x6f, 0x66, 0x69, 0x6c, 0x65, 0x12, 0x2c, 0x0a,
-	0x07, 0x63, 0x6f, 0x6e, 0x74, 0x65, 0x78, 0x74, 0x18, 0x02, 0x20, 0x01, 0x28, 0x0b, 0x32, 0x12,
-	0x2e, 0x6d, 0x69, 0x6e, 0x64, 0x65, 0x72, 0x2e, 0x76, 0x31, 0x2e, 0x43, 0x6f, 0x6e, 0x74, 0x65,
-	0x78, 0x74, 0x52, 0x07, 0x63, 0x6f, 0x6e, 0x74, 0x65, 0x78, 0x74, 0x22, 0x45, 0x0a, 0x15, 0x43,
-	0x72, 0x65, 0x61, 0x74, 0x65, 0x50, 0x72, 0x6f, 0x66, 0x69, 0x6c, 0x65, 0x52, 0x65, 0x73, 0x70,
-	0x6f, 0x6e, 0x73, 0x65, 0x12, 0x2c, 0x0a, 0x07, 0x70, 0x72, 0x6f, 0x66, 0x69, 0x6c, 0x65, 0x18,
-	0x01, 0x20, 0x01, 0x28, 0x0b, 0x32, 0x12, 0x2e, 0x6d, 0x69, 0x6e, 0x64, 0x65, 0x72, 0x2e, 0x76,
-	0x31, 0x2e, 0x50, 0x72, 0x6f, 0x66, 0x69, 0x6c, 0x65, 0x52, 0x07, 0x70, 0x72, 0x6f, 0x66, 0x69,
-	0x6c, 0x65, 0x22, 0x72, 0x0a, 0x14, 0x55, 0x70, 0x64, 0x61, 0x74, 0x65, 0x50, 0x72, 0x6f, 0x66,
-	0x69, 0x6c, 0x65, 0x52, 0x65, 0x71, 0x75, 0x65, 0x73, 0x74, 0x12, 0x2c, 0x0a, 0x07, 0x70, 0x72,
-	0x6f, 0x66, 0x69, 0x6c, 0x65, 0x18, 0x01, 0x20, 0x01, 0x28, 0x0b, 0x32, 0x12, 0x2e, 0x6d, 0x69,
-	0x6e, 0x64, 0x65, 0x72, 0x2e, 0x76, 0x31, 0x2e, 0x50, 0x72, 0x6f, 0x66, 0x69, 0x6c, 0x65, 0x52,
-	0x07, 0x70, 0x72, 0x6f, 0x66, 0x69, 0x6c, 0x65, 0x12, 0x2c, 0x0a, 0x07, 0x63, 0x6f, 0x6e, 0x74,
-	0x65, 0x78, 0x74, 0x18, 0x02, 0x20, 0x01, 0x28, 0x0b, 0x32, 0x12, 0x2e, 0x6d, 0x69, 0x6e, 0x64,
-	0x65, 0x72, 0x2e, 0x76, 0x31, 0x2e, 0x43, 0x6f, 0x6e, 0x74, 0x65, 0x78, 0x74, 0x52, 0x07, 0x63,
-	0x6f, 0x6e, 0x74, 0x65, 0x78, 0x74, 0x22, 0x45, 0x0a, 0x15, 0x55, 0x70, 0x64, 0x61, 0x74, 0x65,
+	0x66, 0x69, 0x6c, 0x65, 0x52, 0x07, 0x70, 0x72, 0x6f, 0x66, 0x69, 0x6c, 0x65, 0x4a, 0x04, 0x08,
+	0x02, 0x10, 0x03, 0x22, 0x45, 0x0a, 0x15, 0x43, 0x72, 0x65, 0x61, 0x74, 0x65, 0x50, 0x72, 0x6f,
+	0x66, 0x69, 0x6c, 0x65, 0x52, 0x65, 0x73, 0x70, 0x6f, 0x6e, 0x73, 0x65, 0x12, 0x2c, 0x0a, 0x07,
+	0x70, 0x72, 0x6f, 0x66, 0x69, 0x6c, 0x65, 0x18, 0x01, 0x20, 0x01, 0x28, 0x0b, 0x32, 0x12, 0x2e,
+	0x6d, 0x69, 0x6e, 0x64, 0x65, 0x72, 0x2e, 0x76, 0x31, 0x2e, 0x50, 0x72, 0x6f, 0x66, 0x69, 0x6c,
+	0x65, 0x52, 0x07, 0x70, 0x72, 0x6f, 0x66, 0x69, 0x6c, 0x65, 0x22, 0x4a, 0x0a, 0x14, 0x55, 0x70,
+	0x64, 0x61, 0x74, 0x65, 0x50, 0x72, 0x6f, 0x66, 0x69, 0x6c, 0x65, 0x52, 0x65, 0x71, 0x75, 0x65,
+	0x73, 0x74, 0x12, 0x2c, 0x0a, 0x07, 0x70, 0x72, 0x6f, 0x66, 0x69, 0x6c, 0x65, 0x18, 0x01, 0x20,
+	0x01, 0x28, 0x0b, 0x32, 0x12, 0x2e, 0x6d, 0x69, 0x6e, 0x64, 0x65, 0x72, 0x2e, 0x76, 0x31, 0x2e,
+	0x50, 0x72, 0x6f, 0x66, 0x69, 0x6c, 0x65, 0x52, 0x07, 0x70, 0x72, 0x6f, 0x66, 0x69, 0x6c, 0x65,
+	0x4a, 0x04, 0x08, 0x02, 0x10, 0x03, 0x22, 0x45, 0x0a, 0x15, 0x55, 0x70, 0x64, 0x61, 0x74, 0x65,
 	0x50, 0x72, 0x6f, 0x66, 0x69, 0x6c, 0x65, 0x52, 0x65, 0x73, 0x70, 0x6f, 0x6e, 0x73, 0x65, 0x12,
 	0x2c, 0x0a, 0x07, 0x70, 0x72, 0x6f, 0x66, 0x69, 0x6c, 0x65, 0x18, 0x01, 0x20, 0x01, 0x28, 0x0b,
 	0x32, 0x12, 0x2e, 0x6d, 0x69, 0x6e, 0x64, 0x65, 0x72, 0x2e, 0x76, 0x31, 0x2e, 0x50, 0x72, 0x6f,
@@ -7686,27 +7649,22 @@ var file_minder_v1_minder_proto_rawDesc = []byte{
 	0x65, 0x12, 0x30, 0x0a, 0x09, 0x72, 0x75, 0x6c, 0x65, 0x5f, 0x74, 0x79, 0x70, 0x65, 0x18, 0x01,
 	0x20, 0x01, 0x28, 0x0b, 0x32, 0x13, 0x2e, 0x6d, 0x69, 0x6e, 0x64, 0x65, 0x72, 0x2e, 0x76, 0x31,
 	0x2e, 0x52, 0x75, 0x6c, 0x65, 0x54, 0x79, 0x70, 0x65, 0x52, 0x08, 0x72, 0x75, 0x6c, 0x65, 0x54,
-	0x79, 0x70, 0x65, 0x22, 0x77, 0x0a, 0x15, 0x43, 0x72, 0x65, 0x61, 0x74, 0x65, 0x52, 0x75, 0x6c,
+	0x79, 0x70, 0x65, 0x22, 0x4f, 0x0a, 0x15, 0x43, 0x72, 0x65, 0x61, 0x74, 0x65, 0x52, 0x75, 0x6c,
 	0x65, 0x54, 0x79, 0x70, 0x65, 0x52, 0x65, 0x71, 0x75, 0x65, 0x73, 0x74, 0x12, 0x30, 0x0a, 0x09,
 	0x72, 0x75, 0x6c, 0x65, 0x5f, 0x74, 0x79, 0x70, 0x65, 0x18, 0x01, 0x20, 0x01, 0x28, 0x0b, 0x32,
 	0x13, 0x2e, 0x6d, 0x69, 0x6e, 0x64, 0x65, 0x72, 0x2e, 0x76, 0x31, 0x2e, 0x52, 0x75, 0x6c, 0x65,
-	0x54, 0x79, 0x70, 0x65, 0x52, 0x08, 0x72, 0x75, 0x6c, 0x65, 0x54, 0x79, 0x70, 0x65, 0x12, 0x2c,
-	0x0a, 0x07, 0x63, 0x6f, 0x6e, 0x74, 0x65, 0x78, 0x74, 0x18, 0x02, 0x20, 0x01, 0x28, 0x0b, 0x32,
-	0x12, 0x2e, 0x6d, 0x69, 0x6e, 0x64, 0x65, 0x72, 0x2e, 0x76, 0x31, 0x2e, 0x43, 0x6f, 0x6e, 0x74,
-	0x65, 0x78, 0x74, 0x52, 0x07, 0x63, 0x6f, 0x6e, 0x74, 0x65, 0x78, 0x74, 0x22, 0x4a, 0x0a, 0x16,
-	0x43, 0x72, 0x65, 0x61, 0x74, 0x65, 0x52, 0x75, 0x6c, 0x65, 0x54, 0x79, 0x70, 0x65, 0x52, 0x65,
-	0x73, 0x70, 0x6f, 0x6e, 0x73, 0x65, 0x12, 0x30, 0x0a, 0x09, 0x72, 0x75, 0x6c, 0x65, 0x5f, 0x74,
-	0x79, 0x70, 0x65, 0x18, 0x01, 0x20, 0x01, 0x28, 0x0b, 0x32, 0x13, 0x2e, 0x6d, 0x69, 0x6e, 0x64,
-	0x65, 0x72, 0x2e, 0x76, 0x31, 0x2e, 0x52, 0x75, 0x6c, 0x65, 0x54, 0x79, 0x70, 0x65, 0x52, 0x08,
-	0x72, 0x75, 0x6c, 0x65, 0x54, 0x79, 0x70, 0x65, 0x22, 0x77, 0x0a, 0x15, 0x55, 0x70, 0x64, 0x61,
-	0x74, 0x65, 0x52, 0x75, 0x6c, 0x65, 0x54, 0x79, 0x70, 0x65, 0x52, 0x65, 0x71, 0x75, 0x65, 0x73,
-	0x74, 0x12, 0x30, 0x0a, 0x09, 0x72, 0x75, 0x6c, 0x65, 0x5f, 0x74, 0x79, 0x70, 0x65, 0x18, 0x02,
-	0x20, 0x01, 0x28, 0x0b, 0x32, 0x13, 0x2e, 0x6d, 0x69, 0x6e, 0x64, 0x65, 0x72, 0x2e, 0x76, 0x31,
-	0x2e, 0x52, 0x75, 0x6c, 0x65, 0x54, 0x79, 0x70, 0x65, 0x52, 0x08, 0x72, 0x75, 0x6c, 0x65, 0x54,
-	0x79, 0x70, 0x65, 0x12, 0x2c, 0x0a, 0x07, 0x63, 0x6f, 0x6e, 0x74, 0x65, 0x78, 0x74, 0x18, 0x03,
-	0x20, 0x01, 0x28, 0x0b, 0x32, 0x12, 0x2e, 0x6d, 0x69, 0x6e, 0x64, 0x65, 0x72, 0x2e, 0x76, 0x31,
-	0x2e, 0x43, 0x6f, 0x6e, 0x74, 0x65, 0x78, 0x74, 0x52, 0x07, 0x63, 0x6f, 0x6e, 0x74, 0x65, 0x78,
-	0x74, 0x22, 0x4a, 0x0a, 0x16, 0x55, 0x70, 0x64, 0x61, 0x74, 0x65, 0x52, 0x75, 0x6c, 0x65, 0x54,
+	0x54, 0x79, 0x70, 0x65, 0x52, 0x08, 0x72, 0x75, 0x6c, 0x65, 0x54, 0x79, 0x70, 0x65, 0x4a, 0x04,
+	0x08, 0x02, 0x10, 0x03, 0x22, 0x4a, 0x0a, 0x16, 0x43, 0x72, 0x65, 0x61, 0x74, 0x65, 0x52, 0x75,
+	0x6c, 0x65, 0x54, 0x79, 0x70, 0x65, 0x52, 0x65, 0x73, 0x70, 0x6f, 0x6e, 0x73, 0x65, 0x12, 0x30,
+	0x0a, 0x09, 0x72, 0x75, 0x6c, 0x65, 0x5f, 0x74, 0x79, 0x70, 0x65, 0x18, 0x01, 0x20, 0x01, 0x28,
+	0x0b, 0x32, 0x13, 0x2e, 0x6d, 0x69, 0x6e, 0x64, 0x65, 0x72, 0x2e, 0x76, 0x31, 0x2e, 0x52, 0x75,
+	0x6c, 0x65, 0x54, 0x79, 0x70, 0x65, 0x52, 0x08, 0x72, 0x75, 0x6c, 0x65, 0x54, 0x79, 0x70, 0x65,
+	0x22, 0x4f, 0x0a, 0x15, 0x55, 0x70, 0x64, 0x61, 0x74, 0x65, 0x52, 0x75, 0x6c, 0x65, 0x54, 0x79,
+	0x70, 0x65, 0x52, 0x65, 0x71, 0x75, 0x65, 0x73, 0x74, 0x12, 0x30, 0x0a, 0x09, 0x72, 0x75, 0x6c,
+	0x65, 0x5f, 0x74, 0x79, 0x70, 0x65, 0x18, 0x02, 0x20, 0x01, 0x28, 0x0b, 0x32, 0x13, 0x2e, 0x6d,
+	0x69, 0x6e, 0x64, 0x65, 0x72, 0x2e, 0x76, 0x31, 0x2e, 0x52, 0x75, 0x6c, 0x65, 0x54, 0x79, 0x70,
+	0x65, 0x52, 0x08, 0x72, 0x75, 0x6c, 0x65, 0x54, 0x79, 0x70, 0x65, 0x4a, 0x04, 0x08, 0x03, 0x10,
+	0x04, 0x22, 0x4a, 0x0a, 0x16, 0x55, 0x70, 0x64, 0x61, 0x74, 0x65, 0x52, 0x75, 0x6c, 0x65, 0x54,
 	0x79, 0x70, 0x65, 0x52, 0x65, 0x73, 0x70, 0x6f, 0x6e, 0x73, 0x65, 0x12, 0x30, 0x0a, 0x09, 0x72,
 	0x75, 0x6c, 0x65, 0x5f, 0x74, 0x79, 0x70, 0x65, 0x18, 0x01, 0x20, 0x01, 0x28, 0x0b, 0x32, 0x13,
 	0x2e, 0x6d, 0x69, 0x6e, 0x64, 0x65, 0x72, 0x2e, 0x76, 0x31, 0x2e, 0x52, 0x75, 0x6c, 0x65, 0x54,
@@ -8481,145 +8439,141 @@ var file_minder_v1_minder_proto_depIdxs = []int32{
 	49,  // 47: minder.v1.GetUserResponse.user:type_name -> minder.v1.UserRecord
 	24,  // 48: minder.v1.GetUserResponse.projects:type_name -> minder.v1.Project
 	89,  // 49: minder.v1.CreateProfileRequest.profile:type_name -> minder.v1.Profile
-	70,  // 50: minder.v1.CreateProfileRequest.context:type_name -> minder.v1.Context
-	89,  // 51: minder.v1.CreateProfileResponse.profile:type_name -> minder.v1.Profile
-	89,  // 52: minder.v1.UpdateProfileRequest.profile:type_name -> minder.v1.Profile
-	70,  // 53: minder.v1.UpdateProfileRequest.context:type_name -> minder.v1.Context
-	89,  // 54: minder.v1.UpdateProfileResponse.profile:type_name -> minder.v1.Profile
-	70,  // 55: minder.v1.DeleteProfileRequest.context:type_name -> minder.v1.Context
-	70,  // 56: minder.v1.ListProfilesRequest.context:type_name -> minder.v1.Context
-	89,  // 57: minder.v1.ListProfilesResponse.profiles:type_name -> minder.v1.Profile
-	70,  // 58: minder.v1.GetProfileByIdRequest.context:type_name -> minder.v1.Context
-	89,  // 59: minder.v1.GetProfileByIdResponse.profile:type_name -> minder.v1.Profile
-	113, // 60: minder.v1.ProfileStatus.last_updated:type_name -> google.protobuf.Timestamp
-	113, // 61: minder.v1.RuleEvaluationStatus.last_updated:type_name -> google.protobuf.Timestamp
-	93,  // 62: minder.v1.RuleEvaluationStatus.entity_info:type_name -> minder.v1.RuleEvaluationStatus.EntityInfoEntry
-	113, // 63: minder.v1.RuleEvaluationStatus.remediation_last_updated:type_name -> google.protobuf.Timestamp
-	70,  // 64: minder.v1.GetProfileStatusByNameRequest.context:type_name -> minder.v1.Context
-	94,  // 65: minder.v1.GetProfileStatusByNameRequest.entity:type_name -> minder.v1.GetProfileStatusByNameRequest.EntityTypedId
-	62,  // 66: minder.v1.GetProfileStatusByNameResponse.profile_status:type_name -> minder.v1.ProfileStatus
-	63,  // 67: minder.v1.GetProfileStatusByNameResponse.rule_evaluation_status:type_name -> minder.v1.RuleEvaluationStatus
-	70,  // 68: minder.v1.GetProfileStatusByProjectRequest.context:type_name -> minder.v1.Context
-	62,  // 69: minder.v1.GetProfileStatusByProjectResponse.profile_status:type_name -> minder.v1.ProfileStatus
-	70,  // 70: minder.v1.ListRuleTypesRequest.context:type_name -> minder.v1.Context
-	88,  // 71: minder.v1.ListRuleTypesResponse.rule_types:type_name -> minder.v1.RuleType
-	70,  // 72: minder.v1.GetRuleTypeByNameRequest.context:type_name -> minder.v1.Context
-	88,  // 73: minder.v1.GetRuleTypeByNameResponse.rule_type:type_name -> minder.v1.RuleType
-	70,  // 74: minder.v1.GetRuleTypeByIdRequest.context:type_name -> minder.v1.Context
-	88,  // 75: minder.v1.GetRuleTypeByIdResponse.rule_type:type_name -> minder.v1.RuleType
-	88,  // 76: minder.v1.CreateRuleTypeRequest.rule_type:type_name -> minder.v1.RuleType
-	70,  // 77: minder.v1.CreateRuleTypeRequest.context:type_name -> minder.v1.Context
-	88,  // 78: minder.v1.CreateRuleTypeResponse.rule_type:type_name -> minder.v1.RuleType
-	88,  // 79: minder.v1.UpdateRuleTypeRequest.rule_type:type_name -> minder.v1.RuleType
-	70,  // 80: minder.v1.UpdateRuleTypeRequest.context:type_name -> minder.v1.Context
-	88,  // 81: minder.v1.UpdateRuleTypeResponse.rule_type:type_name -> minder.v1.RuleType
-	70,  // 82: minder.v1.DeleteRuleTypeRequest.context:type_name -> minder.v1.Context
-	95,  // 83: minder.v1.RestType.fallback:type_name -> minder.v1.RestType.Fallback
-	96,  // 84: minder.v1.DiffType.ecosystems:type_name -> minder.v1.DiffType.Ecosystem
-	70,  // 85: minder.v1.RuleType.context:type_name -> minder.v1.Context
-	97,  // 86: minder.v1.RuleType.def:type_name -> minder.v1.RuleType.Definition
-	70,  // 87: minder.v1.Profile.context:type_name -> minder.v1.Context
-	112, // 88: minder.v1.Profile.repository:type_name -> minder.v1.Profile.Rule
-	112, // 89: minder.v1.Profile.build_environment:type_name -> minder.v1.Profile.Rule
-	112, // 90: minder.v1.Profile.artifact:type_name -> minder.v1.Profile.Rule
-	112, // 91: minder.v1.Profile.pull_request:type_name -> minder.v1.Profile.Rule
-	15,  // 92: minder.v1.PrDependencies.ContextualDependency.dep:type_name -> minder.v1.Dependency
-	91,  // 93: minder.v1.PrDependencies.ContextualDependency.file:type_name -> minder.v1.PrDependencies.ContextualDependency.FilePatch
-	2,   // 94: minder.v1.GetProfileStatusByNameRequest.EntityTypedId.type:type_name -> minder.v1.Entity
-	114, // 95: minder.v1.RuleType.Definition.rule_schema:type_name -> google.protobuf.Struct
-	114, // 96: minder.v1.RuleType.Definition.param_schema:type_name -> google.protobuf.Struct
-	98,  // 97: minder.v1.RuleType.Definition.ingest:type_name -> minder.v1.RuleType.Definition.Ingest
-	99,  // 98: minder.v1.RuleType.Definition.eval:type_name -> minder.v1.RuleType.Definition.Eval
-	100, // 99: minder.v1.RuleType.Definition.remediate:type_name -> minder.v1.RuleType.Definition.Remediate
-	101, // 100: minder.v1.RuleType.Definition.alert:type_name -> minder.v1.RuleType.Definition.Alert
-	83,  // 101: minder.v1.RuleType.Definition.Ingest.rest:type_name -> minder.v1.RestType
-	84,  // 102: minder.v1.RuleType.Definition.Ingest.builtin:type_name -> minder.v1.BuiltinType
-	85,  // 103: minder.v1.RuleType.Definition.Ingest.artifact:type_name -> minder.v1.ArtifactType
-	86,  // 104: minder.v1.RuleType.Definition.Ingest.git:type_name -> minder.v1.GitType
-	87,  // 105: minder.v1.RuleType.Definition.Ingest.diff:type_name -> minder.v1.DiffType
-	102, // 106: minder.v1.RuleType.Definition.Eval.jq:type_name -> minder.v1.RuleType.Definition.Eval.JQComparison
-	103, // 107: minder.v1.RuleType.Definition.Eval.rego:type_name -> minder.v1.RuleType.Definition.Eval.Rego
-	104, // 108: minder.v1.RuleType.Definition.Eval.vulncheck:type_name -> minder.v1.RuleType.Definition.Eval.Vulncheck
-	105, // 109: minder.v1.RuleType.Definition.Eval.trusty:type_name -> minder.v1.RuleType.Definition.Eval.Trusty
-	83,  // 110: minder.v1.RuleType.Definition.Remediate.rest:type_name -> minder.v1.RestType
-	107, // 111: minder.v1.RuleType.Definition.Remediate.gh_branch_protection:type_name -> minder.v1.RuleType.Definition.Remediate.GhBranchProtectionType
-	108, // 112: minder.v1.RuleType.Definition.Remediate.pull_request:type_name -> minder.v1.RuleType.Definition.Remediate.PullRequestRemediation
-	111, // 113: minder.v1.RuleType.Definition.Alert.security_advisory:type_name -> minder.v1.RuleType.Definition.Alert.AlertTypeSA
-	106, // 114: minder.v1.RuleType.Definition.Eval.JQComparison.ingested:type_name -> minder.v1.RuleType.Definition.Eval.JQComparison.Operator
-	106, // 115: minder.v1.RuleType.Definition.Eval.JQComparison.profile:type_name -> minder.v1.RuleType.Definition.Eval.JQComparison.Operator
-	109, // 116: minder.v1.RuleType.Definition.Remediate.PullRequestRemediation.contents:type_name -> minder.v1.RuleType.Definition.Remediate.PullRequestRemediation.Content
-	110, // 117: minder.v1.RuleType.Definition.Remediate.PullRequestRemediation.actions_replace_tags_with_sha:type_name -> minder.v1.RuleType.Definition.Remediate.PullRequestRemediation.ActionsReplaceTagsWithSha
-	114, // 118: minder.v1.Profile.Rule.params:type_name -> google.protobuf.Struct
-	114, // 119: minder.v1.Profile.Rule.def:type_name -> google.protobuf.Struct
-	115, // 120: minder.v1.rpc_options:extendee -> google.protobuf.MethodOptions
-	3,   // 121: minder.v1.rpc_options:type_name -> minder.v1.RpcOptions
-	17,  // 122: minder.v1.HealthService.CheckHealth:input_type -> minder.v1.CheckHealthRequest
-	4,   // 123: minder.v1.ArtifactService.ListArtifacts:input_type -> minder.v1.ListArtifactsRequest
-	10,  // 124: minder.v1.ArtifactService.GetArtifactById:input_type -> minder.v1.GetArtifactByIdRequest
-	12,  // 125: minder.v1.ArtifactService.GetArtifactByName:input_type -> minder.v1.GetArtifactByNameRequest
-	19,  // 126: minder.v1.OAuthService.GetAuthorizationURL:input_type -> minder.v1.GetAuthorizationURLRequest
-	21,  // 127: minder.v1.OAuthService.ExchangeCodeForTokenCLI:input_type -> minder.v1.ExchangeCodeForTokenCLIRequest
-	22,  // 128: minder.v1.OAuthService.StoreProviderToken:input_type -> minder.v1.StoreProviderTokenRequest
-	42,  // 129: minder.v1.OAuthService.VerifyProviderTokenFrom:input_type -> minder.v1.VerifyProviderTokenFromRequest
-	29,  // 130: minder.v1.RepositoryService.RegisterRepository:input_type -> minder.v1.RegisterRepositoryRequest
-	25,  // 131: minder.v1.RepositoryService.ListRemoteRepositoriesFromProvider:input_type -> minder.v1.ListRemoteRepositoriesFromProviderRequest
-	40,  // 132: minder.v1.RepositoryService.ListRepositories:input_type -> minder.v1.ListRepositoriesRequest
-	32,  // 133: minder.v1.RepositoryService.GetRepositoryById:input_type -> minder.v1.GetRepositoryByIdRequest
-	36,  // 134: minder.v1.RepositoryService.GetRepositoryByName:input_type -> minder.v1.GetRepositoryByNameRequest
-	34,  // 135: minder.v1.RepositoryService.DeleteRepositoryById:input_type -> minder.v1.DeleteRepositoryByIdRequest
-	38,  // 136: minder.v1.RepositoryService.DeleteRepositoryByName:input_type -> minder.v1.DeleteRepositoryByNameRequest
-	45,  // 137: minder.v1.UserService.CreateUser:input_type -> minder.v1.CreateUserRequest
-	47,  // 138: minder.v1.UserService.DeleteUser:input_type -> minder.v1.DeleteUserRequest
-	50,  // 139: minder.v1.UserService.GetUser:input_type -> minder.v1.GetUserRequest
-	52,  // 140: minder.v1.ProfileService.CreateProfile:input_type -> minder.v1.CreateProfileRequest
-	54,  // 141: minder.v1.ProfileService.UpdateProfile:input_type -> minder.v1.UpdateProfileRequest
-	56,  // 142: minder.v1.ProfileService.DeleteProfile:input_type -> minder.v1.DeleteProfileRequest
-	58,  // 143: minder.v1.ProfileService.ListProfiles:input_type -> minder.v1.ListProfilesRequest
-	60,  // 144: minder.v1.ProfileService.GetProfileById:input_type -> minder.v1.GetProfileByIdRequest
-	64,  // 145: minder.v1.ProfileService.GetProfileStatusByName:input_type -> minder.v1.GetProfileStatusByNameRequest
-	66,  // 146: minder.v1.ProfileService.GetProfileStatusByProject:input_type -> minder.v1.GetProfileStatusByProjectRequest
-	71,  // 147: minder.v1.ProfileService.ListRuleTypes:input_type -> minder.v1.ListRuleTypesRequest
-	73,  // 148: minder.v1.ProfileService.GetRuleTypeByName:input_type -> minder.v1.GetRuleTypeByNameRequest
-	75,  // 149: minder.v1.ProfileService.GetRuleTypeById:input_type -> minder.v1.GetRuleTypeByIdRequest
-	77,  // 150: minder.v1.ProfileService.CreateRuleType:input_type -> minder.v1.CreateRuleTypeRequest
-	79,  // 151: minder.v1.ProfileService.UpdateRuleType:input_type -> minder.v1.UpdateRuleTypeRequest
-	81,  // 152: minder.v1.ProfileService.DeleteRuleType:input_type -> minder.v1.DeleteRuleTypeRequest
-	18,  // 153: minder.v1.HealthService.CheckHealth:output_type -> minder.v1.CheckHealthResponse
-	5,   // 154: minder.v1.ArtifactService.ListArtifacts:output_type -> minder.v1.ListArtifactsResponse
-	11,  // 155: minder.v1.ArtifactService.GetArtifactById:output_type -> minder.v1.GetArtifactByIdResponse
-	13,  // 156: minder.v1.ArtifactService.GetArtifactByName:output_type -> minder.v1.GetArtifactByNameResponse
-	20,  // 157: minder.v1.OAuthService.GetAuthorizationURL:output_type -> minder.v1.GetAuthorizationURLResponse
-	116, // 158: minder.v1.OAuthService.ExchangeCodeForTokenCLI:output_type -> google.api.HttpBody
-	23,  // 159: minder.v1.OAuthService.StoreProviderToken:output_type -> minder.v1.StoreProviderTokenResponse
-	43,  // 160: minder.v1.OAuthService.VerifyProviderTokenFrom:output_type -> minder.v1.VerifyProviderTokenFromResponse
-	31,  // 161: minder.v1.RepositoryService.RegisterRepository:output_type -> minder.v1.RegisterRepositoryResponse
-	26,  // 162: minder.v1.RepositoryService.ListRemoteRepositoriesFromProvider:output_type -> minder.v1.ListRemoteRepositoriesFromProviderResponse
-	41,  // 163: minder.v1.RepositoryService.ListRepositories:output_type -> minder.v1.ListRepositoriesResponse
-	33,  // 164: minder.v1.RepositoryService.GetRepositoryById:output_type -> minder.v1.GetRepositoryByIdResponse
-	37,  // 165: minder.v1.RepositoryService.GetRepositoryByName:output_type -> minder.v1.GetRepositoryByNameResponse
-	35,  // 166: minder.v1.RepositoryService.DeleteRepositoryById:output_type -> minder.v1.DeleteRepositoryByIdResponse
-	39,  // 167: minder.v1.RepositoryService.DeleteRepositoryByName:output_type -> minder.v1.DeleteRepositoryByNameResponse
-	46,  // 168: minder.v1.UserService.CreateUser:output_type -> minder.v1.CreateUserResponse
-	48,  // 169: minder.v1.UserService.DeleteUser:output_type -> minder.v1.DeleteUserResponse
-	51,  // 170: minder.v1.UserService.GetUser:output_type -> minder.v1.GetUserResponse
-	53,  // 171: minder.v1.ProfileService.CreateProfile:output_type -> minder.v1.CreateProfileResponse
-	55,  // 172: minder.v1.ProfileService.UpdateProfile:output_type -> minder.v1.UpdateProfileResponse
-	57,  // 173: minder.v1.ProfileService.DeleteProfile:output_type -> minder.v1.DeleteProfileResponse
-	59,  // 174: minder.v1.ProfileService.ListProfiles:output_type -> minder.v1.ListProfilesResponse
-	61,  // 175: minder.v1.ProfileService.GetProfileById:output_type -> minder.v1.GetProfileByIdResponse
-	65,  // 176: minder.v1.ProfileService.GetProfileStatusByName:output_type -> minder.v1.GetProfileStatusByNameResponse
-	67,  // 177: minder.v1.ProfileService.GetProfileStatusByProject:output_type -> minder.v1.GetProfileStatusByProjectResponse
-	72,  // 178: minder.v1.ProfileService.ListRuleTypes:output_type -> minder.v1.ListRuleTypesResponse
-	74,  // 179: minder.v1.ProfileService.GetRuleTypeByName:output_type -> minder.v1.GetRuleTypeByNameResponse
-	76,  // 180: minder.v1.ProfileService.GetRuleTypeById:output_type -> minder.v1.GetRuleTypeByIdResponse
-	78,  // 181: minder.v1.ProfileService.CreateRuleType:output_type -> minder.v1.CreateRuleTypeResponse
-	80,  // 182: minder.v1.ProfileService.UpdateRuleType:output_type -> minder.v1.UpdateRuleTypeResponse
-	82,  // 183: minder.v1.ProfileService.DeleteRuleType:output_type -> minder.v1.DeleteRuleTypeResponse
-	153, // [153:184] is the sub-list for method output_type
-	122, // [122:153] is the sub-list for method input_type
-	121, // [121:122] is the sub-list for extension type_name
-	120, // [120:121] is the sub-list for extension extendee
-	0,   // [0:120] is the sub-list for field type_name
+	89,  // 50: minder.v1.CreateProfileResponse.profile:type_name -> minder.v1.Profile
+	89,  // 51: minder.v1.UpdateProfileRequest.profile:type_name -> minder.v1.Profile
+	89,  // 52: minder.v1.UpdateProfileResponse.profile:type_name -> minder.v1.Profile
+	70,  // 53: minder.v1.DeleteProfileRequest.context:type_name -> minder.v1.Context
+	70,  // 54: minder.v1.ListProfilesRequest.context:type_name -> minder.v1.Context
+	89,  // 55: minder.v1.ListProfilesResponse.profiles:type_name -> minder.v1.Profile
+	70,  // 56: minder.v1.GetProfileByIdRequest.context:type_name -> minder.v1.Context
+	89,  // 57: minder.v1.GetProfileByIdResponse.profile:type_name -> minder.v1.Profile
+	113, // 58: minder.v1.ProfileStatus.last_updated:type_name -> google.protobuf.Timestamp
+	113, // 59: minder.v1.RuleEvaluationStatus.last_updated:type_name -> google.protobuf.Timestamp
+	93,  // 60: minder.v1.RuleEvaluationStatus.entity_info:type_name -> minder.v1.RuleEvaluationStatus.EntityInfoEntry
+	113, // 61: minder.v1.RuleEvaluationStatus.remediation_last_updated:type_name -> google.protobuf.Timestamp
+	70,  // 62: minder.v1.GetProfileStatusByNameRequest.context:type_name -> minder.v1.Context
+	94,  // 63: minder.v1.GetProfileStatusByNameRequest.entity:type_name -> minder.v1.GetProfileStatusByNameRequest.EntityTypedId
+	62,  // 64: minder.v1.GetProfileStatusByNameResponse.profile_status:type_name -> minder.v1.ProfileStatus
+	63,  // 65: minder.v1.GetProfileStatusByNameResponse.rule_evaluation_status:type_name -> minder.v1.RuleEvaluationStatus
+	70,  // 66: minder.v1.GetProfileStatusByProjectRequest.context:type_name -> minder.v1.Context
+	62,  // 67: minder.v1.GetProfileStatusByProjectResponse.profile_status:type_name -> minder.v1.ProfileStatus
+	70,  // 68: minder.v1.ListRuleTypesRequest.context:type_name -> minder.v1.Context
+	88,  // 69: minder.v1.ListRuleTypesResponse.rule_types:type_name -> minder.v1.RuleType
+	70,  // 70: minder.v1.GetRuleTypeByNameRequest.context:type_name -> minder.v1.Context
+	88,  // 71: minder.v1.GetRuleTypeByNameResponse.rule_type:type_name -> minder.v1.RuleType
+	70,  // 72: minder.v1.GetRuleTypeByIdRequest.context:type_name -> minder.v1.Context
+	88,  // 73: minder.v1.GetRuleTypeByIdResponse.rule_type:type_name -> minder.v1.RuleType
+	88,  // 74: minder.v1.CreateRuleTypeRequest.rule_type:type_name -> minder.v1.RuleType
+	88,  // 75: minder.v1.CreateRuleTypeResponse.rule_type:type_name -> minder.v1.RuleType
+	88,  // 76: minder.v1.UpdateRuleTypeRequest.rule_type:type_name -> minder.v1.RuleType
+	88,  // 77: minder.v1.UpdateRuleTypeResponse.rule_type:type_name -> minder.v1.RuleType
+	70,  // 78: minder.v1.DeleteRuleTypeRequest.context:type_name -> minder.v1.Context
+	95,  // 79: minder.v1.RestType.fallback:type_name -> minder.v1.RestType.Fallback
+	96,  // 80: minder.v1.DiffType.ecosystems:type_name -> minder.v1.DiffType.Ecosystem
+	70,  // 81: minder.v1.RuleType.context:type_name -> minder.v1.Context
+	97,  // 82: minder.v1.RuleType.def:type_name -> minder.v1.RuleType.Definition
+	70,  // 83: minder.v1.Profile.context:type_name -> minder.v1.Context
+	112, // 84: minder.v1.Profile.repository:type_name -> minder.v1.Profile.Rule
+	112, // 85: minder.v1.Profile.build_environment:type_name -> minder.v1.Profile.Rule
+	112, // 86: minder.v1.Profile.artifact:type_name -> minder.v1.Profile.Rule
+	112, // 87: minder.v1.Profile.pull_request:type_name -> minder.v1.Profile.Rule
+	15,  // 88: minder.v1.PrDependencies.ContextualDependency.dep:type_name -> minder.v1.Dependency
+	91,  // 89: minder.v1.PrDependencies.ContextualDependency.file:type_name -> minder.v1.PrDependencies.ContextualDependency.FilePatch
+	2,   // 90: minder.v1.GetProfileStatusByNameRequest.EntityTypedId.type:type_name -> minder.v1.Entity
+	114, // 91: minder.v1.RuleType.Definition.rule_schema:type_name -> google.protobuf.Struct
+	114, // 92: minder.v1.RuleType.Definition.param_schema:type_name -> google.protobuf.Struct
+	98,  // 93: minder.v1.RuleType.Definition.ingest:type_name -> minder.v1.RuleType.Definition.Ingest
+	99,  // 94: minder.v1.RuleType.Definition.eval:type_name -> minder.v1.RuleType.Definition.Eval
+	100, // 95: minder.v1.RuleType.Definition.remediate:type_name -> minder.v1.RuleType.Definition.Remediate
+	101, // 96: minder.v1.RuleType.Definition.alert:type_name -> minder.v1.RuleType.Definition.Alert
+	83,  // 97: minder.v1.RuleType.Definition.Ingest.rest:type_name -> minder.v1.RestType
+	84,  // 98: minder.v1.RuleType.Definition.Ingest.builtin:type_name -> minder.v1.BuiltinType
+	85,  // 99: minder.v1.RuleType.Definition.Ingest.artifact:type_name -> minder.v1.ArtifactType
+	86,  // 100: minder.v1.RuleType.Definition.Ingest.git:type_name -> minder.v1.GitType
+	87,  // 101: minder.v1.RuleType.Definition.Ingest.diff:type_name -> minder.v1.DiffType
+	102, // 102: minder.v1.RuleType.Definition.Eval.jq:type_name -> minder.v1.RuleType.Definition.Eval.JQComparison
+	103, // 103: minder.v1.RuleType.Definition.Eval.rego:type_name -> minder.v1.RuleType.Definition.Eval.Rego
+	104, // 104: minder.v1.RuleType.Definition.Eval.vulncheck:type_name -> minder.v1.RuleType.Definition.Eval.Vulncheck
+	105, // 105: minder.v1.RuleType.Definition.Eval.trusty:type_name -> minder.v1.RuleType.Definition.Eval.Trusty
+	83,  // 106: minder.v1.RuleType.Definition.Remediate.rest:type_name -> minder.v1.RestType
+	107, // 107: minder.v1.RuleType.Definition.Remediate.gh_branch_protection:type_name -> minder.v1.RuleType.Definition.Remediate.GhBranchProtectionType
+	108, // 108: minder.v1.RuleType.Definition.Remediate.pull_request:type_name -> minder.v1.RuleType.Definition.Remediate.PullRequestRemediation
+	111, // 109: minder.v1.RuleType.Definition.Alert.security_advisory:type_name -> minder.v1.RuleType.Definition.Alert.AlertTypeSA
+	106, // 110: minder.v1.RuleType.Definition.Eval.JQComparison.ingested:type_name -> minder.v1.RuleType.Definition.Eval.JQComparison.Operator
+	106, // 111: minder.v1.RuleType.Definition.Eval.JQComparison.profile:type_name -> minder.v1.RuleType.Definition.Eval.JQComparison.Operator
+	109, // 112: minder.v1.RuleType.Definition.Remediate.PullRequestRemediation.contents:type_name -> minder.v1.RuleType.Definition.Remediate.PullRequestRemediation.Content
+	110, // 113: minder.v1.RuleType.Definition.Remediate.PullRequestRemediation.actions_replace_tags_with_sha:type_name -> minder.v1.RuleType.Definition.Remediate.PullRequestRemediation.ActionsReplaceTagsWithSha
+	114, // 114: minder.v1.Profile.Rule.params:type_name -> google.protobuf.Struct
+	114, // 115: minder.v1.Profile.Rule.def:type_name -> google.protobuf.Struct
+	115, // 116: minder.v1.rpc_options:extendee -> google.protobuf.MethodOptions
+	3,   // 117: minder.v1.rpc_options:type_name -> minder.v1.RpcOptions
+	17,  // 118: minder.v1.HealthService.CheckHealth:input_type -> minder.v1.CheckHealthRequest
+	4,   // 119: minder.v1.ArtifactService.ListArtifacts:input_type -> minder.v1.ListArtifactsRequest
+	10,  // 120: minder.v1.ArtifactService.GetArtifactById:input_type -> minder.v1.GetArtifactByIdRequest
+	12,  // 121: minder.v1.ArtifactService.GetArtifactByName:input_type -> minder.v1.GetArtifactByNameRequest
+	19,  // 122: minder.v1.OAuthService.GetAuthorizationURL:input_type -> minder.v1.GetAuthorizationURLRequest
+	21,  // 123: minder.v1.OAuthService.ExchangeCodeForTokenCLI:input_type -> minder.v1.ExchangeCodeForTokenCLIRequest
+	22,  // 124: minder.v1.OAuthService.StoreProviderToken:input_type -> minder.v1.StoreProviderTokenRequest
+	42,  // 125: minder.v1.OAuthService.VerifyProviderTokenFrom:input_type -> minder.v1.VerifyProviderTokenFromRequest
+	29,  // 126: minder.v1.RepositoryService.RegisterRepository:input_type -> minder.v1.RegisterRepositoryRequest
+	25,  // 127: minder.v1.RepositoryService.ListRemoteRepositoriesFromProvider:input_type -> minder.v1.ListRemoteRepositoriesFromProviderRequest
+	40,  // 128: minder.v1.RepositoryService.ListRepositories:input_type -> minder.v1.ListRepositoriesRequest
+	32,  // 129: minder.v1.RepositoryService.GetRepositoryById:input_type -> minder.v1.GetRepositoryByIdRequest
+	36,  // 130: minder.v1.RepositoryService.GetRepositoryByName:input_type -> minder.v1.GetRepositoryByNameRequest
+	34,  // 131: minder.v1.RepositoryService.DeleteRepositoryById:input_type -> minder.v1.DeleteRepositoryByIdRequest
+	38,  // 132: minder.v1.RepositoryService.DeleteRepositoryByName:input_type -> minder.v1.DeleteRepositoryByNameRequest
+	45,  // 133: minder.v1.UserService.CreateUser:input_type -> minder.v1.CreateUserRequest
+	47,  // 134: minder.v1.UserService.DeleteUser:input_type -> minder.v1.DeleteUserRequest
+	50,  // 135: minder.v1.UserService.GetUser:input_type -> minder.v1.GetUserRequest
+	52,  // 136: minder.v1.ProfileService.CreateProfile:input_type -> minder.v1.CreateProfileRequest
+	54,  // 137: minder.v1.ProfileService.UpdateProfile:input_type -> minder.v1.UpdateProfileRequest
+	56,  // 138: minder.v1.ProfileService.DeleteProfile:input_type -> minder.v1.DeleteProfileRequest
+	58,  // 139: minder.v1.ProfileService.ListProfiles:input_type -> minder.v1.ListProfilesRequest
+	60,  // 140: minder.v1.ProfileService.GetProfileById:input_type -> minder.v1.GetProfileByIdRequest
+	64,  // 141: minder.v1.ProfileService.GetProfileStatusByName:input_type -> minder.v1.GetProfileStatusByNameRequest
+	66,  // 142: minder.v1.ProfileService.GetProfileStatusByProject:input_type -> minder.v1.GetProfileStatusByProjectRequest
+	71,  // 143: minder.v1.ProfileService.ListRuleTypes:input_type -> minder.v1.ListRuleTypesRequest
+	73,  // 144: minder.v1.ProfileService.GetRuleTypeByName:input_type -> minder.v1.GetRuleTypeByNameRequest
+	75,  // 145: minder.v1.ProfileService.GetRuleTypeById:input_type -> minder.v1.GetRuleTypeByIdRequest
+	77,  // 146: minder.v1.ProfileService.CreateRuleType:input_type -> minder.v1.CreateRuleTypeRequest
+	79,  // 147: minder.v1.ProfileService.UpdateRuleType:input_type -> minder.v1.UpdateRuleTypeRequest
+	81,  // 148: minder.v1.ProfileService.DeleteRuleType:input_type -> minder.v1.DeleteRuleTypeRequest
+	18,  // 149: minder.v1.HealthService.CheckHealth:output_type -> minder.v1.CheckHealthResponse
+	5,   // 150: minder.v1.ArtifactService.ListArtifacts:output_type -> minder.v1.ListArtifactsResponse
+	11,  // 151: minder.v1.ArtifactService.GetArtifactById:output_type -> minder.v1.GetArtifactByIdResponse
+	13,  // 152: minder.v1.ArtifactService.GetArtifactByName:output_type -> minder.v1.GetArtifactByNameResponse
+	20,  // 153: minder.v1.OAuthService.GetAuthorizationURL:output_type -> minder.v1.GetAuthorizationURLResponse
+	116, // 154: minder.v1.OAuthService.ExchangeCodeForTokenCLI:output_type -> google.api.HttpBody
+	23,  // 155: minder.v1.OAuthService.StoreProviderToken:output_type -> minder.v1.StoreProviderTokenResponse
+	43,  // 156: minder.v1.OAuthService.VerifyProviderTokenFrom:output_type -> minder.v1.VerifyProviderTokenFromResponse
+	31,  // 157: minder.v1.RepositoryService.RegisterRepository:output_type -> minder.v1.RegisterRepositoryResponse
+	26,  // 158: minder.v1.RepositoryService.ListRemoteRepositoriesFromProvider:output_type -> minder.v1.ListRemoteRepositoriesFromProviderResponse
+	41,  // 159: minder.v1.RepositoryService.ListRepositories:output_type -> minder.v1.ListRepositoriesResponse
+	33,  // 160: minder.v1.RepositoryService.GetRepositoryById:output_type -> minder.v1.GetRepositoryByIdResponse
+	37,  // 161: minder.v1.RepositoryService.GetRepositoryByName:output_type -> minder.v1.GetRepositoryByNameResponse
+	35,  // 162: minder.v1.RepositoryService.DeleteRepositoryById:output_type -> minder.v1.DeleteRepositoryByIdResponse
+	39,  // 163: minder.v1.RepositoryService.DeleteRepositoryByName:output_type -> minder.v1.DeleteRepositoryByNameResponse
+	46,  // 164: minder.v1.UserService.CreateUser:output_type -> minder.v1.CreateUserResponse
+	48,  // 165: minder.v1.UserService.DeleteUser:output_type -> minder.v1.DeleteUserResponse
+	51,  // 166: minder.v1.UserService.GetUser:output_type -> minder.v1.GetUserResponse
+	53,  // 167: minder.v1.ProfileService.CreateProfile:output_type -> minder.v1.CreateProfileResponse
+	55,  // 168: minder.v1.ProfileService.UpdateProfile:output_type -> minder.v1.UpdateProfileResponse
+	57,  // 169: minder.v1.ProfileService.DeleteProfile:output_type -> minder.v1.DeleteProfileResponse
+	59,  // 170: minder.v1.ProfileService.ListProfiles:output_type -> minder.v1.ListProfilesResponse
+	61,  // 171: minder.v1.ProfileService.GetProfileById:output_type -> minder.v1.GetProfileByIdResponse
+	65,  // 172: minder.v1.ProfileService.GetProfileStatusByName:output_type -> minder.v1.GetProfileStatusByNameResponse
+	67,  // 173: minder.v1.ProfileService.GetProfileStatusByProject:output_type -> minder.v1.GetProfileStatusByProjectResponse
+	72,  // 174: minder.v1.ProfileService.ListRuleTypes:output_type -> minder.v1.ListRuleTypesResponse
+	74,  // 175: minder.v1.ProfileService.GetRuleTypeByName:output_type -> minder.v1.GetRuleTypeByNameResponse
+	76,  // 176: minder.v1.ProfileService.GetRuleTypeById:output_type -> minder.v1.GetRuleTypeByIdResponse
+	78,  // 177: minder.v1.ProfileService.CreateRuleType:output_type -> minder.v1.CreateRuleTypeResponse
+	80,  // 178: minder.v1.ProfileService.UpdateRuleType:output_type -> minder.v1.UpdateRuleTypeResponse
+	82,  // 179: minder.v1.ProfileService.DeleteRuleType:output_type -> minder.v1.DeleteRuleTypeResponse
+	149, // [149:180] is the sub-list for method output_type
+	118, // [118:149] is the sub-list for method input_type
+	117, // [117:118] is the sub-list for extension type_name
+	116, // [116:117] is the sub-list for extension extendee
+	0,   // [0:116] is the sub-list for field type_name
 }
 
 func init() { file_minder_v1_minder_proto_init() }

--- a/pkg/api/protobuf/go/minder/v1/profile.go
+++ b/pkg/api/protobuf/go/minder/v1/profile.go
@@ -20,3 +20,19 @@ const (
 	// ProfileTypeVersion is the version of the profile resource.
 	ProfileTypeVersion = "v1"
 )
+
+// GetContext returns the context from the nested Profile
+func (r *CreateProfileRequest) GetContext() *Context {
+	if r != nil && r.Profile != nil {
+		return r.Profile.Context
+	}
+	return nil
+}
+
+// GetContext returns the context from the nested Profile
+func (r *UpdateProfileRequest) GetContext() *Context {
+	if r != nil && r.Profile != nil {
+		return r.Profile.Context
+	}
+	return nil
+}

--- a/pkg/api/protobuf/go/minder/v1/rule_types.go
+++ b/pkg/api/protobuf/go/minder/v1/rule_types.go
@@ -48,3 +48,19 @@ func ParseRuleType(r io.Reader) (*RuleType, error) {
 
 	return rt, nil
 }
+
+// GetContext returns the context from the nested RuleType
+func (r *CreateRuleTypeRequest) GetContext() *Context {
+	if r != nil && r.RuleType != nil {
+		return r.RuleType.Context
+	}
+	return nil
+}
+
+// GetContext returns the context from the nested RuleType
+func (r *UpdateRuleTypeRequest) GetContext() *Context {
+	if r != nil && r.RuleType != nil {
+		return r.RuleType.Context
+	}
+	return nil
+}

--- a/proto/minder/v1/minder.proto
+++ b/proto/minder/v1/minder.proto
@@ -773,7 +773,7 @@ message GetUserResponse {
 // Profile service
 message CreateProfileRequest {
     Profile profile = 1;
-    Context context = 2;
+    reserved 2; // deprecated context
 }
 
 message CreateProfileResponse {
@@ -782,7 +782,7 @@ message CreateProfileResponse {
 
 message UpdateProfileRequest {
     Profile profile = 1;
-    Context context = 2;
+    reserved 2; // deprecated context
 }
 
 message UpdateProfileResponse {
@@ -987,7 +987,7 @@ message GetRuleTypeByIdResponse {
 message CreateRuleTypeRequest {
     // rule_type is the rule type to be created.
     RuleType rule_type = 1;
-    Context context = 2;
+    reserved 2; // deprecated context
 }
 
 // CreateRuleTypeResponse is the response to create a rule type.
@@ -1000,7 +1000,7 @@ message CreateRuleTypeResponse {
 message UpdateRuleTypeRequest {
     // rule_type is the rule type to be updated.
     RuleType rule_type = 2;
-    Context context = 3;
+    reserved 3; // deprecated context
 }
 
 // UpdateRuleTypeResponse is the response to update a rule type.


### PR DESCRIPTION
- Remove the top level context from protos that already have a nested context (ruletype, profile)
- Add function to fetch nested context
- Allow CLI command flags to override YAML context

Note: this does not change the DB implementation, where ruletypes, profiles and repos are still tied to a provider and project.

Fix #2103