### PR TITLE
Add BusinessTelemetry to authenticated RPC calls

### DIFF
--- a/internal/controlplane/handlers_artifacts.go
+++ b/internal/controlplane/handlers_artifacts.go
@@ -19,6 +19,7 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"github.com/stacklok/minder/internal/logger"
 	"slices"
 	"strings"
 
@@ -59,6 +60,10 @@ func (s *Server) ListArtifacts(ctx context.Context, in *pb.ListArtifactsRequest)
 	if err != nil {
 		return nil, fmt.Errorf("failed to list artifacts: %w", err)
 	}
+
+	// Telemetry logging
+	logger.BusinessRecord(ctx).Provider = provider.Name
+	logger.BusinessRecord(ctx).Project = projectID
 
 	return &pb.ListArtifactsResponse{Results: results}, nil
 }
@@ -120,6 +125,12 @@ func (s *Server) GetArtifactByName(ctx context.Context, in *pb.GetArtifactByName
 		return nil, status.Errorf(codes.Unknown, "failed to get artifact versions: %s", err)
 	}
 
+	// Telemetry logging
+	logger.BusinessRecord(ctx).Provider = artifact.Provider
+	logger.BusinessRecord(ctx).Project = artifact.ProjectID
+	logger.BusinessRecord(ctx).Artifact = artifact.ID
+	logger.BusinessRecord(ctx).Repository = artifact.RepositoryID
+
 	return &pb.GetArtifactByNameResponse{Artifact: &pb.Artifact{
 		ArtifactPk: artifact.ID.String(),
 		Owner:      artifact.RepoOwner,
@@ -173,6 +184,12 @@ func (s *Server) GetArtifactById(ctx context.Context, in *pb.GetArtifactByIdRequ
 	if err != nil {
 		return nil, status.Errorf(codes.Unknown, "failed to get artifact versions: %s", err)
 	}
+
+	// Telemetry logging
+	logger.BusinessRecord(ctx).Provider = artifact.Provider
+	logger.BusinessRecord(ctx).Project = artifact.ProjectID
+	logger.BusinessRecord(ctx).Artifact = artifact.ID
+	logger.BusinessRecord(ctx).Repository = artifact.RepositoryID
 
 	return &pb.GetArtifactByIdResponse{Artifact: &pb.Artifact{
 		ArtifactPk: artifact.ID.String(),

--- a/internal/controlplane/handlers_artifacts.go
+++ b/internal/controlplane/handlers_artifacts.go
@@ -19,7 +19,6 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
-	"github.com/stacklok/minder/internal/logger"
 	"slices"
 	"strings"
 
@@ -31,6 +30,7 @@ import (
 
 	"github.com/stacklok/minder/internal/db"
 	"github.com/stacklok/minder/internal/engine"
+	"github.com/stacklok/minder/internal/logger"
 	"github.com/stacklok/minder/internal/util"
 	pb "github.com/stacklok/minder/pkg/api/protobuf/go/minder/v1"
 )

--- a/internal/controlplane/handlers_authz.go
+++ b/internal/controlplane/handlers_authz.go
@@ -16,7 +16,10 @@ package controlplane
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
+	"github.com/stacklok/minder/internal/logger"
 
 	"github.com/google/uuid"
 	"github.com/rs/zerolog"
@@ -50,6 +53,10 @@ func lookupUserPermissions(ctx context.Context, store db.Store) auth.UserPermiss
 	emptyPermissions := auth.UserPermissions{}
 
 	subject := auth.GetUserSubjectFromContext(ctx)
+
+	// Attach the login sha for telemetry usage (hash of the user subject from the JWT)
+	loginSHA := sha256.Sum256([]byte(subject))
+	logger.BusinessRecord(ctx).LoginHash = hex.EncodeToString(loginSHA[:])
 
 	// read all information for user claims
 	userInfo, err := store.GetUserBySubject(ctx, subject)

--- a/internal/controlplane/handlers_authz.go
+++ b/internal/controlplane/handlers_authz.go
@@ -19,7 +19,6 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
-	"github.com/stacklok/minder/internal/logger"
 
 	"github.com/google/uuid"
 	"github.com/rs/zerolog"
@@ -31,6 +30,7 @@ import (
 	"github.com/stacklok/minder/internal/auth"
 	"github.com/stacklok/minder/internal/db"
 	"github.com/stacklok/minder/internal/engine"
+	"github.com/stacklok/minder/internal/logger"
 	"github.com/stacklok/minder/internal/util"
 	minder "github.com/stacklok/minder/pkg/api/protobuf/go/minder/v1"
 )

--- a/internal/controlplane/handlers_oauth.go
+++ b/internal/controlplane/handlers_oauth.go
@@ -20,7 +20,6 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"errors"
-	"github.com/stacklok/minder/internal/logger"
 
 	"github.com/google/uuid"
 	"go.opentelemetry.io/otel/attribute"
@@ -34,6 +33,7 @@ import (
 	mcrypto "github.com/stacklok/minder/internal/crypto"
 	"github.com/stacklok/minder/internal/db"
 	"github.com/stacklok/minder/internal/engine"
+	"github.com/stacklok/minder/internal/logger"
 	"github.com/stacklok/minder/internal/util"
 	pb "github.com/stacklok/minder/pkg/api/protobuf/go/minder/v1"
 )

--- a/internal/controlplane/handlers_profile.go
+++ b/internal/controlplane/handlers_profile.go
@@ -20,7 +20,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/stacklok/minder/internal/logger"
 	"strings"
 
 	"github.com/google/uuid"
@@ -32,6 +31,7 @@ import (
 	"github.com/stacklok/minder/internal/db"
 	"github.com/stacklok/minder/internal/engine"
 	"github.com/stacklok/minder/internal/engine/entities"
+	"github.com/stacklok/minder/internal/logger"
 	"github.com/stacklok/minder/internal/reconcilers"
 	"github.com/stacklok/minder/internal/util"
 	minderv1 "github.com/stacklok/minder/pkg/api/protobuf/go/minder/v1"

--- a/internal/controlplane/handlers_profile.go
+++ b/internal/controlplane/handlers_profile.go
@@ -20,6 +20,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"github.com/stacklok/minder/internal/logger"
 	"strings"
 
 	"github.com/google/uuid"
@@ -168,6 +169,11 @@ func (s *Server) CreateProfile(ctx context.Context,
 		log.Printf("error publishing reconciler event: %v", err)
 	}
 
+	// Telemetry logging
+	logger.BusinessRecord(ctx).Provider = profile.Provider
+	logger.BusinessRecord(ctx).Project = profile.ProjectID
+	logger.BusinessRecord(ctx).Profile = logger.Profile{Name: profile.Name, ID: profile.ID}
+
 	return resp, nil
 }
 
@@ -240,7 +246,7 @@ func (s *Server) DeleteProfile(ctx context.Context,
 		return nil, util.UserVisibleError(codes.InvalidArgument, "invalid profile ID")
 	}
 
-	_, err = s.store.GetProfileByID(ctx, parsedProfileID)
+	profile, err := s.store.GetProfileByID(ctx, parsedProfileID)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return nil, status.Error(codes.NotFound, "profile not found")
@@ -252,6 +258,11 @@ func (s *Server) DeleteProfile(ctx context.Context,
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "failed to delete profile: %s", err)
 	}
+
+	// Telemetry logging
+	logger.BusinessRecord(ctx).Provider = profile.Provider
+	logger.BusinessRecord(ctx).Project = profile.ProjectID
+	logger.BusinessRecord(ctx).Profile = logger.Profile{Name: profile.Name, ID: profile.ID}
 
 	return &minderv1.DeleteProfileResponse{}, nil
 }
@@ -281,6 +292,10 @@ func (s *Server) ListProfiles(ctx context.Context,
 	for _, profile := range engine.MergeDatabaseListIntoProfiles(profiles) {
 		resp.Profiles = append(resp.Profiles, profile)
 	}
+
+	// Telemetry logging
+	logger.BusinessRecord(ctx).Provider = entityCtx.Provider.Name
+	logger.BusinessRecord(ctx).Project = entityCtx.Project.ID
 
 	return &resp, nil
 }
@@ -314,6 +329,11 @@ func (s *Server) GetProfileById(ctx context.Context,
 
 		return nil, status.Errorf(codes.Internal, "failed to get profile: %s", err)
 	}
+
+	// Telemetry logging
+	logger.BusinessRecord(ctx).Provider = entityCtx.Provider.Name
+	logger.BusinessRecord(ctx).Project = entityCtx.Project.ID
+	logger.BusinessRecord(ctx).Profile = logger.Profile{Name: prof.Name, ID: parsedProfileID}
 
 	return &minderv1.GetProfileByIdResponse{
 		Profile: prof,
@@ -498,6 +518,11 @@ func (s *Server) GetProfileStatusByName(ctx context.Context,
 		// TODO: Add other entities once we have database entries for them
 	}
 
+	// Telemetry logging
+	logger.BusinessRecord(ctx).Provider = entityCtx.Provider.Name
+	logger.BusinessRecord(ctx).Project = entityCtx.Project.ID
+	logger.BusinessRecord(ctx).Profile = logger.Profile{Name: dbstat.Name, ID: dbstat.ID}
+
 	return &minderv1.GetProfileStatusByNameResponse{
 		ProfileStatus: &minderv1.ProfileStatus{
 			ProfileId:     dbstat.ID.String(),
@@ -545,6 +570,10 @@ func (s *Server) GetProfileStatusByProject(ctx context.Context,
 			ProfileStatus: string(dbstat.ProfileStatus),
 		})
 	}
+
+	// Telemetry logging
+	logger.BusinessRecord(ctx).Provider = entityCtx.Provider.Name
+	logger.BusinessRecord(ctx).Project = entityCtx.Project.ID
 
 	return res, nil
 }
@@ -684,6 +713,11 @@ func (s *Server) UpdateProfile(ctx context.Context,
 	if err := s.evt.Publish(reconcilers.InternalProfileInitEventTopic, msg); err != nil {
 		log.Printf("error publishing reconciler event: %v", err)
 	}
+
+	// Telemetry logging
+	logger.BusinessRecord(ctx).Provider = profile.Provider
+	logger.BusinessRecord(ctx).Project = profile.ProjectID
+	logger.BusinessRecord(ctx).Profile = logger.Profile{Name: profile.Name, ID: profile.ID}
 
 	return resp, nil
 }

--- a/internal/controlplane/handlers_repositories.go
+++ b/internal/controlplane/handlers_repositories.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"database/sql"
 	"errors"
-	"github.com/stacklok/minder/internal/logger"
 	"strings"
 
 	"github.com/google/uuid"
@@ -29,6 +28,7 @@ import (
 
 	"github.com/stacklok/minder/internal/db"
 	"github.com/stacklok/minder/internal/engine"
+	"github.com/stacklok/minder/internal/logger"
 	"github.com/stacklok/minder/internal/providers"
 	github "github.com/stacklok/minder/internal/providers/github"
 	"github.com/stacklok/minder/internal/reconcilers"

--- a/internal/controlplane/handlers_ruletype.go
+++ b/internal/controlplane/handlers_ruletype.go
@@ -19,7 +19,6 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
-	"github.com/stacklok/minder/internal/logger"
 	"strings"
 
 	"github.com/google/uuid"
@@ -28,6 +27,7 @@ import (
 
 	"github.com/stacklok/minder/internal/db"
 	"github.com/stacklok/minder/internal/engine"
+	"github.com/stacklok/minder/internal/logger"
 	"github.com/stacklok/minder/internal/util"
 	"github.com/stacklok/minder/internal/util/schemaupdate"
 	minderv1 "github.com/stacklok/minder/pkg/api/protobuf/go/minder/v1"

--- a/internal/controlplane/handlers_user.go
+++ b/internal/controlplane/handlers_user.go
@@ -19,7 +19,6 @@ import (
 	"database/sql"
 	"encoding/json"
 	"errors"
-	"github.com/stacklok/minder/internal/logger"
 	"net/http"
 	"net/url"
 
@@ -32,6 +31,7 @@ import (
 	"google.golang.org/protobuf/types/known/timestamppb"
 
 	"github.com/stacklok/minder/internal/db"
+	"github.com/stacklok/minder/internal/logger"
 	pb "github.com/stacklok/minder/pkg/api/protobuf/go/minder/v1"
 )
 

--- a/internal/controlplane/handlers_user.go
+++ b/internal/controlplane/handlers_user.go
@@ -19,6 +19,7 @@ import (
 	"database/sql"
 	"encoding/json"
 	"errors"
+	"github.com/stacklok/minder/internal/logger"
 	"net/http"
 	"net/url"
 
@@ -115,6 +116,9 @@ func (s *Server) CreateUser(ctx context.Context,
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "failed to commit transaction: %s", err)
 	}
+
+	// Telemetry logging
+	logger.BusinessRecord(ctx).Project = userProject
 
 	return &pb.CreateUserResponse{
 		Id:              user.ID,

--- a/internal/engine/executor_test.go
+++ b/internal/engine/executor_test.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/json"
-	"fmt"
 	"os"
 	"testing"
 	"time"
@@ -309,9 +308,9 @@ default allow = true`,
 	require.NoError(t, err, "expected no error")
 
 	ts := &logger.TelemetryStore{
-		Project:  projectID.String(),
-		Provider: providerName,
-		Resource: fmt.Sprintf("repository/%s", repositoryID),
+		Project:    projectID,
+		Provider:   providerName,
+		Repository: repositoryID,
 	}
 	ctx = ts.WithTelemetry(ctx)
 	msg.SetContext(ctx)
@@ -333,9 +332,9 @@ default allow = true`,
 
 	require.Len(t, ts.Evals, 1, "expected one eval to be logged")
 	requredEval := ts.Evals[0]
-	require.Equal(t, "test-profile", requredEval.ProfileName)
+	require.Equal(t, "test-profile", requredEval.Profile.Name)
 	require.Equal(t, "success", requredEval.EvalResult)
-	require.Equal(t, "passthrough", requredEval.RuleName)
+	require.Equal(t, "passthrough", requredEval.RuleType.Name)
 	require.Equal(t, "off", requredEval.Actions[alert.ActionType].State)
 	require.Equal(t, "off", requredEval.Actions[remediate.ActionType].State)
 }

--- a/internal/logger/telemetry_store.go
+++ b/internal/logger/telemetry_store.go
@@ -16,8 +16,8 @@ package logger
 
 import (
 	"context"
-	"github.com/google/uuid"
 
+	"github.com/google/uuid"
 	"github.com/rs/zerolog"
 
 	"github.com/stacklok/minder/internal/engine/actions/alert"

--- a/internal/logger/telemetry_store.go
+++ b/internal/logger/telemetry_store.go
@@ -16,6 +16,7 @@ package logger
 
 import (
 	"context"
+	"github.com/google/uuid"
 
 	"github.com/rs/zerolog"
 
@@ -32,6 +33,18 @@ const (
 	telemetryContextKey key = iota
 )
 
+// RuleType is a struct describing a rule type for telemetry purposes
+type RuleType struct {
+	Name string    `json:"name"`
+	ID   uuid.UUID `json:"id"`
+}
+
+// Profile is a struct describing a Profile for telemetry purposes
+type Profile struct {
+	Name string    `json:"name"`
+	ID   uuid.UUID `json:"id"`
+}
+
 // ActionEvalData reports
 type ActionEvalData struct {
 	// how was the action configured - on, off, ...
@@ -42,8 +55,8 @@ type ActionEvalData struct {
 
 // RuleEvalData reports
 type RuleEvalData struct {
-	RuleName    string `json:"rule_name"`
-	ProfileName string `json:"profile_name"`
+	RuleType RuleType `json:"ruletype"`
+	Profile  Profile  `json:"profile"`
 
 	EvalResult string                                   `json:"eval_result"`
 	Actions    map[interfaces.ActionType]ActionEvalData `json:"actions"`
@@ -53,14 +66,26 @@ type RuleEvalData struct {
 
 // TelemetryStore is a struct that can be used to store telemetry data in the context.
 type TelemetryStore struct {
-	// Project records the project that the request was associated with.
-	Project string `json:"project"`
+	// Project records the project ID that the request was associated with.
+	Project uuid.UUID `json:"project"`
 
-	// Provider records the provider that the request was associated with.
+	// Provider records the provider name that the request was associated with.
 	Provider string `json:"provider"`
 
-	// The resource processed by the request, for example, a repository or a profile.
-	Resource string `json:"resource"`
+	// Repository is the repository ID that the request was associated with.
+	Repository uuid.UUID `json:"repository"`
+
+	// Artifact is the artifact ID that the request was associated with.
+	Artifact uuid.UUID `json:"artifact"`
+
+	// PullRequest is the pull request ID that the request was associated with.
+	PullRequest uuid.UUID `json:"pr"`
+
+	// Profile is the profile that the request was associated with.
+	Profile Profile `json:"profile"`
+
+	// RuleType is the rule type that the request was associated with.
+	RuleType RuleType `json:"ruletype"`
 
 	// Data from RPCs
 
@@ -82,10 +107,21 @@ func (ts *TelemetryStore) AddRuleEval(
 		return
 	}
 
+	// Get rule type ID
+	ruleTypeID, err := uuid.Parse(evalInfo.GetRuleType().GetId())
+	if err != nil {
+		return
+	}
+	// Get profile ID
+	profileID, err := uuid.Parse(evalInfo.GetProfile().GetId())
+	if err != nil {
+		return
+	}
+
 	red := RuleEvalData{
-		RuleName:    evalInfo.GetRule().GetType(),
-		ProfileName: evalInfo.GetProfile().GetName(),
-		EvalResult:  errors.EvalErrorAsString(evalInfo.GetEvalErr()),
+		RuleType:   RuleType{Name: evalInfo.GetRuleType().GetName(), ID: ruleTypeID},
+		Profile:    Profile{Name: evalInfo.GetProfile().GetName(), ID: profileID},
+		EvalResult: errors.EvalErrorAsString(evalInfo.GetEvalErr()),
 		Actions: map[interfaces.ActionType]ActionEvalData{
 			remediate.ActionType: {
 				State:  evalInfo.GetActionsOnOff()[remediate.ActionType].String(),
@@ -134,17 +170,26 @@ func (ts *TelemetryStore) Record(e *zerolog.Event) *zerolog.Event {
 	}
 	// We could use reflection here like json.Marshal, but given
 	// the small number of fields, we'll just add them explicitly.
-	if ts.Project != "" {
-		e.Str("project", ts.Project)
+	if ts.Project != uuid.Nil {
+		e.Str("project", ts.Project.String())
 	}
 	if ts.Provider != "" {
 		e.Str("provider", ts.Provider)
 	}
-	if ts.Resource != "" {
-		e.Str("resource", ts.Resource)
-	}
 	if ts.LoginHash != "" {
 		e.Str("login_sha", ts.LoginHash)
+	}
+	if ts.Repository != uuid.Nil {
+		e.Str("repository", ts.Repository.String())
+	}
+	if ts.Artifact != uuid.Nil {
+		e.Str("artifact", ts.Artifact.String())
+	}
+	if ts.Profile != (Profile{}) {
+		e.Any("profile", ts.Profile)
+	}
+	if ts.RuleType != (RuleType{}) {
+		e.Any("ruletype", ts.RuleType)
 	}
 	if len(ts.Evals) > 0 {
 		e.Any("rules", ts.Evals)

--- a/internal/logger/telemetry_store.go
+++ b/internal/logger/telemetry_store.go
@@ -185,6 +185,9 @@ func (ts *TelemetryStore) Record(e *zerolog.Event) *zerolog.Event {
 	if ts.Artifact != uuid.Nil {
 		e.Str("artifact", ts.Artifact.String())
 	}
+	if ts.PullRequest != uuid.Nil {
+		e.Str("pr", ts.PullRequest.String())
+	}
 	if ts.Profile != (Profile{}) {
 		e.Any("profile", ts.Profile)
 	}

--- a/internal/logger/telemetry_store_test.go
+++ b/internal/logger/telemetry_store_test.go
@@ -139,7 +139,7 @@ func TestTelemetryStore_Record(t *testing.T) {
 		recordFunc: func(_ context.Context, _ engif.ActionsParams) {
 		},
 		expected:   `{"telemetry": true}`,
-		notPresent: []string{"project", "rules", "login_sha"},
+		notPresent: []string{"project", "rules", "login_sha", "repository", "provider", "profile", "ruletype", "artifact", "pr"},
 	}}
 
 	count := len(cases)

--- a/internal/logger/telemetry_store_test.go
+++ b/internal/logger/telemetry_store_test.go
@@ -21,6 +21,7 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/google/uuid"
 	"github.com/rs/zerolog"
 
 	"github.com/stacklok/minder/internal/engine/actions/alert"
@@ -32,6 +33,9 @@ import (
 )
 
 func TestTelemetryStore_Record(t *testing.T) {
+	testUUIDString := "00000000-0000-0000-0000-000000000001"
+	testUUID := uuid.MustParse(testUUIDString)
+
 	t.Parallel()
 	cases := []struct {
 		name           string
@@ -45,11 +49,13 @@ func TestTelemetryStore_Record(t *testing.T) {
 		evalParamsFunc: func() *engif.EvalStatusParams {
 			ep := &engif.EvalStatusParams{}
 
-			ep.Rule = &minderv1.Profile_Rule{
-				Type: "artifact_signature",
-			}
 			ep.Profile = &minderv1.Profile{
 				Name: "artifact_profile",
+				Id:   &testUUIDString,
+			}
+			ep.RuleType = &minderv1.RuleType{
+				Name: "artifact_signature",
+				Id:   &testUUIDString,
 			}
 			ep.SetEvalErr(enginerr.NewErrEvaluationFailed("evaluation failure reason"))
 			ep.SetActionsOnOff(map[engif.ActionType]engif.ActionOpt{
@@ -63,9 +69,8 @@ func TestTelemetryStore_Record(t *testing.T) {
 			return ep
 		},
 		recordFunc: func(ctx context.Context, evalParams engif.ActionsParams) {
-			logger.BusinessRecord(ctx).Project = "bar"
-
-			logger.BusinessRecord(ctx).Resource = "foo/repo"
+			logger.BusinessRecord(ctx).Project = testUUID
+			logger.BusinessRecord(ctx).Repository = testUUID
 			logger.BusinessRecord(ctx).AddRuleEval(evalParams)
 		},
 	}, {
@@ -74,11 +79,13 @@ func TestTelemetryStore_Record(t *testing.T) {
 		evalParamsFunc: func() *engif.EvalStatusParams {
 			ep := &engif.EvalStatusParams{}
 
-			ep.Rule = &minderv1.Profile_Rule{
-				Type: "artifact_signature",
-			}
 			ep.Profile = &minderv1.Profile{
 				Name: "artifact_profile",
+				Id:   &testUUIDString,
+			}
+			ep.RuleType = &minderv1.RuleType{
+				Name: "artifact_signature",
+				Id:   &testUUIDString,
 			}
 			ep.SetEvalErr(enginerr.NewErrEvaluationFailed("evaluation failure reason"))
 			ep.SetActionsOnOff(map[engif.ActionType]engif.ActionOpt{
@@ -92,29 +99,34 @@ func TestTelemetryStore_Record(t *testing.T) {
 			return ep
 		},
 		recordFunc: func(ctx context.Context, evalParams engif.ActionsParams) {
-			logger.BusinessRecord(ctx).Project = "bar"
-
-			logger.BusinessRecord(ctx).Resource = "foo/repo"
+			logger.BusinessRecord(ctx).Project = testUUID
+			logger.BusinessRecord(ctx).Repository = testUUID
 			logger.BusinessRecord(ctx).AddRuleEval(evalParams)
 		},
 		expected: `{
-    "project": "bar",
-    "resource": "foo/repo",
+    "project": "00000000-0000-0000-0000-000000000001",
+    "repository": "00000000-0000-0000-0000-000000000001",
     "rules": [
         {
-            "rule_name": "artifact_signature",
-            "profile_name": "artifact_profile",
-            "eval_result": "failure",
-            "actions": {
-                "alert": {
-                    "state": "off",
-                    "result": "skipped"
-                },
-                "remediate": {
-                    "state": "on",
-                    "result": "success"
-                }
-            }
+			"ruletype": {
+				"name": "artifact_signature",
+				"id": "00000000-0000-0000-0000-000000000001"
+			},
+			"profile": {
+				"name": "artifact_profile",
+				"id": "00000000-0000-0000-0000-000000000001"
+			},
+			"eval_result": "failure",
+			"actions": {
+				"alert": {
+					"state": "off",
+					"result": "skipped"
+				},
+				"remediate": {
+					"state": "on",
+					"result": "success"
+				}
+			}
         }
     ]
     }`,
@@ -127,7 +139,7 @@ func TestTelemetryStore_Record(t *testing.T) {
 		recordFunc: func(_ context.Context, _ engif.ActionsParams) {
 		},
 		expected:   `{"telemetry": true}`,
-		notPresent: []string{"project", "resource", "rules", "login_sha"},
+		notPresent: []string{"project", "rules", "login_sha"},
 	}}
 
 	count := len(cases)

--- a/internal/logger/telemetry_store_watermill.go
+++ b/internal/logger/telemetry_store_watermill.go
@@ -16,9 +16,9 @@ package logger
 
 import (
 	"fmt"
-	"github.com/google/uuid"
 
 	"github.com/ThreeDotsLabs/watermill/message"
+	"github.com/google/uuid"
 	"github.com/rs/zerolog"
 
 	"github.com/stacklok/minder/internal/engine/entities"
@@ -46,9 +46,11 @@ func (m *TelemetryStoreWMMiddleware) TelemetryStoreMiddleware(h message.HandlerF
 		}
 
 		// Create a new telemetry store from entity
-		ts, err := newTelemetryFromEntity(inf)
+		ts, err := newTelemetryStoreFromEntity(inf)
 		if err != nil {
-			return nil, fmt.Errorf("error creating telemetry store from entity: %w", err)
+			// Log the error but don't fail the event processing, use the returned empty telemetry store instead
+			logger := zerolog.Ctx(msg.Context())
+			logger.Info().Msg("error creating telemetry store from entity")
 		}
 
 		// Store telemetry data in the context
@@ -68,18 +70,21 @@ func (m *TelemetryStoreWMMiddleware) TelemetryStoreMiddleware(h message.HandlerF
 	}
 }
 
-func newTelemetryFromEntity(inf *entities.EntityInfoWrapper) (*TelemetryStore, error) {
+// newTelemetryStoreFromEntity creates a new telemetry store from an entity.
+func newTelemetryStoreFromEntity(inf *entities.EntityInfoWrapper) (*TelemetryStore, error) {
+	// Create a new telemetry store
+	ts := &TelemetryStore{}
+
 	// Get the entity UUID - this is the entity we are processing
 	ent, err := getEntityID(inf)
 	if err != nil {
-		return nil, fmt.Errorf("error getting entity ID: %w", err)
+		// Return an error but also return the telemetry store so we don't fail the event
+		return ts, fmt.Errorf("error getting entity ID: %w", err)
 	}
 
-	// Create a new telemetry store
-	ts := &TelemetryStore{
-		Project:  *inf.ProjectID,
-		Provider: inf.Provider,
-	}
+	// Set the provider name and project ID
+	ts.Provider = inf.Provider
+	ts.Project = *inf.ProjectID
 
 	// Set the entity telemetry field based on the entity type
 	switch inf.Type {
@@ -89,11 +94,15 @@ func newTelemetryFromEntity(inf *entities.EntityInfoWrapper) (*TelemetryStore, e
 		ts.Artifact = ent
 	case minderv1.Entity_ENTITY_PULL_REQUESTS:
 		ts.PullRequest = ent
+	case minderv1.Entity_ENTITY_BUILD_ENVIRONMENTS:
+	case minderv1.Entity_ENTITY_UNSPECIFIED:
+		// Do nothing
 	}
 
 	return ts, nil
 }
 
+// getEntityID returns the entity ID from the entity info wrapper based on its type.
 func getEntityID(inf *entities.EntityInfoWrapper) (uuid.UUID, error) {
 	repoID, artID, prID := inf.GetEntityDBIDs()
 

--- a/internal/logger/telemetry_store_watermill_test.go
+++ b/internal/logger/telemetry_store_watermill_test.go
@@ -18,7 +18,6 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"fmt"
 	"testing"
 
 	"github.com/google/uuid"
@@ -90,7 +89,6 @@ func TestTelemetryStoreWMMiddlewareLogsRepositoryInfo(t *testing.T) {
 
 	require.Equal(t, projectID.String(), logged["project"], "expected project ID to be logged")
 	require.Equal(t, providerName, logged["provider"], "expected provider to be logged")
-	resourceString := fmt.Sprintf("%s/%s", minderv1.RepositoryEntity.String(), repositoryID.String())
-	require.Equal(t, resourceString, logged["resource"], "expected repository ID to be logged")
+	require.Equal(t, repositoryID.String(), logged["repository"], "expected repository ID to be logged")
 	require.Equal(t, true, logged["telemetry"], "expected telemetry to be logged")
 }


### PR DESCRIPTION
The following PR adds telemetry data for authenticated RPC calls for each Minder service.

**Context related:**
* `login_sha` - SHA256 hash of the user's identity from Keycloak (sub field from the token)
* `provider` name and `project` UUID (project name was removed in https://github.com/stacklok/minder/pull/2124) 

**Resource related:**

* `repository` and `artifact` ID 
* Both IDs and Names of `profiles` and `rule types` in requests and in evaluation results

**Improvements:** (not part of this PR)

* I saw @eleftherias's comment at https://github.com/stacklok/minder/pull/2130#issuecomment-1894104431 and that would be nice once we have it, because then we should be able to move most of the telemetry code from this PR out of the handlers and replace it with one in the middleware.

**Questions:**

- [x]  Noticed that the EvalParams we now log use names (not IDs) for referring to the profile and rule type. Should we provide additional parameters for providing the human-readable format and not just the UUID for objects where this is possible? Or perhaps converge on one?
- [x]  Should we include the OrgID also (wasn't part of the issue) or wait for when it starts making more sense? A: No, plan is to remove it completely.

Fixes: https://github.com/stacklok/minder/issues/1880