### PR TITLE
Switch to offline Sigstore verification and set TimestampVerificationData to nil

### DIFF
--- a/internal/verifier/sigstore/container/container.go
+++ b/internal/verifier/sigstore/container/container.go
@@ -253,15 +253,9 @@ func getBundleVerificationMaterial(params *verifyResult, manifestLayer *v1.Descr
 	}
 	// 3. Construct the verification material
 	return &protobundle.VerificationMaterial{
-		Content:     signingCert,
-		TlogEntries: tlogEntries,
-		TimestampVerificationData: &protobundle.TimestampVerificationData{
-			Rfc3161Timestamps: []*protocommon.RFC3161SignedTimestamp{
-				{
-					SignedTimestamp: tlogEntries[0].InclusionPromise.SignedEntryTimestamp,
-				},
-			},
-		},
+		Content:                   signingCert,
+		TlogEntries:               tlogEntries,
+		TimestampVerificationData: nil,
 	}, nil
 }
 

--- a/internal/verifier/sigstore/sigstore.go
+++ b/internal/verifier/sigstore/sigstore.go
@@ -49,7 +49,7 @@ func New(trustedRoot, accessToken, cacheDir string) (*Sigstore, error) {
 		return nil, err
 	}
 	sev, err := verify.NewSignedEntityVerifier(trustedMaterial, verify.WithSignedCertificateTimestamps(1),
-		verify.WithTransparencyLog(1), verify.WithOnlineVerification(), verify.WithObserverTimestamps(1))
+		verify.WithTransparencyLog(1), verify.WithObserverTimestamps(1))
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
The following PR has the following changes:
* Recreates https://github.com/stacklok/minder/pull/2120 switching Minder to using offline sigstore verification. For those that are interested there's a nice and detailed explanation of how this works at https://github.com/stacklok/minder/pull/2120#issuecomment-1892619405 
* Sets the TimestampVerificationData to nil. The reason is it was wrongfully used, but also its value is obtained from the `SignedEntryTimestamp` assuming `verifyWithObserverTimestamps()` is set (we do set it).

Thanks to @haydentherapper for raising this! 🍻 