### PR TITLE
Replace unpinned actions with pinned action

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,7 +26,6 @@ jobs:
       # Run the tests
       - name: Run tests
         run: make test-silent
-
   cover:
     name: Coverage
     permissions:
@@ -48,11 +47,10 @@ jobs:
       - name: Try converting to LCOV
         run: go run github.com/jandelgado/gcov2lcov@latest -infile=./coverage.out -outfile=./coverage.lcov
       - name: Coveralls GitHub Action
-        uses: coverallsapp/github-action@v2.2.3
+        uses: coverallsapp/github-action@e5e2507fa218d2031f39816cd7d078ebd1f1a6c6 # v2.2.3
         with:
           measure: true
           debug: true
-
   authz:
     name: Authz tests
     runs-on: ubuntu-latest
@@ -65,11 +63,9 @@ jobs:
         uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5
         with:
           go-version-file: 'go.mod'
-
       - name: Run `make bootstrap`
         run: |
           make bootstrap
-
       - name: Run authz tests
-        run: |
+        run: |-
           make authz-tests


### PR DESCRIPTION
<!-- minder: pr-remediation-body: { "ContentSha": "23eec6828cb11f5dc6f23e976a0fa006ee0dd81b" } -->

This is a Minder automated pull request.

This pull request replaces references to actions by tag to references to actions by SHA.

Verifies that any actions use pinned tags
Pinning an action to a full length commit SHA is currently the only way to use
an action as an immutable release. Pinning to a particular SHA helps mitigate
the risk of a bad actor adding a backdoor to the action's repository, as they
would need to generate a SHA-1 collision for a valid Git object payload.
When selecting a SHA, you should verify it is from the action's repository
and not a repository fork.

For more information, see
https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions
