### PR TITLE
migrate webhook IDs to 64-bit integers

### DIFF
--- a/database/migrations/000020_webhook_id_resize.down.sql
+++ b/database/migrations/000020_webhook_id_resize.down.sql
@@ -1,0 +1,25 @@
+-- Copyright 2024 Stacklok, Inc
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--      http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+-- repositories.webhook_id was stored as an int32, but it is an int64 from GitHub
+-- Note that this takes an exclusive write lock on the table, which should be okay
+-- as long as the actual number of repositories is small.
+-- Given that we're shrinking the range, we'll need to check that the values are
+-- all within range; if not, this migration will fail and need manual intervention.
+
+BEGIN;
+-- repo_id column is NOT NULL, so this will *fail* and abort transaction.
+UPDATE repositories SET webhook_id = NULL WHERE webhook_id > 2147483647;
+ALTER TABLE repositories ALTER COLUMN webhook_id TYPE INTEGER;
+COMMIT;

--- a/database/migrations/000020_webhook_id_resize.down.sql
+++ b/database/migrations/000020_webhook_id_resize.down.sql
@@ -19,7 +19,7 @@
 -- all within range; if not, this migration will fail and need manual intervention.
 
 BEGIN;
--- repo_id column is NOT NULL, so this will *fail* and abort transaction.
+-- webhook_id column is NOT NULL, so this will *fail* and abort transaction.
 UPDATE repositories SET webhook_id = NULL WHERE webhook_id > 2147483647;
 ALTER TABLE repositories ALTER COLUMN webhook_id TYPE INTEGER;
 COMMIT;

--- a/database/migrations/000020_webhook_id_resize.up.sql
+++ b/database/migrations/000020_webhook_id_resize.up.sql
@@ -1,0 +1,18 @@
+-- Copyright 2024 Stacklok, Inc
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--      http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+-- repositories.webhook_id was stored as an int32, but it is an int64 from GitHub
+-- Note that this takes an exclusive write lock on the table, which should be okay
+-- as long as the actual number of repositories is small.
+ALTER TABLE repositories ALTER COLUMN webhook_id TYPE BIGINT;

