### PR TITLE
Fix OSV support for Go to properly identify go.mod packages

### DIFF
--- a/internal/engine/eval/vulncheck/pkgdb.go
+++ b/internal/engine/eval/vulncheck/pkgdb.go
@@ -317,18 +317,12 @@ type goModPackage struct {
 	DependencyHash string `json:"dependency_hash"`
 }
 
-func (gmp *goModPackage) IndentedString(_ int, _ string, _ *pb.Dependency) string {
-	return fmt.Sprintf("%s %s %s\n%s %s/go.mod %s",
-		gmp.Name, gmp.Version, gmp.ModuleHash,
-		gmp.Name, gmp.Version, gmp.DependencyHash)
+func (gmp *goModPackage) IndentedString(indent int, _ string, _ *pb.Dependency) string {
+	return fmt.Sprintf("%s%s %s", strings.Repeat(" ", indent), gmp.Name, gmp.Version)
 }
 
 func (gmp *goModPackage) LineHasDependency(line string) bool {
-	parts := strings.Split(line, " ")
-	if len(parts) != 3 {
-		return false
-	}
-	return parts[0] == gmp.Name && parts[1] == gmp.oldVersion
+	return strings.Contains(line, gmp.Name) && strings.Contains(line, gmp.oldVersion)
 }
 
 func (gmp *goModPackage) HasPatchedVersion() bool {

--- a/internal/engine/eval/vulncheck/review.go
+++ b/internal/engine/eval/vulncheck/review.go
@@ -56,6 +56,10 @@ const (
 	reviewTmplStr      = "{{.MagicComment}}\n\n{{.ReviewText}}"
 )
 
+const (
+	tabSize = 8
+)
+
 type reviewTemplateData struct {
 	MagicComment string
 	ReviewText   string
@@ -92,7 +96,11 @@ type reviewLocation struct {
 func countLeadingWhitespace(line string) int {
 	count := 0
 	for _, ch := range line {
-		if ch != ' ' && ch != '\t' {
+		if ch == '\t' {
+			count += tabSize
+			continue
+		}
+		if ch != ' ' {
 			return count
 		}
 		count++


### PR DESCRIPTION
# Summary

Fixes a few issues that affected the OSV support in Minder:
* Previously we were parsing the go.sum file which it does make sense, but we have no control over. Once we switched to parsing the go.mod file this broke the patching action Minder does (different format)
* Finding the line where the vulnerable package resides was prone to errors (line should be split to exactly 3 pieces)
* Counting the indentation was wrong and rendered poorly the suggested commit

## Change Type

***Mark the type of change your PR introduces:***

- [x] Bug fix (resolves an issue without affecting existing features)
- [ ] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [ ] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

***Outline how the changes were tested, including steps to reproduce and any relevant configurations. 
Attach screenshots if helpful.***

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [ ] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [ ] Included tests that validate the fix or feature.
- [x] Checked that related changes are merged.
