### PR TITLE
Implement Write and Delete tuple functions for OpenFGA Authz Client

### DIFF
--- a/internal/authz/interface.go
+++ b/internal/authz/interface.go
@@ -38,6 +38,10 @@ const (
 	AuthzRoleViewer Role = "viewer"
 )
 
+func (r Role) String() string {
+	return string(r)
+}
+
 // Client provides an abstract interface which simplifies interacting with
 // OpenFGA and supports no-op and fake implementations.
 type Client interface {


### PR DESCRIPTION
This fills up the implementation for the Write and Delete tuples for the
OpenFGA Authz client in such a way that it's easy to hook up in the
minder server.
