### PR TITLE
rego: Return `true` for `file.exists` for directories too

### DIFF
--- a/internal/engine/eval/rego/lib.go
+++ b/internal/engine/eval/rego/lib.go
@@ -77,16 +77,12 @@ func FileExists(res *engif.Result) func(*rego.Rego) {
 			fs := res.Fs
 
 			cpath := filepath.Clean(path)
-			finfo, err := fs.Stat(cpath)
+			_, err := fs.Stat(cpath)
 			if err != nil {
 				if errors.Is(err, os.ErrNotExist) {
 					return ast.BooleanTerm(false), nil
 				}
 				return nil, err
-			}
-
-			if finfo.IsDir() {
-				return ast.BooleanTerm(false), nil
 			}
 
 			return ast.BooleanTerm(true), nil


### PR DESCRIPTION
I'm not sure why we made it to return `true` only for non-directory
files. But I think it makes sense to have it be `true` for directories
as well.
