### PR TITLE
Elevate the permissions on the linting job in main.yml

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,6 +29,13 @@ jobs:
   license-check:
     uses: ./.github/workflows/license-check.yml
   lint:
+    permissions: # needed for golangci-lint
+      # Required: allow read access to the content for analysis.
+      contents: read
+      # Optional: allow read access to pull request. Use with `only-new-issues` option.
+      pull-requests: read
+      # Optional: Allow write access to checks to allow the action to annotate code in the PR.
+      checks: write
     uses: ./.github/workflows/lint.yml
   build:
     uses: ./.github/workflows/build.yml


### PR DESCRIPTION
Elevate the permissions on the linting job to allow for golangci-lint to comment and set statuses

Fixes: https://github.com/stacklok/minder/actions/runs/7962377835