### PR TITLE
Handle rate limiting errors for GitHub API

### DIFF
--- a/cmd/dev/app/container/cmd_verify.go
+++ b/cmd/dev/app/container/cmd_verify.go
@@ -83,7 +83,7 @@ func runCmdVerify(cmd *cobra.Command, _ []string) error {
 
 	token := viper.GetString("auth.token")
 
-	ghcli, err := buildGitHubClient(context.Background(), token)
+	ghcli, err := buildGitHubClient(token)
 	if err != nil {
 		return fmt.Errorf("cannot build github client: %w", err)
 	}
@@ -107,7 +107,7 @@ func runCmdVerify(cmd *cobra.Command, _ []string) error {
 	return nil
 }
 
-func buildGitHubClient(ctx context.Context, token string) (provifv1.GitHub, error) {
+func buildGitHubClient(token string) (provifv1.GitHub, error) {
 	pbuild := providers.NewProviderBuilder(
 		&db.Provider{
 			Name:    "test",
@@ -126,5 +126,5 @@ func buildGitHubClient(ctx context.Context, token string) (provifv1.GitHub, erro
 		token,
 	)
 
-	return pbuild.GetGitHub(ctx)
+	return pbuild.GetGitHub()
 }

--- a/internal/controlplane/handlers_githubwebhooks.go
+++ b/internal/controlplane/handlers_githubwebhooks.go
@@ -226,7 +226,7 @@ func (s *Server) registerWebhookForRepository(
 		return nil, fmt.Errorf("provider %s is not supported for github webhook", pbuild.GetName())
 	}
 
-	client, err := pbuild.GetGitHub(ctx)
+	client, err := pbuild.GetGitHub()
 	if err != nil {
 		return nil, fmt.Errorf("error creating github provider: %w", err)
 	}
@@ -349,13 +349,14 @@ func (s *Server) deleteWebhookFromRepository(
 ) error {
 	pbOpts := []providers.ProviderBuilderOption{
 		providers.WithProviderMetrics(s.provMt),
+		providers.WithRestClientCache(s.restClientCache),
 	}
 	providerBuilder, err := providers.GetProviderBuilder(ctx, provider, projectID, s.store, s.cryptoEngine, pbOpts...)
 	if err != nil {
 		return status.Errorf(codes.Internal, "cannot get provider builder: %v", err)
 	}
 
-	client, err := providerBuilder.GetGitHub(ctx)
+	client, err := providerBuilder.GetGitHub()
 	if err != nil {
 		return status.Errorf(codes.Internal, "cannot create github client: %v", err)
 	}
@@ -408,6 +409,7 @@ func (s *Server) parseGithubEventForProcessing(
 
 	pbOpts := []providers.ProviderBuilderOption{
 		providers.WithProviderMetrics(s.provMt),
+		providers.WithRestClientCache(s.restClientCache),
 	}
 	provBuilder, err := providers.GetProviderBuilder(ctx, prov, dbRepo.ProjectID, s.store, s.cryptoEngine, pbOpts...)
 	if err != nil {
@@ -471,7 +473,7 @@ func (s *Server) parseArtifactPublishedEvent(
 		return nil
 	}
 
-	cli, err := prov.GetGitHub(ctx)
+	cli, err := prov.GetGitHub()
 	if err != nil {
 		log.Printf("error creating github provider: %v", err)
 		return err
@@ -523,7 +525,7 @@ func parsePullRequestModEvent(
 		return nil
 	}
 
-	cli, err := prov.GetGitHub(ctx)
+	cli, err := prov.GetGitHub()
 	if err != nil {
 		log.Printf("error creating github provider: %v", err)
 		return nil

--- a/internal/controlplane/handlers_repositories.go
+++ b/internal/controlplane/handlers_repositories.go
@@ -55,6 +55,7 @@ func (s *Server) RegisterRepository(ctx context.Context,
 
 	pbOpts := []providers.ProviderBuilderOption{
 		providers.WithProviderMetrics(s.provMt),
+		providers.WithRestClientCache(s.restClientCache),
 	}
 	p, err := providers.GetProviderBuilder(ctx, provider, projectID, s.store, s.cryptoEngine, pbOpts...)
 	if err != nil {
@@ -404,6 +405,7 @@ func (s *Server) ListRemoteRepositoriesFromProvider(
 
 	pbOpts := []providers.ProviderBuilderOption{
 		providers.WithProviderMetrics(s.provMt),
+		providers.WithRestClientCache(s.restClientCache),
 	}
 	p, err := providers.GetProviderBuilder(ctx, provider, projectID, s.store, s.cryptoEngine, pbOpts...)
 	if err != nil {
@@ -414,7 +416,7 @@ func (s *Server) ListRemoteRepositoriesFromProvider(
 		return nil, util.UserVisibleError(codes.Unimplemented, "provider does not implement repository listing")
 	}
 
-	client, err := p.GetRepoLister(ctx)
+	client, err := p.GetRepoLister()
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "cannot create github client: %v", err)
 	}

--- a/internal/controlplane/server.go
+++ b/internal/controlplane/server.go
@@ -53,6 +53,7 @@ import (
 	"github.com/stacklok/minder/internal/db"
 	"github.com/stacklok/minder/internal/events"
 	"github.com/stacklok/minder/internal/logger"
+	"github.com/stacklok/minder/internal/providers/ratecache"
 	provtelemetry "github.com/stacklok/minder/internal/providers/telemetry"
 	"github.com/stacklok/minder/internal/util"
 	pb "github.com/stacklok/minder/pkg/api/protobuf/go/minder/v1"
@@ -66,18 +67,19 @@ var (
 
 // Server represents the controlplane server
 type Server struct {
-	store        db.Store
-	cfg          *serverconfig.Config
-	evt          *events.Eventer
-	mt           *metrics
-	provMt       provtelemetry.ProviderMetrics
-	grpcServer   *grpc.Server
-	vldtr        auth.JwtValidator
-	OAuth2       *oauth2.Config
-	ClientID     string
-	ClientSecret string
-	authzClient  authz.Client
-	cryptoEngine *crypto.Engine
+	store           db.Store
+	cfg             *serverconfig.Config
+	evt             *events.Eventer
+	mt              *metrics
+	provMt          provtelemetry.ProviderMetrics
+	grpcServer      *grpc.Server
+	vldtr           auth.JwtValidator
+	OAuth2          *oauth2.Config
+	ClientID        string
+	ClientSecret    string
+	authzClient     authz.Client
+	cryptoEngine    *crypto.Engine
+	restClientCache ratecache.RestClientCache
 
 	// Implementations for service registration
 	pb.UnimplementedHealthServiceServer
@@ -104,6 +106,13 @@ func WithProviderMetrics(mt provtelemetry.ProviderMetrics) ServerOption {
 func WithAuthzClient(c authz.Client) ServerOption {
 	return func(s *Server) {
 		s.authzClient = c
+	}
+}
+
+// WithRestClientCache sets the rest client cache for the server
+func WithRestClientCache(c ratecache.RestClientCache) ServerOption {
+	return func(s *Server) {
+		s.restClientCache = c
 	}
 }
 

--- a/internal/engine/actions/alert/security_advisory/security_advisory.go
+++ b/internal/engine/actions/alert/security_advisory/security_advisory.go
@@ -152,7 +152,7 @@ func NewSecurityAdvisoryAlert(
 		return nil, fmt.Errorf("cannot parse description template: %w", err)
 	}
 	// Get the GitHub client
-	cli, err := pbuild.GetGitHub(context.Background())
+	cli, err := pbuild.GetGitHub()
 	if err != nil {
 		return nil, fmt.Errorf("cannot get http client: %w", err)
 	}

--- a/internal/engine/actions/remediate/gh_branch_protect/gh_branch_protect.go
+++ b/internal/engine/actions/remediate/gh_branch_protect/gh_branch_protect.go
@@ -64,7 +64,7 @@ func NewGhBranchProtectRemediator(
 		return nil, fmt.Errorf("cannot parse patch template: %w", err)
 	}
 
-	cli, err := pbuild.GetGitHub(context.Background())
+	cli, err := pbuild.GetGitHub()
 	if err != nil {
 		return nil, fmt.Errorf("cannot get http client: %w", err)
 	}

--- a/internal/engine/actions/remediate/pull_request/pull_request.go
+++ b/internal/engine/actions/remediate/pull_request/pull_request.go
@@ -99,7 +99,7 @@ func NewPullRequestRemediate(
 		return nil, fmt.Errorf("cannot parse body template: %w", err)
 	}
 
-	ghCli, err := pbuild.GetGitHub(context.Background())
+	ghCli, err := pbuild.GetGitHub()
 	if err != nil {
 		return nil, fmt.Errorf("failed to get github client: %w", err)
 	}

--- a/internal/engine/actions/remediate/rest/rest.go
+++ b/internal/engine/actions/remediate/rest/rest.go
@@ -74,7 +74,7 @@ func NewRestRemediate(actionType interfaces.ActionType, restCfg *pb.RestType,
 
 	method := util.HttpMethodFromString(restCfg.Method, http.MethodPatch)
 
-	cli, err := pbuild.GetHTTP(context.Background())
+	cli, err := pbuild.GetHTTP()
 	if err != nil {
 		return nil, fmt.Errorf("cannot get http client: %w", err)
 	}

--- a/internal/engine/eval/homoglyphs/application/invisible_characters_eval.go
+++ b/internal/engine/eval/homoglyphs/application/invisible_characters_eval.go
@@ -36,7 +36,7 @@ func NewInvisibleCharactersEvaluator(pbuild *providers.ProviderBuilder) (*Invisi
 		return nil, fmt.Errorf("provider builder is nil")
 	}
 
-	ghClient, err := pbuild.GetGitHub(context.Background())
+	ghClient, err := pbuild.GetGitHub()
 	if err != nil {
 		return nil, fmt.Errorf("could not fetch GitHub client: %w", err)
 	}

--- a/internal/engine/eval/homoglyphs/application/mixed_scripts_eval.go
+++ b/internal/engine/eval/homoglyphs/application/mixed_scripts_eval.go
@@ -36,7 +36,7 @@ func NewMixedScriptEvaluator(pbuild *providers.ProviderBuilder) (*MixedScriptsEv
 		return nil, fmt.Errorf("provider builder is nil")
 	}
 
-	ghClient, err := pbuild.GetGitHub(context.Background())
+	ghClient, err := pbuild.GetGitHub()
 	if err != nil {
 		return nil, fmt.Errorf("could not fetch GitHub client: %w", err)
 	}

--- a/internal/engine/eval/trusty/trusty.go
+++ b/internal/engine/eval/trusty/trusty.go
@@ -54,7 +54,7 @@ func NewTrustyEvaluator(
 		return nil, fmt.Errorf("endpoint is not set")
 	}
 
-	ghcli, err := pbuild.GetGitHub(context.Background())
+	ghcli, err := pbuild.GetGitHub()
 	if err != nil {
 		return nil, fmt.Errorf("failed to get github client: %w", err)
 	}

--- a/internal/engine/eval/vulncheck/vulncheck.go
+++ b/internal/engine/eval/vulncheck/vulncheck.go
@@ -46,7 +46,7 @@ func NewVulncheckEvaluator(_ *pb.RuleType_Definition_Eval_Vulncheck, pbuild *pro
 		return nil, fmt.Errorf("provider builder is nil")
 	}
 
-	ghcli, err := pbuild.GetGitHub(context.Background())
+	ghcli, err := pbuild.GetGitHub()
 	if err != nil {
 		return nil, fmt.Errorf("failed to get github client: %w", err)
 	}

--- a/internal/engine/ingester/artifact/artifact.go
+++ b/internal/engine/ingester/artifact/artifact.go
@@ -68,7 +68,7 @@ func NewArtifactDataIngest(
 	pbuild *providers.ProviderBuilder,
 ) (*Ingest, error) {
 
-	ghCli, err := pbuild.GetGitHub(context.Background())
+	ghCli, err := pbuild.GetGitHub()
 	if err != nil {
 		return nil, fmt.Errorf("failed to get github client: %w", err)
 	}

--- a/internal/engine/ingester/diff/diff.go
+++ b/internal/engine/ingester/diff/diff.go
@@ -59,7 +59,7 @@ func NewDiffIngester(
 		return nil, fmt.Errorf("provider builder is nil")
 	}
 
-	cli, err := pbuild.GetGitHub(context.Background())
+	cli, err := pbuild.GetGitHub()
 	if err != nil {
 		return nil, fmt.Errorf("failed to get github client: %w", err)
 	}

--- a/internal/engine/ingester/rest/rest.go
+++ b/internal/engine/ingester/rest/rest.go
@@ -75,7 +75,7 @@ func NewRestRuleDataIngest(
 
 	method := util.HttpMethodFromString(restCfg.Method, http.MethodGet)
 
-	cli, err := pbuild.GetHTTP(context.Background())
+	cli, err := pbuild.GetHTTP()
 	if err != nil {
 		return nil, fmt.Errorf("cannot get http client: %w", err)
 	}

--- a/internal/providers/github/github_test.go
+++ b/internal/providers/github/github_test.go
@@ -18,10 +18,17 @@ import (
 	"context"
 	"net/http"
 	"net/http/httptest"
+	"strconv"
+	"sync"
 	"testing"
+	"time"
 
+	"github.com/google/go-github/v56/github"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
+	"github.com/stacklok/minder/internal/db"
+	"github.com/stacklok/minder/internal/providers/ratecache"
 	provtelemetry "github.com/stacklok/minder/internal/providers/telemetry"
 	minderv1 "github.com/stacklok/minder/pkg/api/protobuf/go/minder/v1"
 )
@@ -29,11 +36,11 @@ import (
 func TestNewRestClient(t *testing.T) {
 	t.Parallel()
 
-	client, err := NewRestClient(context.Background(), &minderv1.GitHubProviderConfig{
+	client, err := NewRestClient(&minderv1.GitHubProviderConfig{
 		Endpoint: "https://api.github.com",
 	},
 		provtelemetry.NewNoopMetrics(),
-		"token", "")
+		nil, "token", "")
 
 	assert.NoError(t, err)
 	assert.NotNil(t, client)
@@ -103,11 +110,11 @@ func TestArtifactAPIEscapes(t *testing.T) {
 			testServer := httptest.NewServer(tt.testHandler)
 			defer testServer.Close()
 
-			client, err := NewRestClient(context.Background(), &minderv1.GitHubProviderConfig{
+			client, err := NewRestClient(&minderv1.GitHubProviderConfig{
 				Endpoint: testServer.URL + "/",
 			},
 				provtelemetry.NewNoopMetrics(),
-				"token", "")
+				nil, "token", "")
 			assert.NoError(t, err)
 			assert.NotNil(t, client)
 
@@ -115,4 +122,104 @@ func TestArtifactAPIEscapes(t *testing.T) {
 		})
 	}
 
+}
+
+func TestWaitForRateLimitReset(t *testing.T) {
+	t.Parallel()
+
+	token := "mockToken-2"
+
+	reqCount := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		reqCount++
+		if reqCount == 1 {
+			w.Header().Set("x-ratelimit-remaining", "0")
+			w.Header().Set("x-ratelimit-reset", strconv.FormatInt(time.Now().Add(1*time.Second).Unix(), 10))
+			w.WriteHeader(http.StatusForbidden)
+		} else {
+			w.WriteHeader(http.StatusOK)
+		}
+	}))
+	defer server.Close()
+
+	client, err := NewRestClient(&minderv1.GitHubProviderConfig{Endpoint: server.URL + "/"}, provtelemetry.NewNoopMetrics(), ratecache.NewRestClientCache(context.Background()), token, "mockOwner")
+	require.NoError(t, err)
+
+	err = client.CreateComment(context.Background(), "mockOwner", "mockRepo", 1, "Test Comment")
+	require.NoError(t, err)
+
+	// Ensure that the second request was made after the rate limit reset
+	expectedReq := 2
+	assert.Equal(t, expectedReq, reqCount)
+}
+
+func TestConcurrentWaitForRateLimitReset(t *testing.T) {
+	t.Parallel()
+
+	restClientCache := ratecache.NewRestClientCache(context.Background())
+	token := "mockToken-3"
+	owner := "mockOwner-3"
+
+	var reqCount int
+	var mu sync.Mutex
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		mu.Lock()
+		reqCount++
+		defer mu.Unlock()
+
+		if reqCount == 1 {
+			w.Header().Set("x-ratelimit-remaining", "0")
+			// 50 minute reset time is more than max allowed wait time
+			rateLimitResetTime := 50 * time.Minute
+			w.Header().Set("x-ratelimit-reset", strconv.FormatInt(time.Now().Add(rateLimitResetTime).Unix(), 10))
+			w.WriteHeader(http.StatusForbidden)
+		} else {
+			w.WriteHeader(http.StatusOK)
+		}
+	}))
+	defer server.Close()
+
+	wg := sync.WaitGroup{}
+
+	wg.Add(1)
+	// Start a goroutine that will make a request to the server, rate limiting the gh client
+	go func() {
+		defer wg.Done()
+		client, err := NewRestClient(&minderv1.GitHubProviderConfig{Endpoint: server.URL + "/"}, provtelemetry.NewNoopMetrics(), restClientCache, token, owner)
+		require.NoError(t, err)
+
+		err = client.CreateComment(context.Background(), owner, "mockRepo", 1, "Test Comment")
+		var rateLimitErr *github.RateLimitError
+		require.ErrorAs(t, err, &rateLimitErr)
+	}()
+
+	wg.Wait()
+
+	ctx := context.Background()
+
+	numGoroutines := 5
+	for i := 0; i < numGoroutines; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+
+			client, ok := restClientCache.Get(owner, token, db.ProviderTypeGithub)
+			require.True(t, ok)
+
+			ghClient, ok := client.(*RestClient)
+			require.True(t, ok)
+
+			err := ghClient.CreateComment(ctx, owner, "mockRepo", 1, "Test Comment")
+			var rateLimitErr *github.RateLimitError
+			require.ErrorAs(t, err, &rateLimitErr)
+		}()
+	}
+
+	wg.Wait()
+
+	// We only want to see one request to the server, the rest should be rate limited and gh client
+	// should return a made up response i.e. not a real http response by contacting the server
+	expectedServerReq := 1
+	assert.Equal(t, expectedServerReq, reqCount)
 }

--- a/internal/providers/ratecache/store.go
+++ b/internal/providers/ratecache/store.go
@@ -1,0 +1,125 @@
+// Copyright 2024 Stacklok, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package ratecache provides a cache for the REST clients
+package ratecache
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	xsyncv3 "github.com/puzpuzpuz/xsync/v3"
+
+	"github.com/stacklok/minder/internal/db"
+	provinfv1 "github.com/stacklok/minder/pkg/providers/v1"
+)
+
+const (
+	defaultCacheExpiration = 30 * time.Minute
+)
+
+// RestClientCache is the interface for the REST client cache
+type RestClientCache interface {
+	Get(owner, token string, provider db.ProviderType) (provinfv1.REST, bool)
+	Set(owner, token string, provider db.ProviderType, rest provinfv1.REST)
+
+	// Wait waits for the background eviction routine to finish
+	Wait()
+}
+
+type restClientCache struct {
+	cache                *xsyncv3.MapOf[string, cacheEntry]
+	evictionTime         time.Duration
+	ctx                  context.Context
+	wgBackgroundEviction sync.WaitGroup
+}
+
+type cacheEntry struct {
+	value      provinfv1.REST
+	expiration time.Time
+}
+
+var _ RestClientCache = (*restClientCache)(nil)
+
+// NewRestClientCache creates a new REST client cache
+func NewRestClientCache(ctx context.Context) RestClientCache {
+	c := &restClientCache{
+		cache:        xsyncv3.NewMapOf[string, cacheEntry](),
+		evictionTime: defaultCacheExpiration,
+		ctx:          ctx,
+	}
+
+	c.wgBackgroundEviction.Add(1)
+	go c.evictExpiredEntriesRoutine(ctx)
+	return c
+}
+
+func (r *restClientCache) Get(owner, token string, provider db.ProviderType) (provinfv1.REST, bool) {
+	key := r.getKey(owner, token, provider)
+	entry, ok := r.cache.Load(key)
+	if !ok || time.Now().After(entry.expiration) {
+		// Entry doesn't exist or has expired
+		return nil, false
+	}
+	return entry.value, true
+}
+
+func (r *restClientCache) Set(owner, token string, provider db.ProviderType, rest provinfv1.REST) {
+	// If the context has been cancelled, don't allow setting new entries
+	if r.ctx.Err() != nil {
+		return
+	}
+
+	key := r.getKey(owner, token, provider)
+	r.cache.Store(key, cacheEntry{
+		value:      rest,
+		expiration: time.Now().Add(r.evictionTime), // Set expiration time
+	})
+}
+
+func (r *restClientCache) Wait() {
+	r.wgBackgroundEviction.Wait()
+}
+
+func (_ *restClientCache) getKey(owner, token string, provider db.ProviderType) string {
+	return owner + token + string(provider)
+}
+
+func (r *restClientCache) evictExpiredEntries() {
+	now := time.Now()
+	r.cache.Range(func(key string, entry cacheEntry) bool {
+		if now.After(entry.expiration) {
+			r.cache.Delete(key)
+		}
+		return true
+	})
+}
+
+func (r *restClientCache) evictExpiredEntriesRoutine(ctx context.Context) {
+	defer r.wgBackgroundEviction.Done()
+
+	// We check for expired entries every half of the eviction time
+	evictionDuration := r.evictionTime / 2
+	ticker := time.NewTicker(evictionDuration)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			r.evictExpiredEntries()
+		}
+	}
+}

--- a/internal/providers/ratecache/store_test.go
+++ b/internal/providers/ratecache/store_test.go
@@ -1,0 +1,151 @@
+// Copyright 2024 Stacklok, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ratecache
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	backoffv4 "github.com/cenkalti/backoff/v4"
+	"github.com/golang/mock/gomock"
+	xsyncv3 "github.com/puzpuzpuz/xsync/v3"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/stacklok/minder/internal/db"
+	mockgh "github.com/stacklok/minder/internal/providers/github/mock"
+)
+
+func TestRestClientCache_GetSet(t *testing.T) {
+	t.Parallel()
+
+	restClient := mockgh.NewMockREST(gomock.NewController(t))
+	cache := newTestRestClientCache(context.Background(), t, 10*time.Minute)
+
+	cache.Set("owner", "token", db.ProviderTypeGithub, restClient)
+
+	numOfGoroutines := 50
+	var wg sync.WaitGroup
+
+	for i := 0; i < numOfGoroutines; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			recdRestClient, ok := cache.Get("owner", "token", db.ProviderTypeGithub)
+			assert.True(t, ok)
+			assert.Equal(t, restClient, recdRestClient)
+		}()
+	}
+
+	wg.Wait()
+}
+
+func TestRestClientCache_evictExpiredEntriesRoutine(t *testing.T) {
+	t.Parallel()
+
+	restClient := mockgh.NewMockREST(gomock.NewController(t))
+	cache := newTestRestClientCache(context.Background(), t, 10*time.Millisecond)
+
+	owner := "owner"
+	token := "token"
+	cache.Set(owner, token, db.ProviderTypeGithub, restClient)
+
+	op := func() error {
+		_, ok := cache.Get(owner, token, db.ProviderTypeGithub)
+		if ok {
+			return fmt.Errorf("entry not evicted")
+		}
+		return nil
+	}
+
+	err := backoffv4.Retry(op, getBackoffPolicy(t))
+	assert.NoError(t, err)
+}
+
+func TestRestClientCache_evictMultipleExpiredEntries(t *testing.T) {
+	t.Parallel()
+
+	restClient := mockgh.NewMockREST(gomock.NewController(t))
+	cache := newTestRestClientCache(context.Background(), t, 10*time.Millisecond)
+
+	op := func() error {
+		size := cache.cache.Size()
+		if size != 0 {
+			return fmt.Errorf("cache not empty")
+		}
+		return nil
+	}
+
+	owner := "owner"
+	token := "token"
+	cache.Set(owner, token, db.ProviderTypeGithub, restClient)
+	require.NoError(t, backoffv4.Retry(op, getBackoffPolicy(t)))
+
+	owner2 := "owner2"
+	token2 := "token2"
+	cache.Set(owner2, token2, db.ProviderTypeGithub, restClient)
+	require.NoError(t, backoffv4.Retry(op, getBackoffPolicy(t)))
+}
+
+func TestRestClientCache_contextCancellation(t *testing.T) {
+	t.Parallel()
+
+	restClient := mockgh.NewMockREST(gomock.NewController(t))
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	cache := newTestRestClientCache(ctx, t, 10*time.Minute)
+
+	owner := "owner-a"
+	token := "token-a"
+	cache.Set(owner, token, db.ProviderTypeGithub, restClient)
+	_, ok := cache.Get(owner, token, db.ProviderTypeGithub)
+	require.True(t, ok)
+
+	// cancel the context, which would stop the eviction routine
+	cancel()
+
+	owner2 := "owner2-a"
+	token2 := "token2-a"
+	cache.Set(owner2, token2, db.ProviderTypeGithub, restClient)
+	_, ok = cache.Get(owner2, token2, db.ProviderTypeGithub)
+	require.False(t, ok)
+	require.Equal(t, 1, cache.cache.Size())
+
+	cache.Wait()
+}
+
+func newTestRestClientCache(ctx context.Context, t *testing.T, evictionTime time.Duration) *restClientCache {
+	t.Helper()
+	c := &restClientCache{
+		cache:        xsyncv3.NewMapOf[string, cacheEntry](),
+		evictionTime: evictionTime,
+		ctx:          ctx,
+	}
+
+	c.wgBackgroundEviction.Add(1)
+	go c.evictExpiredEntriesRoutine(ctx)
+	return c
+}
+
+func getBackoffPolicy(t *testing.T) backoffv4.BackOff {
+	t.Helper()
+
+	constBackoff := backoffv4.NewConstantBackOff(2 * time.Second)
+	return backoffv4.WithMaxRetries(constBackoff, 5)
+}

--- a/internal/reconcilers/artifacts.go
+++ b/internal/reconcilers/artifacts.go
@@ -108,6 +108,7 @@ func (e *Reconciler) handleArtifactsReconcilerEvent(ctx context.Context, evt *Re
 
 	pbOpts := []providers.ProviderBuilderOption{
 		providers.WithProviderMetrics(e.provMt),
+		providers.WithRestClientCache(e.restClientCache),
 	}
 	p, err := providers.GetProviderBuilder(ctx, prov, evt.Project, e.store, e.crypteng, pbOpts...)
 	if err != nil {
@@ -132,7 +133,7 @@ func (e *Reconciler) handleArtifactsReconcilerEvent(ctx context.Context, evt *Re
 		return nil
 	}
 
-	cli, err := p.GetGitHub(ctx)
+	cli, err := p.GetGitHub()
 	if err != nil {
 		return fmt.Errorf("error getting github client: %w", err)
 	}

--- a/internal/reconcilers/reconcilers.go
+++ b/internal/reconcilers/reconcilers.go
@@ -21,6 +21,7 @@ import (
 	"github.com/stacklok/minder/internal/crypto"
 	"github.com/stacklok/minder/internal/db"
 	"github.com/stacklok/minder/internal/events"
+	"github.com/stacklok/minder/internal/providers/ratecache"
 	providertelemetry "github.com/stacklok/minder/internal/providers/telemetry"
 )
 
@@ -33,10 +34,11 @@ const (
 
 // Reconciler is a helper that reconciles entities
 type Reconciler struct {
-	store    db.Store
-	evt      *events.Eventer
-	crypteng *crypto.Engine
-	provMt   providertelemetry.ProviderMetrics
+	store           db.Store
+	evt             *events.Eventer
+	crypteng        *crypto.Engine
+	restClientCache ratecache.RestClientCache
+	provMt          providertelemetry.ProviderMetrics
 }
 
 // ReconcilerOption is a function that modifies a reconciler
@@ -46,6 +48,13 @@ type ReconcilerOption func(*Reconciler)
 func WithProviderMetrics(mt providertelemetry.ProviderMetrics) ReconcilerOption {
 	return func(r *Reconciler) {
 		r.provMt = mt
+	}
+}
+
+// WithRestClientCache sets the rest client cache for the reconciler
+func WithRestClientCache(cache ratecache.RestClientCache) ReconcilerOption {
+	return func(r *Reconciler) {
+		r.restClientCache = cache
 	}
 }
 


### PR DESCRIPTION
Issue #2261 

* We employ an optimistic concurrency control model to minimize goroutine blocking and reduce rate limit errors, thus preventing integration bans

* Each server replica maintains its own set of rate-limited clients, eliminating the need for synchronization across replicas. If a rate limit error occurs, the client self-blocks and is added to a cache for future requests

* Requests that return rate limit errors are retried following a backoff period

Note:

The current watermill pub-sub implementation being used, i.e. SQL and go channels, are both a single channel with head-of-line blocking, which means that blocking in middleware/handler blocks all processing. So, currently, if a token is blocked, the entire processing will be blocked.

This will change when we shift to other pub-sub implementations and have multiple workers. 