### PR TITLE
Fix CLI error output for `role grant list`

### DIFF
--- a/cmd/cli/app/project/role/role_grant_list.go
+++ b/cmd/cli/app/project/role/role_grant_list.go
@@ -61,7 +61,7 @@ func GrantListCommand(ctx context.Context, cmd *cobra.Command, conn *grpc.Client
 		},
 	})
 	if err != nil {
-		return cli.MessageAndError("Error granting role", err)
+		return cli.MessageAndError("Error listing role grants", err)
 	}
 
 	switch format {


### PR DESCRIPTION
I had left there the error that comes out of `role grant` which is not
what we want to show to users for this scenario.
