### PR TITLE
Allow to configure a custom sigstore tuf root

### DIFF
--- a/cmd/dev/app/container/cmd_verify.go
+++ b/cmd/dev/app/container/cmd_verify.go
@@ -28,6 +28,7 @@ import (
 	"github.com/stacklok/minder/internal/db"
 	"github.com/stacklok/minder/internal/providers"
 	"github.com/stacklok/minder/internal/verifier"
+	"github.com/stacklok/minder/internal/verifier/sigstore"
 	"github.com/stacklok/minder/internal/verifier/sigstore/container"
 	provifv1 "github.com/stacklok/minder/pkg/providers/v1"
 )
@@ -86,6 +87,7 @@ func runCmdVerify(cmd *cobra.Command, _ []string) error {
 
 	artifactVerifier, err := verifier.NewVerifier(
 		verifier.VerifierSigstore,
+		sigstore.SigstorePublicTrustedRootRepo,
 		container.WithAccessToken(token), container.WithGitHubClient(ghcli))
 	if err != nil {
 		return fmt.Errorf("error getting sigstore verifier: %w", err)

--- a/internal/controlplane/handlers_githubwebhooks.go
+++ b/internal/controlplane/handlers_githubwebhooks.go
@@ -48,6 +48,7 @@ import (
 	"github.com/stacklok/minder/internal/reconcilers"
 	"github.com/stacklok/minder/internal/util"
 	"github.com/stacklok/minder/internal/verifier"
+	"github.com/stacklok/minder/internal/verifier/sigstore"
 	"github.com/stacklok/minder/internal/verifier/sigstore/container"
 	pb "github.com/stacklok/minder/pkg/api/protobuf/go/minder/v1"
 	provifv1 "github.com/stacklok/minder/pkg/providers/v1"
@@ -748,6 +749,7 @@ func storeSignatureAndWorkflowInVersion(
 	// get the verifier for sigstore
 	artifactVerifier, err := verifier.NewVerifier(
 		verifier.VerifierSigstore,
+		sigstore.SigstorePublicTrustedRootRepo,
 		container.WithAccessToken(client.GetToken()), container.WithGitHubClient(client))
 	if err != nil {
 		return fmt.Errorf("error getting sigstore verifier: %w", err)

--- a/internal/engine/ingester/artifact/config.go
+++ b/internal/engine/ingester/artifact/config.go
@@ -42,6 +42,7 @@ func newArtifactIngestType(s string) artifactType {
 type ingesterConfig struct {
 	Name     string       `yaml:"name" json:"name" mapstructure:"name"`
 	Tags     []string     `yaml:"tags" json:"tags" mapstructure:"tags"`
+	Sigstore string       `yaml:"sigstore" json:"sigstore" mapstructure:"sigstore"`
 	TagRegex string       `yaml:"tag_regex" json:"tag_regex" mapstructure:"tag_regex"`
 	Type     artifactType `yaml:"type" json:"type" mapstructure:"type"`
 }

--- a/internal/reconcilers/artifacts.go
+++ b/internal/reconcilers/artifacts.go
@@ -36,6 +36,7 @@ import (
 	"github.com/stacklok/minder/internal/providers/github"
 	"github.com/stacklok/minder/internal/util"
 	"github.com/stacklok/minder/internal/verifier"
+	"github.com/stacklok/minder/internal/verifier/sigstore"
 	"github.com/stacklok/minder/internal/verifier/sigstore/container"
 	pb "github.com/stacklok/minder/pkg/api/protobuf/go/minder/v1"
 )
@@ -156,6 +157,7 @@ func (e *Reconciler) handleArtifactsReconcilerEvent(ctx context.Context, evt *Re
 	// create artifact verifier
 	artifactVerifier, err := verifier.NewVerifier(
 		verifier.VerifierSigstore,
+		sigstore.SigstorePublicTrustedRootRepo,
 		container.WithAccessToken(cli.GetToken()), container.WithGitHubClient(cli))
 	if err != nil {
 		return fmt.Errorf("error getting sigstore verifier: %w", err)

--- a/internal/verifier/verifier.go
+++ b/internal/verifier/verifier.go
@@ -75,7 +75,7 @@ type Verifier struct {
 }
 
 // NewVerifier creates a new Verifier object
-func NewVerifier(verifier Type, containerAuth ...container.AuthMethod) (*Verifier, error) {
+func NewVerifier(verifier Type, verifierURL string, containerAuth ...container.AuthMethod) (*Verifier, error) {
 	var err error
 	var v ArtifactVerifier
 	// create a temporary directory for storing the sigstore cache
@@ -83,11 +83,13 @@ func NewVerifier(verifier Type, containerAuth ...container.AuthMethod) (*Verifie
 	if err != nil {
 		return nil, fmt.Errorf("failed to create temporary sigstore cache directory: %w", err)
 	}
-
+	if verifierURL == "" {
+		verifierURL = sigstore.SigstorePublicTrustedRootRepo
+	}
 	// create the verifier
 	switch verifier {
 	case VerifierSigstore:
-		v, err = sigstore.New(sigstore.SigstorePublicTrustedRootRepo, tmpDir, containerAuth...)
+		v, err = sigstore.New(verifierURL, tmpDir, containerAuth...)
 		if err != nil {
 			return nil, fmt.Errorf("error creating sigstore verifier: %w", err)
 		}


### PR DESCRIPTION
The following PR allows for configuring a custom sigstore root. Currently defaults to the PGI.

Motivated by https://github.com/stacklok/epics/issues/182