### PR TITLE
Solidify authz Client interface

### DIFF
--- a/cmd/server/app/serve.go
+++ b/cmd/server/app/serve.go
@@ -105,7 +105,7 @@ var serveCmd = &cobra.Command{
 			return fmt.Errorf("failed to fetch and cache identity provider JWKS: %w\n", err)
 		}
 
-		authzc, err := authz.NewAuthzClient(&cfg.Authz)
+		authzc, err := authz.NewAuthzClient(&cfg.Authz, l)
 		if err != nil {
 			return fmt.Errorf("unable to create authz client: %w", err)
 		}

--- a/internal/authz/interface.go
+++ b/internal/authz/interface.go
@@ -62,4 +62,11 @@ type Client interface {
 	// NOTE: this method _DOES NOT CHECK_ that the current user in the context
 	// has permissions to update the project.
 	Delete(ctx context.Context, user string, role Role, project uuid.UUID) error
+
+	// PrepareForRun allows for any preflight configurations to be done before
+	// the server is started.
+	PrepareForRun(ctx context.Context) error
+
+	// MigrateUp runs the authz migrations
+	MigrateUp(ctx context.Context) error
 }

--- a/internal/authz/mock/noop_authz.go
+++ b/internal/authz/mock/noop_authz.go
@@ -52,3 +52,13 @@ func (_ *NoopClient) Write(_ context.Context, _ string, _ authz.Role, _ uuid.UUI
 func (_ *NoopClient) Delete(_ context.Context, _ string, _ authz.Role, _ uuid.UUID) error {
 	return nil
 }
+
+// PrepareForRun implements authz.Client
+func (_ *NoopClient) PrepareForRun(_ context.Context) error {
+	return nil
+}
+
+// MigrateUp implements authz.Client
+func (_ *NoopClient) MigrateUp(_ context.Context) error {
+	return nil
+}

--- a/internal/authz/mock/simple_authz.go
+++ b/internal/authz/mock/simple_authz.go
@@ -55,3 +55,13 @@ func (n *SimpleClient) Delete(_ context.Context, _ string, _ authz.Role, project
 	}
 	return nil
 }
+
+// PrepareForRun implements authz.Client
+func (_ *SimpleClient) PrepareForRun(_ context.Context) error {
+	return nil
+}
+
+// MigrateUp implements authz.Client
+func (_ *SimpleClient) MigrateUp(_ context.Context) error {
+	return nil
+}


### PR DESCRIPTION
This removes the OpenFGA-specific logic from the migration script and
relies instead on a more general interface. This also makes the authz
constructor to return that interface to make this happen. The functions
that no longer need exporting are now private, and unused functions are
removed.
