### PR TITLE
Upsert provider access tokens instead of Create and Delete

### DIFF
--- a/database/mock/store.go
+++ b/database/mock/store.go
@@ -146,21 +146,6 @@ func (mr *MockStoreMockRecorder) CountUsers(arg0 any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CountUsers", reflect.TypeOf((*MockStore)(nil).CountUsers), arg0)
 }
 
-// CreateAccessToken mocks base method.
-func (m *MockStore) CreateAccessToken(arg0 context.Context, arg1 db.CreateAccessTokenParams) (db.ProviderAccessToken, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CreateAccessToken", arg0, arg1)
-	ret0, _ := ret[0].(db.ProviderAccessToken)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// CreateAccessToken indicates an expected call of CreateAccessToken.
-func (mr *MockStoreMockRecorder) CreateAccessToken(arg0, arg1 any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateAccessToken", reflect.TypeOf((*MockStore)(nil).CreateAccessToken), arg0, arg1)
-}
-
 // CreateArtifact mocks base method.
 func (m *MockStore) CreateArtifact(arg0 context.Context, arg1 db.CreateArtifactParams) (db.Artifact, error) {
 	m.ctrl.T.Helper()
@@ -339,20 +324,6 @@ func (m *MockStore) CreateUser(arg0 context.Context, arg1 db.CreateUserParams) (
 func (mr *MockStoreMockRecorder) CreateUser(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateUser", reflect.TypeOf((*MockStore)(nil).CreateUser), arg0, arg1)
-}
-
-// DeleteAccessToken mocks base method.
-func (m *MockStore) DeleteAccessToken(arg0 context.Context, arg1 db.DeleteAccessTokenParams) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DeleteAccessToken", arg0, arg1)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// DeleteAccessToken indicates an expected call of DeleteAccessToken.
-func (mr *MockStoreMockRecorder) DeleteAccessToken(arg0, arg1 any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteAccessToken", reflect.TypeOf((*MockStore)(nil).DeleteAccessToken), arg0, arg1)
 }
 
 // DeleteArtifact mocks base method.
@@ -1463,21 +1434,6 @@ func (mr *MockStoreMockRecorder) Rollback(arg0 any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Rollback", reflect.TypeOf((*MockStore)(nil).Rollback), arg0)
 }
 
-// UpdateAccessToken mocks base method.
-func (m *MockStore) UpdateAccessToken(arg0 context.Context, arg1 db.UpdateAccessTokenParams) (db.ProviderAccessToken, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UpdateAccessToken", arg0, arg1)
-	ret0, _ := ret[0].(db.ProviderAccessToken)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// UpdateAccessToken indicates an expected call of UpdateAccessToken.
-func (mr *MockStoreMockRecorder) UpdateAccessToken(arg0, arg1 any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateAccessToken", reflect.TypeOf((*MockStore)(nil).UpdateAccessToken), arg0, arg1)
-}
-
 // UpdateLease mocks base method.
 func (m *MockStore) UpdateLease(arg0 context.Context, arg1 db.UpdateLeaseParams) error {
 	m.ctrl.T.Helper()
@@ -1534,6 +1490,21 @@ func (m *MockStore) UpdateRuleType(arg0 context.Context, arg1 db.UpdateRuleTypeP
 func (mr *MockStoreMockRecorder) UpdateRuleType(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateRuleType", reflect.TypeOf((*MockStore)(nil).UpdateRuleType), arg0, arg1)
+}
+
+// UpsertAccessToken mocks base method.
+func (m *MockStore) UpsertAccessToken(arg0 context.Context, arg1 db.UpsertAccessTokenParams) (db.ProviderAccessToken, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpsertAccessToken", arg0, arg1)
+	ret0, _ := ret[0].(db.ProviderAccessToken)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// UpsertAccessToken indicates an expected call of UpsertAccessToken.
+func (mr *MockStoreMockRecorder) UpsertAccessToken(arg0, arg1 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpsertAccessToken", reflect.TypeOf((*MockStore)(nil).UpsertAccessToken), arg0, arg1)
 }
 
 // UpsertArtifact mocks base method.

--- a/database/query/provider_access_tokens.sql
+++ b/database/query/provider_access_tokens.sql
@@ -1,17 +1,22 @@
--- name: CreateAccessToken :one
-INSERT INTO provider_access_tokens (project_id, provider, encrypted_token, expiration_time, owner_filter) VALUES ($1, $2, $3, $4, $5) RETURNING *;
-
 -- name: GetAccessTokenByProjectID :one
 SELECT * FROM provider_access_tokens WHERE provider = $1 AND project_id = $2;
-
--- name: UpdateAccessToken :one
-UPDATE provider_access_tokens SET encrypted_token = $3, expiration_time = $4, owner_filter = $5, updated_at = NOW() WHERE provider = $1 AND project_id = $2 RETURNING *;
-
--- name: DeleteAccessToken :exec
-DELETE FROM provider_access_tokens WHERE provider = $1 AND project_id = $2;
 
 -- name: GetAccessTokenByProvider :many
 SELECT * FROM provider_access_tokens WHERE provider = $1;
 
 -- name: GetAccessTokenSinceDate :one
-SELECT * FROM provider_access_tokens WHERE provider = $1 AND project_id = $2 AND created_at >= $3;
+SELECT * FROM provider_access_tokens WHERE provider = $1 AND project_id = $2 AND updated_at >= $3;
+
+-- name: UpsertAccessToken :one
+INSERT INTO provider_access_tokens
+(project_id, provider, encrypted_token, expiration_time, owner_filter)
+VALUES
+    ($1, $2, $3, $4, $5)
+ON CONFLICT (project_id, provider)
+    DO UPDATE SET
+                  encrypted_token = $3,
+                  expiration_time = $4,
+                  owner_filter = $5,
+                  updated_at = NOW()
+WHERE provider_access_tokens.project_id = $1 AND provider_access_tokens.provider = $2
+RETURNING *;

--- a/internal/db/provider_access_tokens_test.go
+++ b/internal/db/provider_access_tokens_test.go
@@ -1,0 +1,65 @@
+//
+// Copyright 2023 Stacklok, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package db
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestUpsertProviderAccessToken(t *testing.T) {
+	t.Parallel()
+
+	org := createRandomOrganization(t)
+	project := createRandomProject(t, org.ID)
+	prov := createRandomProvider(t, project.ID)
+
+	tok, err := testQueries.UpsertAccessToken(context.Background(), UpsertAccessTokenParams{
+		ProjectID:      project.ID,
+		Provider:       prov.Name,
+		EncryptedToken: "abc",
+		OwnerFilter:    sql.NullString{},
+	})
+
+	require.NoError(t, err)
+	require.NotEmpty(t, tok)
+	require.NotEmpty(t, tok.ID)
+	require.NotEmpty(t, tok.CreatedAt)
+	require.NotEmpty(t, tok.UpdatedAt)
+	require.Equal(t, project.ID, tok.ProjectID)
+	require.Equal(t, prov.Name, tok.Provider)
+	require.Equal(t, "abc", tok.EncryptedToken)
+	require.Equal(t, sql.NullString{}, tok.OwnerFilter)
+
+	tokUpdate, err := testQueries.UpsertAccessToken(context.Background(), UpsertAccessTokenParams{
+		ProjectID:      project.ID,
+		Provider:       prov.Name,
+		EncryptedToken: "def",
+		OwnerFilter:    sql.NullString{},
+	})
+
+	require.NoError(t, err)
+	require.Equal(t, project.ID, tokUpdate.ProjectID)
+	require.Equal(t, prov.Name, tokUpdate.Provider)
+	require.Equal(t, "def", tokUpdate.EncryptedToken)
+	require.Equal(t, sql.NullString{}, tokUpdate.OwnerFilter)
+	require.Equal(t, tok.ID, tokUpdate.ID)
+	require.Equal(t, tok.CreatedAt, tokUpdate.CreatedAt)
+	require.NotEqual(t, tok.UpdatedAt, tokUpdate.UpdatedAt)
+}

--- a/internal/db/querier.go
+++ b/internal/db/querier.go
@@ -16,7 +16,6 @@ type Querier interface {
 	CountProfilesByName(ctx context.Context, name string) (int64, error)
 	CountRepositories(ctx context.Context) (int64, error)
 	CountUsers(ctx context.Context) (int64, error)
-	CreateAccessToken(ctx context.Context, arg CreateAccessTokenParams) (ProviderAccessToken, error)
 	CreateArtifact(ctx context.Context, arg CreateArtifactParams) (Artifact, error)
 	CreateOrganization(ctx context.Context, arg CreateOrganizationParams) (Project, error)
 	CreateProfile(ctx context.Context, arg CreateProfileParams) (Profile, error)
@@ -29,7 +28,6 @@ type Querier interface {
 	CreateRuleType(ctx context.Context, arg CreateRuleTypeParams) (RuleType, error)
 	CreateSessionState(ctx context.Context, arg CreateSessionStateParams) (SessionStore, error)
 	CreateUser(ctx context.Context, arg CreateUserParams) (User, error)
-	DeleteAccessToken(ctx context.Context, arg DeleteAccessTokenParams) error
 	DeleteArtifact(ctx context.Context, id uuid.UUID) error
 	DeleteExpiredSessionStates(ctx context.Context) error
 	DeleteOrganization(ctx context.Context, id uuid.UUID) error
@@ -120,11 +118,11 @@ type Querier interface {
 	// entity_execution_lock record if the lock is held by the given locked_by
 	// value.
 	ReleaseLock(ctx context.Context, arg ReleaseLockParams) error
-	UpdateAccessToken(ctx context.Context, arg UpdateAccessTokenParams) (ProviderAccessToken, error)
 	UpdateLease(ctx context.Context, arg UpdateLeaseParams) error
 	UpdateOrganization(ctx context.Context, arg UpdateOrganizationParams) (Project, error)
 	UpdateProfile(ctx context.Context, arg UpdateProfileParams) (Profile, error)
 	UpdateRuleType(ctx context.Context, arg UpdateRuleTypeParams) error
+	UpsertAccessToken(ctx context.Context, arg UpsertAccessTokenParams) (ProviderAccessToken, error)
 	UpsertArtifact(ctx context.Context, arg UpsertArtifactParams) (Artifact, error)
 	UpsertProfileForEntity(ctx context.Context, arg UpsertProfileForEntityParams) (EntityProfile, error)
 	UpsertPullRequest(ctx context.Context, arg UpsertPullRequestParams) (PullRequest, error)


### PR DESCRIPTION
# Summary

For OAuth flow provider enrollments we used to delete and recreate the
provider access token in order to be able to list the new token based on
CreatedAt. For the case where we pass a PAT, we would just error out
in case the token was already created.

Let's just upsert in both cases and instead of CreatedAt let's look at
UpdatedAt.

This will be useful for tests.

Fixes: #2411

## Change Type

***Mark the type of change your PR introduces:***

- [x] Bug fix (resolves an issue without affecting existing features)
- [ ] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [ ] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

Manual testing with both PAT enrollment and OAuth flow.

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [x] Added comments to complex or tricky code sections.
- [N/A] Updated any affected documentation.
- [x] Included tests that validate the fix or feature.
- [N/A] Checked that related changes are merged.