--- a/internal/controlplane/handlers_githubwebhooks.go
+++ b/internal/controlplane/handlers_githubwebhooks.go
@@ -370,7 +370,7 @@ func (s *Server) deleteWebhookFromRepository(
 
 	webhookId := dbrepo.WebhookID
 	if webhookId.Valid {
-		resp, err := client.DeleteHook(ctx, dbrepo.RepoOwner, dbrepo.RepoName, int64(webhookId.Int32))
+		resp, err := client.DeleteHook(ctx, dbrepo.RepoOwner, dbrepo.RepoName, webhookId.Int64)
 		if err != nil {
 			if resp != nil && resp.StatusCode == http.StatusNotFound {
 				// if the hook is not found, we can ignore the error, user might have deleted it manually

--- a/internal/controlplane/handlers_repositories.go
+++ b/internal/controlplane/handlers_repositories.go
@@ -97,8 +97,8 @@ func (s *Server) RegisterRepository(ctx context.Context,
 		RepoID:    r.RepoId,
 		IsPrivate: r.IsPrivate,
 		IsFork:    r.IsFork,
-		WebhookID: sql.NullInt32{
-			Int32: int32(r.HookId),
+		WebhookID: sql.NullInt64{
+			Int64: r.HookId,
 			Valid: true,
 		},
 		CloneUrl:   r.CloneUrl,

--- a/internal/db/models.go
+++ b/internal/db/models.go
@@ -411,7 +411,7 @@ type Repository struct {
 	RepoID        int64          `json:"repo_id"`
 	IsPrivate     bool           `json:"is_private"`
 	IsFork        bool           `json:"is_fork"`
-	WebhookID     sql.NullInt32  `json:"webhook_id"`
+	WebhookID     sql.NullInt64  `json:"webhook_id"`
 	WebhookUrl    string         `json:"webhook_url"`
 	DeployUrl     string         `json:"deploy_url"`
 	CloneUrl      string         `json:"clone_url"`

--- a/internal/db/repositories.sql.go
+++ b/internal/db/repositories.sql.go
@@ -47,7 +47,7 @@ type CreateRepositoryParams struct {
 	RepoID        int64          `json:"repo_id"`
 	IsPrivate     bool           `json:"is_private"`
 	IsFork        bool           `json:"is_fork"`
-	WebhookID     sql.NullInt32  `json:"webhook_id"`
+	WebhookID     sql.NullInt64  `json:"webhook_id"`
 	WebhookUrl    string         `json:"webhook_url"`
 	DeployUrl     string         `json:"deploy_url"`
 	CloneUrl      string         `json:"clone_url"`
@@ -458,7 +458,7 @@ type UpdateRepositoryParams struct {
 	RepoID        int64          `json:"repo_id"`
 	IsPrivate     bool           `json:"is_private"`
 	IsFork        bool           `json:"is_fork"`
-	WebhookID     sql.NullInt32  `json:"webhook_id"`
+	WebhookID     sql.NullInt64  `json:"webhook_id"`
 	WebhookUrl    string         `json:"webhook_url"`
 	DeployUrl     string         `json:"deploy_url"`
 	Provider      string         `json:"provider"`
@@ -528,7 +528,7 @@ type UpdateRepositoryByIDParams struct {
 	RepoName      string         `json:"repo_name"`
 	IsPrivate     bool           `json:"is_private"`
 	IsFork        bool           `json:"is_fork"`
-	WebhookID     sql.NullInt32  `json:"webhook_id"`
+	WebhookID     sql.NullInt64  `json:"webhook_id"`
 	WebhookUrl    string         `json:"webhook_url"`
 	DeployUrl     string         `json:"deploy_url"`
 	Provider      string         `json:"provider"`

--- a/internal/db/repositories_test.go
+++ b/internal/db/repositories_test.go
@@ -41,7 +41,7 @@ func createRandomRepository(t *testing.T, project uuid.UUID, prov string, opts .
 		RepoID:     rand.RandomInt(0, 5000, seed),
 		IsPrivate:  false,
 		IsFork:     false,
-		WebhookID:  sql.NullInt32{Int32: int32(rand.RandomInt(0, 1000, seed)), Valid: true},
+		WebhookID:  sql.NullInt64{Int64: rand.RandomInt(0, 1000, seed), Valid: true},
 		WebhookUrl: randomURL(seed),
 		DeployUrl:  randomURL(seed),
 	}
@@ -194,7 +194,7 @@ func TestUpdateRepository(t *testing.T) {
 		RepoID:     repo1.RepoID,
 		IsPrivate:  repo1.IsPrivate,
 		IsFork:     repo1.IsFork,
-		WebhookID:  sql.NullInt32{Int32: 1234, Valid: true},
+		WebhookID:  sql.NullInt64{Int64: 1234, Valid: true},
 		WebhookUrl: repo1.WebhookUrl,
 		DeployUrl:  repo1.DeployUrl,
 	}
@@ -234,7 +234,7 @@ func TestUpdateRepositoryByRepoId(t *testing.T) {
 		RepoName:   repo1.RepoName,
 		IsPrivate:  repo1.IsPrivate,
 		IsFork:     repo1.IsFork,
-		WebhookID:  sql.NullInt32{Int32: 1234, Valid: true},
+		WebhookID:  sql.NullInt64{Int64: 1234, Valid: true},
 		WebhookUrl: repo1.WebhookUrl,
 		DeployUrl:  repo1.DeployUrl,
 	}


### PR DESCRIPTION
Fixes #2443 (other fixes needed)

Related to the repo ID change made by Evan recently: use 64-bit ints for webhook IDs. This involves increasing the size of integer we use in the DB schema, and making changes to the business logic where we set the IDs.

# Summary

***Provide a brief overview of the changes and the issue being addressed. 
Explain the rationale and any background necessary for understanding the changes. 
List dependencies required by this change, if any.***

Fixes #(related issue)

## Change Type

***Mark the type of change your PR introduces:***

- [x] Bug fix (resolves an issue without affecting existing features)
- [ ] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [ ] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

***Outline how the changes were tested, including steps to reproduce and any relevant configurations. 
Attach screenshots if helpful.***

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [ ] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [x] Included tests that validate the fix or feature.
- [ ] Checked that related changes are merged.
