### PR TITLE
Create initial configuration for authz and create store as part of migration

### DIFF
--- a/config/server-config.yaml.example
+++ b/config/server-config.yaml.example
@@ -81,3 +81,10 @@ events:
   driver: go-channel
   router_close_timeout: 10
   go-channel: {}
+
+authz:
+  api_url: http://openfga
+  store_name: minder
+  auth:
+    # Set to token for production
+    method: none

--- a/deployment/helm/Chart.lock
+++ b/deployment/helm/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 2.13.4
-digest: sha256:3d041bf804861d1b205322f51bbf39745e1437de236c1fc0e74f6e5031a70e73
-generated: "2023-12-18T13:06:30.589568-08:00"
+  version: 2.14.1
+digest: sha256:f6cbb5e3d033290dcd0145c6c1bd13aa2e0813f9267c2f5559e5469ae705c520
+generated: "2024-01-11T14:23:46.142037752+02:00"

--- a/deployment/helm_tests/basic.yaml-out
+++ b/deployment/helm_tests/basic.yaml-out
@@ -112,6 +112,13 @@ data:
       router_close_timeout: 10
       go-channel: {}
     
+    authz:
+      api_url: http://openfga
+      store_name: minder
+      auth:
+        # Set to token for production
+        method: none
+    
   overrides.yaml: |
     
     database:
@@ -699,6 +706,13 @@ data:
       driver: go-channel
       router_close_timeout: 10
       go-channel: {}
+    
+    authz:
+      api_url: http://openfga
+      store_name: minder
+      auth:
+        # Set to token for production
+        method: none
     
   overrides.yaml: |
     

--- a/deployment/helm_tests/sidecar.yaml-out
+++ b/deployment/helm_tests/sidecar.yaml-out
@@ -112,6 +112,13 @@ data:
       router_close_timeout: 10
       go-channel: {}
     
+    authz:
+      api_url: http://openfga
+      store_name: minder
+      auth:
+        # Set to token for production
+        method: none
+    
   overrides.yaml: |
     
     database:
@@ -718,6 +725,13 @@ data:
       driver: go-channel
       router_close_timeout: 10
       go-channel: {}
+    
+    authz:
+      api_url: http://openfga
+      store_name: minder
+      auth:
+        # Set to token for production
+        method: none
     
   overrides.yaml: |
     

