### PR TITLE
Add ability to evaluate scores based on detailed scores for trusty

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -57,6 +57,7 @@ services:
       - MINDER_AUTH_REFRESH_TOKEN_PRIVATE_KEY=/app/.ssh/refresh_token_rsa
       - MINDER_AUTH_REFRESH_TOKEN_PUBLIC_KEY=/app/.ssh/refresh_token_rsa.pub
       - MINDER_AUTH_TOKEN_KEY=/app/.ssh/token_key_passphrase
+      - MINDER_UNSTABLE_TRUSTY_ENDPOINT=https://api.trustypkg.dev
     networks:
       - app_net
     depends_on:

--- a/internal/engine/eval/trusty/config.go
+++ b/internal/engine/eval/trusty/config.go
@@ -27,10 +27,27 @@ import (
 	pb "github.com/stacklok/minder/pkg/api/protobuf/go/minder/v1"
 )
 
+var (
+	// SummaryScore is the score to use for the summary score
+	SummaryScore = "score"
+	// DefaultScore is the default score to use
+	DefaultScore = ""
+)
+
 type ecosystemConfig struct {
 	Name string `json:"name" mapstructure:"name" validate:"required"`
-	//nolint:lll
+
+	// Score is the score to use for the ecosystem. The actual score
+	// evaluated depends on the `evaluate_score` field.
 	Score float64 `json:"score" mapstructure:"score" validate:"required"`
+
+	// EvaluateScore tells the trusty executor which score to use
+	// for evaluation. This is useful when the trusty API returns.
+	// The default is the summary score. If `score` or an empty string, the
+	// summary score is used.
+	// If `evaluate_score` is set to something else (e.g. `provenance`)
+	// then that score is used, which comes from the details field.
+	EvaluateScore string `json:"evaluate_score" mapstructure:"evaluate_score"`
 }
 
 // config is the configuration for the vulncheck evaluator
@@ -72,4 +89,31 @@ func (c *config) getEcosystemConfig(ecosystem pb.DepEcosystem) *ecosystemConfig 
 	}
 
 	return nil
+}
+
+func (ec *ecosystemConfig) getScoreSource() string {
+	if ec.EvaluateScore == DefaultScore || ec.EvaluateScore == SummaryScore {
+		return SummaryScore
+	}
+
+	return ec.EvaluateScore
+}
+
+func (ec *ecosystemConfig) getScore(inSummary ScoreSummary) (float64, error) {
+	if ec.EvaluateScore == DefaultScore || ec.EvaluateScore == SummaryScore {
+		return inSummary.Score, nil
+	}
+
+	// If the score is not the summary score, then it must be in the details
+	rawScore, ok := inSummary.Description[ec.EvaluateScore]
+	if !ok {
+		return 0, fmt.Errorf("score %s not found in details", ec.EvaluateScore)
+	}
+
+	s, ok := rawScore.(float64)
+	if !ok {
+		return 0, fmt.Errorf("score %s is not a float64", ec.EvaluateScore)
+	}
+
+	return s, nil
 }

--- a/internal/engine/eval/trusty/trusty.go
+++ b/internal/engine/eval/trusty/trusty.go
@@ -135,10 +135,16 @@ func (e *Evaluator) Eval(ctx context.Context, pol map[string]any, res *engif.Res
 			continue
 		}
 
-		if resp.Summary.Score >= ecoConfig.Score {
+		s, err := ecoConfig.getScore(resp.Summary)
+		if err != nil {
+			return fmt.Errorf("failed to get score: %w", err)
+		}
+
+		if s >= ecoConfig.Score {
 			logger.Debug().
 				Str("dependency", dep.Dep.Name).
-				Float64("pkgScore", resp.Summary.Score).
+				Str("score-source", ecoConfig.getScoreSource()).
+				Float64("score", s).
 				Float64("threshold", ecoConfig.Score).
 				Msgf("the dependency has higher score than threshold, skipping")
 			continue
@@ -146,7 +152,8 @@ func (e *Evaluator) Eval(ctx context.Context, pol map[string]any, res *engif.Res
 
 		logger.Debug().
 			Str("dependency", dep.Dep.Name).
-			Float64("pkgScore", resp.Summary.Score).
+			Str("score-source", ecoConfig.getScoreSource()).
+			Float64("score", s).
 			Float64("threshold", ecoConfig.Score).
 			Msgf("the dependency has lower score than threshold, tracking")
 

--- a/internal/engine/eval/trusty/trusty_rest_handler.go
+++ b/internal/engine/eval/trusty/trusty_rest_handler.go
@@ -58,13 +58,17 @@ type Alternative struct {
 	Score       float64 `json:"score"`
 }
 
+// ScoreSummary is the summary score returned from the package intelligence API
+type ScoreSummary struct {
+	Score       float64        `json:"score"`
+	Description map[string]any `json:"description"`
+}
+
 // Reply is the response from the package intelligence API
 type Reply struct {
-	PackageName string `json:"package_name"`
-	PackageType string `json:"package_type"`
-	Summary     struct {
-		Score float64 `json:"score"`
-	} `json:"summary"`
+	PackageName  string       `json:"package_name"`
+	PackageType  string       `json:"package_type"`
+	Summary      ScoreSummary `json:"summary"`
 	Alternatives struct {
 		Status   string        `json:"status"`
 		Packages []Alternative `json:"packages"`


### PR DESCRIPTION
This uses the `description` scores in trusty to be able to evluate
scores using the trusty evaluator. This allows for having more detailed
policies such as the following:

```yaml
version: v1
type: profile
name: acme-github-profile
context:
  provider: github
alert: "on"
remediate: "off"
pull_request:
  - type: pr_trusty_check
    def:
      action: summary
      ecosystem_config:
        - name: npm
          score: 8
          evaluate_score: provenance
        - name: pypi
          score: 8
          evaluate_score: provenance
```

That is, we're able to just care about provenance and not just the
trusty summary.
