### PR TITLE
Add a mindev command to verify containers

### DIFF
--- a/cmd/dev/app/container/cmd_verify.go
+++ b/cmd/dev/app/container/cmd_verify.go
@@ -1,0 +1,87 @@
+// Copyright 2023 Stacklok, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package container provides the root command for the container subcommands
+package container
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+
+	"github.com/stacklok/minder/internal/verifier"
+)
+
+// CmdVerify returns the verify container command
+func CmdVerify() *cobra.Command {
+	var verifyCmd = &cobra.Command{
+		Use:          "verify",
+		Short:        "verify a container signature",
+		RunE:         runCmdVerify,
+		SilenceUsage: true,
+	}
+
+	verifyCmd.Flags().StringP("owner", "o", "", "owner of the artifact")
+	verifyCmd.Flags().StringP("name", "n", "", "name of the artifact")
+	verifyCmd.Flags().StringP("digest", "s", "", "digest of the artifact")
+
+	if err := verifyCmd.MarkFlagRequired("owner"); err != nil {
+		fmt.Fprintf(os.Stderr, "Error marking flag as required: %s\n", err)
+		os.Exit(1)
+	}
+
+	if err := verifyCmd.MarkFlagRequired("name"); err != nil {
+		fmt.Fprintf(os.Stderr, "Error marking flag as required: %s\n", err)
+		os.Exit(1)
+	}
+
+	if err := verifyCmd.MarkFlagRequired("digest"); err != nil {
+		fmt.Fprintf(os.Stderr, "Error marking flag as required: %s\n", err)
+		os.Exit(1)
+	}
+
+	viper.SetEnvKeyReplacer(strings.NewReplacer(".", "_"))
+
+	return verifyCmd
+}
+
+func runCmdVerify(cmd *cobra.Command, _ []string) error {
+	owner := cmd.Flag("owner")
+	name := cmd.Flag("name")
+	digest := cmd.Flag("digest")
+
+	token := viper.GetString("auth.token")
+
+	artifactVerifier, err := verifier.NewVerifier(verifier.VerifierSigstore, token)
+	if err != nil {
+		return fmt.Errorf("error getting sigstore verifier: %w", err)
+	}
+	defer artifactVerifier.ClearCache()
+
+	res, err := artifactVerifier.Verify(context.Background(), verifier.ArtifactTypeContainer, "",
+		owner.Value.String(), name.Value.String(), digest.Value.String())
+	if err != nil {
+		return fmt.Errorf("error verifying container: %w", err)
+	}
+
+	fmt.Fprintf(cmd.OutOrStdout(), "Signature: %s\n", res.SignatureInfo)
+	fmt.Fprintf(cmd.OutOrStdout(), "Workflow: %s\n", res.WorkflowInfo)
+	fmt.Fprintf(cmd.OutOrStdout(), "URI: %s\n", res.URI)
+
+	return nil
+}

--- a/cmd/dev/app/container/container.go
+++ b/cmd/dev/app/container/container.go
@@ -12,20 +12,19 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package rule_type provides the root command for the ruletype subcommands
-package rule_type
+// Package container provides the root command for the container subcommands
+package container
 
 import "github.com/spf13/cobra"
 
-// CmdRuleType is the root command for the ruletype subcommands
-func CmdRuleType() *cobra.Command {
+// CmdContainer is the root command for the container subcommands
+func CmdContainer() *cobra.Command {
 	var rtCmd = &cobra.Command{
-		Use:   "ruletype",
-		Short: "ruletype provides utilities for testing rule types",
+		Use:   "container",
+		Short: "container provides utilities to test minder container support",
 	}
 
-	rtCmd.AddCommand(CmdTest())
-	rtCmd.AddCommand(CmdLint())
+	rtCmd.AddCommand(CmdVerify())
 
 	return rtCmd
 }

--- a/cmd/dev/app/root.go
+++ b/cmd/dev/app/root.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/stacklok/minder/cmd/dev/app/container"
 	"github.com/stacklok/minder/cmd/dev/app/rule_type"
 	"github.com/stacklok/minder/internal/util/cli"
 )
@@ -35,6 +36,7 @@ https://docs.stacklok.com/minder`,
 	}
 
 	cmd.AddCommand(rule_type.CmdRuleType())
+	cmd.AddCommand(container.CmdContainer())
 
 	return cmd
 }


### PR DESCRIPTION
This is useful when hacking on artifact attestation support so that the
developer doesn't have to run the full minder machinery.

Example usage:
```
mindev container verify --owner=jakubtestorg --name=bad-go --digest=sha256:d7c4ea4a259b5886c42b66182ab7632b8bc3e3751af8393372d2806e6abdc83
```
