### PR TITLE
Fix linting permissions for pr.yml and tags.yml workflows

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -25,6 +25,13 @@ jobs:
   license-check:
     uses: ./.github/workflows/license-check.yml
   lint:
+    permissions: # needed for golangci-lint
+      # Required: allow read access to the content for analysis.
+      contents: read
+      # Optional: allow read access to pull request. Use with `only-new-issues` option.
+      pull-requests: read
+      # Optional: Allow write access to checks to allow the action to annotate code in the PR.
+      checks: write
     uses: ./.github/workflows/lint.yml
   build:
     uses: ./.github/workflows/build.yml

--- a/.github/workflows/tags.yml
+++ b/.github/workflows/tags.yml
@@ -28,6 +28,13 @@ jobs:
   license-check:
     uses: ./.github/workflows/license-check.yml
   lint:
+    permissions: # needed for golangci-lint
+      # Required: allow read access to the content for analysis.
+      contents: read
+      # Optional: allow read access to pull request. Use with `only-new-issues` option.
+      pull-requests: read
+      # Optional: Allow write access to checks to allow the action to annotate code in the PR.
+      checks: write
     uses: ./.github/workflows/lint.yml
   build:
     uses: ./.github/workflows/build.yml


### PR DESCRIPTION
Missed fixing this for the other workflows running the linter job.