### PR TITLE
Checkout back to the original branch to reset the filesystem preventing ingest cache from corrupting

### DIFF
--- a/internal/engine/ingester/git/git_test.go
+++ b/internal/engine/ingester/git/git_test.go
@@ -11,7 +11,6 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-// Package rule provides the CLI subcommand for managing rules
 
 package git_test
 


### PR DESCRIPTION
Fixes #2159 

--- 

- The initial approach was to copy the billy filesystem, but `go-git` internally restores the filesystem while checking out to different branches.
- The ingested data would be technically modified after being cached, but the state of the originally fetched branch would be preserved.