### PR TITLE
Fix a few Trusty issues that enable support for Go in Minder

### DIFF
--- a/docs/docs/ref/proto.md
+++ b/docs/docs/ref/proto.md
@@ -1446,7 +1446,7 @@ endpoint and how we compare it to the rule.
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
-| endpoint | [string](#string) |  | e.g. https://staging.stacklok.dev/ |
+| endpoint | [string](#string) |  | e.g. https://api.trustypkg.dev/ |
 
 
 <a name="minder-v1-RuleType-Definition-Eval-Vulncheck"></a>

--- a/internal/engine/eval/trusty/actions.go
+++ b/internal/engine/eval/trusty/actions.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	htmltemplate "html/template"
+	"net/url"
 	"strings"
 
 	"github.com/stacklok/minder/internal/constants"
@@ -53,7 +54,7 @@ Minder profiles. Below is a summary of the packages with low scores and their al
 	<td>{{ $.Ecosystem }}</td>
 	<td>{{ $.Name }}</td>
 	<td>{{ $.Score }}</td>
-	<td>{{ if .PackageName }}<a href="{{ $.BaseUrl }}/{{ $.Ecosystem }}/{{ .PackageName }}">{{ .PackageName }}</a>{{ else }}No alternative found{{ end }}</td>
+	<td>{{ if .PackageName }}<a href="{{ $.BaseUrl }}/{{ $.Ecosystem }}/{{ .PackageNameURL }}">{{ .PackageName }}</a>{{ else }}No alternative found{{ end }}</td>
 	<td>{{ if .PackageName }}{{ .Score }}{{ else }}-{{ end }}</td>
   </tr>
 {{ end }}
@@ -120,6 +121,7 @@ func (sph *summaryPrHandler) generateSummary() (string, error) {
 		higherScoringAlternatives := make([]Alternative, 0)
 		for _, alt := range sph.trackedAlternatives[i].trustyReply.Alternatives.Packages {
 			if alt.Score > sph.trackedAlternatives[i].trustyReply.Summary.Score {
+				alt.PackageNameURL = url.PathEscape(alt.PackageName)
 				higherScoringAlternatives = append(higherScoringAlternatives, alt)
 			}
 		}

--- a/internal/engine/eval/trusty/actions.go
+++ b/internal/engine/eval/trusty/actions.go
@@ -37,25 +37,26 @@ Minder profiles. Below is a summary of the packages with low scores and their al
 
 <table>
   <tr>
-    <td> Ecosystem </td>
-    <td> DependencyName </td>
-    <td> DependencyScore </td>
+    <td> Pkg </td>
+    <td> Name </td>
+    <td> Score </td>
     <td> Alternative Name </td>
     <td> Alternative Score </td>
   </tr>
 `
 	tableFooter       = "</table>"
 	tableRowsTmplName = "alternativesTableRow"
-	tableTemplateRow  = `
-  {{ range .Alternatives }}
+	// nolint:lll
+	tableTemplateRow = `
+{{ range .Alternatives }}
   <tr>
-    <td>{{ $.DependencyEcosystem }}</td>
-    <td>{{ $.DependencyName }}</td>
-    <td>{{ $.DependencyScore }}</td>
-    <td><a href="{{ $.BaseUrl }}/{{ $.DependencyEcosystem }}/{{ .PackageName }}" >{{ .PackageName }}</a></td>
-    <td>{{ .Score }}</td>
+	<td>{{ $.Ecosystem }}</td>
+	<td>{{ $.Name }}</td>
+	<td>{{ $.Score }}</td>
+	<td>{{ if .PackageName }}<a href="{{ $.BaseUrl }}/{{ $.Ecosystem }}/{{ .PackageName }}">{{ .PackageName }}</a>{{ else }}No alternative found{{ end }}</td>
+	<td>{{ if .PackageName }}{{ .Score }}{{ else }}-{{ end }}</td>
   </tr>
-  {{ end }}
+{{ end }}
 `
 )
 
@@ -101,6 +102,7 @@ func (sph *summaryPrHandler) submit(ctx context.Context) error {
 
 func (sph *summaryPrHandler) generateSummary() (string, error) {
 	var summary strings.Builder
+
 	if len(sph.trackedAlternatives) == 0 {
 		summary.WriteString(noLowScoresText)
 		return summary.String(), nil
@@ -121,19 +123,25 @@ func (sph *summaryPrHandler) generateSummary() (string, error) {
 				higherScoringAlternatives = append(higherScoringAlternatives, alt)
 			}
 		}
+		if len(higherScoringAlternatives) == 0 {
+			higherScoringAlternatives = append(higherScoringAlternatives, Alternative{
+				PackageName: "", // Note: Set it to empty to indicate no alternative found in the template
+				Score:       0,
+			})
+		}
 
 		if err := sph.rowsTmpl.Execute(&rowBuf, struct {
-			DependencyEcosystem string
-			DependencyName      string
-			DependencyScore     float64
-			Alternatives        []Alternative
-			BaseUrl             string
+			Ecosystem    string
+			Name         string
+			Score        float64
+			Alternatives []Alternative
+			BaseUrl      string
 		}{
-			DependencyEcosystem: strings.ToLower(sph.trackedAlternatives[i].Dependency.Ecosystem.AsString()),
-			DependencyName:      sph.trackedAlternatives[i].Dependency.Name,
-			DependencyScore:     sph.trackedAlternatives[i].trustyReply.Summary.Score,
-			Alternatives:        higherScoringAlternatives,
-			BaseUrl:             constants.TrustyHttpURL,
+			Ecosystem:    strings.ToLower(sph.trackedAlternatives[i].Dependency.Ecosystem.AsString()),
+			Name:         sph.trackedAlternatives[i].Dependency.Name,
+			Score:        sph.trackedAlternatives[i].trustyReply.Summary.Score,
+			Alternatives: higherScoringAlternatives,
+			BaseUrl:      constants.TrustyHttpURL,
 		}); err != nil {
 			return "", fmt.Errorf("could not execute template: %w", err)
 		}

--- a/internal/engine/eval/trusty/trusty_rest_handler.go
+++ b/internal/engine/eval/trusty/trusty_rest_handler.go
@@ -54,8 +54,9 @@ type trustyClient struct {
 
 // Alternative is an alternative package returned from the package intelligence API
 type Alternative struct {
-	PackageName string  `json:"package_name"`
-	Score       float64 `json:"score"`
+	PackageName    string  `json:"package_name"`
+	Score          float64 `json:"score"`
+	PackageNameURL string
 }
 
 // ScoreSummary is the summary score returned from the package intelligence API

--- a/internal/engine/eval/vulncheck/review.go
+++ b/internal/engine/eval/vulncheck/review.go
@@ -465,9 +465,9 @@ Minder found the following vulnerabilities in this PR:
 	tableVulnerabilitiesRows     = `
   {{ range .Vulnerabilities }}
   <tr>
-    <td>{{ $.DependencyEcosystem }}</td>
-    <td>{{ $.DependencyName }}</td>
-    <td>{{ $.DependencyVersion }}</td>
+    <td>{{ $.Ecosystem }}</td>
+    <td>{{ $.Name }}</td>
+    <td>{{ $.Version }}</td>
     <td>{{ .ID }}</td>
     <td>{{ .Summary }}</td>
     <td>{{ .Introduced }}</td>
@@ -527,15 +527,15 @@ func (sph *summaryPrHandler) generateSummary() (string, error) {
 		var rowBuf bytes.Buffer
 
 		if err := sph.rowsTmpl.Execute(&rowBuf, struct {
-			DependencyEcosystem string
-			DependencyName      string
-			DependencyVersion   string
-			Vulnerabilities     []Vulnerability
+			Ecosystem       string
+			Name            string
+			Version         string
+			Vulnerabilities []Vulnerability
 		}{
-			DependencyEcosystem: sph.trackedDeps[i].Dependency.Ecosystem.AsString(),
-			DependencyName:      sph.trackedDeps[i].Dependency.Name,
-			DependencyVersion:   sph.trackedDeps[i].Dependency.Version,
-			Vulnerabilities:     sph.trackedDeps[i].Vulnerabilities,
+			Ecosystem:       sph.trackedDeps[i].Dependency.Ecosystem.AsString(),
+			Name:            sph.trackedDeps[i].Dependency.Name,
+			Version:         sph.trackedDeps[i].Dependency.Version,
+			Vulnerabilities: sph.trackedDeps[i].Vulnerabilities,
 		}); err != nil {
 			return "", fmt.Errorf("could not execute template: %w", err)
 		}

--- a/internal/engine/ingester/diff/parse.go
+++ b/internal/engine/ingester/diff/parse.go
@@ -19,6 +19,7 @@ import (
 	"bufio"
 	"path/filepath"
 	"regexp"
+	"slices"
 	"strings"
 
 	"github.com/stacklok/minder/internal/util"
@@ -137,31 +138,52 @@ func pyNormalizeName(pkgName string) string {
 }
 
 func goParse(patch string) ([]*pb.Dependency, error) {
-	scanner := bufio.NewScanner(strings.NewReader(patch))
 	var deps []*pb.Dependency
+	scanner := bufio.NewScanner(strings.NewReader(patch))
 
 	for scanner.Scan() {
 		line := scanner.Text()
-
-		if strings.HasPrefix(line, "+") {
-			fields := strings.Split(line, " ")
-			if len(fields) > 2 && !strings.HasSuffix(fields[1], "/go.mod") {
-				name, version := fields[0], fields[1]
-				dep := &pb.Dependency{
-					Ecosystem: pb.DepEcosystem_DEP_ECOSYSTEM_GO,
-					Name:      name[1:],
-					Version:   version,
-				}
-
-				deps = append(deps, dep)
+		// Look for lines that add dependencies.
+		if strings.HasPrefix(line, "+") && !strings.HasPrefix(line, "+++") {
+			// Extract the part after the '+' sign.
+			lineContent := line[1:]
+			fields := strings.Fields(lineContent)
+			if len(fields) < 2 {
+				continue
 			}
+			dep := &pb.Dependency{
+				Ecosystem: pb.DepEcosystem_DEP_ECOSYSTEM_GO,
+			}
+			if fields[0] == "require" && fields[1] != "(" {
+				dep.Name = fields[1]
+				dep.Version = fields[2]
+			} else if strings.HasPrefix(lineContent, "\t") {
+				dep.Name = fields[0]
+				dep.Version = fields[1]
+			} else if fields[0] == "replace" && strings.Contains(lineContent, "=>") && len(fields) == 5 {
+				// For lines with version replacements, the new version is after the "=>"
+				// Assuming format is module path version => newModulePath newVersion
+				dep.Name = fields[3]
+				dep.Version = fields[4]
+			} else {
+				continue
+			}
+			// If the dependency is already in the slice, we don't want to add it again
+			if slices.ContainsFunc(deps, func(n *pb.Dependency) bool {
+				if n.Name == dep.Name && n.Version == dep.Version {
+					return true
+				}
+				return false
+			}) {
+				continue
+			}
+			// Add the dependency to the slice
+			deps = append(deps, dep)
 		}
 	}
-
 	if err := scanner.Err(); err != nil {
 		return nil, err
 	}
-
 	return deps, nil
 }
 

--- a/internal/engine/ingester/diff/parse.go
+++ b/internal/engine/ingester/diff/parse.go
@@ -160,7 +160,7 @@ func goParse(patch string) ([]*pb.Dependency, error) {
 			} else if strings.HasPrefix(lineContent, "\t") {
 				dep.Name = fields[0]
 				dep.Version = fields[1]
-			} else if fields[0] == "replace" && strings.Contains(lineContent, "=>") && len(fields) == 5 {
+			} else if fields[0] == "replace" && strings.Contains(lineContent, "=>") && len(fields) >= 5 {
 				// For lines with version replacements, the new version is after the "=>"
 				// Assuming format is module path version => newModulePath newVersion
 				dep.Name = fields[3]

--- a/internal/engine/ingester/diff/parse_test.go
+++ b/internal/engine/ingester/diff/parse_test.go
@@ -36,49 +36,65 @@ func TestGoParse(t *testing.T) {
 		{
 			description: "Single addition",
 			content: `
-+cloud.google.com/go/compute v1.23.0 h1:tP41Zoavr8ptEqaW6j+LQOnyBBhO7OkOMAGrgLopTwY=
-+cloud.google.com/go/compute v1.23.0/go.mod h1:4tCnrn48xsqlwSAiLf1HXMQk8CONslYbdiEZc9FEIbM=
-cloud.google.com/go/compute/metadata v0.2.3 h1:mg4jlk7mCAj6xXp9UJ4fjI9VUI5rubuGBW5aJ7UnBMY=
-cloud.google.com/go/compute/metadata v0.2.3/go.mod h1:VAV5nSsACxMJvgaAuX6Pk2AawlZn8kiOGuCv6gTkwuA=`,
+	github.com/openfga/go-sdk v0.3.4
++	github.com/openfga/openfga v1.4.3
+	github.com/pkg/browser v0.0.0-20210911075715-681adbf594b8
+	github.com/prometheus/client_golang v1.18.0`,
 			expectedCount: 1,
 			expectedDependencies: []*pb.Dependency{
 				{
 					Ecosystem: pb.DepEcosystem_DEP_ECOSYSTEM_GO,
-					Name:      "cloud.google.com/go/compute",
-					Version:   "v1.23.0",
+					Name:      "github.com/openfga/openfga",
+					Version:   "v1.4.3",
 				},
 			},
 		},
 		{
 			description: "Single removal",
 			content: `
--cloud.google.com/go/compute v1.23.0 h1:tP41Zoavr8ptEqaW6j+LQOnyBBhO7OkOMAGrgLopTwY=
--cloud.google.com/go/compute v1.23.0/go.mod h1:4tCnrn48xsqlwSAiLf1HXMQk8CONslYbdiEZc9FEIbM=
-cloud.google.com/go/compute/metadata v0.2.3 h1:mg4jlk7mCAj6xXp9UJ4fjI9VUI5rubuGBW5aJ7UnBMY=
-cloud.google.com/go/compute/metadata v0.2.3/go.mod h1:VAV5nSsACxMJvgaAuX6Pk2AawlZn8kiOGuCv6gTkwuA=`,
+	gopkg.in/go-jose/go-jose.v2 v2.6.1 // indirect
+-	gotest.tools/v3 v3.4.0 // indirect
+	k8s.io/utils v0.0.0-20230726121419-3b25d923346b // indirect`,
 			expectedCount:        0,
 			expectedDependencies: nil,
 		},
 		{
 			description: "Mixed additions and removals",
 			content: `
--cloud.google.com/go/compute v1.23.0 h1:tP41Zoavr8ptEqaW6j+LQOnyBBhO7OkOMAGrgLopTwY=
--cloud.google.com/go/compute v1.23.0/go.mod h1:4tCnrn48xsqlwSAiLf1HXMQk8CONslYbdiEZc9FEIbM=
-+cloud.google.com/go/compute/metadata v0.2.3 h1:mg4jlk7mCAj6xXp9UJ4fjI9VUI5rubuGBW5aJ7UnBMY=
-+cloud.google.com/go/compute/metadata v0.2.3/go.mod h1:VAV5nSsACxMJvgaAuX6Pk2AawlZn8kiOGuCv6gTkwuA=
-+dario.cat/mergo v1.0.0 h1:AGCNq9Evsj31mOgNPcLyXc+4PNABt905YmuqPYYpBWk=
-+dario.cat/mergo v1.0.0/go.mod h1:uNxQE+84aUszobStD9th8a29P2fMDhsBdgRYvZOxGmk=`,
++	go.opentelemetry.io/proto/otlp v1.0.0 // indirect
++	go.uber.org/mock v0.4.0 // indirect
+	golang.org/x/time v0.5.0 // indirect
+	gopkg.in/go-jose/go-jose.v2 v2.6.1 // indirect
+-	gotest.tools/v3 v3.4.0 // indirect
+	k8s.io/utils v0.0.0-20230726121419-3b25d923346b // indirect`,
 			expectedCount: 2,
 			expectedDependencies: []*pb.Dependency{
 				{
 					Ecosystem: pb.DepEcosystem_DEP_ECOSYSTEM_GO,
-					Name:      "cloud.google.com/go/compute/metadata",
-					Version:   "v0.2.3",
+					Name:      "go.opentelemetry.io/proto/otlp",
+					Version:   "v1.0.0",
 				},
 				{
 					Ecosystem: pb.DepEcosystem_DEP_ECOSYSTEM_GO,
-					Name:      "dario.cat/mergo",
-					Version:   "v1.0.0",
+					Name:      "go.uber.org/mock",
+					Version:   "v0.4.0",
+				},
+			},
+		},
+		{
+			description: "Replace",
+			content: `
+	k8s.io/klog/v2 v2.110.1 // indirect
+	sigs.k8s.io/yaml v1.4.0 // indirect
+)
++
++replace github.com/opencontainers/runc => github.com/stacklok/runc v1.1.12 // indirect`,
+			expectedCount: 1,
+			expectedDependencies: []*pb.Dependency{
+				{
+					Ecosystem: pb.DepEcosystem_DEP_ECOSYSTEM_GO,
+					Name:      "github.com/stacklok/runc",
+					Version:   "v1.1.12",
 				},
 			},
 		},

--- a/pkg/api/openapi/minder/v1/minder.swagger.json
+++ b/pkg/api/openapi/minder/v1/minder.swagger.json
@@ -659,18 +659,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "type": "object",
-              "properties": {
-                "accessToken": {
-                  "type": "string"
-                },
-                "owner": {
-                  "type": "string"
-                },
-                "context": {
-                  "$ref": "#/definitions/v1Context"
-                }
-              }
+              "$ref": "#/definitions/OAuthServiceStoreProviderTokenBody"
             }
           }
         ],
@@ -1866,15 +1855,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "type": "object",
-              "properties": {
-                "repository": {
-                  "$ref": "#/definitions/v1UpstreamRepositoryRef"
-                },
-                "context": {
-                  "$ref": "#/definitions/v1Context"
-                }
-              }
+              "$ref": "#/definitions/RepositoryServiceRegisterRepositoryBody"
             }
           }
         ],
