### PR TITLE
Replace unpinned actions with pinned action

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -1,33 +1,31 @@
 name: Pull Request Validation
-
 on:
   pull_request:
-    types: [ opened, edited, reopened ]
-
+    types: [opened, edited, reopened]
 jobs:
   check-pr-content:
     runs-on: ubuntu-latest
     if: ${{ github.actor != 'dependabot[bot]' && github.actor != 'stacklokbot[bot]' }}
     steps:
       - name: Check PR for Change Type Selection
-        uses: actions/github-script@v7
+        uses: actions/github-script@5c56fde4671bc2d3592fb0f2c5b5bab9ddae03b1 # v7
         with:
           script: |
             const pr = context.payload.pull_request;
-            
+
             if (!pr) {
               console.log('This action must be run on a pull request event.');
               core.setFailed('No pull request data found.');
               return;
             }
-            
+
             const prNumber = pr.number;
             const body = pr.body;
-            
+
             console.log(`Processing PR #${prNumber}`);
-            
+
             const changeTypeRegex = /\- \[[xX]\] (Bug fix|Feature|Breaking change|Documentation)/;
-            
+
             if (!changeTypeRegex.test(body)) {
               core.setFailed("You must select at least one Change Type.");
             }


### PR DESCRIPTION
<!-- minder: pr-remediation-body: { "ContentSha": "ad85d4fdbe0ded0a528caaa37d7ee3be6fe982a1" } -->

This is a Minder automated pull request.

This pull request replaces references to actions by tag to references to actions by SHA.

Verifies that any actions use pinned tags
Pinning an action to a full length commit SHA is currently the only way to use
an action as an immutable release. Pinning to a particular SHA helps mitigate
the risk of a bad actor adding a backdoor to the action's repository, as they
would need to generate a SHA-1 collision for a valid Git object payload.
When selecting a SHA, you should verify it is from the action's repository
and not a repository fork.

For more information, see
https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions
