### PR TITLE
Mischief managed, return buf breaking checks to normal.

### DIFF
--- a/proto/buf.yaml
+++ b/proto/buf.yaml
@@ -20,9 +20,6 @@ deps:
 breaking:
   use:
     - WIRE_JSON
-  # Temporary maneuver for #2395, remove in a followup PR
-  except:
-    - RESERVED_MESSAGE_NO_DELETE
 lint:
   use:
     - DEFAULT


### PR DESCRIPTION
See #2395 for details -- we needed to restore a removed proto field.
