### PR TITLE
Fix infinite wait for ratecache using non blocking Close() func

### DIFF
--- a/cmd/server/app/serve.go
+++ b/cmd/server/app/serve.go
@@ -124,6 +124,7 @@ var serveCmd = &cobra.Command{
 		serverMetrics := controlplane.NewMetrics()
 		providerMetrics := provtelemetry.NewProviderMetrics()
 		restClientCache := ratecache.NewRestClientCache(ctx)
+		defer restClientCache.Close()
 
 		s, err := controlplane.NewServer(
 			store, evt, serverMetrics, cfg, vldtr,
@@ -182,9 +183,6 @@ var serveCmd = &cobra.Command{
 
 		// Wait for all entity events to be executed
 		exec.Wait()
-
-		// Wait for the client cache background routine to finish
-		restClientCache.Wait()
 
 		return errg.Wait()
 	},


### PR DESCRIPTION
Issue #2261 (From https://github.com/stacklok/minder/pull/2271#discussion_r1495557451)

* Using Wait() in server.go introduced the bug where if the context is not cancelled, the server will continue to wait even if other go routines finished

* Replaces Wait() with non blocking Close() operation

* All this is done to free the resources associated with ticker