### PR TITLE
Migrate to github.com/puzpuzpuz/xsync/v3

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -36,7 +36,7 @@ require (
 	github.com/openfga/go-sdk v0.3.4
 	github.com/pkg/browser v0.0.0-20210911075715-681adbf594b8
 	github.com/prometheus/client_golang v1.18.0
-	github.com/puzpuzpuz/xsync v1.5.2
+	github.com/puzpuzpuz/xsync/v3 v3.0.2
 	github.com/robfig/cron/v3 v3.0.1
 	github.com/rs/zerolog v1.32.0
 	github.com/signalfx/splunk-otel-go/instrumentation/database/sql/splunksql v1.12.0
@@ -98,6 +98,7 @@ require (
 	github.com/muesli/ansi v0.0.0-20230316100256-276c6243b2f6 // indirect
 	github.com/muesli/cancelreader v0.2.2 // indirect
 	github.com/muhlemmer/gu v0.3.1 // indirect
+	github.com/puzpuzpuz/xsync v1.5.2 // indirect
 	github.com/sagikazarmark/locafero v0.4.0 // indirect
 	github.com/sagikazarmark/slog-shim v0.1.0 // indirect
 	github.com/secure-systems-lab/go-securesystemslib v0.8.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -566,6 +566,8 @@ github.com/prometheus/procfs v0.12.0 h1:jluTpSng7V9hY0O2R9DzzJHYb2xULk9VTR1V1R/k
 github.com/prometheus/procfs v0.12.0/go.mod h1:pcuDEFsWDnvcgNzo4EEweacyhjeA9Zk3cnaOZAZEfOo=
 github.com/puzpuzpuz/xsync v1.5.2 h1:yRAP4wqSOZG+/4pxJ08fPTwrfL0IzE/LKQ/cw509qGY=
 github.com/puzpuzpuz/xsync v1.5.2/go.mod h1:K98BYhX3k1dQ2M63t1YNVDanbwUPmBCAhNmVrrxfiGg=
+github.com/puzpuzpuz/xsync/v3 v3.0.2 h1:3yESHrRFYr6xzkz61LLkvNiPFXxJEAABanTQpKbAaew=
+github.com/puzpuzpuz/xsync/v3 v3.0.2/go.mod h1:VjzYrABPabuM4KyBh1Ftq6u8nhwY5tBPKP9jpmh0nnA=
 github.com/rcrowley/go-metrics v0.0.0-20201227073835-cf1acfcdf475 h1:N/ElC8H3+5XpJzTSTfLsJV/mx9Q9g7kxmchpfZyxgzM=
 github.com/rcrowley/go-metrics v0.0.0-20201227073835-cf1acfcdf475/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
 github.com/rivo/uniseg v0.1.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=

--- a/internal/engine/eval/vulncheck/pkgdb.go
+++ b/internal/engine/eval/vulncheck/pkgdb.go
@@ -25,7 +25,7 @@ import (
 	"net/url"
 	"strings"
 
-	"github.com/puzpuzpuz/xsync"
+	"github.com/puzpuzpuz/xsync/v3"
 
 	"github.com/stacklok/minder/internal/util"
 	pb "github.com/stacklok/minder/pkg/api/protobuf/go/minder/v1"
@@ -67,7 +67,7 @@ type repoCache struct {
 
 func newRepoCache() *repoCache {
 	return &repoCache{
-		cache: xsync.NewMapOf[RepoQuerier](),
+		cache: xsync.NewMapOf[string, RepoQuerier](),
 	}
 }
 

--- a/internal/engine/ingestcache/ingestcache.go
+++ b/internal/engine/ingestcache/ingestcache.go
@@ -19,7 +19,7 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/puzpuzpuz/xsync"
+	"github.com/puzpuzpuz/xsync/v3"
 	"github.com/rs/zerolog/log"
 	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/reflect/protoreflect"
@@ -39,7 +39,7 @@ type cache struct {
 // NewCache returns a new cache
 func NewCache() Cache {
 	return &cache{
-		cache: xsync.NewMapOf[*engif.Result](),
+		cache: xsync.NewMapOf[string, *engif.Result](),
 	}
 }
 

--- a/internal/providers/telemetry/telemetry.go
+++ b/internal/providers/telemetry/telemetry.go
@@ -20,7 +20,7 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/puzpuzpuz/xsync"
+	"github.com/puzpuzpuz/xsync/v3"
 	"github.com/rs/zerolog/log"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
@@ -78,9 +78,7 @@ type httpClientMetrics struct {
 }
 
 func newProviderMapOf[V any]() *xsync.MapOf[db.ProviderType, V] {
-	return xsync.NewTypedMapOf[db.ProviderType, V](func(k db.ProviderType) uint64 {
-		return xsync.StrHash64(string(k))
-	})
+	return xsync.NewMapOf[db.ProviderType, V]()
 }
 
 // newHttpClientMetrics creates a new http provider metrics instance.


### PR DESCRIPTION
We were using an old release of `xsync` from 2022 which hasn't been
receiving updates through dependabot because of the `v3` module bump.
