### PR TITLE
Cleanup entity context

### DIFF
--- a/internal/controlplane/handlers_profile.go
+++ b/internal/controlplane/handlers_profile.go
@@ -52,7 +52,7 @@ func (s *Server) authAndContextValidation(ctx context.Context, inout *minderv1.C
 		return ctx, fmt.Errorf("context cannot be nil")
 	}
 
-	if err := s.ensureDefaultProjectForContext(ctx, inout); err != nil {
+	if err := ensureDefaultProjectForContext(ctx, inout); err != nil {
 		return ctx, err
 	}
 
@@ -70,18 +70,13 @@ func (s *Server) authAndContextValidation(ctx context.Context, inout *minderv1.C
 
 // ensureDefaultProjectForContext ensures a valid project is set in the context or sets the default project
 // if the project is not set in the incoming entity context, it'll set it.
-func (s *Server) ensureDefaultProjectForContext(ctx context.Context, inout *minderv1.Context) error {
+func ensureDefaultProjectForContext(ctx context.Context, inout *minderv1.Context) error {
 	// Project is already set
 	if inout.GetProject() != "" {
 		return nil
 	}
 
 	gid, err := auth.GetDefaultProject(ctx)
-	if err != nil {
-		return status.Errorf(codes.InvalidArgument, "cannot infer project id")
-	}
-
-	_, err = s.store.GetProjectByID(ctx, gid)
 	if err != nil {
 		return status.Errorf(codes.InvalidArgument, "cannot infer project id")
 	}

--- a/internal/controlplane/handlers_profile.go
+++ b/internal/controlplane/handlers_profile.go
@@ -94,7 +94,7 @@ func (s *Server) ensureDefaultProjectForContext(ctx context.Context, inout *mind
 // verifyValidProject verifies that the project is valid and the user is authorized to access it
 // TODO: This will have to change once we have the hierarchy tree in place.
 func verifyValidProject(ctx context.Context, in *engine.EntityContext) error {
-	if err := AuthorizedOnProject(ctx, in.GetProject().GetID()); err != nil {
+	if err := AuthorizedOnProject(ctx, in.GetProject().ID); err != nil {
 		return status.Errorf(codes.PermissionDenied, "user is not authorized to access this resource")
 	}
 
@@ -166,7 +166,7 @@ func (s *Server) CreateProfile(ctx context.Context,
 
 	params := db.CreateProfileParams{
 		Provider:  provider.Name,
-		ProjectID: entityCtx.GetProject().GetID(),
+		ProjectID: entityCtx.GetProject().ID,
 		Name:      in.GetName(),
 		Remediate: validateActionType(in.GetRemediate()),
 		Alert:     validateActionType(in.GetAlert()),
@@ -711,7 +711,7 @@ func (s *Server) getAndValidateRulesFromProfile(
 		// the hierarchy tree once that's settled in.
 		rtdb, err := s.store.GetRuleTypeByName(ctx, db.GetRuleTypeByNameParams{
 			Provider:  entityCtx.GetProvider().Name,
-			ProjectID: entityCtx.GetProject().GetID(),
+			ProjectID: entityCtx.GetProject().ID,
 			Name:      r.GetType(),
 		})
 		if err != nil {
@@ -772,7 +772,7 @@ func (s *Server) getRulesFromProfile(
 		// the hierarchy tree once that's settled in.
 		rtdb, err := s.store.GetRuleTypeByName(ctx, db.GetRuleTypeByNameParams{
 			Provider:  entityCtx.GetProvider().Name,
-			ProjectID: entityCtx.GetProject().GetID(),
+			ProjectID: entityCtx.GetProject().ID,
 			Name:      r.GetType(),
 		})
 		if err != nil {
@@ -913,7 +913,7 @@ func validateProfileUpdate(old *db.Profile, new *minderv1.Profile, entityCtx *en
 		return util.UserVisibleError(codes.InvalidArgument, "cannot change profile project")
 	}
 
-	if old.Provider != entityCtx.Provider.Name {
+	if old.Provider != entityCtx.GetProvider().Name {
 		return util.UserVisibleError(codes.InvalidArgument, "cannot change profile provider")
 	}
 

--- a/internal/controlplane/handlers_ruletype.go
+++ b/internal/controlplane/handlers_ruletype.go
@@ -46,7 +46,7 @@ func (s *Server) ListRuleTypes(
 
 	lrt, err := s.store.ListRuleTypesByProviderAndProject(ctx, db.ListRuleTypesByProviderAndProjectParams{
 		Provider:  entityCtx.GetProvider().Name,
-		ProjectID: entityCtx.GetProject().GetID(),
+		ProjectID: entityCtx.GetProject().ID,
 	})
 	if err != nil {
 		return nil, status.Errorf(codes.Unknown, "failed to get rule types: %s", err)
@@ -83,7 +83,7 @@ func (s *Server) GetRuleTypeByName(
 
 	rtdb, err := s.store.GetRuleTypeByName(ctx, db.GetRuleTypeByNameParams{
 		Provider:  entityCtx.GetProvider().Name,
-		ProjectID: entityCtx.GetProject().GetID(),
+		ProjectID: entityCtx.GetProject().ID,
 		Name:      in.GetName(),
 	})
 	if err != nil {
@@ -147,7 +147,7 @@ func (s *Server) CreateRuleType(
 	entityCtx := engine.EntityFromContext(ctx)
 	_, err = s.store.GetRuleTypeByName(ctx, db.GetRuleTypeByNameParams{
 		Provider:  entityCtx.GetProvider().Name,
-		ProjectID: entityCtx.GetProject().GetID(),
+		ProjectID: entityCtx.GetProject().ID,
 		Name:      in.GetName(),
 	})
 	if err == nil {
@@ -173,7 +173,7 @@ func (s *Server) CreateRuleType(
 	dbrtyp, err := s.store.CreateRuleType(ctx, db.CreateRuleTypeParams{
 		Name:        in.GetName(),
 		Provider:    entityCtx.GetProvider().Name,
-		ProjectID:   entityCtx.GetProject().GetID(),
+		ProjectID:   entityCtx.GetProject().ID,
 		Description: in.GetDescription(),
 		Definition:  def,
 		Guidance:    in.GetGuidance(),
@@ -206,7 +206,7 @@ func (s *Server) UpdateRuleType(
 
 	rtdb, err := s.store.GetRuleTypeByName(ctx, db.GetRuleTypeByNameParams{
 		Provider:  entityCtx.GetProvider().Name,
-		ProjectID: entityCtx.GetProject().GetID(),
+		ProjectID: entityCtx.GetProject().ID,
 		Name:      in.GetName(),
 	})
 	if err != nil {

--- a/internal/engine/context.go
+++ b/internal/engine/context.go
@@ -51,24 +51,12 @@ func EntityFromContext(ctx context.Context) *EntityContext {
 // Project is a construct relevant to an entity's context.
 // This is relevant for getting the full information about an entity.
 type Project struct {
-	ID   uuid.UUID
-	Name string
-}
-
-// GetID returns the ID of the project
-func (g Project) GetID() uuid.UUID {
-	return g.ID
-}
-
-// GetName returns the name of the project
-func (g Project) GetName() string {
-	return g.Name
+	ID uuid.UUID
 }
 
 // Provider is a construct relevant to an entity's context.
 // This is relevant for getting the full information about an entity.
 type Provider struct {
-	ID   uuid.UUID
 	Name string
 }
 
@@ -117,11 +105,9 @@ func GetContextFromInput(ctx context.Context, in *pb.Context, q db.Querier) (*En
 
 	return &EntityContext{
 		Project: Project{
-			ID:   project.ID,
-			Name: project.Name,
+			ID: project.ID,
 		},
 		Provider: Provider{
-			ID:   prov.ID,
 			Name: prov.Name,
 		},
 	}, nil

--- a/internal/engine/executor.go
+++ b/internal/engine/executor.go
@@ -197,12 +197,10 @@ func (e *Executor) prepAndEvalEntityEvent(ctx context.Context, inf *entities.Ent
 
 	ectx := &EntityContext{
 		Project: Project{
-			ID:   project.ID,
-			Name: project.Name,
+			ID: project.ID,
 		},
 		Provider: Provider{
 			Name: inf.Provider,
-			ID:   provider.ID,
 		},
 	}
 

--- a/internal/reconcilers/run_profile.go
+++ b/internal/reconcilers/run_profile.go
@@ -102,7 +102,6 @@ func (e *Reconciler) handleProfileInitEvent(msg *message.Message) error {
 		},
 		Provider: engine.Provider{
 			Name: provInfo.Name,
-			ID:   provInfo.ID,
 		},
 	}
 


### PR DESCRIPTION
- Directly access project ID field for consistency
- Remove unused field project name and provider ID
- Remove check for project existence in entity validator, because it's checked later, and the check here is inconsistent because the execution only reaches here when the user doesn't supply a value