### PR TITLE
Hook up authz tuple writing to Minder server

### DIFF
--- a/database/mock/store.go
+++ b/database/mock/store.go
@@ -276,6 +276,21 @@ func (mr *MockStoreMockRecorder) CreateProject(arg0, arg1 interface{}) *gomock.C
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateProject", reflect.TypeOf((*MockStore)(nil).CreateProject), arg0, arg1)
 }
 
+// CreateProjectWithID mocks base method.
+func (m *MockStore) CreateProjectWithID(arg0 context.Context, arg1 db.CreateProjectWithIDParams) (db.Project, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CreateProjectWithID", arg0, arg1)
+	ret0, _ := ret[0].(db.Project)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// CreateProjectWithID indicates an expected call of CreateProjectWithID.
+func (mr *MockStoreMockRecorder) CreateProjectWithID(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateProjectWithID", reflect.TypeOf((*MockStore)(nil).CreateProjectWithID), arg0, arg1)
+}
+
 // CreateProvider mocks base method.
 func (m *MockStore) CreateProvider(arg0 context.Context, arg1 db.CreateProviderParams) (db.Provider, error) {
 	m.ctrl.T.Helper()

--- a/database/query/projects.sql
+++ b/database/query/projects.sql
@@ -7,6 +7,16 @@ INSERT INTO projects (
     $1, $2, sqlc.arg(metadata)::jsonb
 ) RETURNING *;
 
+-- name: CreateProjectWithID :one
+INSERT INTO projects (
+    id,
+    name,
+    parent_id,
+    metadata
+) VALUES (
+    $1, $2, $3, sqlc.arg(metadata)::jsonb
+) RETURNING *;
+
 -- name: GetRootProjects :many
 SELECT * FROM projects
 WHERE parent_id IS NULL;

--- a/internal/controlplane/handlers_user.go
+++ b/internal/controlplane/handlers_user.go
@@ -88,7 +88,7 @@ func (s *Server) CreateUser(ctx context.Context,
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "failed to create organization: %s", err)
 	}
-	orgProject, userRoles, err := CreateDefaultRecordsForOrg(ctx, qtx, organization, baseName)
+	orgProject, userRoles, err := s.CreateDefaultRecordsForOrg(ctx, qtx, organization, baseName, subject)
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "failed to create default organization records: %s", err)
 	}
@@ -187,7 +187,7 @@ func (s *Server) DeleteUser(ctx context.Context,
 		return nil, status.Errorf(codes.Internal, "unexpected status code when deleting account: %d", resp.StatusCode)
 	}
 
-	err = DeleteUser(ctx, s.store, subject)
+	err = DeleteUser(ctx, s.store, s.authzClient, subject)
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "failed to delete user from database: %v", err)
 	}

--- a/internal/controlplane/identity_events_test.go
+++ b/internal/controlplane/identity_events_test.go
@@ -27,6 +27,7 @@ import (
 	"golang.org/x/oauth2"
 
 	mockdb "github.com/stacklok/minder/database/mock"
+	"github.com/stacklok/minder/internal/authz/mock"
 	serverconfig "github.com/stacklok/minder/internal/config/server"
 	"github.com/stacklok/minder/internal/db"
 )
@@ -72,6 +73,8 @@ func TestHandleEvents(t *testing.T) {
 	mockStore.EXPECT().
 		GetUserBySubject(gomock.Any(), "alreadyDeletedUserId").
 		Return(db.User{}, sql.ErrNoRows)
+	mockStore.EXPECT().GetUserProjects(gomock.Any(), gomock.Any()).
+		Return([]db.GetUserProjectsRow{}, nil)
 	mockStore.EXPECT().Rollback(gomock.Any())
 
 	c := serverconfig.Config{
@@ -83,7 +86,7 @@ func TestHandleEvents(t *testing.T) {
 			},
 		},
 	}
-	HandleEvents(context.Background(), mockStore, &c)
+	HandleEvents(context.Background(), mockStore, &mock.NoopClient{Authorized: true}, &c)
 }
 
 func tokenHandler(t *testing.T, w http.ResponseWriter) {

--- a/internal/controlplane/server.go
+++ b/internal/controlplane/server.go
@@ -124,15 +124,13 @@ func NewServer(
 		vldtr:        vldtr,
 		mt:           cpm,
 		provMt:       provtelemetry.NewNoopMetrics(),
+		// TODO: this currently always returns authorized as a transitionary measure.
+		// When OpenFGA is fully rolled out, we may want to make this a hard error or set to false.
+		authzClient: &mock.NoopClient{Authorized: true},
 	}
 
 	for _, opt := range opts {
 		opt(s)
-	}
-	if s.authzClient == nil {
-		// TODO: this currently always returns authorized as a transitionary measure.
-		// When OpenFGA is fully rolled out, we may want to make this a hard error or set to false.
-		s.authzClient = &mock.NoopClient{Authorized: true}
 	}
 
 	return s, nil

--- a/internal/db/querier.go
+++ b/internal/db/querier.go
@@ -25,6 +25,7 @@ type Querier interface {
 	CreateProfile(ctx context.Context, arg CreateProfileParams) (Profile, error)
 	CreateProfileForEntity(ctx context.Context, arg CreateProfileForEntityParams) (EntityProfile, error)
 	CreateProject(ctx context.Context, arg CreateProjectParams) (Project, error)
+	CreateProjectWithID(ctx context.Context, arg CreateProjectWithIDParams) (Project, error)
 	CreateProvider(ctx context.Context, arg CreateProviderParams) (Provider, error)
 	CreatePullRequest(ctx context.Context, arg CreatePullRequestParams) (PullRequest, error)
 	CreateRepository(ctx context.Context, arg CreateRepositoryParams) (Repository, error)


### PR DESCRIPTION
This hooks up the initial creation of tuples for authorization in the
server.

Tuples define the relationships between users and projects in minder via
a role.

The intent is for these to happen first, and roll them back if database
operations fail.

Closes: https://github.com/stacklok/minder/issues/1851
Closes: #1850
