### PR TITLE
Support for offline tokens

### DIFF
--- a/cmd/cli/app/auth/auth_login.go
+++ b/cmd/cli/app/auth/auth_login.go
@@ -18,26 +18,14 @@ package auth
 import (
 	"context"
 	_ "embed"
-	"fmt"
-	"net/http"
-	"net/url"
-	"os"
-	"time"
 
-	"github.com/gorilla/securecookie"
-	"github.com/pkg/browser"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
-	"github.com/zitadel/oidc/v2/pkg/client/rp"
-	httphelper "github.com/zitadel/oidc/v2/pkg/http"
-	"github.com/zitadel/oidc/v2/pkg/oidc"
 
 	"github.com/stacklok/minder/internal/config"
 	clientconfig "github.com/stacklok/minder/internal/config/client"
-	mcrypto "github.com/stacklok/minder/internal/crypto"
 	"github.com/stacklok/minder/internal/util"
 	"github.com/stacklok/minder/internal/util/cli"
-	"github.com/stacklok/minder/internal/util/rand"
 	minderv1 "github.com/stacklok/minder/pkg/api/protobuf/go/minder/v1"
 )
 
@@ -62,100 +50,15 @@ func LoginCommand(cmd *cobra.Command, _ []string) error {
 		return cli.MessageAndError("Unable to read config", err)
 	}
 
-	issuerUrlStr := clientConfig.Identity.CLI.IssuerUrl
-	clientID := clientConfig.Identity.CLI.ClientId
-
-	parsedURL, err := url.Parse(issuerUrlStr)
-	if err != nil {
-		return cli.MessageAndError("Error parsing issuer URL", err)
-	}
-
 	// No longer print usage on returned error, since we've parsed our inputs
 	// See https://github.com/spf13/cobra/issues/340#issuecomment-374617413
 	cmd.SilenceUsage = true
 
-	issuerUrl := parsedURL.JoinPath("realms/stacklok")
-	scopes := []string{"openid"}
-	callbackPath := "/auth/callback"
-
-	// create encrypted cookie handler to mitigate CSRF attacks
-	hashKey := securecookie.GenerateRandomKey(32)
-	encryptKey := securecookie.GenerateRandomKey(32)
-	cookieHandler := httphelper.NewCookieHandler(hashKey, encryptKey, httphelper.WithUnsecure(),
-		httphelper.WithSameSite(http.SameSiteLaxMode))
-	options := []rp.Option{
-		rp.WithCookieHandler(cookieHandler),
-		rp.WithVerifierOpts(rp.WithIssuedAtOffset(5 * time.Second)),
-		rp.WithPKCE(cookieHandler),
-	}
-
-	// Get random port
-	port, err := rand.GetRandomPort()
-	if err != nil {
-		return cli.MessageAndError("Error getting random port", err)
-	}
-
-	parsedURL, err = url.Parse(fmt.Sprintf("http://localhost:%v", port))
-	if err != nil {
-		return cli.MessageAndError("Error parsing callback URL", err)
-	}
-	redirectURI := parsedURL.JoinPath(callbackPath)
-
-	provider, err := rp.NewRelyingPartyOIDC(issuerUrl.String(), clientID, "", redirectURI.String(), scopes, options...)
-	if err != nil {
-		return cli.MessageAndError("Error creating relying party", err)
-	}
-
-	stateFn := func() string {
-		state, err := mcrypto.GenerateNonce()
-		if err != nil {
-			cmd.PrintErrln("error generating state for login")
-			os.Exit(1)
-		}
-		return state
-	}
-
-	tokenChan := make(chan *oidc.Tokens[*oidc.IDTokenClaims])
-
-	callback := func(w http.ResponseWriter, _ *http.Request,
-		tokens *oidc.Tokens[*oidc.IDTokenClaims], _ string, _ rp.RelyingParty) {
-
-		tokenChan <- tokens
-		// send a success message to the browser
-		w.Header().Set("Content-Type", "text/html; charset=utf-8")
-		_, err := w.Write(loginSuccessHtml)
-		if err != nil {
-			// if we cannot display the success page, just print a success message
-			cmd.Println("Authentication Successful")
-		}
-	}
-	http.Handle("/login", rp.AuthURLHandler(stateFn, provider))
-	http.Handle(callbackPath, rp.CodeExchangeHandler(callback, provider))
-
-	server := &http.Server{
-		Addr:              fmt.Sprintf(":%d", port),
-		ReadHeaderTimeout: time.Second * 10,
-	}
-	// Start the server in a goroutine
-	go func() {
-		_ = server.ListenAndServe()
-	}()
-	// get the OAuth authorization URL
-	loginUrl := fmt.Sprintf("http://localhost:%v/login", port)
-
-	// Redirect user to provider to log in
-	cmd.Printf("Your browser will now be opened to: %s\n", loginUrl)
-	cmd.Println("Please follow the instructions on the page to log in.")
-
-	// open user's browser to login page
-	if err := browser.OpenURL(loginUrl); err != nil {
-		cmd.Printf("You may login by pasting this URL into your browser: %s\n", loginUrl)
-	}
-
-	cmd.Println("Waiting for token...")
-
 	// wait for the token to be received
