### PR TITLE
Switch to offline Sigstore verification

### DIFF
--- a/internal/verifier/sigstore/sigstore.go
+++ b/internal/verifier/sigstore/sigstore.go
@@ -49,7 +49,7 @@ func New(trustedRoot, accessToken, cacheDir string) (*Sigstore, error) {
 		return nil, err
 	}
 	sev, err := verify.NewSignedEntityVerifier(trustedMaterial, verify.WithSignedCertificateTimestamps(1),
-		verify.WithTransparencyLog(1), verify.WithOnlineVerification(), verify.WithObserverTimestamps(1))
+		verify.WithTransparencyLog(1), verify.WithObserverTimestamps(1))
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
As discussed in previous PRs, the v0.1 bundle format that's being used does not contain inclusion proofs. However, it does contain SignedEntryTimestamps (https://github.com/sigstore/sigstore-go/blob/main/examples/oci-image-verification/main.go#L388), which assert a similar property - The log signs a commitment to include an entry. An inclusion proof is the same, a signed commitment (hash + checkpoint), with the additional benefit being we can verify consistency (append-only) of the log.

It is sufficient to check only the SET, that's what we've been doing in Cosign since adding Rekor support.

This will improve latency since no request to Rekor will be made. This also improves privacy since the log is not aware of every time a signed event is verified.