### PR TITLE
some docs changes

### DIFF
--- a/config/server-config.yaml.example
+++ b/config/server-config.yaml.example
@@ -83,7 +83,7 @@ events:
   go-channel: {}
 
 authz:
-  api_url: http://openfga:8080
+  api_url: http://openfga:8080 # Use http://localhost:8082 instead for running minder outside of docker-compose
   store_name: minder
   auth:
     # Set to token for production

--- a/docs/docs/developer_guide/get-hacking.md
+++ b/docs/docs/developer_guide/get-hacking.md
@@ -23,28 +23,28 @@ git clone git@github.com:stacklok/minder.git
 make build
 ```
 
-## Run the application
+## Install tools
+
+You may bootstrap the whole development environment, which includes initializing the `config.yaml` and `server-config.yaml`
+files with:
+
+```bash
+make bootstrap
+```
+
+Note that if you intend to run minder outside docker-compose, you should
+change the Keycloak and OpenFGA URLs in `server-config.yaml` to refer to
+localhost instead of the docker-compose names. There are comments inside the
+config file which explain what needs to be changed.
+
+## Start dependencies
 
 Note that the application requires a database to be running. This can be achieved
 using docker-compose:
 
 ```bash
-services="postgres keycloak migrate" make run-docker
+services="postgres keycloak migrate openfga" make run-docker
 ```
-
-Then run the application
-
-```bash
-bin/minder-server serve
-```
-
-Or direct from source
-
-```bash
-go run cmd/server/main.go serve
-```
-
-The application will be available on `https://localhost:8080` and gRPC on `https://localhost:8090`.
 
 ## Set up a Keycloak user
 
@@ -64,8 +64,8 @@ to create a `testuser` Keycloak user with the password `tester`.  (You can creat
 ### GitHub App
 
 [Create an OAuth2 application for GitHub](../run_minder_server/config_oauth.md).
-Select `New OAuth App` and fill in the details. The callback URL should be
-`http://localhost:8081/realms/stacklok/broker/github/endpoint`.
+Select `New OAuth App` and fill in the details.
+
 Create a new client secret for your OAuth2 client.
 
 Using the client ID and client secret you created above, enable GitHub login on Keycloak by running the following command:
@@ -73,24 +73,31 @@ Using the client ID and client secret you created above, enable GitHub login on 
 make KC_GITHUB_CLIENT_ID=<client_id> KC_GITHUB_CLIENT_SECRET=<client_secret> github-login
 ```
 
+## Run the application
+
+Then run the application
+
+```bash
+bin/minder-server serve
+```
+
+Or direct from source
+
+```bash
+go run cmd/server/main.go serve
+```
+
+The application will be available on `https://localhost:8080` and gRPC on `https://localhost:8090`.
+
 ## Run the tests
 
 ```bash
 make test
 ```
 
-## Install tools
-
-You may bootstrap the whole development environment, which includes initializing the `config.yaml` and `server-config.yaml`
-files with:
-
-```bash
-make bootstrap
-```
-
 ## CLI
 
-The CLI is available in the `cmd/cli` directory.  You can also use the pre-built `minder` CLI with your new application; you'll need to set the `--grpc_host localhost --grpc_port 8090` arguments in either case.
+The CLI is available in the `cmd/cli` directory.  You can also use the pre-built `minder` CLI with your new application; you'll need to set the `--grpc-host localhost --grpc-port 8090` arguments in either case.
 
 ```bash
 go run cmd/cli/main.go --help

--- a/docs/docs/run_minder_server/config_oauth.md
+++ b/docs/docs/run_minder_server/config_oauth.md
@@ -23,6 +23,7 @@ Minder uses OAuth2 to authenticate users. This means that you will need to confi
    - Application Name: `Minder` (or any other name you like)
    - Homepage URL: `http://localhost:8080`
    - Authorization callback URL: `http://localhost:8080/api/v1/auth/callback/github`
+   - If you are prompted to enter a `Webhook URL`, deselect the `Active` option in the `Webhook` section.
 6. Select "Register Application"
 7. Generate a client secret
 7. Copy the "Client ID" , "Client Secret" and "Authorization callback URL" values


### PR DESCRIPTION
1. Reorder some of the steps in get-hacking - previously, some of the steps depended on steps which came later in the guide.
2. Add comment into the sample config about OpenFGA URL
3. Add comment about creating github app - github prompts you to enter a webhook URL, but you can disable it.
4. get-hacking and config_oauth docs have different instructions about what the callback URL should be, and the URL in get-hacking did not work for me.
5. Fix typo in the argument names for setting the gRPC host.