### PR TITLE
Don't default to `minder` as default store ID is authz configuration

### DIFF
--- a/internal/config/server/authz.go
+++ b/internal/config/server/authz.go
@@ -28,7 +28,7 @@ type AuthzConfig struct {
 	// StoreName is the name of the store to use for authorization
 	StoreName string `mapstructure:"store_name" default:"minder" validate:"required_without=StoreID"`
 	// StoreID is the ID of the store to use for authorization
-	StoreID string `mapstructure:"store_id" default:"minder" validate:"required_without=StoreName"`
+	StoreID string `mapstructure:"store_id" default:"" validate:"required_without=StoreName"`
 	// Auth is the authentication configuration for the authorization server
 	Auth OpenFGAAuth `mapstructure:"auth" validate:"required"`
 }


### PR DESCRIPTION
We should default to an empty string since we initially generate and
then list the store ID's when building the authz client. Passing a
default store ID is not the right thing to do. We should instead just
pass a store ID from the configuration once we have already bootstrapped
the app.
