### PR TITLE
Update: telemetry field to be string

### DIFF
--- a/internal/logger/telemetry_store.go
+++ b/internal/logger/telemetry_store.go
@@ -197,7 +197,7 @@ func (ts *TelemetryStore) Record(e *zerolog.Event) *zerolog.Event {
 	if len(ts.Evals) > 0 {
 		e.Any("rules", ts.Evals)
 	}
-	e.Bool("telemetry", true)
+	e.Str("telemetry", "true")
 	// Note: we explicitly don't call e.Send() here so that Send() occurs in the
 	// same scope as the event is created.
 	return e

--- a/internal/logger/telemetry_store_test.go
+++ b/internal/logger/telemetry_store_test.go
@@ -138,7 +138,7 @@ func TestTelemetryStore_Record(t *testing.T) {
 		},
 		recordFunc: func(_ context.Context, _ engif.ActionsParams) {
 		},
-		expected:   `{"telemetry": true}`,
+		expected:   `{"telemetry": "true"}`,
 		notPresent: []string{"project", "rules", "login_sha", "repository", "provider", "profile", "ruletype", "artifact", "pr"},
 	}}
 

--- a/internal/logger/telemetry_store_watermill_test.go
+++ b/internal/logger/telemetry_store_watermill_test.go
@@ -90,5 +90,5 @@ func TestTelemetryStoreWMMiddlewareLogsRepositoryInfo(t *testing.T) {
 	require.Equal(t, projectID.String(), logged["project"], "expected project ID to be logged")
 	require.Equal(t, providerName, logged["provider"], "expected provider to be logged")
 	require.Equal(t, repositoryID.String(), logged["repository"], "expected repository ID to be logged")
-	require.Equal(t, true, logged["telemetry"], "expected telemetry to be logged")
+	require.Equal(t, "true", logged["telemetry"], "expected telemetry to be logged")
 }


### PR DESCRIPTION
"telemetry: 1" 
This discrepancy is likely due to how the log data is being serialised or interpreted between Fluent Bit and the Output targets. This "might" be the reason we are not seeing logs exported to S3 since we have a 
`$telemetry ^(true)$` condition.

![image](https://github.com/stacklok/minder/assets/43523832/12f04078-e204-4f5e-a3cd-61e1f707962b)
