### PR TITLE
Change the yarn serve port for docs to 3001

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -20,6 +20,6 @@ yarn build
 
 Serve the docs
 ```
-yarn serve
+yarn serve -p 3001
 ```
-Visit http://localhost:3000/ to view the docs.
+Visit http://localhost:3001/ to view the docs.


### PR DESCRIPTION
OpenFGA seems to be using 3000 in our default docker setup which makes
the default `yarn serve` invocation throw an error. Let's change the
example `yarn` invocation to use a different port.
