### PR TITLE
Add name validation for profiles and rule types, move static validation first, add tests

### DIFF
--- a/internal/controlplane/handlers_profile.go
+++ b/internal/controlplane/handlers_profile.go
@@ -58,6 +58,12 @@ func validateActionType(r string) db.NullActionType {
 func (s *Server) CreateProfile(ctx context.Context,
 	cpr *minderv1.CreateProfileRequest) (*minderv1.CreateProfileResponse, error) {
 	in := cpr.GetProfile()
+	if err := in.Validate(); err != nil {
+		if errors.Is(err, minderv1.ErrValidationFailed) {
+			return nil, util.UserVisibleError(codes.InvalidArgument, "Couldn't create profile: %s", err)
+		}
+		return nil, status.Errorf(codes.InvalidArgument, "invalid profile: %v", err)
+	}
 
 	entityCtx := engine.EntityFromContext(ctx)
 	err := entityCtx.Validate(ctx, s.store)
@@ -71,10 +77,6 @@ func (s *Server) CreateProfile(ctx context.Context,
 		ProjectID: entityCtx.Project.ID})
 	if err != nil {
 		return nil, providerError(err)
-	}
-
-	if err := in.Validate(); err != nil {
-		return nil, status.Errorf(codes.InvalidArgument, "invalid profile: %v", err)
 	}
 
 	rulesInProf, err := s.profileValidator.ValidateAndExtractRules(ctx, in, entityCtx)

--- a/internal/controlplane/handlers_ruletype_test.go
+++ b/internal/controlplane/handlers_ruletype_test.go
@@ -1,0 +1,183 @@
+// Copyright 2023 Stacklok, Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package controlplane
+
+import (
+	"context"
+	"testing"
+
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/structpb"
+
+	"github.com/stacklok/minder/internal/db"
+	"github.com/stacklok/minder/internal/db/embedded"
+	"github.com/stacklok/minder/internal/engine"
+	"github.com/stacklok/minder/internal/profiles"
+	"github.com/stacklok/minder/internal/util"
+	minderv1 "github.com/stacklok/minder/pkg/api/protobuf/go/minder/v1"
+)
+
+func TestCreateRuleType(t *testing.T) {
+	t.Parallel()
+
+	// We can't use mockdb.NewMockStore because BeginTransaction returns a *sql.Tx,
+	// which is not an interface and can't be mocked.
+	dbStore, cancelFunc, err := embedded.GetFakeStore()
+	if cancelFunc != nil {
+		t.Cleanup(cancelFunc)
+	}
+	if err != nil {
+		t.Fatalf("Error creating fake store: %v", err)
+	}
+
+	// Common database setup
+	ctx := context.Background()
+	dbproj, err := dbStore.CreateProject(ctx, db.CreateProjectParams{
+		Name:     "test",
+		Metadata: []byte(`{}`),
+	})
+	if err != nil {
+		t.Fatalf("Error creating project: %v", err)
+	}
+	provider, err := dbStore.CreateProvider(ctx, db.CreateProviderParams{
+		Name:       "github",
+		ProjectID:  dbproj.ID,
+		Implements: []db.ProviderType{db.ProviderTypeGithub},
+		Definition: []byte(`{}`),
+	})
+	if err != nil {
+		t.Fatalf("Error creating provider: %v", err)
+	}
+
+	tests := []struct {
+		name     string
+		ruletype *minderv1.CreateRuleTypeRequest
+		wantErr  string
+		result   *minderv1.CreateRuleTypeResponse
+	}{{
+		name: "Create ruletype with empty name",
+		ruletype: &minderv1.CreateRuleTypeRequest{
+			RuleType: &minderv1.RuleType{
+				Name: "",
+			},
+		},
+		wantErr: `Couldn't create rule: invalid rule type: rule type name is empty`,
+	}, {
+		name: "Create ruletype with invalid name",
+		ruletype: &minderv1.CreateRuleTypeRequest{
+			RuleType: &minderv1.RuleType{
+				Name: "colon:invalid",
+			},
+		},
+		wantErr: `Couldn't create rule: invalid rule type: rule type name may only contain letters, numbers, hyphens and underscores`,
+	}, {
+		name: "Create ruletype without definition",
+		ruletype: &minderv1.CreateRuleTypeRequest{
+			RuleType: &minderv1.RuleType{
+				Name: "empty",
+			},
+		},
+		wantErr: `Couldn't create rule: invalid rule type: rule type definition is nil`,
+	}, {
+		name: "Create ruletype with valid name and content",
+		ruletype: &minderv1.CreateRuleTypeRequest{
+			RuleType: &minderv1.RuleType{
+				Name: "rule_type_1",
+				Def: &minderv1.RuleType_Definition{
+					InEntity: string(minderv1.RepositoryEntity),
+					RuleSchema: &structpb.Struct{},
+					Ingest: &minderv1.RuleType_Definition_Ingest{},
+					Eval: &minderv1.RuleType_Definition_Eval{},
+				},
+			},
+		},
+		result: &minderv1.CreateRuleTypeResponse{
+			RuleType: &minderv1.RuleType{
+				Name: "rule_type_1",
+				Def: &minderv1.RuleType_Definition{
+					InEntity: string(minderv1.RepositoryEntity),
+					RuleSchema: &structpb.Struct{},
+					Ingest: &minderv1.RuleType_Definition_Ingest{},
+					Eval: &minderv1.RuleType_Definition_Eval{},
+				},
+				Severity: &minderv1.Severity{
+					Value: minderv1.Severity_VALUE_UNKNOWN,
+				},
+			},
+		},
+	}}
+
+	for _, tc := range tests {
+		tc := tc
+
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			ctx := context.Background()
+
+			if tc.ruletype.GetContext() == nil {
+				tc.ruletype.RuleType.Context = &minderv1.Context{
+					Project:  proto.String(dbproj.ID.String()),
+					Provider: proto.String("github"),
+				}
+				if tc.result != nil {
+					tc.result.GetRuleType().Context = tc.ruletype.GetContext()
+				}
+			}
+
+			ctx = engine.WithEntityContext(context.Background(), &engine.EntityContext{
+				Project:  engine.Project{ID: dbproj.ID},
+				Provider: engine.Provider{Name: "github"},
+			})
+			s := &Server{
+				store:            dbStore,
+				profileValidator: profiles.NewValidator(dbStore),
+				evt:              &StubEventer{},
+			}
+
+			res, err := s.CreateRuleType(ctx, tc.ruletype)
+			if tc.wantErr != "" {
+				niceErr, ok := err.(*util.NiceStatus)
+				if !ok {
+					t.Fatalf("Unexpected error type from CreateProfile: %v", err)
+				}
+				if niceErr.Details != tc.wantErr {
+					t.Errorf("CreateProfile() error = %q, wantErr %q", err, tc.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("Unexpected error from CreateProfile: %v", err)
+			}
+
+			ruletype, err := dbStore.GetRuleTypeByName(ctx, db.GetRuleTypeByNameParams{
+				Provider:  provider.Name,
+				Name:      tc.ruletype.GetRuleType().GetName(),
+				ProjectID: dbproj.ID,
+			})
+			if err != nil {
+				t.Fatalf("Error getting profile: %v", err)
+			}
+
+			if tc.result.GetRuleType().GetId() == "" {
+				tc.result.GetRuleType().Id = proto.String(ruletype.ID.String())
+			}
+			// For some reason, comparing these protos directly doesn't seem to work...
+			if !proto.Equal(res, tc.result) {
+				t.Errorf("CreateRuleType() got = %v, want %v", res, tc.result)
+			}
+		})
+	}
+}

--- a/internal/db/embedded/testdb.go
+++ b/internal/db/embedded/testdb.go
@@ -1,0 +1,84 @@
+// Copyright 2024 Stacklok, Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package embedded provides a test-only embedded Postgres database for testing queries.
+package embedded
+
+import (
+	"database/sql"
+	"fmt"
+	"net"
+	"os"
+
+	embeddedpostgres "github.com/fergusstrange/embedded-postgres"
+	"github.com/golang-migrate/migrate/v4"
+	_ "github.com/golang-migrate/migrate/v4/database/postgres" // nolint
+	_ "github.com/golang-migrate/migrate/v4/source/file"
+
+	"github.com/stacklok/minder/internal/db"
+)
+
+type CancelFunc func()
+
+// GetFakeStore returns a new embedded Postgres database and a cancel function
+// to clean up the database.
+func GetFakeStore() (db.Store, CancelFunc, error) {
+	cfg := embeddedpostgres.DefaultConfig()
+	port, err := pickUnusedPort()
+	if err != nil {
+		return nil, nil, err
+	}
+	tmpName, err := os.MkdirTemp("", "minder-db-test")
+	if err != nil {
+		return nil, nil, err
+	}
+	cleanupDir := func() {
+		if err := os.RemoveAll(tmpName); err != nil {
+			fmt.Printf("Unable to remove tmpdir %q: %v\n", tmpName, err)
+		}
+	}
+	cfg = cfg.Port(uint32(port)).RuntimePath(tmpName)
+
+	postgres := embeddedpostgres.NewDatabase(cfg)
+	if err := postgres.Start(); err != nil {
+		return nil, cleanupDir, err
+	}
+	cancel := func() {
+		if err := postgres.Stop(); err != nil {
+			fmt.Printf("Unable to stop postgres: %v\n", err)
+		}
+		cleanupDir()
+	}
+	sqlDB, err := sql.Open("postgres", cfg.GetConnectionURL()+"?sslmode=disable")
+
+	configpath := "file://../../database/migrations"
+	mig, err := migrate.New(configpath, cfg.GetConnectionURL()+"?sslmode=disable")
+	if err != nil {
+		return nil, cancel, err
+	}
+	if err := mig.Up(); err != nil {
+		return nil, cancel, err
+	}
+
+	return db.NewStore(sqlDB), cancel, nil
+}
+
+func pickUnusedPort() (int, error) {
+	l, err := net.Listen("tcp", "localhost:0")
+	if err != nil {
+		return 0, err
+	}
+	defer l.Close()
+	return l.Addr().(*net.TCPAddr).Port, nil
+}

--- a/pkg/api/protobuf/go/minder/v1/validators.go
+++ b/pkg/api/protobuf/go/minder/v1/validators.go
@@ -17,11 +17,15 @@ package v1
 import (
 	"errors"
 	"fmt"
+	"regexp"
 )
 
 var (
 	// ErrValidationFailed is returned when a profile fails validation
 	ErrValidationFailed = fmt.Errorf("validation failed")
+
+	// Starts with a letter/digit, then a string of letter/digit and hypen or underscore
+	dnsStyleNameRegex = regexp.MustCompile(`^[a-zA-Z0-9][-_a-zA-Z0-9]{0,62}$`)
 )
 
 // Validator is an interface which allows for the validation of a struct.
@@ -84,6 +88,13 @@ var _ Validator = (*RuleType)(nil)
 func (rt *RuleType) Validate() error {
 	if rt == nil {
 		return fmt.Errorf("%w: rule type is nil", ErrInvalidRuleType)
+	}
+
+	if rt.Name == "" {
+		return fmt.Errorf("%w: rule type name is empty", ErrInvalidRuleType)
+	}
+	if !dnsStyleNameRegex.MatchString(rt.Name) {
+		return fmt.Errorf("%w: rule type name may only contain letters, numbers, hyphens and underscores", ErrInvalidRuleType)
 	}
 
 	if rt.Def == nil {
@@ -177,14 +188,17 @@ func (p *Profile) Validate() error {
 		return fmt.Errorf("%w: profile version is invalid: %s", ErrValidationFailed, p.Version)
 	}
 
-	if p.Name == "" {
+	if p.GetName() == "" {
 		return fmt.Errorf("%w: profile name cannot be empty", ErrValidationFailed)
 	}
+	if !dnsStyleNameRegex.MatchString(p.GetName()) {
+		return fmt.Errorf("%w: profile names may only contain letters, numbers, hyphens and underscores", ErrValidationFailed)
+	}
 
-	repoRuleCount := len(p.Repository)
-	buildEnvRuleCount := len(p.BuildEnvironment)
-	artifactRuleCount := len(p.Artifact)
-	pullRequestRuleCount := len(p.PullRequest)
+	repoRuleCount := len(p.GetRepository())
+	buildEnvRuleCount := len(p.GetBuildEnvironment())
+	artifactRuleCount := len(p.GetArtifact())
+	pullRequestRuleCount := len(p.GetPullRequest())
 	totalRuleCount := repoRuleCount + buildEnvRuleCount + artifactRuleCount + pullRequestRuleCount
 
 	if totalRuleCount == 0 {
@@ -192,37 +206,27 @@ func (p *Profile) Validate() error {
 	}
 
 	// If the profile is nil or empty, we don't need to validate it
-	if p.Repository != nil && repoRuleCount > 0 {
-		return validateEntity(p.Repository)
-	}
-
-	if p.BuildEnvironment != nil && buildEnvRuleCount > 0 {
-		return validateEntity(p.BuildEnvironment)
-	}
-
-	if p.Artifact != nil && artifactRuleCount > 0 {
-		return validateEntity(p.Artifact)
-	}
-
-	if p.PullRequest != nil && pullRequestRuleCount > 0 {
-		return validateEntity(p.PullRequest)
-	}
-
-	return nil
-}
-
-func validateEntity(e []*Profile_Rule) error {
-	if len(e) == 0 {
-		return fmt.Errorf("%w: entity rules cannot be empty", ErrValidationFailed)
-	}
-
-	for _, r := range e {
-		if r == nil {
-			return fmt.Errorf("%w: entity contextual rules cannot be nil", ErrValidationFailed)
-		}
-
+	for i, r := range p.GetRepository() {
 		if err := validateRule(r); err != nil {
-			return err
+			return fmt.Errorf("repository rule %d is invalid: %w", i, err)
+		}
+	}
+
+	for i, b := range p.GetBuildEnvironment() {
+		if err := validateRule(b); err != nil {
+			return fmt.Errorf("build environment rule %d is invalid: %w", i, err)
+		}
+	}
+
+	for i, a := range p.GetArtifact() {
+		if err := validateRule(a); err != nil {
+			return fmt.Errorf("artifact rule %d is invalid: %w", i, err)
+		}
+	}
+
+	for i, pr := range p.GetPullRequest() {
+		if err := validateRule(pr); err != nil {
+			return fmt.Errorf("pull request rule %d is invalid: %w", i, err)
 		}
 	}
 
@@ -230,11 +234,12 @@ func validateEntity(e []*Profile_Rule) error {
 }
 
 func validateRule(r *Profile_Rule) error {
-	if r.Type == "" {
+	if r.GetType() == "" {
 		return fmt.Errorf("%w: rule type cannot be empty", ErrValidationFailed)
 	}
 
-	if r.Def == nil {
+	// TODO: can we omit this if the rule doesn't have values?
+	if r.GetDef() == nil {
 		return fmt.Errorf("%w: rule def cannot be nil", ErrValidationFailed)
 	}
 


### PR DESCRIPTION
# Summary

We currently accept any strings for profile and rule names, but this is probably unwise.  Start with a narrow (DNS label) character set.

## Change Type

***Mark the type of change your PR introduces:***

- [ ] Bug fix (resolves an issue without affecting existing features)
- [ ] Feature (adds new functionality without breaking changes)
- [x] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [ ] Refactoring or test improvements (no bug fixes or new functionality)

Rationale: We don't currently have any rules or profiles with these names, but we could.  Will do manual checks and cleanup after this is merged / rolled out.

# Testing

Added unit tests.  Discovered that you can't use the mock DB with transactions, because `sql.Tx` is a concrete type.  Switched to using embedded Postgres, made a library for easy setup.

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [x] Added comments to complex or tricky code sections.
- [x] Updated any affected documentation.
- [x] Included tests that validate the fix or feature.
- [x] Checked that related changes are merged.
