### PR TITLE
Fully rely on OpenFGA to delete user permissions

### DIFF
--- a/internal/authz/interface.go
+++ b/internal/authz/interface.go
@@ -40,6 +40,15 @@ const (
 	AuthzRolePolicyWriter Role = "policy_writer"
 )
 
+var (
+	allRoles = []Role{
+		AuthzRoleAdmin,
+		AuthzRoleEditor,
+		AuthzRoleViewer,
+		AuthzRolePolicyWriter,
+	}
+)
+
 func (r Role) String() string {
 	return string(r)
 }
@@ -62,6 +71,9 @@ type Client interface {
 	// NOTE: this method _DOES NOT CHECK_ that the current user in the context
 	// has permissions to update the project.
 	Delete(ctx context.Context, user string, role Role, project uuid.UUID) error
+
+	// DeleteUser removes all authorizations for the given user.
+	DeleteUser(ctx context.Context, user string) error
 
 	// PrepareForRun allows for any preflight configurations to be done before
 	// the server is started.

--- a/internal/authz/mock/noop_authz.go
+++ b/internal/authz/mock/noop_authz.go
@@ -53,6 +53,11 @@ func (_ *NoopClient) Delete(_ context.Context, _ string, _ authz.Role, _ uuid.UU
 	return nil
 }
 
+// DeleteUser implements authz.Client
+func (_ *NoopClient) DeleteUser(_ context.Context, _ string) error {
+	return nil
+}
+
 // PrepareForRun implements authz.Client
 func (_ *NoopClient) PrepareForRun(_ context.Context) error {
 	return nil

--- a/internal/authz/mock/simple_authz.go
+++ b/internal/authz/mock/simple_authz.go
@@ -56,6 +56,11 @@ func (n *SimpleClient) Delete(_ context.Context, _ string, _ authz.Role, project
 	return nil
 }
 
+// DeleteUser implements authz.Client
+func (_ *SimpleClient) DeleteUser(_ context.Context, _ string) error {
+	return nil
+}
+
 // PrepareForRun implements authz.Client
 func (_ *SimpleClient) PrepareForRun(_ context.Context) error {
 	return nil

--- a/internal/controlplane/handlers_user_test.go
+++ b/internal/controlplane/handlers_user_test.go
@@ -341,8 +341,6 @@ func TestDeleteUserDBMock(t *testing.T) {
 	mockStore.EXPECT().
 		DeleteOrganization(gomock.Any(), orgID).
 		Return(nil)
-	mockStore.EXPECT().GetUserProjects(gomock.Any(), gomock.Any()).
-		Return([]db.GetUserProjectsRow{}, nil)
 	mockStore.EXPECT().Commit(gomock.Any())
 	mockStore.EXPECT().Rollback(gomock.Any())
 
@@ -398,8 +396,6 @@ func TestDeleteUser_gRPC(t *testing.T) {
 					Return(db.User{
 						OrganizationID: orgID,
 					}, nil)
-				store.EXPECT().GetUserProjects(gomock.Any(), gomock.Any()).
-					Return([]db.GetUserProjectsRow{}, nil)
 				store.EXPECT().
 					DeleteOrganization(gomock.Any(), orgID).
 					Return(nil)

--- a/internal/controlplane/identity_events.go
+++ b/internal/controlplane/identity_events.go
@@ -157,15 +157,8 @@ func DeleteUser(ctx context.Context, store db.Store, authzClient authz.Client, u
 		return fmt.Errorf("error retrieving user %v", err)
 	}
 
-	projs, err := store.GetUserProjects(ctx, user.ID)
-	if err != nil {
-		return fmt.Errorf("error retrieving user projects %v", err)
-	}
-
-	for _, proj := range projs {
-		if err := authzClient.Delete(ctx, userId, authz.AuthzRoleAdmin, proj.ID); err != nil {
-			return fmt.Errorf("error deleting authorization tuple %v", err)
-		}
+	if err := authzClient.DeleteUser(ctx, userId); err != nil {
+		return fmt.Errorf("error deleting authorization tuple %v", err)
 	}
 
 	err = qtx.DeleteOrganization(ctx, user.OrganizationID)

--- a/internal/controlplane/identity_events_test.go
+++ b/internal/controlplane/identity_events_test.go
@@ -73,8 +73,6 @@ func TestHandleEvents(t *testing.T) {
 	mockStore.EXPECT().
 		GetUserBySubject(gomock.Any(), "alreadyDeletedUserId").
 		Return(db.User{}, sql.ErrNoRows)
-	mockStore.EXPECT().GetUserProjects(gomock.Any(), gomock.Any()).
-		Return([]db.GetUserProjectsRow{}, nil)
 	mockStore.EXPECT().Rollback(gomock.Any())
 
 	c := serverconfig.Config{


### PR DESCRIPTION
This removes the minder check for projects while deleting a user to
instead fully rely on OpenFGA's relationships to make the deletion.