--- a/go.mod
+++ b/go.mod
@@ -34,6 +34,7 @@ require (
 	github.com/olekukonko/tablewriter v0.0.5
 	github.com/open-policy-agent/opa v0.60.0
 	github.com/openfga/cli v0.2.4
+	github.com/openfga/go-sdk v0.3.3
 	github.com/pkg/browser v0.0.0-20210911075715-681adbf594b8
 	github.com/prometheus/client_golang v1.18.0
 	github.com/puzpuzpuz/xsync v1.5.2
@@ -70,6 +71,7 @@ require (
 	gopkg.in/yaml.v2 v2.4.0
 	gopkg.in/yaml.v3 v3.0.1
 	k8s.io/apimachinery v0.29.1
+	k8s.io/client-go v0.29.0
 )
 
 require (
@@ -110,7 +112,6 @@ require (
 	github.com/nwidger/jsoncolor v0.3.2 // indirect
 	github.com/oklog/ulid/v2 v2.1.0 // indirect
 	github.com/openfga/api/proto v0.0.0-20231222042535-3037910c90c0 // indirect
-	github.com/openfga/go-sdk v0.3.3 // indirect
 	github.com/openfga/language/pkg/go v0.0.0-20240109134059-a66ff55aca89 // indirect
 	github.com/openfga/openfga v1.4.2 // indirect
 	github.com/sagikazarmark/locafero v0.4.0 // indirect
@@ -126,7 +127,9 @@ require (
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.21.0 // indirect
 	go.opentelemetry.io/proto/otlp v1.0.0 // indirect
 	go.uber.org/mock v0.4.0 // indirect
+	golang.org/x/time v0.5.0 // indirect
 	gopkg.in/go-jose/go-jose.v2 v2.6.1 // indirect
+	k8s.io/utils v0.0.0-20230726121419-3b25d923346b // indirect
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -1012,8 +1012,12 @@ honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWh
 honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 k8s.io/apimachinery v0.29.1 h1:KY4/E6km/wLBguvCZv8cKTeOwwOBqFNjwJIdMkMbbRc=
 k8s.io/apimachinery v0.29.1/go.mod h1:6HVkd1FwxIagpYrHSwJlQqZI3G9LfYWRPAkUvLnXTKU=
+k8s.io/client-go v0.29.0 h1:KmlDtFcrdUzOYrBhXHgKw5ycWzc3ryPX5mQe0SkG3y8=
+k8s.io/client-go v0.29.0/go.mod h1:yLkXH4HKMAywcrD82KMSmfYg2DlE8mepPR4JGSo5n38=
 k8s.io/klog/v2 v2.110.1 h1:U/Af64HJf7FcwMcXyKm2RPM22WZzyR7OSpYj5tg3cL0=
 k8s.io/klog/v2 v2.110.1/go.mod h1:YGtd1984u+GgbuZ7e08/yBuAfKLSO0+uR1Fhi6ExXjo=
+k8s.io/utils v0.0.0-20230726121419-3b25d923346b h1:sgn3ZU783SCgtaSJjpcVVlRqd6GSnlTLKgpAAttJvpI=
+k8s.io/utils v0.0.0-20230726121419-3b25d923346b/go.mod h1:OLgZIPagt7ERELqWJFomSt595RzquPNLL48iOWgYOg0=
 sigs.k8s.io/yaml v1.4.0 h1:Mk1wCc2gy/F0THH0TAp1QYyJNzRm2KCLy3o5ASXVI5E=
 sigs.k8s.io/yaml v1.4.0/go.mod h1:Ejl7/uTz7PSA4eKMyQCUTnhZYNmLIl+5c2lQPGR2BPY=
 software.sslmate.com/src/go-pkcs12 v0.2.0 h1:nlFkj7bTysH6VkC4fGphtjXRbezREPgrHuJG20hBGPE=

--- a/internal/authz/authz.go
+++ b/internal/authz/authz.go
@@ -1,0 +1,93 @@
+//
+// Copyright 2023 Stacklok, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package authz provides the authorization utilities for minder
+package authz
+
+import (
+	"fmt"
+	"net/http"
+
+	fgaclient "github.com/openfga/go-sdk/client"
+	"github.com/openfga/go-sdk/credentials"
+	"k8s.io/client-go/transport"
+
+	srvconfig "github.com/stacklok/minder/internal/config/server"
+)
+
+// ClientWrapper is a wrapper for the OpenFgaClient.
+// It is used to provide a common interface for the client and a way to
+// refresh authentication to the authz provider when needed.
+type ClientWrapper struct {
+	cfg *srvconfig.AuthzConfig
+	cli *fgaclient.OpenFgaClient
+}
+
+// NewAuthzClient returns a new AuthzClientWrapper
+func NewAuthzClient(cfg *srvconfig.AuthzConfig) (*ClientWrapper, error) {
+	if err := cfg.Validate(); err != nil {
+		return nil, err
+	}
+
+	clicfg := &fgaclient.ClientConfiguration{
+		ApiUrl: cfg.ApiUrl,
+		Credentials: &credentials.Credentials{
+			// We use our own bearer auth round tripper so we can refresh the token
+			Method: credentials.CredentialsMethodNone,
+		},
+	}
+
+	if cfg.StoreID != "" {
+		clicfg.StoreId = cfg.StoreID
+	}
+
+	if cfg.Auth.Method == "token" {
+		rt, err := transport.NewBearerAuthWithRefreshRoundTripper("", cfg.Auth.Token.TokenPath, http.DefaultTransport)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create bearer auth round tripper: %w", err)
+		}
+
+		clicfg.HTTPClient = &http.Client{
+			Transport: rt,
+		}
+	}
+
+	cli, err := fgaclient.NewSdkClient(clicfg)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create SDK client: %w", err)
+	}
+
+	return &ClientWrapper{
+		cfg: cfg,
+		cli: cli,
+	}, nil
+}
+
+// GetClient returns the OpenFgaClient
+func (a *ClientWrapper) GetClient() *fgaclient.OpenFgaClient {
+	// TODO: check if token is expired and refresh it
+	// Note that this will probably need a mutex
+	return a.cli
+}
+
+// GetConfig returns the authz configuration used to build the client
+func (a *ClientWrapper) GetConfig() *srvconfig.AuthzConfig {
+	return a.cfg
+}
+
+// StoreIDProvided returns true if the store ID was provided in the configuration
+func (a *ClientWrapper) StoreIDProvided() bool {
+	return a.cfg.StoreID != ""
+}

--- a/internal/config/server/authz.go
+++ b/internal/config/server/authz.go
@@ -1,0 +1,91 @@
+//
+// Copyright 2023 Stacklok, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package server
+
+import (
+	"os"
+
+	"github.com/go-playground/validator/v10"
+)
+
+// AuthzConfig is the configuration for minder's authorization
+type AuthzConfig struct {
+	// ApiUrl is the URL to the authorization server
+	ApiUrl string `mapstructure:"api_url" validate:"required"`
+	// StoreName is the name of the store to use for authorization
+	StoreName string `mapstructure:"store_name" default:"minder" validate:"required_without=StoreID"`
+	// StoreID is the ID of the store to use for authorization
+	StoreID string `mapstructure:"store_id" default:"minder" validate:"required_without=StoreName"`
+	// Auth is the authentication configuration for the authorization server
+	Auth OpenFGAAuth `mapstructure:"auth" validate:"required"`
+}
+
+// Validate validates the Authz configuration
+func (a *AuthzConfig) Validate() error {
+	validate := validator.New(validator.WithRequiredStructEnabled())
+	if err := validate.Struct(a); err != nil {
+		return err
+	}
+
+	return a.Auth.Validate()
+}
+
+// OpenFGAAuth contains the authentication configuration for OpenFGA
+type OpenFGAAuth struct {
+	// Method is the authentication method to use
+	Method string `mapstructure:"method" default:"none" validate:"oneof=token none"`
+
+	// Token is the configuration for OpenID Connect authentication
+	Token TokenAuth `mapstructure:"token"`
+}
+
+// Validate validates the OpenFGAAuth configuration
+func (o *OpenFGAAuth) Validate() error {
+	validate := validator.New(validator.WithRequiredStructEnabled())
+	if err := validate.Struct(o); err != nil {
+		return err
+	}
+
+	if o.Method == "none" {
+		return nil
+	}
+
+	return o.Token.Validate()
+}
+
+// TokenAuth contains the configuration for token authentication
+type TokenAuth struct {
+	// TokenPath is the path to the token to use for authentication.
+	// defaults to the kubernetes service account token
+	//nolint:lll
+	TokenPath string `mapstructure:"token_path" default:"/var/run/secrets/kubernetes.io/serviceaccount/token" validate:"required,file"`
+}
+
+// Validate validates the TokenAuth configuration
+func (t *TokenAuth) Validate() error {
+	validate := validator.New(validator.WithRequiredStructEnabled())
+	return validate.Struct(t)
+}
+
+// ReadToken reads the token from the configured path
+func (t *TokenAuth) ReadToken() (string, error) {
+	tok, err := os.ReadFile(t.TokenPath)
+	if err != nil {
+		return "", err
+	}
+
+	return string(tok), nil
+}

--- a/internal/config/server/config.go
+++ b/internal/config/server/config.go
@@ -40,6 +40,7 @@ type Config struct {
 	Auth          AuthConfig            `mapstructure:"auth"`
 	WebhookConfig WebhookConfig         `mapstructure:"webhook-config"`
 	Events        EventConfig           `mapstructure:"events"`
+	Authz         AuthzConfig           `mapstructure:"authz"`
 }
 
 // DefaultConfigForTest returns a configuration with all the struct defaults set,


### PR DESCRIPTION
This ensures that we create an authz store as part of the migration command.

To enable this, an Authz configuration section was created.

The next step is to actually populate the model.
