### PR TITLE
Remove double-wrapping of "provider error"

### DIFF
--- a/internal/controlplane/handlers_oauth.go
+++ b/internal/controlplane/handlers_oauth.go
@@ -20,7 +20,6 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"errors"
-	"fmt"
 
 	"github.com/google/uuid"
 	"go.opentelemetry.io/otel/attribute"
@@ -54,7 +53,7 @@ func (s *Server) GetAuthorizationURL(ctx context.Context,
 	// get provider info
 	provider, err := getProviderFromRequestOrDefault(ctx, s.store, req, projectID)
 	if err != nil {
-		return nil, providerError(fmt.Errorf("provider error: %w", err))
+		return nil, providerError(err)
 	}
 
 	// Configure tracing
@@ -152,7 +151,7 @@ func (s *Server) ExchangeCodeForTokenCLI(ctx context.Context,
 	// get provider
 	provider, err := getProviderFromRequestOrDefault(ctx, s.store, in, stateData.ProjectID)
 	if err != nil {
-		return nil, providerError(fmt.Errorf("provider error: %w", err))
+		return nil, providerError(err)
 	}
 
 	// generate a new OAuth2 config for the given provider
@@ -260,7 +259,7 @@ func (s *Server) StoreProviderToken(ctx context.Context,
 
 	provider, err := getProviderFromRequestOrDefault(ctx, s.store, in, projectID)
 	if err != nil {
-		return nil, providerError(fmt.Errorf("provider error: %w", err))
+		return nil, providerError(err)
 	}
 
 	// validate token
@@ -321,7 +320,7 @@ func (s *Server) VerifyProviderTokenFrom(ctx context.Context,
 
 	provider, err := getProviderFromRequestOrDefault(ctx, s.store, in, projectID)
 	if err != nil {
-		return nil, providerError(fmt.Errorf("provider error: %w", err))
+		return nil, providerError(err)
 	}
 
 	// check if a token has been created since timestamp

--- a/internal/controlplane/handlers_profile.go
+++ b/internal/controlplane/handlers_profile.go
@@ -134,7 +134,7 @@ func (s *Server) CreateProfile(ctx context.Context,
 		Name:      entityCtx.GetProvider().Name,
 		ProjectID: entityCtx.GetProject().ID})
 	if err != nil {
-		return nil, providerError(fmt.Errorf("provider error: %w", err))
+		return nil, providerError(err)
 	}
 
 	if err := in.Validate(); err != nil {

--- a/internal/controlplane/handlers_repositories.go
+++ b/internal/controlplane/handlers_repositories.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"database/sql"
 	"errors"
-	"fmt"
 	"strings"
 
 	"github.com/google/uuid"
@@ -53,7 +52,7 @@ func (s *Server) RegisterRepository(ctx context.Context,
 
 	provider, err := getProviderFromRequestOrDefault(ctx, s.store, in, projectID)
 	if err != nil {
-		return nil, providerError(fmt.Errorf("provider error: %w", err))
+		return nil, providerError(err)
 	}
 
 	pbOpts := []providers.ProviderBuilderOption{
@@ -158,7 +157,7 @@ func (s *Server) ListRepositories(ctx context.Context,
 
 	provider, err := getProviderFromRequestOrDefault(ctx, s.store, in, projectID)
 	if err != nil {
-		return nil, providerError(fmt.Errorf("provider error: %w", err))
+		return nil, providerError(err)
 	}
 
 	repos, err := s.store.ListRepositoriesByProjectID(ctx, db.ListRepositoriesByProjectIDParams{
@@ -244,7 +243,7 @@ func (s *Server) GetRepositoryByName(ctx context.Context,
 
 	provider, err := getProviderFromRequestOrDefault(ctx, s.store, in, projectID)
 	if err != nil {
-		return nil, providerError(fmt.Errorf("provider error: %w", err))
+		return nil, providerError(err)
 	}
 
 	repo, err := s.store.GetRepositoryByRepoName(ctx,
@@ -322,7 +321,7 @@ func (s *Server) DeleteRepositoryByName(ctx context.Context,
 
 	provider, err := getProviderFromRequestOrDefault(ctx, s.store, in, projectID)
 	if err != nil {
-		return nil, providerError(fmt.Errorf("provider error: %w", err))
+		return nil, providerError(err)
 	}
 
 	repo, err := s.store.GetRepositoryByRepoName(ctx,
@@ -366,7 +365,7 @@ func (s *Server) ListRemoteRepositoriesFromProvider(
 
 	provider, err := getProviderFromRequestOrDefault(ctx, s.store, in, projectID)
 	if err != nil {
-		return nil, providerError(fmt.Errorf("provider error: %w", err))
+		return nil, providerError(err)
 	}
 
 	zerolog.Ctx(ctx).Debug().


### PR DESCRIPTION
The body of `providerError` is:

```golang
func providerError(err error) error {
	if errors.Is(err, sql.ErrNoRows) {
		return util.UserVisibleError(codes.NotFound, "provider not found")
	}
	return fmt.Errorf("provider error: %w", err)
}
```

So all these cases were doubling-up `"provider error: provider error: "`
