### PR TITLE
Remove unused functions from `internal/util/rand`

### DIFF
--- a/internal/db/repositories_test.go
+++ b/internal/db/repositories_test.go
@@ -42,8 +42,8 @@ func createRandomRepository(t *testing.T, project uuid.UUID, prov string, opts .
 		IsPrivate:  false,
 		IsFork:     false,
 		WebhookID:  sql.NullInt32{Int32: int32(rand.RandomInt(0, 1000, seed)), Valid: true},
-		WebhookUrl: rand.RandomURL(seed),
-		DeployUrl:  rand.RandomURL(seed),
+		WebhookUrl: randomURL(seed),
+		DeployUrl:  randomURL(seed),
 	}
 	// Allow arbitrary fixups to the Repository
 	for _, o := range opts {
@@ -273,4 +273,8 @@ func TestDeleteRepository(t *testing.T) {
 	require.Error(t, err)
 	require.EqualError(t, err, sql.ErrNoRows.Error())
 	require.Empty(t, repo2)
+}
+
+func randomURL(seed int64) string {
+	return "http://" + rand.RandomString(10, seed) + ".com"
 }

--- a/internal/util/rand/random.go
+++ b/internal/util/rand/random.go
@@ -19,14 +19,8 @@
 package rand
 
 import (
-	crand "crypto/rand"
-	"crypto/rsa"
-	"crypto/x509"
-	"encoding/pem"
 	"math/rand"
 	"net"
-	"os"
-	"path/filepath"
 	"sync/atomic"
 )
 
@@ -56,147 +50,9 @@ func RandomString(n int, seed int64) string {
 	return string(s)
 }
 
-// RandomEmail returns a random email address.
-func RandomEmail(seed int64) string {
-	return RandomString(10, seed) + "@example.com"
-}
-
 // RandomName returns a random name.
 func RandomName(seed int64) string {
 	return RandomString(10, seed)
-}
-
-// RandomURL returns a random URL.
-func RandomURL(seed int64) string {
-	return "http://" + RandomString(10, seed) + ".com"
-}
-
-// RandomPassword returns a random password.
-func RandomPassword(length int, seed int64) string {
-	// Define character pools
-	upperChars := "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
-	lowerChars := "abcdefghijklmnopqrstuvwxyz"
-	numberChars := "0123456789"
-	specialChars := "_.;?&@"
-
-	r := NewRand(seed)
-
-	// Create a slice to hold the password characters
-	password := make([]byte, length)
-
-	// Determine the number of characters needed from each pool
-	numUpper := 1
-	numLower := 1
-	numNumber := 1
-	numSpecial := 1
-	numRemaining := length - numUpper - numLower - numNumber - numSpecial
-
-	// Fill the password with random characters
-	fillPasswordChars(r, password, upperChars, numUpper)
-	fillPasswordChars(r, password, lowerChars, numLower)
-	fillPasswordChars(r, password, numberChars, numNumber)
-	fillPasswordChars(r, password, specialChars, numSpecial)
-	fillPasswordChars(r, password, upperChars+lowerChars+numberChars+specialChars, numRemaining)
-
-	// Shuffle the password characters
-	r.Shuffle(length, func(i, j int) {
-		password[i], password[j] = password[j], password[i]
-	})
-
-	return string(password)
-}
-
-func fillPasswordChars(r *rand.Rand, password []byte, charset string, count int) {
-	for i := 0; i < count; i++ {
-		randomIndex := r.Intn(len(password))
-		for password[randomIndex] != 0 {
-			randomIndex = r.Intn(len(password))
-		}
-		password[randomIndex] = getRandomChar(r, charset)
-	}
-}
-
-func getRandomChar(r *rand.Rand, charset string) byte {
-	return charset[r.Intn(len(charset))]
-}
-
-// RandomKeypair returns a random RSA keypair
-func RandomKeypair(length int) (*rsa.PrivateKey, *rsa.PublicKey) {
-	privateKey, err := rsa.GenerateKey(crand.Reader, length)
-	if err != nil {
-		return nil, nil
-	}
-	publicKey := &privateKey.PublicKey
-
-	return privateKey, publicKey
-}
-
-// RandomKeypairFile generates a random RSA keypair and writes it to files
-func RandomKeypairFile(length int, privateFilePath string, publicFilePath string) error {
-	filePriv, err := os.Create(filepath.Clean(privateFilePath))
-	if err != nil {
-		return err
-	}
-	defer filePriv.Close()
-
-	filePub, err := os.Create(filepath.Clean(publicFilePath))
-	if err != nil {
-		return err
-	}
-	defer filePub.Close()
-
-	privateKey, err := rsa.GenerateKey(crand.Reader, length)
-	if err != nil {
-		return err
-	}
-	privateKeyBytes := x509.MarshalPKCS1PrivateKey(privateKey)
-	pemBlock := &pem.Block{
-		Type:  "RSA PRIVATE KEY",
-		Bytes: privateKeyBytes,
-	}
-
-	err = pem.Encode(filePriv, pemBlock)
-	if err != nil {
-		return err
-	}
-
-	publicKey := &privateKey.PublicKey
-	publicKeyPEM := &pem.Block{
-		Type:  "RSA PUBLIC KEY",
-		Bytes: x509.MarshalPKCS1PublicKey(publicKey),
-	}
-
-	err = pem.Encode(filePub, publicKeyPEM)
-	if err != nil {
-		return err
-	}
-	return nil
-}
-
-// RandomPrivateKeyFile generates a random RSA private key and writes it to a file
-func RandomPrivateKeyFile(length int, filePath string) error {
-	privateKey, err := rsa.GenerateKey(crand.Reader, length)
-	if err != nil {
-		return err
-	}
-	file, err := os.Create(filepath.Clean(filePath))
-	if err != nil {
-		return err
-	}
-	defer file.Close()
-
-	privateKeyBytes := x509.MarshalPKCS1PrivateKey(privateKey)
-	pemBlock := &pem.Block{
-		Type:  "RSA PRIVATE KEY",
-		Bytes: privateKeyBytes,
-	}
-
-	err = pem.Encode(file, pemBlock)
-	if err != nil {
-		return err
-	}
-
-	return nil
 }
 
 // GetRandomPort returns a random port number.

--- a/internal/util/rand/random_test.go
+++ b/internal/util/rand/random_test.go
@@ -42,17 +42,6 @@ func TestRandomString(t *testing.T) {
 	require.Len(t, randomString, 10)
 }
 
-func TestRandomEmail(t *testing.T) {
-	t.Parallel()
-
-	seed := int64(12345)
-	email := rand.RandomEmail(seed)
-	require.NotEmpty(t, email)
-	require.Contains(t, email, "@")
-	require.Contains(t, email, ".")
-	require.Len(t, email, 22)
-}
-
 func TestRandomName(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
This cleans up the aforementioned package, thus minimizing it and
removing a bunch of dead code. some code that was only used in one
package's tests was moved to the relevant test file.

Signed-off-by: Juan Antonio Osorio <ozz@stacklok.com>
