### PR TITLE
Add "openfga" to list of services to start

### DIFF
--- a/docs/docs/developer_guide/get-hacking.md
+++ b/docs/docs/developer_guide/get-hacking.md
@@ -29,7 +29,7 @@ Note that the application requires a database to be running. This can be achieve
 using docker-compose:
 
 ```bash
-services="postgres keycloak migrate" make run-docker
+services="postgres keycloak migrate openfga" make run-docker
 ```
 
 Then run the application


### PR DESCRIPTION
When running minder outside of docker-compose, openfga also needs to be started explicitly.
Document this fact in the README.

Note: In future, it may make sense to solve this problem by using `profiles` in the docker-compose
file. For example, all the dependencies needed for running minder outside of docker could be
added to `dependencies` profile, so that they can be started with:

`docker-compose up --profile dependencies`

(Perhaps with a Makefile wrapper, e.g. `make docker-dependencies-run`)