### PR TITLE
Allow for configuring CORS in minder's HTTP server

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -23,6 +23,7 @@ require (
 	github.com/google/go-containerregistry v0.19.0
 	github.com/google/go-github/v56 v56.0.0
 	github.com/google/uuid v1.6.0
+	github.com/gorilla/handlers v1.5.2
 	github.com/gorilla/securecookie v1.1.2
 	github.com/grpc-ecosystem/go-grpc-middleware/v2 v2.0.1
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.19.1

--- a/go.sum
+++ b/go.sum
@@ -371,6 +371,8 @@ github.com/googleapis/enterprise-certificate-proxy v0.3.2 h1:Vie5ybvEvT75RniqhfF
 github.com/googleapis/enterprise-certificate-proxy v0.3.2/go.mod h1:VLSiSSBs/ksPL8kq3OBOQ6WRI2QnaFynd1DCjZ62+V0=
 github.com/googleapis/gax-go/v2 v2.12.0 h1:A+gCJKdRfqXkr+BIRGtZLibNXf0m1f9E4HG56etFpas=
 github.com/googleapis/gax-go/v2 v2.12.0/go.mod h1:y+aIqrI5eb1YGMVJfuV3185Ts/D7qKpsEkdD5+I6QGU=
+github.com/gorilla/handlers v1.5.2 h1:cLTUSsNkgcwhgRqvCNmdbRWG0A3N4F+M2nWKdScwyEE=
+github.com/gorilla/handlers v1.5.2/go.mod h1:dX+xVpaxdSw+q0Qek8SSsl3dfMk3jNddUkMzo0GtH0w=
 github.com/gorilla/mux v1.8.1 h1:TuBL49tXwgrFYWhqrNgrUNEY92u81SPhu7sTdzQEiWY=
 github.com/gorilla/mux v1.8.1/go.mod h1:AKf9I4AEqPTmMytcMc0KkNouC66V3BtZ4qD5fmWSiMQ=
 github.com/gorilla/schema v1.2.0 h1:YufUaxZYCKGFuAq3c96BOhjgd5nmXiOY9NGzF247Tsc=

--- a/internal/config/server/config.go
+++ b/internal/config/server/config.go
@@ -108,6 +108,8 @@ func setViperStructDefaults(v *viper.Viper, prefix string, s any) {
 			defaultValue, err = strconv.ParseFloat(value, 64)
 		case reflect.Bool:
 			defaultValue, err = strconv.ParseBool(value)
+		case reflect.Slice:
+			defaultValue = nil
 		default:
 			err = fmt.Errorf("unhandled type %s", fieldType)
 		}

--- a/internal/config/server/server.go
+++ b/internal/config/server/server.go
@@ -30,6 +30,27 @@ type HTTPServerConfig struct {
 	Host string `mapstructure:"host" default:"127.0.0.1"`
 	// Port is the port to bind to
 	Port int `mapstructure:"port" default:"8080"`
+
+	// CORS is the configuration for CORS
+	CORS CORSConfig `mapstructure:"cors"`
+}
+
+// CORSConfig is the configuration for the CORS middleware
+// that can be used with the HTTP server. Note that this
+// is not applicable to the gRPC server.
+type CORSConfig struct {
+	// Enabled is the flag to enable CORS
+	Enabled bool `mapstructure:"enabled" default:"false"`
+	// AllowOrigins is the list of allowed origins
+	AllowOrigins []string `mapstructure:"allow_origins"`
+	// AllowMethods is the list of allowed methods
+	AllowMethods []string `mapstructure:"allow_methods"`
+	// AllowHeaders is the list of allowed headers
+	AllowHeaders []string `mapstructure:"allow_headers"`
+	// ExposeHeaders is the list of exposed headers
+	ExposeHeaders []string `mapstructure:"expose_headers"`
+	// AllowCredentials is the flag to allow credentials
+	AllowCredentials bool `mapstructure:"allow_credentials" default:"false"`
 }
 
 // GetAddress returns the address to bind to

--- a/internal/controlplane/server.go
+++ b/internal/controlplane/server.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	"github.com/ThreeDotsLabs/watermill/message"
+	"github.com/gorilla/handlers"
 	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/rs/zerolog/log"
@@ -326,7 +327,7 @@ func (s *Server) StartHTTPServer(ctx context.Context) error {
 		return fmt.Errorf("failed to register provider callback handler: %w", err)
 	}
 
-	mux.Handle("/", gwmux)
+	mux.Handle("/", s.handlerWithHTTPMiddleware(gwmux))
 	mux.Handle("/api/v1/webhook/", mw(s.HandleGitHubWebHook()))
 	mux.Handle("/static/", fs)
 
@@ -368,6 +369,31 @@ func (s *Server) StartHTTPServer(ctx context.Context) error {
 
 		return server.Shutdown(shutdownCtx)
 	}
+}
+
+func (s *Server) handlerWithHTTPMiddleware(h http.Handler) http.Handler {
+	if s.cfg.HTTPServer.CORS.Enabled {
+		var opts []handlers.CORSOption
+		if len(s.cfg.HTTPServer.CORS.AllowOrigins) > 0 {
+			opts = append(opts, handlers.AllowedOrigins(s.cfg.HTTPServer.CORS.AllowOrigins))
+		}
+		if len(s.cfg.HTTPServer.CORS.AllowMethods) > 0 {
+			opts = append(opts, handlers.AllowedMethods(s.cfg.HTTPServer.CORS.AllowMethods))
+		}
+		if len(s.cfg.HTTPServer.CORS.AllowHeaders) > 0 {
+			opts = append(opts, handlers.AllowedHeaders(s.cfg.HTTPServer.CORS.AllowHeaders))
+		}
+		if len(s.cfg.HTTPServer.CORS.ExposeHeaders) > 0 {
+			opts = append(opts, handlers.ExposedHeaders(s.cfg.HTTPServer.CORS.ExposeHeaders))
+		}
+		if s.cfg.HTTPServer.CORS.AllowCredentials {
+			opts = append(opts, handlers.AllowCredentials())
+		}
+
+		return handlers.CORS(opts...)(h)
+	}
+
+	return h
 }
 
 // startMetricServer starts a Prometheus metrics server and blocks while serving


### PR DESCRIPTION
# Summary

This configures CORS middleware for minder's HTTP server which currently
is merely a gateway that converts from JSON to the GRPC implementation.
This also adds the means to configure CORS's allowed origins.

Signed-off-by: Juan Antonio Osorio <ozz@stacklok.com>

## Change Type

***Mark the type of change your PR introduces:***

- [ ] Bug fix (resolves an issue without affecting existing features)
- [x] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [ ] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [ ] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [ ] Included tests that validate the fix or feature.
- [ ] Checked that related changes are merged.