@@ -2459,6 +2440,20 @@
         }
       }
     },
+    "OAuthServiceStoreProviderTokenBody": {
+      "type": "object",
+      "properties": {
+        "accessToken": {
+          "type": "string"
+        },
+        "owner": {
+          "type": "string"
+        },
+        "context": {
+          "$ref": "#/definitions/v1Context"
+        }
+      }
+    },
     "ProfileRule": {
       "type": "object",
       "properties": {
@@ -2551,6 +2546,17 @@
       },
       "title": "the name stutters a bit but we already use a PullRequest message for handling PR entities"
     },
+    "RepositoryServiceRegisterRepositoryBody": {
+      "type": "object",
+      "properties": {
+        "repository": {
+          "$ref": "#/definitions/v1UpstreamRepositoryRef"
+        },
+        "context": {
+          "$ref": "#/definitions/v1Context"
+        }
+      }
+    },
     "RestTypeFallback": {
       "type": "object",
       "properties": {
@@ -2640,11 +2646,11 @@
       "properties": {
         "@type": {
           "type": "string",
-          "description": "A URL/resource name that uniquely identifies the type of the serialized\nprotocol buffer message. This string must contain at least\none \"/\" character. The last segment of the URL's path must represent\nthe fully qualified name of the type (as in\n`path/google.protobuf.Duration`). The name should be in a canonical form\n(e.g., leading \".\" is not accepted).\n\nIn practice, teams usually precompile into the binary all types that they\nexpect it to use in the context of Any. However, for URLs which use the\nscheme `http`, `https`, or no scheme, one can optionally set up a type\nserver that maps type URLs to message definitions as follows:\n\n* If no scheme is provided, `https` is assumed.\n* An HTTP GET on the URL must yield a [google.protobuf.Type][]\n  value in binary format, or produce an error.\n* Applications are allowed to cache lookup results based on the\n  URL, or have them precompiled into a binary to avoid any\n  lookup. Therefore, binary compatibility needs to be preserved\n  on changes to types. (Use versioned type names to manage\n  breaking changes.)\n\nNote: this functionality is not currently available in the official\nprotobuf release, and it is not used for type URLs beginning with\ntype.googleapis.com.\n\nSchemes other than `http`, `https` (or the empty scheme) might be\nused with implementation specific semantics."
+          "description": "A URL/resource name that uniquely identifies the type of the serialized\nprotocol buffer message. This string must contain at least\none \"/\" character. The last segment of the URL's path must represent\nthe fully qualified name of the type (as in\n`path/google.protobuf.Duration`). The name should be in a canonical form\n(e.g., leading \".\" is not accepted).\n\nIn practice, teams usually precompile into the binary all types that they\nexpect it to use in the context of Any. However, for URLs which use the\nscheme `http`, `https`, or no scheme, one can optionally set up a type\nserver that maps type URLs to message definitions as follows:\n\n* If no scheme is provided, `https` is assumed.\n* An HTTP GET on the URL must yield a [google.protobuf.Type][]\n  value in binary format, or produce an error.\n* Applications are allowed to cache lookup results based on the\n  URL, or have them precompiled into a binary to avoid any\n  lookup. Therefore, binary compatibility needs to be preserved\n  on changes to types. (Use versioned type names to manage\n  breaking changes.)\n\nNote: this functionality is not currently available in the official\nprotobuf release, and it is not used for type URLs beginning with\ntype.googleapis.com. As of May 2023, there are no widely used type server\nimplementations and no plans to implement one.\n\nSchemes other than `http`, `https` (or the empty scheme) might be\nused with implementation specific semantics."
         }
       },
       "additionalProperties": {},
-      "description": "`Any` contains an arbitrary serialized protocol buffer message along with a\nURL that describes the type of the serialized message.\n\nProtobuf library provides support to pack/unpack Any values in the form\nof utility functions or additional generated methods of the Any type.\n\nExample 1: Pack and unpack a message in C++.\n\n    Foo foo = ...;\n    Any any;\n    any.PackFrom(foo);\n    ...\n    if (any.UnpackTo(\u0026foo)) {\n      ...\n    }\n\nExample 2: Pack and unpack a message in Java.\n\n    Foo foo = ...;\n    Any any = Any.pack(foo);\n    ...\n    if (any.is(Foo.class)) {\n      foo = any.unpack(Foo.class);\n    }\n    // or ...\n    if (any.isSameTypeAs(Foo.getDefaultInstance())) {\n      foo = any.unpack(Foo.getDefaultInstance());\n    }\n\nExample 3: Pack and unpack a message in Python.\n\n    foo = Foo(...)\n    any = Any()\n    any.Pack(foo)\n    ...\n    if any.Is(Foo.DESCRIPTOR):\n      any.Unpack(foo)\n      ...\n\nExample 4: Pack and unpack a message in Go\n\n     foo := \u0026pb.Foo{...}\n     any, err := anypb.New(foo)\n     if err != nil {\n       ...\n     }\n     ...\n     foo := \u0026pb.Foo{}\n     if err := any.UnmarshalTo(foo); err != nil {\n       ...\n     }\n\nThe pack methods provided by protobuf library will by default use\n'type.googleapis.com/full.type.name' as the type URL and the unpack\nmethods only use the fully qualified type name after the last '/'\nin the type URL, for example \"foo.bar.com/x/y.z\" will yield type\nname \"y.z\".\n\nJSON\n\nThe JSON representation of an `Any` value uses the regular\nrepresentation of the deserialized, embedded message, with an\nadditional field `@type` which contains the type URL. Example:\n\n    package google.profile;\n    message Person {\n      string first_name = 1;\n      string last_name = 2;\n    }\n\n    {\n      \"@type\": \"type.googleapis.com/google.profile.Person\",\n      \"firstName\": \u003cstring\u003e,\n      \"lastName\": \u003cstring\u003e\n    }\n\nIf the embedded message type is well-known and has a custom JSON\nrepresentation, that representation will be embedded adding a field\n`value` which holds the custom JSON in addition to the `@type`\nfield. Example (for message [google.protobuf.Duration][]):\n\n    {\n      \"@type\": \"type.googleapis.com/google.protobuf.Duration\",\n      \"value\": \"1.212s\"\n    }"
+      "description": "`Any` contains an arbitrary serialized protocol buffer message along with a\nURL that describes the type of the serialized message.\n\nProtobuf library provides support to pack/unpack Any values in the form\nof utility functions or additional generated methods of the Any type.\n\nExample 1: Pack and unpack a message in C++.\n\n    Foo foo = ...;\n    Any any;\n    any.PackFrom(foo);\n    ...\n    if (any.UnpackTo(\u0026foo)) {\n      ...\n    }\n\nExample 2: Pack and unpack a message in Java.\n\n    Foo foo = ...;\n    Any any = Any.pack(foo);\n    ...\n    if (any.is(Foo.class)) {\n      foo = any.unpack(Foo.class);\n    }\n    // or ...\n    if (any.isSameTypeAs(Foo.getDefaultInstance())) {\n      foo = any.unpack(Foo.getDefaultInstance());\n    }\n\n Example 3: Pack and unpack a message in Python.\n\n    foo = Foo(...)\n    any = Any()\n    any.Pack(foo)\n    ...\n    if any.Is(Foo.DESCRIPTOR):\n      any.Unpack(foo)\n      ...\n\n Example 4: Pack and unpack a message in Go\n\n     foo := \u0026pb.Foo{...}\n     any, err := anypb.New(foo)\n     if err != nil {\n       ...\n     }\n     ...\n     foo := \u0026pb.Foo{}\n     if err := any.UnmarshalTo(foo); err != nil {\n       ...\n     }\n\nThe pack methods provided by protobuf library will by default use\n'type.googleapis.com/full.type.name' as the type URL and the unpack\nmethods only use the fully qualified type name after the last '/'\nin the type URL, for example \"foo.bar.com/x/y.z\" will yield type\nname \"y.z\".\n\nJSON\n====\nThe JSON representation of an `Any` value uses the regular\nrepresentation of the deserialized, embedded message, with an\nadditional field `@type` which contains the type URL. Example:\n\n    package google.profile;\n    message Person {\n      string first_name = 1;\n      string last_name = 2;\n    }\n\n    {\n      \"@type\": \"type.googleapis.com/google.profile.Person\",\n      \"firstName\": \u003cstring\u003e,\n      \"lastName\": \u003cstring\u003e\n    }\n\nIf the embedded message type is well-known and has a custom JSON\nrepresentation, that representation will be embedded adding a field\n`value` which holds the custom JSON in addition to the `@type`\nfield. Example (for message [google.protobuf.Duration][]):\n\n    {\n      \"@type\": \"type.googleapis.com/google.protobuf.Duration\",\n      \"value\": \"1.212s\"\n    }"
     },
     "protobufNullValue": {
       "type": "string",
@@ -2652,7 +2658,7 @@
         "NULL_VALUE"
       ],
       "default": "NULL_VALUE",
-      "description": "`NullValue` is a singleton enumeration to represent the null value for the\n`Value` type union.\n\n The JSON representation for `NullValue` is JSON `null`.\n\n - NULL_VALUE: Null value."
+      "description": "`NullValue` is a singleton enumeration to represent the null value for the\n`Value` type union.\n\nThe JSON representation for `NullValue` is JSON `null`.\n\n - NULL_VALUE: Null value."
     },
     "v1Artifact": {
       "type": "object",

--- a/pkg/api/openapi/minder/v1/minder.swagger.json
+++ b/pkg/api/openapi/minder/v1/minder.swagger.json
@@ -2429,7 +2429,7 @@
       "properties": {
         "endpoint": {
           "type": "string",
-          "title": "e.g. https://staging.stacklok.dev/"
+          "title": "e.g. https://api.trustypkg.dev/"
         }
       }
     },

