### PR TITLE
Make authz tuple deletion idempotent

### DIFF
--- a/internal/authz/authz.go
+++ b/internal/authz/authz.go
@@ -255,7 +255,9 @@ func (a *ClientWrapper) Delete(ctx context.Context, user string, role Role, proj
 			Object:   getProjectForTuple(project),
 		},
 	}).Execute()
-	if err != nil {
+	if err != nil && strings.Contains(err.Error(), "cannot delete a tuple which does not exist") {
+		return nil
+	} else if err != nil {
 		return fmt.Errorf("unable to remove authorization tuple: %w", err)
 	}
 


### PR DESCRIPTION
This detect if the error for deleting an object is caused by the tuple
not existing, and if so, it discards the error since that's what we
wanted. Thus making calls to the tuple deletion idempotent.
