### PR TITLE
Change the database migration CI workflow to check for the expected DB version instead

### DIFF
--- a/.github/workflows/compose-migrate.yml
+++ b/.github/workflows/compose-migrate.yml
@@ -34,5 +34,9 @@ jobs:
               docker logs minder_migrate_up
               exit 1
           fi
-      - name: Check that the database contains the tables found in the migrations folder
-        run: "set -e\n\ntables=$(grep -Ri 'CREATE TABLE' database/migrations | sed -E 's/.*CREATE TABLE (IF NOT EXISTS )?(.*) \\(/\\2/i')\nfor table in $tables; do\n  docker exec $(docker ps -a | grep postgres | awk '{print $1}') psql -U postgres -d minder -c \"SELECT * FROM $table\"\ndone \n"
+      - name: Check that the database has the expected version
+        run: |
+          set -e
+
+          highest_prefix=$(ls database/migrations | grep -o '^[0-9]\+' | sort -n | tail -1 | sed 's/^0*//')
+          docker logs minder_migrate_up | grep "Version=${highest_prefix} dirty=false"

--- a/cmd/server/app/migrate_up.go
+++ b/cmd/server/app/migrate_up.go
@@ -103,6 +103,14 @@ var upCmd = &cobra.Command{
 
 		cmd.Println("Database migration completed successfully")
 
+		version, dirty, err := m.Version()
+		if err != nil {
+			cmd.Printf("Error while getting migration version: %v\n", err)
+			// not fatal
+		} else {
+			cmd.Printf("Version=%v dirty=%v\n", version, dirty)
+		}
+
 		cmd.Println("Ensuring authorization store...")
 		l := zerolog.Ctx(ctx)
 


### PR DESCRIPTION
Instead of checking for the expected tables which might come and go,
make sure that the version corresponds to the highest version in the
database migration files.
