### PR TITLE
Do not ingest indirect go dependencies

### DIFF
--- a/internal/engine/ingester/diff/parse_test.go
+++ b/internal/engine/ingester/diff/parse_test.go
@@ -61,25 +61,32 @@ func TestGoParse(t *testing.T) {
 		{
 			description: "Mixed additions and removals",
 			content: `
-+	go.opentelemetry.io/proto/otlp v1.0.0 // indirect
++	go.opentelemetry.io/proto/otlp v1.0.0
 +	go.uber.org/mock v0.4.0 // indirect
 	golang.org/x/time v0.5.0 // indirect
 	gopkg.in/go-jose/go-jose.v2 v2.6.1 // indirect
 -	gotest.tools/v3 v3.4.0 // indirect
 	k8s.io/utils v0.0.0-20230726121419-3b25d923346b // indirect`,
-			expectedCount: 2,
+			expectedCount: 1,
 			expectedDependencies: []*pb.Dependency{
 				{
 					Ecosystem: pb.DepEcosystem_DEP_ECOSYSTEM_GO,
 					Name:      "go.opentelemetry.io/proto/otlp",
 					Version:   "v1.0.0",
 				},
-				{
-					Ecosystem: pb.DepEcosystem_DEP_ECOSYSTEM_GO,
-					Name:      "go.uber.org/mock",
-					Version:   "v0.4.0",
-				},
 			},
+		},
+		{
+			description: "Indirect addition",
+			content: `
++	go.opentelemetry.io/proto/otlp v1.0.0 // indirect
++	go.uber.org/mock v0.4.0 // indirect
+	golang.org/x/time v0.5.0 // indirect
+	gopkg.in/go-jose/go-jose.v2 v2.6.1 // indirect
+-	gotest.tools/v3 v3.4.0 // indirect
+	k8s.io/utils v0.0.0-20230726121419-3b25d923346b // indirect`,
+			expectedCount:        0,
+			expectedDependencies: []*pb.Dependency{},
 		},
 		{
 			description: "Replace",
@@ -88,7 +95,7 @@ func TestGoParse(t *testing.T) {
 	sigs.k8s.io/yaml v1.4.0 // indirect
 )
 +
-+replace github.com/opencontainers/runc => github.com/stacklok/runc v1.1.12 // indirect`,
++replace github.com/opencontainers/runc => github.com/stacklok/runc v1.1.12`,
 			expectedCount: 1,
 			expectedDependencies: []*pb.Dependency{
 				{


### PR DESCRIPTION
# Summary

Currently we are querying with Trusty all newly introduced dependencies, including the transitive ones which are not something we can update.

The following PR updates the diff ingester to skip ingesting Go dependencies that are indirect as they are transitive to the the main dependencies and are not actionable.

## Change Type

***Mark the type of change your PR introduces:***

- [x] Bug fix (resolves an issue without affecting existing features)
- [ ] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [ ] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

Before:
<img width="932" alt="image" src="https://github.com/stacklok/minder/assets/16540482/3cbcb048-bcb6-4d06-ace4-03bcdc9ced1a">

After:
<img width="921" alt="image" src="https://github.com/stacklok/minder/assets/16540482/7b5ad815-288f-4d9d-b549-fd8dd331d30a">

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [ ] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [ ] Included tests that validate the fix or feature.
- [ ] Checked that related changes are merged.
