### PR TITLE
When the `context` of a request is nil, return InvalidArgument/400

### DIFF
--- a/internal/controlplane/handlers_authz.go
+++ b/internal/controlplane/handlers_authz.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"database/sql"
 	"errors"
+
 	"github.com/google/uuid"
 	"github.com/rs/zerolog"
 	"google.golang.org/grpc"

--- a/internal/controlplane/handlers_authz.go
+++ b/internal/controlplane/handlers_authz.go
@@ -18,8 +18,6 @@ import (
 	"context"
 	"database/sql"
 	"errors"
-	"fmt"
-
 	"github.com/google/uuid"
 	"github.com/rs/zerolog"
 	"google.golang.org/grpc"
@@ -119,7 +117,7 @@ func populateEntityContext(
 	in HasProtoContext,
 ) (context.Context, error) {
 	if in.GetContext() == nil {
-		return ctx, fmt.Errorf("context cannot be nil")
+		return ctx, util.UserVisibleError(codes.InvalidArgument, "context cannot be nil")
 	}
 
 	projectID, err := getProjectFromRequestOrDefault(ctx, store, authzClient, in)

--- a/internal/controlplane/handlers_authz_test.go
+++ b/internal/controlplane/handlers_authz_test.go
@@ -90,6 +90,14 @@ func TestEntityContextProjectInterceptor(t *testing.T) {
 			expectedContext: engine.EntityContext{},
 		},
 		{
+			name:     "invalid request with nil context",
+			resource: minder.TargetResource_TARGET_RESOURCE_PROJECT,
+			req: &request{
+				Context: nil,
+			},
+			rpcErr: util.UserVisibleError(codes.InvalidArgument, "context cannot be nil"),
+		},
+		{
 			name: "malformed project ID",
 			req: &request{
 				Context: &minder.Context{


### PR DESCRIPTION
Fixes #2376

When the context of a request is missing, return a user-visible "InvalidArgument" response. Previously, this returned a regular Go error which caused the GRPC server to return a 500 response to the client.