### PR TITLE
Move authorization logic to interceptor

### DIFF
--- a/internal/auth/jwtauth.go
+++ b/internal/auth/jwtauth.go
@@ -17,7 +17,6 @@ package auth
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"net/url"
 
@@ -151,15 +150,6 @@ func GetUserSubjectFromContext(ctx context.Context) string {
 // WithUserSubjectContext stores the specified user subject in the context.
 func WithUserSubjectContext(ctx context.Context, subject string) context.Context {
 	return context.WithValue(ctx, userSubjectContextKey, subject)
-}
-
-// GetDefaultProject returns the default project id for the user
-func GetDefaultProject(ctx context.Context) (uuid.UUID, error) {
-	permissions := GetPermissionsFromContext(ctx)
-	if len(permissions.ProjectIds) != 1 {
-		return uuid.UUID{}, errors.New("cannot get default project")
-	}
-	return permissions.ProjectIds[0], nil
 }
 
 // UserDetails is a helper struct for getting user details

--- a/internal/controlplane/common.go
+++ b/internal/controlplane/common.go
@@ -26,7 +26,6 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
-	"github.com/stacklok/minder/internal/auth"
 	"github.com/stacklok/minder/internal/db"
 	"github.com/stacklok/minder/internal/util"
 	pb "github.com/stacklok/minder/pkg/api/protobuf/go/minder/v1"
@@ -42,28 +41,6 @@ func providerError(err error) error {
 		return util.UserVisibleError(codes.NotFound, "provider not found")
 	}
 	return fmt.Errorf("provider error: %w", err)
-}
-
-func getProjectFromRequestOrDefault(ctx context.Context, in HasProtoContext) (uuid.UUID, error) {
-	var requestedProject string
-
-	// Prefer the context message from the protobuf
-	if in.GetContext().GetProject() != "" {
-		requestedProject = in.GetContext().GetProject()
-	} else {
-		proj, err := auth.GetDefaultProject(ctx)
-		if err != nil {
-			return uuid.UUID{}, status.Errorf(codes.InvalidArgument, "cannot infer project id: %s", err)
-		}
-
-		return proj, err
-	}
-
-	parsedProjectID, err := uuid.Parse(requestedProject)
-	if err != nil {
-		return uuid.UUID{}, util.UserVisibleError(codes.InvalidArgument, "malformed project ID")
-	}
-	return parsedProjectID, nil
 }
 
 func getProviderFromRequestOrDefault(

--- a/internal/controlplane/handlers_artifacts.go
+++ b/internal/controlplane/handlers_artifacts.go
@@ -41,11 +41,6 @@ func (s *Server) ListArtifacts(ctx context.Context, in *pb.ListArtifactsRequest)
 	entityCtx := engine.EntityFromContext(ctx)
 	projectID := entityCtx.Project.ID
 
-	// check if user is authorized
-	if err := AuthorizedOnProject(ctx, projectID); err != nil {
-		return nil, err
-	}
-
 	provider, err := getProviderFromRequestOrDefault(ctx, s.store, in, projectID)
 	if err != nil {
 		return nil, providerError(err)
@@ -115,11 +110,6 @@ func (s *Server) GetArtifactByName(ctx context.Context, in *pb.GetArtifactByName
 		return nil, status.Errorf(codes.Unknown, "failed to get artifact: %s", err)
 	}
 
-	// check if user is authorized
-	if err := AuthorizedOnProject(ctx, artifact.ProjectID); err != nil {
-		return nil, err
-	}
-
 	pbVersions, err := getPbArtifactVersions(ctx, s.store, artifact.ID, in.Tag, in.LatestVersions)
 	if err != nil {
 		return nil, status.Errorf(codes.Unknown, "failed to get artifact versions: %s", err)
@@ -168,11 +158,6 @@ func (s *Server) GetArtifactById(ctx context.Context, in *pb.GetArtifactByIdRequ
 			return nil, status.Errorf(codes.NotFound, "artifact not found")
 		}
 		return nil, status.Errorf(codes.Unknown, "failed to get artifact: %s", err)
-	}
-
-	// check if user is authorized
-	if err := AuthorizedOnProject(ctx, artifact.ProjectID); err != nil {
-		return nil, err
 	}
 
 	// get artifact versions

--- a/internal/controlplane/handlers_oauth.go
+++ b/internal/controlplane/handlers_oauth.go
@@ -46,10 +46,6 @@ func (s *Server) GetAuthorizationURL(ctx context.Context,
 	entityCtx := engine.EntityFromContext(ctx)
 	projectID := entityCtx.Project.ID
 
-	if err := AuthorizedOnProject(ctx, projectID); err != nil {
-		return nil, err
-	}
-
 	// get provider info
 	provider, err := getProviderFromRequestOrDefault(ctx, s.store, req, projectID)
 	if err != nil {
@@ -225,13 +221,7 @@ func (s *Server) ExchangeCodeForTokenCLI(ctx context.Context,
 
 // getProviderAccessToken returns the access token for providers
 func (s *Server) getProviderAccessToken(ctx context.Context, provider string,
-	projectID uuid.UUID, checkAuthz bool) (oauth2.Token, string, error) {
-	// check if user is authorized
-	if checkAuthz {
-		if err := AuthorizedOnProject(ctx, projectID); err != nil {
-			return oauth2.Token{}, "", err
-		}
-	}
+	projectID uuid.UUID) (oauth2.Token, string, error) {
 
 	encToken, err := s.store.GetAccessTokenByProjectID(ctx,
 		db.GetAccessTokenByProjectIDParams{Provider: provider, ProjectID: projectID})
@@ -254,11 +244,6 @@ func (s *Server) StoreProviderToken(ctx context.Context,
 	in *pb.StoreProviderTokenRequest) (*pb.StoreProviderTokenResponse, error) {
 	entityCtx := engine.EntityFromContext(ctx)
 	projectID := entityCtx.Project.ID
-
-	// check if user is authorized
-	if err := AuthorizedOnProject(ctx, projectID); err != nil {
-		return nil, err
-	}
 
 	provider, err := getProviderFromRequestOrDefault(ctx, s.store, in, projectID)
 	if err != nil {
@@ -318,11 +303,6 @@ func (s *Server) VerifyProviderTokenFrom(ctx context.Context,
 	in *pb.VerifyProviderTokenFromRequest) (*pb.VerifyProviderTokenFromResponse, error) {
 	entityCtx := engine.EntityFromContext(ctx)
 	projectID := entityCtx.Project.ID
-
-	// check if user is authorized
-	if err := AuthorizedOnProject(ctx, projectID); err != nil {
-		return nil, err
-	}
 
 	provider, err := getProviderFromRequestOrDefault(ctx, s.store, in, projectID)
 	if err != nil {

--- a/internal/controlplane/handlers_profile.go
+++ b/internal/controlplane/handlers_profile.go
@@ -71,11 +71,6 @@ func (s *Server) CreateProfile(ctx context.Context,
 		return nil, status.Errorf(codes.InvalidArgument, "error in entity context: %v", err)
 	}
 
-	// check if user is authorized
-	if err := AuthorizedOnProject(ctx, entityCtx.Project.ID); err != nil {
-		return nil, err
-	}
-
 	// If provider doesn't exist, return error
 	provider, err := s.store.GetProviderByName(ctx, db.GetProviderByNameParams{
 		Name:      entityCtx.Provider.Name,
@@ -236,11 +231,6 @@ func (s *Server) DeleteProfile(ctx context.Context,
 		return nil, status.Errorf(codes.InvalidArgument, "error in entity context: %v", err)
 	}
 
-	// check if user is authorized
-	if err := AuthorizedOnProject(ctx, entityCtx.Project.ID); err != nil {
-		return nil, err
-	}
-
 	parsedProfileID, err := uuid.Parse(in.Id)
 	if err != nil {
 		return nil, util.UserVisibleError(codes.InvalidArgument, "invalid profile ID")
@@ -277,11 +267,6 @@ func (s *Server) ListProfiles(ctx context.Context,
 		return nil, status.Errorf(codes.InvalidArgument, "error in entity context: %v", err)
 	}
 
-	// check if user is authorized
-	if err := AuthorizedOnProject(ctx, entityCtx.Project.ID); err != nil {
-		return nil, err
-	}
-
 	profiles, err := s.store.ListProfilesByProjectID(ctx, entityCtx.Project.ID)
 	if err != nil {
 		return nil, status.Errorf(codes.Unknown, "failed to get profiles: %s", err)
@@ -309,11 +294,6 @@ func (s *Server) GetProfileById(ctx context.Context,
 	err := entityCtx.Validate(ctx, s.store)
 	if err != nil {
 		return nil, status.Errorf(codes.InvalidArgument, "error in entity context: %v", err)
-	}
-
-	// check if user is authorized
-	if err := AuthorizedOnProject(ctx, entityCtx.Project.ID); err != nil {
-		return nil, err
 	}
 
 	parsedProfileID, err := uuid.Parse(in.Id)
@@ -416,11 +396,6 @@ func (s *Server) GetProfileStatusByName(ctx context.Context,
 	err := entityCtx.Validate(ctx, s.store)
 	if err != nil {
 		return nil, status.Errorf(codes.InvalidArgument, "error in entity context: %v", err)
-	}
-
-	// check if user is authorized
-	if err := AuthorizedOnProject(ctx, entityCtx.Project.ID); err != nil {
-		return nil, err
 	}
 
 	dbstat, err := s.store.GetProfileStatusByNameAndProject(ctx, db.GetProfileStatusByNameAndProjectParams{
@@ -545,11 +520,6 @@ func (s *Server) GetProfileStatusByProject(ctx context.Context,
 		return nil, status.Errorf(codes.InvalidArgument, "error in entity context: %v", err)
 	}
 
-	// check if user is authorized
-	if err := AuthorizedOnProject(ctx, entityCtx.Project.ID); err != nil {
-		return nil, err
-	}
-
 	// read profile status
 	dbstats, err := s.store.GetProfileStatusByProject(ctx, entityCtx.Project.ID)
 	if err != nil {
@@ -590,11 +560,6 @@ func (s *Server) UpdateProfile(ctx context.Context,
 	err := entityCtx.Validate(ctx, s.store)
 	if err != nil {
 		return nil, status.Errorf(codes.InvalidArgument, "error in entity context: %v", err)
-	}
-
-	// check if user is authorized
-	if err := AuthorizedOnProject(ctx, entityCtx.Project.ID); err != nil {
-		return nil, err
 	}
 
 	if err := in.Validate(); err != nil {

--- a/internal/controlplane/handlers_repositories.go
+++ b/internal/controlplane/handlers_repositories.go
@@ -48,11 +48,6 @@ func (s *Server) RegisterRepository(ctx context.Context,
 	entityCtx := engine.EntityFromContext(ctx)
 	projectID := entityCtx.Project.ID
 
-	// check if user is authorized
-	if err := AuthorizedOnProject(ctx, projectID); err != nil {
-		return nil, err
-	}
-
 	provider, err := getProviderFromRequestOrDefault(ctx, s.store, in, projectID)
 	if err != nil {
 		return nil, providerError(err)
@@ -155,11 +150,6 @@ func (s *Server) ListRepositories(ctx context.Context,
 	entityCtx := engine.EntityFromContext(ctx)
 	projectID := entityCtx.Project.ID
 
-	// check if user is authorized
-	if err := AuthorizedOnProject(ctx, projectID); err != nil {
-		return nil, err
-	}
-
 	provider, err := getProviderFromRequestOrDefault(ctx, s.store, in, projectID)
 	if err != nil {
 		return nil, providerError(err)
@@ -249,11 +239,6 @@ func (s *Server) GetRepositoryById(ctx context.Context,
 		return nil, status.Errorf(codes.Internal, "cannot read repository: %v", err)
 	}
 
-	// check if user is authorized
-	if err := AuthorizedOnProject(ctx, repo.ProjectID); err != nil {
-		return nil, err
-	}
-
 	projID := repo.ProjectID.String()
 	r := util.PBRepositoryFromDB(repo)
 	r.Context = &pb.Context{
@@ -284,11 +269,6 @@ func (s *Server) GetRepositoryByName(ctx context.Context,
 	entityCtx := engine.EntityFromContext(ctx)
 	projectID := entityCtx.Project.ID
 
-	// check if user is authorized
-	if err := AuthorizedOnProject(ctx, projectID); err != nil {
-		return nil, err
-	}
-
 	provider, err := getProviderFromRequestOrDefault(ctx, s.store, in, projectID)
 	if err != nil {
 		return nil, providerError(err)
@@ -300,10 +280,6 @@ func (s *Server) GetRepositoryByName(ctx context.Context,
 	if errors.Is(err, sql.ErrNoRows) {
 		return nil, status.Errorf(codes.NotFound, "repository not found")
 	} else if err != nil {
-		return nil, err
-	}
-	// check if user is authorized
-	if err := AuthorizedOnProject(ctx, repo.ProjectID); err != nil {
 		return nil, err
 	}
 
@@ -338,11 +314,6 @@ func (s *Server) DeleteRepositoryById(ctx context.Context,
 		return nil, status.Errorf(codes.Internal, "cannot read repository: %v", err)
 	}
 
-	// check if user is authorized
-	if err := AuthorizedOnProject(ctx, repo.ProjectID); err != nil {
-		return nil, err
-	}
-
 	provider, err := getProviderFromRequestOrDefault(ctx, s.store, in, repo.ProjectID)
 	if err != nil {
 		return nil, providerError(err)
@@ -375,10 +346,6 @@ func (s *Server) DeleteRepositoryByName(ctx context.Context,
 
 	entityCtx := engine.EntityFromContext(ctx)
 	projectID := entityCtx.Project.ID
-	// check if user is authorized
-	if err := AuthorizedOnProject(ctx, projectID); err != nil {
-		return nil, err
-	}
 
 	provider, err := getProviderFromRequestOrDefault(ctx, s.store, in, projectID)
 	if err != nil {
@@ -393,11 +360,6 @@ func (s *Server) DeleteRepositoryByName(ctx context.Context,
 	} else if err != nil {
 		return nil, err
 	}
-	// check if user is authorized
-	if err := AuthorizedOnProject(ctx, repo.ProjectID); err != nil {
-		return nil, err
-	}
-
 	err = s.deleteRepositoryAndWebhook(ctx, repo, projectID, provider)
 	if err != nil {
 		return nil, err
@@ -422,11 +384,6 @@ func (s *Server) ListRemoteRepositoriesFromProvider(
 	entityCtx := engine.EntityFromContext(ctx)
 	projectID := entityCtx.Project.ID
 
-	// check if user is authorized
-	if err := AuthorizedOnProject(ctx, projectID); err != nil {
-		return nil, err
-	}
-
 	provider, err := getProviderFromRequestOrDefault(ctx, s.store, in, projectID)
 	if err != nil {
 		return nil, providerError(err)
@@ -438,7 +395,7 @@ func (s *Server) ListRemoteRepositoriesFromProvider(
 		Msg("listing repositories")
 
 	// FIXME: this is a hack to get the owner filter from the request
-	_, owner_filter, err := s.getProviderAccessToken(ctx, provider.Name, projectID, true)
+	_, owner_filter, err := s.getProviderAccessToken(ctx, provider.Name, projectID)
 
 	if err != nil {
 		return nil, util.UserVisibleError(codes.PermissionDenied,

--- a/internal/controlplane/handlers_ruletype.go
+++ b/internal/controlplane/handlers_ruletype.go
@@ -45,11 +45,6 @@ func (s *Server) ListRuleTypes(
 		return nil, status.Errorf(codes.InvalidArgument, "error in entity context: %v", err)
 	}
 
-	// check if user is authorized
-	if err := AuthorizedOnProject(ctx, entityCtx.Project.ID); err != nil {
-		return nil, err
-	}
-
 	lrt, err := s.store.ListRuleTypesByProviderAndProject(ctx, db.ListRuleTypesByProviderAndProjectParams{
 		Provider:  entityCtx.Provider.Name,
 		ProjectID: entityCtx.Project.ID,
@@ -89,11 +84,6 @@ func (s *Server) GetRuleTypeByName(
 		return nil, status.Errorf(codes.InvalidArgument, "error in entity context: %v", err)
 	}
 
-	// check if user is authorized
-	if err := AuthorizedOnProject(ctx, entityCtx.Project.ID); err != nil {
-		return nil, err
-	}
-
 	resp := &minderv1.GetRuleTypeByNameResponse{}
 
 	rtdb, err := s.store.GetRuleTypeByName(ctx, db.GetRuleTypeByNameParams{
@@ -130,11 +120,6 @@ func (s *Server) GetRuleTypeById(
 	err := entityCtx.Validate(ctx, s.store)
 	if err != nil {
 		return nil, status.Errorf(codes.InvalidArgument, "error in entity context: %v", err)
-	}
-
-	// check if user is authorized
-	if err := AuthorizedOnProject(ctx, entityCtx.Project.ID); err != nil {
-		return nil, err
 	}
 
 	resp := &minderv1.GetRuleTypeByIdResponse{}
@@ -176,11 +161,6 @@ func (s *Server) CreateRuleType(
 	err := entityCtx.Validate(ctx, s.store)
 	if err != nil {
 		return nil, status.Errorf(codes.InvalidArgument, "error in entity context: %v", err)
-	}
-
-	// check if user is authorized
-	if err := AuthorizedOnProject(ctx, entityCtx.Project.ID); err != nil {
-		return nil, err
 	}
 
 	_, err = s.store.GetRuleTypeByName(ctx, db.GetRuleTypeByNameParams{
@@ -247,11 +227,6 @@ func (s *Server) UpdateRuleType(
 	err := entityCtx.Validate(ctx, s.store)
 	if err != nil {
 		return nil, status.Errorf(codes.InvalidArgument, "error in entity context: %v", err)
-	}
-
-	// check if user is authorized
-	if err := AuthorizedOnProject(ctx, entityCtx.Project.ID); err != nil {
-		return nil, err
 	}
 
 	rtdb, err := s.store.GetRuleTypeByName(ctx, db.GetRuleTypeByNameParams{
@@ -361,11 +336,6 @@ func (s *Server) DeleteRuleType(
 	err = entityCtx.Validate(ctx, s.store)
 	if err != nil {
 		return nil, status.Errorf(codes.InvalidArgument, "error in entity context: %v", err)
-	}
-
-	// check if user is authorized
-	if err := AuthorizedOnProject(ctx, entityCtx.Project.ID); err != nil {
-		return nil, err
 	}
 
 	profileInfo, err := s.store.ListProfilesInstantiatingRuleType(ctx, rtdb.ID)

--- a/internal/controlplane/server.go
+++ b/internal/controlplane/server.go
@@ -213,8 +213,9 @@ func (s *Server) StartGRPCServer(ctx context.Context) error {
 		util.SanitizingInterceptor(),
 		logger.Interceptor(s.cfg.LoggingConfig),
 		TokenValidationInterceptor,
-		AuthorizationUnaryInterceptor,
+		PermissionsContextUnaryInterceptor,
 		EntityContextProjectInterceptor,
+		ProjectAuthorizationInterceptor,
 	}
 
 	options := []grpc.ServerOption{


### PR DESCRIPTION
Fix #2167

Perform project based authorization by default, unless it is explicitly specified that the endpoint allows anonymous users, or a different type of non-project based authorization is specified. 

Also rename `AuthorizationUnaryInterceptor` to `PermissionsContextUnaryInterceptor`, which is more descriptive of the current functionality. This interceptor can be removed once we move to OpenFGA.