-	token := <-tokenChan
+	token, err := login(ctx, cmd, clientConfig, nil)
+	if err != nil {
+		return err
+	}
 
 	// save credentials
 	filePath, err := util.SaveCredentials(util.OpenIdCredentials{
@@ -205,10 +108,7 @@ func LoginCommand(cmd *cobra.Command, _ []string) error {
 	}
 
 	cmd.Printf("Your access credentials have been saved to %s\n", filePath)
-
-	// shut down the HTTP server
-	// TODO: should this use the app context?
-	return server.Shutdown(context.Background())
+	return nil
 }
 
 func init() {

--- a/cmd/cli/app/auth/offline.go
+++ b/cmd/cli/app/auth/offline.go
@@ -1,0 +1,40 @@
+//
+// Copyright 2024 Stacklok, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package auth
+
+import (
+	"github.com/spf13/cobra"
+)
+
+// OfflineTokenCmd represents the offline-token set of sub-commands
+var OfflineTokenCmd = &cobra.Command{
+	Use:   "offline-token",
+	Short: "Manage offline tokens",
+	Long: `The minder auth offline-token command project lets you manage offline tokens
+for the minder control plane.
+
+Offline tokens are used to authenticate to the minder control plane without
+requiring the user's presence. This is useful for long-running processes
+that need to authenticate to the control plane.`,
+
+	RunE: func(cmd *cobra.Command, _ []string) error {
+		return cmd.Usage()
+	},
+}
+
+func init() {
+	AuthCmd.AddCommand(OfflineTokenCmd)
+}

--- a/cmd/cli/app/auth/offline_get.go
+++ b/cmd/cli/app/auth/offline_get.go
@@ -1,0 +1,81 @@
+//
+// Copyright 2024 Stacklok, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package auth
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+
+	"github.com/stacklok/minder/internal/config"
+	clientconfig "github.com/stacklok/minder/internal/config/client"
+	"github.com/stacklok/minder/internal/util/cli"
+)
+
+// offlineTokenGetCmd represents the offline-token get command
+var offlineTokenGetCmd = &cobra.Command{
+	Use:   "get",
+	Short: "Retrieve an offline token",
+	Long: `The minder auth offline-token get command project lets you retrieve an offline token
+for the minder control plane.
+
+Offline tokens are used to authenticate to the minder control plane without
+requiring the user's presence. This is useful for long-running processes
+that need to authenticate to the control plane.`,
+
+	RunE: func(cmd *cobra.Command, _ []string) error {
+		ctx, cancel := cli.GetAppContext(cmd.Context(), viper.GetViper())
+		defer cancel()
+
+		clientConfig, err := config.ReadConfigFromViper[clientconfig.Config](viper.GetViper())
+		if err != nil {
+			return fmt.Errorf("error reading config: %w", err)
+		}
+
+		f := viper.GetString("file")
+
+		// No longer print usage on returned error, since we've parsed our inputs
+		// See https://github.com/spf13/cobra/issues/340#issuecomment-374617413
+		cmd.SilenceUsage = true
+
+		// wait for the token to be received
+		token, err := login(ctx, cmd, clientConfig, []string{"offline_access"})
+		if err != nil {
+			return err
+		}
+
+		// write the token to the file
+		if err := os.WriteFile(f, []byte(token.RefreshToken), 0600); err != nil {
+			return fmt.Errorf("error writing offline token to file: %w", err)
+		}
+
+		cmd.Printf("Offline token written to %s\n", f)
+
+		return nil
+	},
+}
+
+func init() {
+	OfflineTokenCmd.AddCommand(offlineTokenGetCmd)
+
+	offlineTokenGetCmd.Flags().StringP("file", "f", "offline.token", "The file to write the offline token to")
+
+	if err := viper.BindPFlag("file", offlineTokenGetCmd.Flag("file")); err != nil {
+		panic(err)
+	}
+}

--- a/cmd/cli/app/auth/offline_revoke.go
+++ b/cmd/cli/app/auth/offline_revoke.go
@@ -1,0 +1,97 @@
+//
+// Copyright 2024 Stacklok, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package auth
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+
+	"github.com/stacklok/minder/internal/config"
+	clientconfig "github.com/stacklok/minder/internal/config/client"
+	"github.com/stacklok/minder/internal/util"
+)
+
+// offlineTokenRevokeCmd represents the offline-token use command
+var offlineTokenRevokeCmd = &cobra.Command{
+	Use:   "revoke",
+	Short: "Revoke an offline token",
+	Long: `The minder auth offline-token use command project lets you revoke an offline token
+for the minder control plane.
+
+Offline tokens are used to authenticate to the minder control plane without
+requiring the user's presence. This is useful for long-running processes
+that need to authenticate to the control plane.`,
+
+	RunE: func(cmd *cobra.Command, _ []string) error {
+		clientConfig, err := config.ReadConfigFromViper[clientconfig.Config](viper.GetViper())
+		if err != nil {
+			return fmt.Errorf("error reading config: %w", err)
+		}
+
+		f := viper.GetString("file")
+		tok := viper.GetString("token")
+		if tok == "" {
+			fpath := filepath.Clean(f)
+			tokbytes, err := os.ReadFile(fpath)
+			if err != nil {
+				return fmt.Errorf("error reading file: %w", err)
+			}
+
+			tok = string(tokbytes)
+		}
+
+		// No longer print usage on returned error, since we've parsed our inputs
+		// See https://github.com/spf13/cobra/issues/340#issuecomment-374617413
+		cmd.SilenceUsage = true
+
+		issuerUrlStr := clientConfig.Identity.CLI.IssuerUrl
+		clientID := clientConfig.Identity.CLI.ClientId
+
+		if err := util.RevokeOfflineToken(tok, issuerUrlStr, clientID); err != nil {
+			return fmt.Errorf("couldn't revoke token: %v", err)
+		}
+
+		cmd.Printf("Token revoked\n")
+
+		return nil
+	},
+}
+
+func init() {
+	OfflineTokenCmd.AddCommand(offlineTokenRevokeCmd)
+
+	offlineTokenRevokeCmd.Flags().StringP("file", "f", "offline.token", "The file that contains the offline token")
+	offlineTokenRevokeCmd.Flags().StringP("token", "t", "",
+		"The environment variable to use for the offline token. "+
+			"Also settable through the MINDER_OFFLINE_TOKEN environment variable.")
+
+	offlineTokenRevokeCmd.MarkFlagsMutuallyExclusive("file", "token")
+
+	if err := viper.BindPFlag("file", offlineTokenRevokeCmd.Flag("file")); err != nil {
+		panic(err)
+	}
+	if err := viper.BindPFlag("token", offlineTokenRevokeCmd.Flag("token")); err != nil {
+		panic(err)
+	}
+
+	if err := viper.BindEnv("token", "MINDER_OFFLINE_TOKEN"); err != nil {
+		panic(err)
+	}
+}

