### PR TITLE
Add middleware that populates project in context

### DIFF
--- a/internal/controlplane/common.go
+++ b/internal/controlplane/common.go
@@ -20,7 +20,6 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
-	"github.com/stacklok/minder/internal/engine"
 	"slices"
 
 	"github.com/google/uuid"
@@ -95,41 +94,4 @@ func getProviderFromRequestOrDefault(
 		return db.Provider{}, util.UserVisibleError(codes.InvalidArgument, "invalid provider name: %s", in.GetContext().GetProvider())
 	}
 	return providers[i], nil
-}
-
-// contextValidation is a helper function to initialize entity context info and validate input
-// It also sets up the needed information in the `in` entity context that's needed for the rest of the flow
-func (s *Server) contextValidation(ctx context.Context, inout *pb.Context) (context.Context, error) {
-	if inout == nil {
-		return ctx, fmt.Errorf("context cannot be nil")
-	}
-
-	if err := ensureDefaultProjectForContext(ctx, inout); err != nil {
-		return ctx, err
-	}
-
-	entityCtx, err := engine.GetContextFromInput(ctx, inout, s.store)
-	if err != nil {
-		return ctx, fmt.Errorf("cannot get context from input: %v", err)
-	}
-
-	return engine.WithEntityContext(ctx, entityCtx), nil
-}
-
-// ensureDefaultProjectForContext ensures a valid project is set in the context or sets the default project
-// if the project is not set in the incoming entity context, it'll set it.
-func ensureDefaultProjectForContext(ctx context.Context, inout *pb.Context) error {
-	// Project is already set
-	if inout.GetProject() != "" {
-		return nil
-	}
-
-	gid, err := auth.GetDefaultProject(ctx)
-	if err != nil {
-		return status.Errorf(codes.InvalidArgument, "cannot infer project id")
-	}
-
-	project := gid.String()
-	inout.Project = &project
-	return nil
 }

--- a/internal/controlplane/handlers_artifacts.go
+++ b/internal/controlplane/handlers_artifacts.go
@@ -29,6 +29,7 @@ import (
 	"google.golang.org/protobuf/types/known/timestamppb"
 
 	"github.com/stacklok/minder/internal/db"
+	"github.com/stacklok/minder/internal/engine"
 	"github.com/stacklok/minder/internal/util"
 	pb "github.com/stacklok/minder/pkg/api/protobuf/go/minder/v1"
 )
