### PR TITLE
Move user id telemetry to token interceptor

### DIFF
--- a/internal/controlplane/handlers_authz.go
+++ b/internal/controlplane/handlers_authz.go
@@ -16,9 +16,7 @@ package controlplane
 
 import (
 	"context"
-	"crypto/sha256"
 	"database/sql"
-	"encoding/hex"
 	"errors"
 	"fmt"
 
@@ -33,7 +31,6 @@ import (
 	"github.com/stacklok/minder/internal/authz"
 	"github.com/stacklok/minder/internal/db"
 	"github.com/stacklok/minder/internal/engine"
-	"github.com/stacklok/minder/internal/logger"
 	"github.com/stacklok/minder/internal/util"
 	minder "github.com/stacklok/minder/pkg/api/protobuf/go/minder/v1"
 )
@@ -51,10 +48,6 @@ func lookupUserPermissions(ctx context.Context, store db.Store) auth.UserPermiss
 	emptyPermissions := auth.UserPermissions{}
 
 	subject := auth.GetUserSubjectFromContext(ctx)
-
-	// Attach the login sha for telemetry usage (hash of the user subject from the JWT)
-	loginSHA := sha256.Sum256([]byte(subject))
-	logger.BusinessRecord(ctx).LoginHash = hex.EncodeToString(loginSHA[:])
 
 	// read all information for user claims
 	userInfo, err := store.GetUserBySubject(ctx, subject)


### PR DESCRIPTION
The token interceptor seemed like a better place for adding the user subject to the business telemetry.