### PR TITLE
Add more coverage to `internal/eea` package

### DIFF
--- a/internal/eea/eea.go
+++ b/internal/eea/eea.go
@@ -215,10 +215,6 @@ func (e *EEA) FlushMessageHandler(msg *message.Message) error {
 func (e *EEA) FlushAll(ctx context.Context) error {
 	caches, err := e.querier.ListFlushCache(ctx)
 	if err != nil {
-		// No rows to flush, this is fine.
-		if errors.Is(err, sql.ErrNoRows) {
-			return nil
-		}
 		return fmt.Errorf("error listing flush cache: %w", err)
 	}
 


### PR DESCRIPTION
This just adds more coverage. Note that this also removed an invalid branch that used to check for `sql.ErrNoRows` upon a `ListFlushCache` call, that branch is never reached as the list would just return an empty array.

Signed-off-by: Juan Antonio Osorio <ozz@stacklok.com>
