### PR TITLE
Remove EntityContext pointers and replace with struct references

### DIFF
--- a/internal/controlplane/handlers_authz.go
+++ b/internal/controlplane/handlers_authz.go
@@ -178,14 +178,14 @@ func populateEntityContext(ctx context.Context, in HasProtoContext) (context.Con
 	}
 
 	// don't look up default provider until user has been authorized
-	providerName := in.GetContext().Provider
+	providerName := in.GetContext().GetProvider()
 
 	entityCtx := &engine.EntityContext{
 		Project: engine.Project{
 			ID: projectID,
 		},
 		Provider: engine.Provider{
-			Name: *providerName,
+			Name: providerName,
 		},
 	}
 

--- a/internal/controlplane/handlers_ruletype.go
+++ b/internal/controlplane/handlers_ruletype.go
@@ -45,13 +45,13 @@ func (s *Server) ListRuleTypes(
 	}
 
 	// check if user is authorized
-	if err := AuthorizedOnProject(ctx, entityCtx.GetProject().ID); err != nil {
+	if err := AuthorizedOnProject(ctx, entityCtx.Project.ID); err != nil {
 		return nil, err
 	}
 
 	lrt, err := s.store.ListRuleTypesByProviderAndProject(ctx, db.ListRuleTypesByProviderAndProjectParams{
-		Provider:  entityCtx.GetProvider().Name,
-		ProjectID: entityCtx.GetProject().ID,
+		Provider:  entityCtx.Provider.Name,
+		ProjectID: entityCtx.Project.ID,
 	})
 	if err != nil {
 		return nil, status.Errorf(codes.Unknown, "failed to get rule types: %s", err)
@@ -85,15 +85,15 @@ func (s *Server) GetRuleTypeByName(
 	}
 
 	// check if user is authorized
-	if err := AuthorizedOnProject(ctx, entityCtx.GetProject().ID); err != nil {
+	if err := AuthorizedOnProject(ctx, entityCtx.Project.ID); err != nil {
 		return nil, err
 	}
 
 	resp := &minderv1.GetRuleTypeByNameResponse{}
 
 	rtdb, err := s.store.GetRuleTypeByName(ctx, db.GetRuleTypeByNameParams{
-		Provider:  entityCtx.GetProvider().Name,
-		ProjectID: entityCtx.GetProject().ID,
+		Provider:  entityCtx.Provider.Name,
+		ProjectID: entityCtx.Project.ID,
 		Name:      in.GetName(),
 	})
 	if err != nil {
@@ -123,7 +123,7 @@ func (s *Server) GetRuleTypeById(
 	}
 
 	// check if user is authorized
-	if err := AuthorizedOnProject(ctx, entityCtx.GetProject().ID); err != nil {
+	if err := AuthorizedOnProject(ctx, entityCtx.Project.ID); err != nil {
 		return nil, err
 	}
 
@@ -164,13 +164,13 @@ func (s *Server) CreateRuleType(
 	}
 
 	// check if user is authorized
-	if err := AuthorizedOnProject(ctx, entityCtx.GetProject().ID); err != nil {
+	if err := AuthorizedOnProject(ctx, entityCtx.Project.ID); err != nil {
 		return nil, err
 	}
 
 	_, err = s.store.GetRuleTypeByName(ctx, db.GetRuleTypeByNameParams{
-		Provider:  entityCtx.GetProvider().Name,
-		ProjectID: entityCtx.GetProject().ID,
+		Provider:  entityCtx.Provider.Name,
+		ProjectID: entityCtx.Project.ID,
 		Name:      in.GetName(),
 	})
 	if err == nil {
@@ -195,8 +195,8 @@ func (s *Server) CreateRuleType(
 
 	dbrtyp, err := s.store.CreateRuleType(ctx, db.CreateRuleTypeParams{
 		Name:        in.GetName(),
-		Provider:    entityCtx.GetProvider().Name,
-		ProjectID:   entityCtx.GetProject().ID,
+		Provider:    entityCtx.Provider.Name,
+		ProjectID:   entityCtx.Project.ID,
 		Description: in.GetDescription(),
 		Definition:  def,
 		Guidance:    in.GetGuidance(),
@@ -230,13 +230,13 @@ func (s *Server) UpdateRuleType(
 	}
 
 	// check if user is authorized
-	if err := AuthorizedOnProject(ctx, entityCtx.GetProject().ID); err != nil {
+	if err := AuthorizedOnProject(ctx, entityCtx.Project.ID); err != nil {
 		return nil, err
 	}
 
 	rtdb, err := s.store.GetRuleTypeByName(ctx, db.GetRuleTypeByNameParams{
-		Provider:  entityCtx.GetProvider().Name,
-		ProjectID: entityCtx.GetProject().ID,
+		Provider:  entityCtx.Provider.Name,
+		ProjectID: entityCtx.Project.ID,
 		Name:      in.GetName(),
 	})
 	if err != nil {
@@ -339,7 +339,7 @@ func (s *Server) DeleteRuleType(
 	}
 
 	// check if user is authorized
-	if err := AuthorizedOnProject(ctx, entityCtx.GetProject().ID); err != nil {
+	if err := AuthorizedOnProject(ctx, entityCtx.Project.ID); err != nil {
 		return nil, err
 	}
 

--- a/internal/engine/context.go
+++ b/internal/engine/context.go
@@ -37,12 +37,12 @@ func WithEntityContext(ctx context.Context, c *EntityContext) context.Context {
 }
 
 // EntityFromContext extracts the current EntityContext, WHICH MAY BE NIL!
-func EntityFromContext(ctx context.Context) *EntityContext {
-	ec, ok := ctx.Value(entityContextKey).(*EntityContext)
-	if !ok {
-		return nil
+func EntityFromContext(ctx context.Context) EntityContext {
+	ec, _ := ctx.Value(entityContextKey).(*EntityContext)
+	if ec == nil {
+		return EntityContext{}
 	}
-	return ec
+	return *ec
 }
 
 // Project is a construct relevant to an entity's context.
@@ -62,16 +62,6 @@ type Provider struct {
 type EntityContext struct {
 	Project  Project
 	Provider Provider
-}
-
-// GetProject returns the project of the entity
-func (c *EntityContext) GetProject() Project {
-	return c.Project
-}
-
-// GetProvider returns the provider of the entity
-func (c *EntityContext) GetProvider() Provider {
-	return c.Provider
 }
 
 // Validate validates that the entity context contains values that are present in the DB


### PR DESCRIPTION
In https://github.com/stacklok/minder/pull/2139#discussion_r1455758961, I noted that we were using the result from `EntityFromContext` without checking to see if it was `nil`.  @eleftherias suggested that we might as well return a concrete struct rather than littering our code with obnoxious checks.  In doing so, I found a case where we `panic` if `Project` is set and `Provider` is not, so I fixed it and added tests until fear turned to boredom.

I also removed `GetProvider` and `GetProject` methods (and switched to direct struct references), since they didn't seem to add any value.  (If they were defaulting values even if `EntityContext` were `nil`, I'd have kept them, but it seemed superfluous in this case.)