### PR TITLE
Improve logging when ProjectsForUser returns an error

### DIFF
--- a/internal/controlplane/handlers_authz.go
+++ b/internal/controlplane/handlers_authz.go
@@ -168,7 +168,7 @@ func getProjectFromRequestOrDefault(
 	}
 	projects, err := authzClient.ProjectsForUser(ctx, userInfo.IdentitySubject)
 	if err != nil {
-		return uuid.UUID{}, status.Errorf(codes.Internal, "cannot find projects for user")
+		return uuid.UUID{}, status.Errorf(codes.Internal, "cannot find projects for user: %v", err)
 	}
 
 	if len(projects) == 0 {


### PR DESCRIPTION
# Summary

I've broken my staging account in a bunch of ways, but one of them is that I don't seem to be able to get project auto-detection to work (`authzClient.ProjectsForUser`).  We don't log the error from this call, so all I see is `cannot find projects for user` in the logs.  Let's include the detailed error message in the logs, in case it explains what's going on.

## Change Type

***Mark the type of change your PR introduces:***

- [ ] Bug fix (resolves an issue without affecting existing features)
- [ ] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [x] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

N/A

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [x] Added comments to complex or tricky code sections.
- [x] Updated any affected documentation.
- [ ] Included tests that validate the fix or feature.
- [x] Checked that related changes are merged.
