### PR TITLE
Support GitHub attestation endpoint

### DIFF
--- a/cmd/dev/app/container/cmd_verify.go
+++ b/cmd/dev/app/container/cmd_verify.go
@@ -25,9 +25,10 @@ import (
 	"github.com/spf13/viper"
 
 	"github.com/stacklok/minder/internal/verifier"
+	"github.com/stacklok/minder/internal/verifier/sigstore/container"
 )
 
-// CmdVerify returns the verify container command
+// CmdVerify is the root command for the container verify subcommands
 func CmdVerify() *cobra.Command {
 	var verifyCmd = &cobra.Command{
 		Use:          "verify",
@@ -67,7 +68,7 @@ func runCmdVerify(cmd *cobra.Command, _ []string) error {
 
 	token := viper.GetString("auth.token")
 
-	artifactVerifier, err := verifier.NewVerifier(verifier.VerifierSigstore, token)
+	artifactVerifier, err := verifier.NewVerifier(verifier.VerifierSigstore, container.WithAccessToken(token))
 	if err != nil {
 		return fmt.Errorf("error getting sigstore verifier: %w", err)
 	}

--- a/go.mod
+++ b/go.mod
@@ -197,7 +197,7 @@ require (
 	github.com/muesli/reflow v0.3.0 // indirect
 	github.com/muesli/termenv v0.15.2 // indirect
 	github.com/oklog/ulid v1.3.1 // indirect
-	github.com/opencontainers/go-digest v1.0.0 // indirect
+	github.com/opencontainers/go-digest v1.0.0
 	github.com/opencontainers/image-spec v1.1.0-rc5 // indirect
 	github.com/opentracing/opentracing-go v1.2.0 // indirect
 	github.com/pelletier/go-toml/v2 v2.1.1 // indirect

--- a/internal/controlplane/handlers_githubwebhooks.go
+++ b/internal/controlplane/handlers_githubwebhooks.go
@@ -746,7 +746,9 @@ func storeSignatureAndWorkflowInVersion(
 	version *pb.ArtifactVersion,
 ) error {
 	// get the verifier for sigstore
-	artifactVerifier, err := verifier.NewVerifier(verifier.VerifierSigstore, container.WithAccessToken(client.GetToken()))
+	artifactVerifier, err := verifier.NewVerifier(
+		verifier.VerifierSigstore,
+		container.WithAccessToken(client.GetToken()), container.WithGitHubClient(client))
 	if err != nil {
 		return fmt.Errorf("error getting sigstore verifier: %w", err)
 	}

--- a/internal/controlplane/handlers_githubwebhooks.go
+++ b/internal/controlplane/handlers_githubwebhooks.go
@@ -48,6 +48,7 @@ import (
 	"github.com/stacklok/minder/internal/reconcilers"
 	"github.com/stacklok/minder/internal/util"
 	"github.com/stacklok/minder/internal/verifier"
+	"github.com/stacklok/minder/internal/verifier/sigstore/container"
 	pb "github.com/stacklok/minder/pkg/api/protobuf/go/minder/v1"
 	provifv1 "github.com/stacklok/minder/pkg/providers/v1"
 )
@@ -745,7 +746,7 @@ func storeSignatureAndWorkflowInVersion(
 	version *pb.ArtifactVersion,
 ) error {
 	// get the verifier for sigstore
-	artifactVerifier, err := verifier.NewVerifier(verifier.VerifierSigstore, client.GetToken())
+	artifactVerifier, err := verifier.NewVerifier(verifier.VerifierSigstore, container.WithAccessToken(client.GetToken()))
 	if err != nil {
 		return fmt.Errorf("error getting sigstore verifier: %w", err)
 	}

--- a/internal/reconcilers/artifacts.go
+++ b/internal/reconcilers/artifacts.go
@@ -36,6 +36,7 @@ import (
 	"github.com/stacklok/minder/internal/providers/github"
 	"github.com/stacklok/minder/internal/util"
 	"github.com/stacklok/minder/internal/verifier"
+	"github.com/stacklok/minder/internal/verifier/sigstore/container"
 	pb "github.com/stacklok/minder/pkg/api/protobuf/go/minder/v1"
 )
 
@@ -153,7 +154,7 @@ func (e *Reconciler) handleArtifactsReconcilerEvent(ctx context.Context, evt *Re
 	}
 
 	// create artifact verifier
-	artifactVerifier, err := verifier.NewVerifier(verifier.VerifierSigstore, cli.GetToken())
+	artifactVerifier, err := verifier.NewVerifier(verifier.VerifierSigstore, container.WithAccessToken(cli.GetToken()))
 	if err != nil {
 		return fmt.Errorf("error getting sigstore verifier: %w", err)
 	}

--- a/internal/reconcilers/artifacts.go
+++ b/internal/reconcilers/artifacts.go
@@ -154,7 +154,9 @@ func (e *Reconciler) handleArtifactsReconcilerEvent(ctx context.Context, evt *Re
 	}
 
 	// create artifact verifier
-	artifactVerifier, err := verifier.NewVerifier(verifier.VerifierSigstore, container.WithAccessToken(cli.GetToken()))
+	artifactVerifier, err := verifier.NewVerifier(
+		verifier.VerifierSigstore,
+		container.WithAccessToken(cli.GetToken()), container.WithGitHubClient(cli))
 	if err != nil {
 		return fmt.Errorf("error getting sigstore verifier: %w", err)
 	}

--- a/internal/verifier/sigstore/sigstore.go
+++ b/internal/verifier/sigstore/sigstore.go
@@ -33,12 +33,12 @@ const (
 
 // Sigstore is the sigstore verifier
 type Sigstore struct {
-	verifier    *verify.SignedEntityVerifier
-	accessToken string
+	verifier *verify.SignedEntityVerifier
+	authOpts []container.AuthMethod
 }
 
 // New creates a new Sigstore verifier
-func New(trustedRoot, accessToken, cacheDir string) (*Sigstore, error) {
+func New(trustedRoot, cacheDir string, authOpts ...container.AuthMethod) (*Sigstore, error) {
 	// init sigstore's verifier
 	trustedrootJSON, err := tuf.GetTrustedrootJSON(trustedRoot, cacheDir)
 	if err != nil {
@@ -55,13 +55,13 @@ func New(trustedRoot, accessToken, cacheDir string) (*Sigstore, error) {
 	}
 	// return the verifier
 	return &Sigstore{
-		verifier:    sev,
-		accessToken: accessToken,
+		verifier: sev,
+		authOpts: authOpts,
 	}, nil
 }
 
 // VerifyContainer verifies a container artifact using sigstore
 func (s *Sigstore) VerifyContainer(ctx context.Context, registry, owner, artifact, version string) (
 	json.RawMessage, json.RawMessage, error) {
-	return container.Verify(ctx, s.verifier, s.accessToken, registry, owner, artifact, version)
+	return container.Verify(ctx, s.verifier, registry, owner, artifact, version, s.authOpts...)
 }

--- a/internal/verifier/verifier.go
+++ b/internal/verifier/verifier.go
@@ -75,7 +75,7 @@ type Verifier struct {
 }
 
 // NewVerifier creates a new Verifier object
-func NewVerifier(verifier Type, accessToken string) (*Verifier, error) {
+func NewVerifier(verifier Type, containerAuth ...container.AuthMethod) (*Verifier, error) {
 	var err error
 	var v ArtifactVerifier
 	// create a temporary directory for storing the sigstore cache
@@ -87,7 +87,7 @@ func NewVerifier(verifier Type, accessToken string) (*Verifier, error) {
 	// create the verifier
 	switch verifier {
 	case VerifierSigstore:
-		v, err = sigstore.New(sigstore.SigstorePublicTrustedRootRepo, accessToken, tmpDir)
+		v, err = sigstore.New(sigstore.SigstorePublicTrustedRootRepo, tmpDir, containerAuth...)
 		if err != nil {
 			return nil, fmt.Errorf("error creating sigstore verifier: %w", err)
 		}


### PR DESCRIPTION
In addition to fetching provenance attestations from an OCI image, let's also
support the GitHub attestation endpoint as a fallback (a fallback since it's
not GA yet).

The attestation reply is unmarshalled into a protobuf representation and
passed to sigstore-go.

Fixes: https://github.com/stacklok/epics/issues/174
