### PR TITLE
Print user subject on `auth` subcommands

### DIFF
--- a/cmd/cli/app/auth/common.go
+++ b/cmd/cli/app/auth/common.go
@@ -41,6 +41,7 @@ func userRegistered(ctx context.Context, client minderv1.UserServiceClient) (boo
 
 func renderNewUser(conn string, newUser *minderv1.CreateUserResponse) {
 	t := table.New(table.Simple, layouts.KeyValue, nil)
+	t.AddRow("Subject", newUser.GetIdentitySubject())
 	t.AddRow("Project ID", newUser.ProjectId)
 	t.AddRow("Project Name", newUser.ProjectName)
 	t.AddRow("Minder Server", conn)
@@ -50,6 +51,7 @@ func renderNewUser(conn string, newUser *minderv1.CreateUserResponse) {
 func renderUserInfo(conn string, user *minderv1.GetUserResponse) {
 	t := table.New(table.Simple, layouts.KeyValue, nil)
 	t.AddRow("Minder Server", conn)
+	t.AddRow("Subject", user.GetUser().GetIdentitySubject())
 	for _, project := range getProjectTableRows(user.Projects) {
 		t.AddRow(project...)
 	}


### PR DESCRIPTION
This prints the user subject on user creation, login and when doing
`whoami`. This will be helpful for setting up roles once the permissions
API is ready.
