### PR TITLE
Add wait to ensure all entity events are executed

### DIFF
--- a/cmd/server/app/serve.go
+++ b/cmd/server/app/serve.go
@@ -173,6 +173,9 @@ var serveCmd = &cobra.Command{
 			return fmt.Errorf("error flushing cache: %w", err)
 		}
 
+		// Wait for all entity events to be executed
+		exec.Wait()
+
 		return errg.Wait()
 	},
 }


### PR DESCRIPTION
From: https://discord.com/channels/1184987096302239844/1185287949240242258/1202878694201237515

The wait group counter was being incremented and decremented, but the server wasn't waiting for all entity event executions to finish. This change ensures that the server waits for all entity events to be executed before exiting.