### PR TITLE
Allow golangci-lint to comment on PRs

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -9,6 +9,13 @@ jobs:
   golangci-lint:
     name: Go Lint
     runs-on: ubuntu-latest
+    permissions:
+      # Required: allow read access to the content for analysis.
+      contents: read
+      # Optional: allow read access to pull request. Use with `only-new-issues` option.
+      pull-requests: read
+      # Optional: Allow write access to checks to allow the action to annotate code in the PR.
+      checks: write
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
       - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5


### PR DESCRIPTION
This allows the action to add relevant comments to the code when
linting. These permissions were taken from the action's doc.

Signed-off-by: Juan Antonio Osorio <ozz@stacklok.com>