--- a/pkg/api/protobuf/go/minder/v1/minder.pb.go
+++ b/pkg/api/protobuf/go/minder/v1/minder.pb.go
@@ -7473,7 +7473,7 @@ type RuleType_Definition_Eval_Trusty struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	// e.g. https://staging.stacklok.dev/
+	// e.g. https://api.trustypkg.dev/
 	Endpoint string `protobuf:"bytes,1,opt,name=endpoint,proto3" json:"endpoint,omitempty"`
 }
 

--- a/pkg/api/protobuf/go/minder/v1/minder.pb.gw.go
+++ b/pkg/api/protobuf/go/minder/v1/minder.pb.gw.go
@@ -50,7 +50,7 @@ func local_request_HealthService_CheckHealth_0(ctx context.Context, marshaler ru
 }
 
 var (
-	filter_ArtifactService_ListArtifacts_0 = &utilities.DoubleArray{Encoding: map[string]int{"provider": 0}, Base: []int{1, 2, 0, 0}, Check: []int{0, 1, 2, 2}}
+	filter_ArtifactService_ListArtifacts_0 = &utilities.DoubleArray{Encoding: map[string]int{"provider": 0}, Base: []int{1, 1, 0}, Check: []int{0, 1, 2}}
 )
 
 func request_ArtifactService_ListArtifacts_0(ctx context.Context, marshaler runtime.Marshaler, client ArtifactServiceClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
@@ -156,7 +156,7 @@ func local_request_ArtifactService_ListArtifacts_1(ctx context.Context, marshale
 }
 
 var (
-	filter_ArtifactService_GetArtifactById_0 = &utilities.DoubleArray{Encoding: map[string]int{"id": 0}, Base: []int{1, 2, 0, 0}, Check: []int{0, 1, 2, 2}}
+	filter_ArtifactService_GetArtifactById_0 = &utilities.DoubleArray{Encoding: map[string]int{"id": 0}, Base: []int{1, 1, 0}, Check: []int{0, 1, 2}}
 )
 
 func request_ArtifactService_GetArtifactById_0(ctx context.Context, marshaler runtime.Marshaler, client ArtifactServiceClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
@@ -226,7 +226,7 @@ func local_request_ArtifactService_GetArtifactById_0(ctx context.Context, marsha
 }
 
 var (
-	filter_ArtifactService_GetArtifactByName_0 = &utilities.DoubleArray{Encoding: map[string]int{"name": 0}, Base: []int{1, 2, 0, 0}, Check: []int{0, 1, 2, 2}}
+	filter_ArtifactService_GetArtifactByName_0 = &utilities.DoubleArray{Encoding: map[string]int{"name": 0}, Base: []int{1, 1, 0}, Check: []int{0, 1, 2}}
 )
 
 func request_ArtifactService_GetArtifactByName_0(ctx context.Context, marshaler runtime.Marshaler, client ArtifactServiceClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
@@ -332,7 +332,7 @@ func local_request_OAuthService_GetAuthorizationURL_0(ctx context.Context, marsh
 }
 
 var (
-	filter_OAuthService_ExchangeCodeForTokenCLI_0 = &utilities.DoubleArray{Encoding: map[string]int{"provider": 0}, Base: []int{1, 2, 0, 0}, Check: []int{0, 1, 2, 2}}
+	filter_OAuthService_ExchangeCodeForTokenCLI_0 = &utilities.DoubleArray{Encoding: map[string]int{"provider": 0}, Base: []int{1, 1, 0}, Check: []int{0, 1, 2}}
 )
 
 func request_OAuthService_ExchangeCodeForTokenCLI_0(ctx context.Context, marshaler runtime.Marshaler, client OAuthServiceClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
@@ -441,11 +441,7 @@ func request_OAuthService_StoreProviderToken_0(ctx context.Context, marshaler ru
 	var protoReq StoreProviderTokenRequest
 	var metadata runtime.ServerMetadata
 
-	newReader, berr := utilities.IOReaderFactory(req.Body)
-	if berr != nil {
-		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", berr)
-	}
-	if err := marshaler.NewDecoder(newReader()).Decode(&protoReq); err != nil && err != io.EOF {
+	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && err != io.EOF {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
 	}
 
@@ -475,11 +471,7 @@ func local_request_OAuthService_StoreProviderToken_0(ctx context.Context, marsha
 	var protoReq StoreProviderTokenRequest
 	var metadata runtime.ServerMetadata
 
-	newReader, berr := utilities.IOReaderFactory(req.Body)
-	if berr != nil {
-		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", berr)
-	}
-	if err := marshaler.NewDecoder(newReader()).Decode(&protoReq); err != nil && err != io.EOF {
+	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && err != io.EOF {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
 	}
 
@@ -542,7 +534,7 @@ func local_request_OAuthService_StoreProviderToken_1(ctx context.Context, marsha
 }
 
 var (
-	filter_OAuthService_VerifyProviderTokenFrom_0 = &utilities.DoubleArray{Encoding: map[string]int{"provider": 0, "timestamp": 1}, Base: []int{1, 2, 4, 0, 0, 0, 0}, Check: []int{0, 1, 1, 2, 2, 3, 3}}
+	filter_OAuthService_VerifyProviderTokenFrom_0 = &utilities.DoubleArray{Encoding: map[string]int{"provider": 0, "timestamp": 1}, Base: []int{1, 1, 2, 0, 0}, Check: []int{0, 1, 1, 2, 3}}
 )
 
 func request_OAuthService_VerifyProviderTokenFrom_0(ctx context.Context, marshaler runtime.Marshaler, client OAuthServiceClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
@@ -632,7 +624,7 @@ func local_request_OAuthService_VerifyProviderTokenFrom_0(ctx context.Context, m
 }
 
 var (
-	filter_OAuthService_VerifyProviderTokenFrom_1 = &utilities.DoubleArray{Encoding: map[string]int{"timestamp": 0}, Base: []int{1, 2, 0, 0}, Check: []int{0, 1, 2, 2}}
+	filter_OAuthService_VerifyProviderTokenFrom_1 = &utilities.DoubleArray{Encoding: map[string]int{"timestamp": 0}, Base: []int{1, 1, 0}, Check: []int{0, 1, 2}}
 )
 
 func request_OAuthService_VerifyProviderTokenFrom_1(ctx context.Context, marshaler runtime.Marshaler, client OAuthServiceClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
@@ -705,11 +697,7 @@ func request_RepositoryService_RegisterRepository_0(ctx context.Context, marshal
 	var protoReq RegisterRepositoryRequest
 	var metadata runtime.ServerMetadata
 
-	newReader, berr := utilities.IOReaderFactory(req.Body)
-	if berr != nil {
-		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", berr)
-	}
-	if err := marshaler.NewDecoder(newReader()).Decode(&protoReq); err != nil && err != io.EOF {
+	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && err != io.EOF {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
 	}
 
@@ -739,11 +727,7 @@ func local_request_RepositoryService_RegisterRepository_0(ctx context.Context, m
 	var protoReq RegisterRepositoryRequest
 	var metadata runtime.ServerMetadata
 
-	newReader, berr := utilities.IOReaderFactory(req.Body)
-	if berr != nil {
-		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", berr)
-	}
-	if err := marshaler.NewDecoder(newReader()).Decode(&protoReq); err != nil && err != io.EOF {
+	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && err != io.EOF {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
 	}
 
@@ -806,7 +790,7 @@ func local_request_RepositoryService_RegisterRepository_1(ctx context.Context, m
 }
 
 var (
-	filter_RepositoryService_ListRemoteRepositoriesFromProvider_0 = &utilities.DoubleArray{Encoding: map[string]int{"provider": 0}, Base: []int{1, 2, 0, 0}, Check: []int{0, 1, 2, 2}}
+	filter_RepositoryService_ListRemoteRepositoriesFromProvider_0 = &utilities.DoubleArray{Encoding: map[string]int{"provider": 0}, Base: []int{1, 1, 0}, Check: []int{0, 1, 2}}
 )
 
 func request_RepositoryService_ListRemoteRepositoriesFromProvider_0(ctx context.Context, marshaler runtime.Marshaler, client RepositoryServiceClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
@@ -912,7 +896,7 @@ func local_request_RepositoryService_ListRemoteRepositoriesFromProvider_1(ctx co
 }
 
 var (
-	filter_RepositoryService_ListRepositories_0 = &utilities.DoubleArray{Encoding: map[string]int{"provider": 0}, Base: []int{1, 2, 0, 0}, Check: []int{0, 1, 2, 2}}
+	filter_RepositoryService_ListRepositories_0 = &utilities.DoubleArray{Encoding: map[string]int{"provider": 0}, Base: []int{1, 1, 0}, Check: []int{0, 1, 2}}
 )
 
 func request_RepositoryService_ListRepositories_0(ctx context.Context, marshaler runtime.Marshaler, client RepositoryServiceClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
@@ -1018,7 +1002,7 @@ func local_request_RepositoryService_ListRepositories_1(ctx context.Context, mar
 }
 
 var (
-	filter_RepositoryService_GetRepositoryById_0 = &utilities.DoubleArray{Encoding: map[string]int{"repository_id": 0, "repositoryId": 1}, Base: []int{1, 1, 2, 0, 0}, Check: []int{0, 1, 1, 2, 3}}
+	filter_RepositoryService_GetRepositoryById_0 = &utilities.DoubleArray{Encoding: map[string]int{"repository_id": 0}, Base: []int{1, 1, 0}, Check: []int{0, 1, 2}}
 )
 
 func request_RepositoryService_GetRepositoryById_0(ctx context.Context, marshaler runtime.Marshaler, client RepositoryServiceClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
@@ -1088,7 +1072,7 @@ func local_request_RepositoryService_GetRepositoryById_0(ctx context.Context, ma
 }
 
 var (
-	filter_RepositoryService_GetRepositoryByName_0 = &utilities.DoubleArray{Encoding: map[string]int{"provider": 0, "name": 1}, Base: []int{1, 2, 4, 0, 0, 0, 0}, Check: []int{0, 1, 1, 2, 2, 3, 3}}
+	filter_RepositoryService_GetRepositoryByName_0 = &utilities.DoubleArray{Encoding: map[string]int{"provider": 0, "name": 1}, Base: []int{1, 1, 2, 0, 0}, Check: []int{0, 1, 1, 2, 3}}
 )
 
 func request_RepositoryService_GetRepositoryByName_0(ctx context.Context, marshaler runtime.Marshaler, client RepositoryServiceClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
@@ -1178,7 +1162,7 @@ func local_request_RepositoryService_GetRepositoryByName_0(ctx context.Context, 
 }
 
 var (
-	filter_RepositoryService_GetRepositoryByName_1 = &utilities.DoubleArray{Encoding: map[string]int{"name": 0}, Base: []int{1, 2, 0, 0}, Check: []int{0, 1, 2, 2}}
+	filter_RepositoryService_GetRepositoryByName_1 = &utilities.DoubleArray{Encoding: map[string]int{"name": 0}, Base: []int{1, 1, 0}, Check: []int{0, 1, 2}}
 )
 
 func request_RepositoryService_GetRepositoryByName_1(ctx context.Context, marshaler runtime.Marshaler, client RepositoryServiceClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
@@ -1248,7 +1232,7 @@ func local_request_RepositoryService_GetRepositoryByName_1(ctx context.Context, 
 }
 
 var (
-	filter_RepositoryService_DeleteRepositoryById_0 = &utilities.DoubleArray{Encoding: map[string]int{"repository_id": 0, "repositoryId": 1}, Base: []int{1, 1, 2, 0, 0}, Check: []int{0, 1, 1, 2, 3}}
+	filter_RepositoryService_DeleteRepositoryById_0 = &utilities.DoubleArray{Encoding: map[string]int{"repository_id": 0}, Base: []int{1, 1, 0}, Check: []int{0, 1, 2}}
 )
 
 func request_RepositoryService_DeleteRepositoryById_0(ctx context.Context, marshaler runtime.Marshaler, client RepositoryServiceClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
@@ -1318,7 +1302,7 @@ func local_request_RepositoryService_DeleteRepositoryById_0(ctx context.Context,
 }
 
 var (
-	filter_RepositoryService_DeleteRepositoryByName_0 = &utilities.DoubleArray{Encoding: map[string]int{"provider": 0, "name": 1}, Base: []int{1, 2, 4, 0, 0, 0, 0}, Check: []int{0, 1, 1, 2, 2, 3, 3}}
+	filter_RepositoryService_DeleteRepositoryByName_0 = &utilities.DoubleArray{Encoding: map[string]int{"provider": 0, "name": 1}, Base: []int{1, 1, 2, 0, 0}, Check: []int{0, 1, 1, 2, 3}}
 )
 
 func request_RepositoryService_DeleteRepositoryByName_0(ctx context.Context, marshaler runtime.Marshaler, client RepositoryServiceClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
@@ -1408,7 +1392,7 @@ func local_request_RepositoryService_DeleteRepositoryByName_0(ctx context.Contex
 }
 
 var (
-	filter_RepositoryService_DeleteRepositoryByName_1 = &utilities.DoubleArray{Encoding: map[string]int{"name": 0}, Base: []int{1, 2, 0, 0}, Check: []int{0, 1, 2, 2}}
+	filter_RepositoryService_DeleteRepositoryByName_1 = &utilities.DoubleArray{Encoding: map[string]int{"name": 0}, Base: []int{1, 1, 0}, Check: []int{0, 1, 2}}
 )
 
 func request_RepositoryService_DeleteRepositoryByName_1(ctx context.Context, marshaler runtime.Marshaler, client RepositoryServiceClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
@@ -1481,11 +1465,7 @@ func request_UserService_CreateUser_0(ctx context.Context, marshaler runtime.Mar
 	var protoReq CreateUserRequest
 	var metadata runtime.ServerMetadata
 
-	newReader, berr := utilities.IOReaderFactory(req.Body)
-	if berr != nil {
-		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", berr)
-	}
-	if err := marshaler.NewDecoder(newReader()).Decode(&protoReq); err != nil && err != io.EOF {
+	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && err != io.EOF {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
 	}
 
@@ -1498,11 +1478,7 @@ func local_request_UserService_CreateUser_0(ctx context.Context, marshaler runti
 	var protoReq CreateUserRequest
 	var metadata runtime.ServerMetadata
 
-	newReader, berr := utilities.IOReaderFactory(req.Body)
-	if berr != nil {
-		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", berr)
-	}
-	if err := marshaler.NewDecoder(newReader()).Decode(&protoReq); err != nil && err != io.EOF {
+	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && err != io.EOF {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
 	}
 
@@ -1551,11 +1527,7 @@ func request_ProfileService_CreateProfile_0(ctx context.Context, marshaler runti
 	var protoReq CreateProfileRequest
 	var metadata runtime.ServerMetadata
 
-	newReader, berr := utilities.IOReaderFactory(req.Body)
-	if berr != nil {
-		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", berr)
-	}
-	if err := marshaler.NewDecoder(newReader()).Decode(&protoReq); err != nil && err != io.EOF {
+	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && err != io.EOF {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
 	}
 
@@ -1568,11 +1540,7 @@ func local_request_ProfileService_CreateProfile_0(ctx context.Context, marshaler
 	var protoReq CreateProfileRequest
 	var metadata runtime.ServerMetadata
 
-	newReader, berr := utilities.IOReaderFactory(req.Body)
-	if berr != nil {
-		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", berr)
-	}
-	if err := marshaler.NewDecoder(newReader()).Decode(&protoReq); err != nil && err != io.EOF {
+	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && err != io.EOF {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
 	}
 
@@ -1585,11 +1553,7 @@ func request_ProfileService_UpdateProfile_0(ctx context.Context, marshaler runti
 	var protoReq UpdateProfileRequest
 	var metadata runtime.ServerMetadata
 
-	newReader, berr := utilities.IOReaderFactory(req.Body)
-	if berr != nil {
-		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", berr)
-	}
-	if err := marshaler.NewDecoder(newReader()).Decode(&protoReq); err != nil && err != io.EOF {
+	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && err != io.EOF {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
 	}
 
@@ -1602,11 +1566,7 @@ func local_request_ProfileService_UpdateProfile_0(ctx context.Context, marshaler
 	var protoReq UpdateProfileRequest
 	var metadata runtime.ServerMetadata
 
-	newReader, berr := utilities.IOReaderFactory(req.Body)
-	if berr != nil {
-		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", berr)
-	}
-	if err := marshaler.NewDecoder(newReader()).Decode(&protoReq); err != nil && err != io.EOF {
+	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && err != io.EOF {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
 	}
 
@@ -1616,7 +1576,7 @@ func local_request_ProfileService_UpdateProfile_0(ctx context.Context, marshaler
 }
 
 var (
-	filter_ProfileService_DeleteProfile_0 = &utilities.DoubleArray{Encoding: map[string]int{"id": 0}, Base: []int{1, 2, 0, 0}, Check: []int{0, 1, 2, 2}}
+	filter_ProfileService_DeleteProfile_0 = &utilities.DoubleArray{Encoding: map[string]int{"id": 0}, Base: []int{1, 1, 0}, Check: []int{0, 1, 2}}
 )
 
 func request_ProfileService_DeleteProfile_0(ctx context.Context, marshaler runtime.Marshaler, client ProfileServiceClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
@@ -1722,7 +1682,7 @@ func local_request_ProfileService_ListProfiles_0(ctx context.Context, marshaler 
 }
 
 var (
-	filter_ProfileService_GetProfileById_0 = &utilities.DoubleArray{Encoding: map[string]int{"id": 0}, Base: []int{1, 2, 0, 0}, Check: []int{0, 1, 2, 2}}
+	filter_ProfileService_GetProfileById_0 = &utilities.DoubleArray{Encoding: map[string]int{"id": 0}, Base: []int{1, 1, 0}, Check: []int{0, 1, 2}}
 )
 
 func request_ProfileService_GetProfileById_0(ctx context.Context, marshaler runtime.Marshaler, client ProfileServiceClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
@@ -1792,7 +1752,7 @@ func local_request_ProfileService_GetProfileById_0(ctx context.Context, marshale
 }
 
 var (
-	filter_ProfileService_GetProfileStatusByName_0 = &utilities.DoubleArray{Encoding: map[string]int{"name": 0}, Base: []int{1, 2, 0, 0}, Check: []int{0, 1, 2, 2}}
+	filter_ProfileService_GetProfileStatusByName_0 = &utilities.DoubleArray{Encoding: map[string]int{"name": 0}, Base: []int{1, 1, 0}, Check: []int{0, 1, 2}}
 )
 
 func request_ProfileService_GetProfileStatusByName_0(ctx context.Context, marshaler runtime.Marshaler, client ProfileServiceClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
@@ -1934,7 +1894,7 @@ func local_request_ProfileService_ListRuleTypes_0(ctx context.Context, marshaler
 }
 
 var (
-	filter_ProfileService_GetRuleTypeByName_0 = &utilities.DoubleArray{Encoding: map[string]int{"name": 0}, Base: []int{1, 2, 0, 0}, Check: []int{0, 1, 2, 2}}
+	filter_ProfileService_GetRuleTypeByName_0 = &utilities.DoubleArray{Encoding: map[string]int{"name": 0}, Base: []int{1, 1, 0}, Check: []int{0, 1, 2}}
 )
 
 func request_ProfileService_GetRuleTypeByName_0(ctx context.Context, marshaler runtime.Marshaler, client ProfileServiceClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
@@ -2004,7 +1964,7 @@ func local_request_ProfileService_GetRuleTypeByName_0(ctx context.Context, marsh
 }
 
 var (
-	filter_ProfileService_GetRuleTypeById_0 = &utilities.DoubleArray{Encoding: map[string]int{"id": 0}, Base: []int{1, 2, 0, 0}, Check: []int{0, 1, 2, 2}}
+	filter_ProfileService_GetRuleTypeById_0 = &utilities.DoubleArray{Encoding: map[string]int{"id": 0}, Base: []int{1, 1, 0}, Check: []int{0, 1, 2}}
 )
 
 func request_ProfileService_GetRuleTypeById_0(ctx context.Context, marshaler runtime.Marshaler, client ProfileServiceClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
@@ -2077,11 +2037,7 @@ func request_ProfileService_CreateRuleType_0(ctx context.Context, marshaler runt
 	var protoReq CreateRuleTypeRequest
 	var metadata runtime.ServerMetadata
 
-	newReader, berr := utilities.IOReaderFactory(req.Body)
-	if berr != nil {
-		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", berr)
-	}
-	if err := marshaler.NewDecoder(newReader()).Decode(&protoReq); err != nil && err != io.EOF {
+	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && err != io.EOF {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
 	}
 
@@ -2094,11 +2050,7 @@ func local_request_ProfileService_CreateRuleType_0(ctx context.Context, marshale
 	var protoReq CreateRuleTypeRequest
 	var metadata runtime.ServerMetadata
 
-	newReader, berr := utilities.IOReaderFactory(req.Body)
-	if berr != nil {
-		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", berr)
-	}
-	if err := marshaler.NewDecoder(newReader()).Decode(&protoReq); err != nil && err != io.EOF {
+	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && err != io.EOF {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
 	}
 
@@ -2111,11 +2063,7 @@ func request_ProfileService_UpdateRuleType_0(ctx context.Context, marshaler runt
 	var protoReq UpdateRuleTypeRequest
 	var metadata runtime.ServerMetadata
 
-	newReader, berr := utilities.IOReaderFactory(req.Body)
-	if berr != nil {
-		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", berr)
-	}
-	if err := marshaler.NewDecoder(newReader()).Decode(&protoReq); err != nil && err != io.EOF {
+	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && err != io.EOF {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
 	}
 
@@ -2128,11 +2076,7 @@ func local_request_ProfileService_UpdateRuleType_0(ctx context.Context, marshale
 	var protoReq UpdateRuleTypeRequest
 	var metadata runtime.ServerMetadata
 
-	newReader, berr := utilities.IOReaderFactory(req.Body)
-	if berr != nil {
-		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", berr)
-	}
-	if err := marshaler.NewDecoder(newReader()).Decode(&protoReq); err != nil && err != io.EOF {
+	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && err != io.EOF {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
 	}
 
@@ -2142,7 +2086,7 @@ func local_request_ProfileService_UpdateRuleType_0(ctx context.Context, marshale
 }
 
 var (
-	filter_ProfileService_DeleteRuleType_0 = &utilities.DoubleArray{Encoding: map[string]int{"id": 0}, Base: []int{1, 2, 0, 0}, Check: []int{0, 1, 2, 2}}
+	filter_ProfileService_DeleteRuleType_0 = &utilities.DoubleArray{Encoding: map[string]int{"id": 0}, Base: []int{1, 1, 0}, Check: []int{0, 1, 2}}
 )
 
 func request_ProfileService_DeleteRuleType_0(ctx context.Context, marshaler runtime.Marshaler, client ProfileServiceClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
@@ -2287,11 +2231,7 @@ func request_PermissionsService_AssignRole_0(ctx context.Context, marshaler runt
 	var protoReq AssignRoleRequest
 	var metadata runtime.ServerMetadata
 
-	newReader, berr := utilities.IOReaderFactory(req.Body)
-	if berr != nil {
-		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", berr)
-	}
-	if err := marshaler.NewDecoder(newReader()).Decode(&protoReq); err != nil && err != io.EOF {
+	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && err != io.EOF {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
 	}
 
@@ -2304,11 +2244,7 @@ func local_request_PermissionsService_AssignRole_0(ctx context.Context, marshale
 	var protoReq AssignRoleRequest
 	var metadata runtime.ServerMetadata
 
-	newReader, berr := utilities.IOReaderFactory(req.Body)
-	if berr != nil {
-		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", berr)
-	}
-	if err := marshaler.NewDecoder(newReader()).Decode(&protoReq); err != nil && err != io.EOF {
+	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && err != io.EOF {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
 	}
 
@@ -2318,7 +2254,7 @@ func local_request_PermissionsService_AssignRole_0(ctx context.Context, marshale
 }
 
 var (
-	filter_PermissionsService_RemoveRole_0 = &utilities.DoubleArray{Encoding: map[string]int{"role_assignment": 0, "role": 1, "subject": 2}, Base: []int{1, 4, 5, 6, 2, 0, 4, 0, 0, 0}, Check: []int{0, 1, 1, 1, 2, 5, 2, 7, 3, 4}}
+	filter_PermissionsService_RemoveRole_0 = &utilities.DoubleArray{Encoding: map[string]int{"role_assignment": 0, "role": 1, "subject": 2}, Base: []int{1, 1, 1, 2, 0, 0}, Check: []int{0, 1, 2, 2, 3, 4}}
 )
 
 func request_PermissionsService_RemoveRole_0(ctx context.Context, marshaler runtime.Marshaler, client PermissionsServiceClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {

--- a/proto/minder/v1/minder.proto
+++ b/proto/minder/v1/minder.proto
@@ -1313,7 +1313,7 @@ message RuleType {
             }
 
             message Trusty {
-                // e.g. https://staging.stacklok.dev/
+                // e.g. https://api.trustypkg.dev/
                 string endpoint = 1;
             }
 


### PR DESCRIPTION
The following PR:
* Updates the go parser extracting the new packages from the `go.mod` diff
* Updates the go parser unit tests, it seemed previously they were addressing `go.sum` patch diffs
* Fixes the Trusty hyperlink for the alternative packages and now shows `No alternative found` when there's no package alternative found.
* Renames the `Ecosystem` column to `Pkg` so there's no horizontal scrolling because of this
* Fixes a bug in Minder which was not rendering to the user low-score packages that had no alternatives. 

Fixes: #2314 

**Before:**
<img width="913" alt="image" src="https://github.com/stacklok/minder/assets/16540482/efe32dac-8c00-440b-ac76-b49cd4530ad7">
<img width="872" alt="image" src="https://github.com/stacklok/minder/assets/16540482/453517a8-da76-4e1c-8b5b-68e412868da6">
**After:**
<img width="934" alt="image" src="https://github.com/stacklok/minder/assets/16540482/fc2c933b-0bac-4968-9d7f-6c6707936c53">
