### PR TITLE
Fix client crash with fix for GHSA-q6h8-4j2v-pjg4

### DIFF
--- a/internal/controlplane/handlers_githubwebhooks.go
+++ b/internal/controlplane/handlers_githubwebhooks.go
@@ -236,6 +236,12 @@ func (s *Server) registerWebhookForRepository(
 	secret := s.cfg.WebhookConfig.WebhookSecret
 
 	regResult := &pb.RegisterRepoResult{
+		// We will overwrite this later when we've looked it up from the provider,
+		// but existing clients expect a message here, so let's add one.
+		Repository: &pb.Repository{
+			Name:  repo.Name,  // Not normalized, from client
+			Owner: repo.Owner, // Not normalized, from client
+		},
 		Status: &pb.RegisterRepoResult_Status{
 			Success: false,
 		},


### PR DESCRIPTION
# Summary

Reported on slack:

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x2 addr=0x48 pc=0x103b59350]

goroutine 1 [running]:
github.com/stacklok/minder/cmd/cli/app/repo.printRepoRegistrationStatus({0x14000128858, 0x1, 0x0?})
	github.com/stacklok/minder/cmd/cli/app/repo/repo_register.go:245 +0xd0
github.com/stacklok/minder/cmd/cli/app/repo.RegisterCmd({0x104122e10, 0x14000536070}, 0x104b17f20, 0x1400063a408)
	github.com/stacklok/minder/cmd/cli/app/repo/repo_register.go:93 +0x678
github.com/stacklok/minder/cmd/cli/app/repo.init.GRPCClientWrapRunE.func5(0x104b17f20, {0x103b61543?, 0x4?, 0x103b61547?})
	github.com/stacklok/minder/internal/util/cli/cli.go:126 +0x138
github.com/spf13/cobra.(*Command).execute(0x104b17f20, {0x1400053e080, 0x2, 0x2})
	github.com/spf13/cobra@v1.8.0/command.go:983 +0x840
github.com/spf13/cobra.(*Command).ExecuteC(0x104b11d60)
	github.com/spf13/cobra@v1.8.0/command.go:1115 +0x344
github.com/spf13/cobra.(*Command).Execute(...)
	github.com/spf13/cobra@v1.8.0/command.go:1039
github.com/stacklok/minder/cmd/cli/app.Execute()
	github.com/stacklok/minder/cmd/cli/app/root.go:94 +0x94
main.main()
	github.com/stacklok/minder/cmd/cli/main.go:36 +0x1c
```

## Change Type

***Mark the type of change your PR introduces:***

- [x] Bug fix (resolves an issue without affecting existing features)
- [ ] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [ ] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

Discussion with @dmjb

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [x] Added comments to complex or tricky code sections.
- [x] Updated any affected documentation.
- [ ] Included tests that validate the fix or feature.
- [x] Checked that related changes are merged.