--- a/cmd/cli/app/auth/offline_use.go
+++ b/cmd/cli/app/auth/offline_use.go
@@ -1,0 +1,108 @@
+//
+// Copyright 2024 Stacklok, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package auth
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+
+	"github.com/stacklok/minder/internal/config"
+	clientconfig "github.com/stacklok/minder/internal/config/client"
+	"github.com/stacklok/minder/internal/util"
+)
+
+// offlineTokenUseCmd represents the offline-token use command
+var offlineTokenUseCmd = &cobra.Command{
+	Use:   "use",
+	Short: "Use an offline token",
+	Long: `The minder auth offline-token use command project lets you install and use an offline token
+for the minder control plane.
+
+Offline tokens are used to authenticate to the minder control plane without
+requiring the user's presence. This is useful for long-running processes
+that need to authenticate to the control plane.`,
+
+	RunE: func(cmd *cobra.Command, _ []string) error {
+		clientConfig, err := config.ReadConfigFromViper[clientconfig.Config](viper.GetViper())
+		if err != nil {
+			return fmt.Errorf("error reading config: %w", err)
+		}
+
+		f := viper.GetString("file")
+		tok := viper.GetString("token")
+		if tok == "" {
+			fpath := filepath.Clean(f)
+			tokbytes, err := os.ReadFile(fpath)
+			if err != nil {
+				return fmt.Errorf("error reading file: %w", err)
+			}
+
+			tok = string(tokbytes)
+		}
+
+		// No longer print usage on returned error, since we've parsed our inputs
+		// See https://github.com/spf13/cobra/issues/340#issuecomment-374617413
+		cmd.SilenceUsage = true
+
+		issuerUrlStr := clientConfig.Identity.CLI.IssuerUrl
+		clientID := clientConfig.Identity.CLI.ClientId
+
+		creds, err := util.RefreshCredentials(tok, issuerUrlStr, clientID)
+		if err != nil {
+			return fmt.Errorf("couldn't fetch credentials: %v", err)
+		}
+
+		// save credentials
+		filePath, err := util.SaveCredentials(util.OpenIdCredentials{
+			AccessToken:          creds.AccessToken,
+			RefreshToken:         creds.RefreshToken,
+			AccessTokenExpiresAt: creds.AccessTokenExpiresAt,
+		})
+		if err != nil {
+			cmd.PrintErrf("couldn't save credentials: %s\n", err)
+		}
+
+		cmd.Printf("Your access credentials have been saved to %s\n", filePath)
+
+		return nil
+	},
+}
+
+func init() {
+	OfflineTokenCmd.AddCommand(offlineTokenUseCmd)
+
+	offlineTokenUseCmd.Flags().StringP("file", "f", "offline.token", "The file that contains the offline token")
+	offlineTokenUseCmd.Flags().StringP("token", "t", "",
+		"The environment variable to use for the offline token. "+
+			"Also settable through the MINDER_OFFLINE_TOKEN environment variable.")
+
+	offlineTokenUseCmd.MarkFlagsMutuallyExclusive("file", "token")
+
+	if err := viper.BindPFlag("file", offlineTokenUseCmd.Flag("file")); err != nil {
+		panic(err)
+	}
+	if err := viper.BindPFlag("token", offlineTokenUseCmd.Flag("token")); err != nil {
+		panic(err)
+	}
+
+	if err := viper.BindEnv("token", "MINDER_OFFLINE_TOKEN"); err != nil {
+		panic(err)
+	}
+}


### PR DESCRIPTION
# Summary

This adds new sub-commands to `minder auth` which enable the usage and installation
of offline tokens. These tokens enable you to create long-lived credentials which are handy
for CI and automation cases.

Co-Authored-By: Eleftheria Stein-Kousathana <eleftheria@stacklok.com>

## Change Type

***Mark the type of change your PR introduces:***

- [ ] Bug fix (resolves an issue without affecting existing features)
- [x] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [ ] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

***Outline how the changes were tested, including steps to reproduce and any relevant configurations. 
Attach screenshots if helpful.***

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [ ] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [ ] Included tests that validate the fix or feature.
- [ ] Checked that related changes are merged.