@@ -36,10 +37,8 @@ import (
 // ListArtifacts lists all artifacts for a given project and provider
 // nolint:gocyclo
 func (s *Server) ListArtifacts(ctx context.Context, in *pb.ListArtifactsRequest) (*pb.ListArtifactsResponse, error) {
-	projectID, err := getProjectFromRequestOrDefault(ctx, in)
-	if err != nil {
-		return nil, util.UserVisibleError(codes.InvalidArgument, err.Error())
-	}
+	entityCtx := engine.EntityFromContext(ctx)
+	projectID := entityCtx.Project.ID
 
 	// check if user is authorized
 	if err := AuthorizedOnProject(ctx, projectID); err != nil {

--- a/internal/controlplane/handlers_authz_test.go
+++ b/internal/controlplane/handlers_authz_test.go
@@ -14,5 +14,95 @@
 
 package controlplane
 
-// TODO: We shoul come up with a different set of tests for authorization
-// since we no longer have most privileged operations.
+import (
+	"context"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"google.golang.org/grpc"
+
+	"github.com/stacklok/minder/internal/engine"
+	minder "github.com/stacklok/minder/pkg/api/protobuf/go/minder/v1"
+)
+
+// Mock for HasProtoContext
+type request struct {
+	Context *minder.Context
+}
+
+func (m request) GetContext() *minder.Context {
+	return m.Context
+}
+
+func TestEntityContextProjectInterceptor(t *testing.T) {
+	t.Parallel()
+	projectID := uuid.New()
+	projectIdStr := projectID.String()
+	//nolint:goconst
+	provider := "github"
+
+	testCases := []struct {
+		name         string
+		req          interface{}
+		rpcOptions   *minder.RpcOptions
+		checkContext func(t *testing.T, ctx context.Context, err error)
+	}{
+		{
+			name: "non project owner bypasses interceptor",
+			req:  struct{}{},
+			rpcOptions: &minder.RpcOptions{
+				Anonymous: false,
+				AuthScope: minder.ObjectOwner_OBJECT_OWNER_USER,
+			},
+			checkContext: func(t *testing.T, ctx context.Context, err error) {
+				t.Helper()
+
+				assert.NoError(t, err)
+
+				entity := engine.EntityFromContext(ctx)
+				assert.Nil(t, entity)
+			},
+		},
+		{
+			name: "sets entity context",
+			req: &request{
+				Context: &minder.Context{
+					Project:  &projectIdStr,
+					Provider: &provider,
+				},
+			},
+			rpcOptions: &minder.RpcOptions{
+				Anonymous: false,
+				AuthScope: minder.ObjectOwner_OBJECT_OWNER_PROJECT,
+			},
+			checkContext: func(t *testing.T, ctx context.Context, err error) {
+				t.Helper()
+
+				assert.NoError(t, err)
+
+				entity := engine.EntityFromContext(ctx)
+				assert.Equal(t, projectID, entity.Project.ID)
+			},
+		},
+	}
+
+	for i := range testCases {
+		tc := testCases[i]
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			unaryHandler := func(ctx context.Context, req interface{}) (any, error) {
+				return ctx, nil
+			}
+			ctx := withRpcOptions(context.Background(), tc.rpcOptions)
+			c, err := EntityContextProjectInterceptor(ctx, tc.req, &grpc.UnaryServerInfo{}, unaryHandler)
+			ctx, ok := c.(context.Context)
+			if !ok {
+				t.Errorf("Unexpected error, unary handler should return context: %v", err)
+			}
+
+			tc.checkContext(t, ctx, err)
+		})
+	}
+}

--- a/internal/controlplane/handlers_oauth.go
+++ b/internal/controlplane/handlers_oauth.go
@@ -32,6 +32,7 @@ import (
 	"github.com/stacklok/minder/internal/auth"
 	mcrypto "github.com/stacklok/minder/internal/crypto"
 	"github.com/stacklok/minder/internal/db"
+	"github.com/stacklok/minder/internal/engine"
 	"github.com/stacklok/minder/internal/util"
 	pb "github.com/stacklok/minder/pkg/api/protobuf/go/minder/v1"
 )
@@ -41,10 +42,8 @@ import (
 // and a boolean indicating whether the client is a CLI or web client
 func (s *Server) GetAuthorizationURL(ctx context.Context,
 	req *pb.GetAuthorizationURLRequest) (*pb.GetAuthorizationURLResponse, error) {
-	projectID, err := getProjectFromRequestOrDefault(ctx, req)
-	if err != nil {
-		return nil, util.UserVisibleError(codes.InvalidArgument, err.Error())
-	}
+	entityCtx := engine.EntityFromContext(ctx)
+	projectID := entityCtx.Project.ID
 
 	if err := AuthorizedOnProject(ctx, projectID); err != nil {
 		return nil, err
@@ -247,10 +246,8 @@ func (s *Server) getProviderAccessToken(ctx context.Context, provider string,
 // StoreProviderToken stores the provider token for a project
 func (s *Server) StoreProviderToken(ctx context.Context,
 	in *pb.StoreProviderTokenRequest) (*pb.StoreProviderTokenResponse, error) {
-	projectID, err := getProjectFromRequestOrDefault(ctx, in)
-	if err != nil {
-		return nil, util.UserVisibleError(codes.InvalidArgument, err.Error())
-	}
+	entityCtx := engine.EntityFromContext(ctx)
+	projectID := entityCtx.Project.ID
 
 	// check if user is authorized
 	if err := AuthorizedOnProject(ctx, projectID); err != nil {
@@ -308,10 +305,8 @@ func (s *Server) StoreProviderToken(ctx context.Context,
 // VerifyProviderTokenFrom verifies the provider token since a timestamp
 func (s *Server) VerifyProviderTokenFrom(ctx context.Context,
 	in *pb.VerifyProviderTokenFromRequest) (*pb.VerifyProviderTokenFromResponse, error) {
-	projectID, err := getProjectFromRequestOrDefault(ctx, in)
-	if err != nil {
-		return nil, util.UserVisibleError(codes.InvalidArgument, err.Error())
-	}
+	entityCtx := engine.EntityFromContext(ctx)
+	projectID := entityCtx.Project.ID
 
 	// check if user is authorized
 	if err := AuthorizedOnProject(ctx, projectID); err != nil {

--- a/internal/controlplane/handlers_oauth_test.go
+++ b/internal/controlplane/handlers_oauth_test.go
@@ -28,6 +28,7 @@ import (
 	mockdb "github.com/stacklok/minder/database/mock"
 	"github.com/stacklok/minder/internal/auth"
 	"github.com/stacklok/minder/internal/db"
+	"github.com/stacklok/minder/internal/engine"
 	pb "github.com/stacklok/minder/pkg/api/protobuf/go/minder/v1"
 )
 
@@ -151,6 +152,12 @@ func TestGetAuthorizationURL(t *testing.T) {
 		IsStaff:        true, // TODO: remove this
 		Roles: []auth.RoleInfo{
 			{RoleID: 1, IsAdmin: true, ProjectID: &projectID, OrganizationID: orgID}},
+	})
+	// Set the entity context
+	ctx = engine.WithEntityContext(ctx, &engine.EntityContext{
+		Project: engine.Project{
+			ID: projectID,
+		},
 	})
 
 	for i := range testCases {

--- a/internal/controlplane/handlers_profile.go
+++ b/internal/controlplane/handlers_profile.go
@@ -64,12 +64,11 @@ func (s *Server) CreateProfile(ctx context.Context,
 	cpr *minderv1.CreateProfileRequest) (*minderv1.CreateProfileResponse, error) {
 	in := cpr.GetProfile()
 
-	ctx, err := s.contextValidation(ctx, cpr.GetContext())
-	if err != nil {
-		return nil, status.Errorf(codes.InvalidArgument, "error ensuring default project: %v", err)
-	}
-
 	entityCtx := engine.EntityFromContext(ctx)
+	err := entityCtx.Validate(ctx, s.store)
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "error in entity context: %v", err)
+	}
 
 	// check if user is authorized
 	if err := AuthorizedOnProject(ctx, entityCtx.GetProject().ID); err != nil {
@@ -148,6 +147,11 @@ func (s *Server) CreateProfile(ctx context.Context,
 
 	idStr := profile.ID.String()
 	in.Id = &idStr
+	project := profile.ProjectID.String()
+	in.Context = &minderv1.Context{
+		Provider: &profile.Provider,
+		Project:  &project,
+	}
 	resp := &minderv1.CreateProfileResponse{
 		Profile: in,
 	}
@@ -219,12 +223,12 @@ func createProfileRulesForEntity(
 // DeleteProfile is a method to delete a profile
 func (s *Server) DeleteProfile(ctx context.Context,
 	in *minderv1.DeleteProfileRequest) (*minderv1.DeleteProfileResponse, error) {
-	_, err := s.contextValidation(ctx, in.GetContext())
-	if err != nil {
-		return nil, status.Errorf(codes.InvalidArgument, "error ensuring default project: %v", err)
-	}
-
 	entityCtx := engine.EntityFromContext(ctx)
+
+	err := entityCtx.Validate(ctx, s.store)
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "error in entity context: %v", err)
+	}
 
 	// check if user is authorized
 	if err := AuthorizedOnProject(ctx, entityCtx.GetProject().ID); err != nil {
@@ -254,13 +258,13 @@ func (s *Server) DeleteProfile(ctx context.Context,
 
 // ListProfiles is a method to get all profiles for a project
 func (s *Server) ListProfiles(ctx context.Context,
-	in *minderv1.ListProfilesRequest) (*minderv1.ListProfilesResponse, error) {
-	ctx, err := s.contextValidation(ctx, in.GetContext())
-	if err != nil {
-		return nil, status.Errorf(codes.InvalidArgument, "error ensuring default project: %v", err)
-	}
-
+	_ *minderv1.ListProfilesRequest) (*minderv1.ListProfilesResponse, error) {
 	entityCtx := engine.EntityFromContext(ctx)
+
+	err := entityCtx.Validate(ctx, s.store)
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "error in entity context: %v", err)
+	}
 
 	// check if user is authorized
 	if err := AuthorizedOnProject(ctx, entityCtx.GetProject().ID); err != nil {
@@ -284,12 +288,13 @@ func (s *Server) ListProfiles(ctx context.Context,
 // GetProfileById is a method to get a profile by id
 func (s *Server) GetProfileById(ctx context.Context,
 	in *minderv1.GetProfileByIdRequest) (*minderv1.GetProfileByIdResponse, error) {
-	ctx, err := s.contextValidation(ctx, in.GetContext())
-	if err != nil {
-		return nil, status.Errorf(codes.InvalidArgument, "error ensuring default project: %v", err)
-	}
 
 	entityCtx := engine.EntityFromContext(ctx)
+
+	err := entityCtx.Validate(ctx, s.store)
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "error in entity context: %v", err)
+	}
 
 	// check if user is authorized
 	if err := AuthorizedOnProject(ctx, entityCtx.GetProject().ID); err != nil {
@@ -385,12 +390,13 @@ func getRuleEvalEntityInfo(
 // nolint:gocyclo // TODO: Refactor this to be more readable
 func (s *Server) GetProfileStatusByName(ctx context.Context,
 	in *minderv1.GetProfileStatusByNameRequest) (*minderv1.GetProfileStatusByNameResponse, error) {
-	ctx, err := s.contextValidation(ctx, in.GetContext())
-	if err != nil {
-		return nil, status.Errorf(codes.InvalidArgument, "error ensuring default project: %v", err)
-	}
 
 	entityCtx := engine.EntityFromContext(ctx)
+
+	err := entityCtx.Validate(ctx, s.store)
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "error in entity context: %v", err)
+	}
 
 	// check if user is authorized
 	if err := AuthorizedOnProject(ctx, entityCtx.GetProject().ID); err != nil {
@@ -505,13 +511,14 @@ func (s *Server) GetProfileStatusByName(ctx context.Context,
 
 // GetProfileStatusByProject is a method to get profile status for a project
 func (s *Server) GetProfileStatusByProject(ctx context.Context,
-	in *minderv1.GetProfileStatusByProjectRequest) (*minderv1.GetProfileStatusByProjectResponse, error) {
-	ctx, err := s.contextValidation(ctx, in.GetContext())
-	if err != nil {
-		return nil, status.Errorf(codes.InvalidArgument, "error ensuring default project: %v", err)
-	}
+	_ *minderv1.GetProfileStatusByProjectRequest) (*minderv1.GetProfileStatusByProjectResponse, error) {
 
 	entityCtx := engine.EntityFromContext(ctx)
+
+	err := entityCtx.Validate(ctx, s.store)
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "error in entity context: %v", err)
+	}
 
 	// check if user is authorized
 	if err := AuthorizedOnProject(ctx, entityCtx.GetProject().ID); err != nil {
@@ -549,12 +556,12 @@ func (s *Server) UpdateProfile(ctx context.Context,
 	cpr *minderv1.UpdateProfileRequest) (*minderv1.UpdateProfileResponse, error) {
 	in := cpr.GetProfile()
 
-	ctx, err := s.contextValidation(ctx, cpr.GetContext())
-	if err != nil {
-		return nil, status.Errorf(codes.InvalidArgument, "error ensuring default project: %v", err)
-	}
-
 	entityCtx := engine.EntityFromContext(ctx)
+
+	err := entityCtx.Validate(ctx, s.store)
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "error in entity context: %v", err)
+	}
 
 	// check if user is authorized
 	if err := AuthorizedOnProject(ctx, entityCtx.GetProject().ID); err != nil {
@@ -656,6 +663,11 @@ func (s *Server) UpdateProfile(ctx context.Context,
 
 	idStr := profile.ID.String()
 	in.Id = &idStr
+	project := profile.ProjectID.String()
+	in.Context = &minderv1.Context{
+		Provider: &profile.Provider,
+		Project:  &project,
+	}
 	resp := &minderv1.UpdateProfileResponse{
 		Profile: in,
 	}

--- a/internal/controlplane/handlers_repositories.go
+++ b/internal/controlplane/handlers_repositories.go
@@ -27,6 +27,7 @@ import (
 	"google.golang.org/grpc/status"
 
 	"github.com/stacklok/minder/internal/db"
+	"github.com/stacklok/minder/internal/engine"
 	"github.com/stacklok/minder/internal/providers"
 	github "github.com/stacklok/minder/internal/providers/github"
 	"github.com/stacklok/minder/internal/reconcilers"
@@ -43,10 +44,8 @@ const maxFetchLimit = 100
 // repositor(ies).
 func (s *Server) RegisterRepository(ctx context.Context,
 	in *pb.RegisterRepositoryRequest) (*pb.RegisterRepositoryResponse, error) {
-	projectID, err := getProjectFromRequestOrDefault(ctx, in)
-	if err != nil {
-		return nil, util.UserVisibleError(codes.InvalidArgument, err.Error())
-	}
+	entityCtx := engine.EntityFromContext(ctx)
+	projectID := entityCtx.Project.ID
 
 	// check if user is authorized
 	if err := AuthorizedOnProject(ctx, projectID); err != nil {
@@ -147,10 +146,8 @@ func (s *Server) RegisterRepository(ctx context.Context,
 // repositories that are registered present in the minder database
 func (s *Server) ListRepositories(ctx context.Context,
 	in *pb.ListRepositoriesRequest) (*pb.ListRepositoriesResponse, error) {
-	projectID, err := getProjectFromRequestOrDefault(ctx, in)
-	if err != nil {
-		return nil, util.UserVisibleError(codes.InvalidArgument, err.Error())
-	}
+	entityCtx := engine.EntityFromContext(ctx)
+	projectID := entityCtx.Project.ID
 
 	// check if user is authorized
 	if err := AuthorizedOnProject(ctx, projectID); err != nil {
@@ -268,10 +265,8 @@ func (s *Server) GetRepositoryByName(ctx context.Context,
 		return nil, util.UserVisibleError(codes.InvalidArgument, "invalid repository name, needs to have the format: owner/name")
 	}
 
-	projectID, err := getProjectFromRequestOrDefault(ctx, in)
-	if err != nil {
-		return nil, util.UserVisibleError(codes.InvalidArgument, err.Error())
-	}
+	entityCtx := engine.EntityFromContext(ctx)
+	projectID := entityCtx.Project.ID
 
 	// check if user is authorized
 	if err := AuthorizedOnProject(ctx, projectID); err != nil {
@@ -351,11 +346,8 @@ func (s *Server) DeleteRepositoryByName(ctx context.Context,
 		return nil, util.UserVisibleError(codes.InvalidArgument, "invalid repository name, needs to have the format: owner/name")
 	}
 
-	projectID, err := getProjectFromRequestOrDefault(ctx, in)
-	if err != nil {
-		return nil, util.UserVisibleError(codes.InvalidArgument, err.Error())
-	}
-
+	entityCtx := engine.EntityFromContext(ctx)
+	projectID := entityCtx.Project.ID
 	// check if user is authorized
 	if err := AuthorizedOnProject(ctx, projectID); err != nil {
 		return nil, err
@@ -395,10 +387,8 @@ func (s *Server) ListRemoteRepositoriesFromProvider(
 	ctx context.Context,
 	in *pb.ListRemoteRepositoriesFromProviderRequest,
 ) (*pb.ListRemoteRepositoriesFromProviderResponse, error) {
-	projectID, err := getProjectFromRequestOrDefault(ctx, in)
-	if err != nil {
-		return nil, util.UserVisibleError(codes.InvalidArgument, err.Error())
-	}
+	entityCtx := engine.EntityFromContext(ctx)
+	projectID := entityCtx.Project.ID
 
 	// check if user is authorized
 	if err := AuthorizedOnProject(ctx, projectID); err != nil {

--- a/internal/controlplane/handlers_ruletype.go
+++ b/internal/controlplane/handlers_ruletype.go
@@ -35,14 +35,14 @@ import (
 // ListRuleTypes is a method to list all rule types for a given context
 func (s *Server) ListRuleTypes(
 	ctx context.Context,
-	in *minderv1.ListRuleTypesRequest,
+	_ *minderv1.ListRuleTypesRequest,
 ) (*minderv1.ListRuleTypesResponse, error) {
-	ctx, err := s.contextValidation(ctx, in.GetContext())
-	if err != nil {
-		return nil, status.Errorf(codes.InvalidArgument, "error ensuring default project: %v", err)
-	}
-
 	entityCtx := engine.EntityFromContext(ctx)
+
+	err := entityCtx.Validate(ctx, s.store)
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "error in entity context: %v", err)
+	}
 
 	// check if user is authorized
 	if err := AuthorizedOnProject(ctx, entityCtx.GetProject().ID); err != nil {
@@ -77,12 +77,12 @@ func (s *Server) GetRuleTypeByName(
 	ctx context.Context,
 	in *minderv1.GetRuleTypeByNameRequest,
 ) (*minderv1.GetRuleTypeByNameResponse, error) {
-	ctx, err := s.contextValidation(ctx, in.GetContext())
-	if err != nil {
-		return nil, status.Errorf(codes.InvalidArgument, "error ensuring default project: %v", err)
-	}
-
 	entityCtx := engine.EntityFromContext(ctx)
+
+	err := entityCtx.Validate(ctx, s.store)
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "error in entity context: %v", err)
+	}
 
 	// check if user is authorized
 	if err := AuthorizedOnProject(ctx, entityCtx.GetProject().ID); err != nil {
@@ -115,12 +115,12 @@ func (s *Server) GetRuleTypeById(
 	ctx context.Context,
 	in *minderv1.GetRuleTypeByIdRequest,
 ) (*minderv1.GetRuleTypeByIdResponse, error) {
-	ctx, err := s.contextValidation(ctx, in.GetContext())
-	if err != nil {
-		return nil, status.Errorf(codes.InvalidArgument, "error ensuring default project: %v", err)
-	}
-
 	entityCtx := engine.EntityFromContext(ctx)
+
+	err := entityCtx.Validate(ctx, s.store)
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "error in entity context: %v", err)
+	}
 
 	// check if user is authorized
 	if err := AuthorizedOnProject(ctx, entityCtx.GetProject().ID); err != nil {
@@ -156,12 +156,12 @@ func (s *Server) CreateRuleType(
 ) (*minderv1.CreateRuleTypeResponse, error) {
 	in := crt.GetRuleType()
 
-	ctx, err := s.contextValidation(ctx, crt.GetContext())
-	if err != nil {
-		return nil, status.Errorf(codes.InvalidArgument, "error ensuring default project: %v", err)
-	}
-
 	entityCtx := engine.EntityFromContext(ctx)
+
+	err := entityCtx.Validate(ctx, s.store)
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "error in entity context: %v", err)
+	}
 
 	// check if user is authorized
 	if err := AuthorizedOnProject(ctx, entityCtx.GetProject().ID); err != nil {
@@ -222,12 +222,12 @@ func (s *Server) UpdateRuleType(
 ) (*minderv1.UpdateRuleTypeResponse, error) {
 	in := urt.GetRuleType()
 
-	ctx, err := s.contextValidation(ctx, urt.GetContext())
-	if err != nil {
-		return nil, status.Errorf(codes.InvalidArgument, "error ensuring default project: %v", err)
-	}
-
 	entityCtx := engine.EntityFromContext(ctx)
+
+	err := entityCtx.Validate(ctx, s.store)
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "error in entity context: %v", err)
+	}
 
 	// check if user is authorized
 	if err := AuthorizedOnProject(ctx, entityCtx.GetProject().ID); err != nil {
@@ -331,12 +331,12 @@ func (s *Server) DeleteRuleType(
 
 	in.Context.Provider = &prov.Name
 
-	ctx, err = s.contextValidation(ctx, in.GetContext())
-	if err != nil {
-		return nil, status.Errorf(codes.InvalidArgument, "error ensuring default project: %v", err)
-	}
-
 	entityCtx := engine.EntityFromContext(ctx)
+
+	err = entityCtx.Validate(ctx, s.store)
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "error in entity context: %v", err)
+	}
 
 	// check if user is authorized
 	if err := AuthorizedOnProject(ctx, entityCtx.GetProject().ID); err != nil {

--- a/internal/controlplane/handlers_ruletype.go
+++ b/internal/controlplane/handlers_ruletype.go
@@ -37,12 +37,17 @@ func (s *Server) ListRuleTypes(
 	ctx context.Context,
 	in *minderv1.ListRuleTypesRequest,
 ) (*minderv1.ListRuleTypesResponse, error) {
-	ctx, err := s.authAndContextValidation(ctx, in.GetContext())
+	ctx, err := s.contextValidation(ctx, in.GetContext())
 	if err != nil {
 		return nil, status.Errorf(codes.InvalidArgument, "error ensuring default project: %v", err)
 	}
 
 	entityCtx := engine.EntityFromContext(ctx)
+
+	// check if user is authorized
+	if err := AuthorizedOnProject(ctx, entityCtx.GetProject().ID); err != nil {
+		return nil, err
+	}
 
 	lrt, err := s.store.ListRuleTypesByProviderAndProject(ctx, db.ListRuleTypesByProviderAndProjectParams{
 		Provider:  entityCtx.GetProvider().Name,
@@ -72,12 +77,17 @@ func (s *Server) GetRuleTypeByName(
 	ctx context.Context,
 	in *minderv1.GetRuleTypeByNameRequest,
 ) (*minderv1.GetRuleTypeByNameResponse, error) {
-	ctx, err := s.authAndContextValidation(ctx, in.GetContext())
+	ctx, err := s.contextValidation(ctx, in.GetContext())
 	if err != nil {
 		return nil, status.Errorf(codes.InvalidArgument, "error ensuring default project: %v", err)
 	}
 
 	entityCtx := engine.EntityFromContext(ctx)
+
+	// check if user is authorized
+	if err := AuthorizedOnProject(ctx, entityCtx.GetProject().ID); err != nil {
+		return nil, err
+	}
 
 	resp := &minderv1.GetRuleTypeByNameResponse{}
 
@@ -105,9 +115,16 @@ func (s *Server) GetRuleTypeById(
 	ctx context.Context,
 	in *minderv1.GetRuleTypeByIdRequest,
 ) (*minderv1.GetRuleTypeByIdResponse, error) {
-	ctx, err := s.authAndContextValidation(ctx, in.GetContext())
+	ctx, err := s.contextValidation(ctx, in.GetContext())
 	if err != nil {
 		return nil, status.Errorf(codes.InvalidArgument, "error ensuring default project: %v", err)
+	}
+
+	entityCtx := engine.EntityFromContext(ctx)
+
+	// check if user is authorized
+	if err := AuthorizedOnProject(ctx, entityCtx.GetProject().ID); err != nil {
+		return nil, err
 	}
 
 	resp := &minderv1.GetRuleTypeByIdResponse{}
@@ -139,12 +156,18 @@ func (s *Server) CreateRuleType(
 ) (*minderv1.CreateRuleTypeResponse, error) {
 	in := crt.GetRuleType()
 
-	ctx, err := s.authAndContextValidation(ctx, crt.GetContext())
+	ctx, err := s.contextValidation(ctx, crt.GetContext())
 	if err != nil {
 		return nil, status.Errorf(codes.InvalidArgument, "error ensuring default project: %v", err)
 	}
 
 	entityCtx := engine.EntityFromContext(ctx)
+
+	// check if user is authorized
+	if err := AuthorizedOnProject(ctx, entityCtx.GetProject().ID); err != nil {
+		return nil, err
+	}
+
 	_, err = s.store.GetRuleTypeByName(ctx, db.GetRuleTypeByNameParams{
 		Provider:  entityCtx.GetProvider().Name,
 		ProjectID: entityCtx.GetProject().ID,
@@ -199,12 +222,17 @@ func (s *Server) UpdateRuleType(
 ) (*minderv1.UpdateRuleTypeResponse, error) {
 	in := urt.GetRuleType()
 
-	ctx, err := s.authAndContextValidation(ctx, urt.GetContext())
+	ctx, err := s.contextValidation(ctx, urt.GetContext())
 	if err != nil {
 		return nil, status.Errorf(codes.InvalidArgument, "error ensuring default project: %v", err)
 	}
 
 	entityCtx := engine.EntityFromContext(ctx)
+
+	// check if user is authorized
+	if err := AuthorizedOnProject(ctx, entityCtx.GetProject().ID); err != nil {
+		return nil, err
+	}
 
 	rtdb, err := s.store.GetRuleTypeByName(ctx, db.GetRuleTypeByNameParams{
 		Provider:  entityCtx.GetProvider().Name,
@@ -303,9 +331,16 @@ func (s *Server) DeleteRuleType(
 
 	in.Context.Provider = &prov.Name
 
-	ctx, err = s.authAndContextValidation(ctx, in.GetContext())
+	ctx, err = s.contextValidation(ctx, in.GetContext())
 	if err != nil {
 		return nil, status.Errorf(codes.InvalidArgument, "error ensuring default project: %v", err)
+	}
+
+	entityCtx := engine.EntityFromContext(ctx)
+
+	// check if user is authorized
+	if err := AuthorizedOnProject(ctx, entityCtx.GetProject().ID); err != nil {
+		return nil, err
 	}
 
 	profileInfo, err := s.store.ListProfilesInstantiatingRuleType(ctx, ruletype.ID)

--- a/internal/controlplane/server.go
+++ b/internal/controlplane/server.go
@@ -199,6 +199,7 @@ func (s *Server) StartGRPCServer(ctx context.Context) error {
 		logger.Interceptor(s.cfg.LoggingConfig),
 		TokenValidationInterceptor,
 		AuthorizationUnaryInterceptor,
+		EntityContextProjectInterceptor,
 	}
 
 	options := []grpc.ServerOption{


### PR DESCRIPTION
- For all requests where the authorization depends on the project, populate the project in the context
- Always fetch the project from the context when making authorization decisions

Fix https://github.com/stacklok/minder/issues/2078