### PR TITLE
Use latest golangci-lint in CI

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -17,8 +17,6 @@ jobs:
           cache: false
       - name: golangci-lint
         uses: golangci/golangci-lint-action@3cfe3a4abbb849e10058ce4af15d205b6da42804 # v3
-        with:
-          version: v1.56.1  
 
   mod-tidy:
     name: Go mod tidy


### PR DESCRIPTION
Instead of having to manually maintain the golangci-lint version in our
job, let's instead default to the latest one. This will get us the
latest and greatest CI checks provided by the tool and reduce the
maintenance burden of manual upgrades to this file. Unfortunately, this
is something that dependabot does not support updating.

Signed-off-by: Juan Antonio Osorio <ozz@stacklok.com>
