### PR TITLE
Allow rule type linting to skip rego and read many rule types

### DIFF
--- a/cmd/dev/app/rule_type/lint.go
+++ b/cmd/dev/app/rule_type/lint.go
@@ -41,6 +41,7 @@ func CmdLint() *cobra.Command {
 		SilenceUsage: true,
 	}
 	lintCmd.Flags().StringP("rule-type", "r", "", "file to read rule type definition from")
+	lintCmd.Flags().BoolP("skip-rego", "s", false, "skip rego rule validation")
 
 	if err := lintCmd.MarkFlagRequired("rule-type"); err != nil {
 		fmt.Fprintf(os.Stderr, "Error marking flag as required: %s\n", err)
@@ -52,30 +53,63 @@ func CmdLint() *cobra.Command {
 
 func lintCmdRun(cmd *cobra.Command, _ []string) error {
 	rtpath := cmd.Flag("rule-type")
+	skipRego := cmd.Flag("skip-rego").Value.String() == "true"
 
 	ctx := cmd.Context()
 
 	rtpathStr := rtpath.Value.String()
 
-	rt, err := readRuleTypeFromFile(rtpathStr)
-	if err != nil {
-		return fmt.Errorf("error reading rule type from file: %w", err)
-	}
-
-	if err := rt.Validate(); err != nil {
-		return fmt.Errorf("error validating rule type: %w", err)
-	}
-
-	// get file name without extension
-	ruleName := strings.TrimSuffix(filepath.Base(rtpathStr), filepath.Ext(rtpathStr))
-	if rt.Name != ruleName {
-		return fmt.Errorf("rule type name does not match file name: %s != %s", rt.Name, ruleName)
-	}
-
-	if rt.Def.Eval.Type == rego.RegoEvalType {
-		if err := validateRegoRule(ctx, rt.Def.Eval.Rego, rtpathStr, cmd.OutOrStdout()); err != nil {
-			return fmt.Errorf("failed validating rego rule: %w", err)
+	var errors []error
+	walkerr := filepath.Walk(rtpathStr, func(path string, info os.FileInfo, walkerr error) error {
+		if walkerr != nil {
+			return fmt.Errorf("error walking path %s: %w", path, walkerr)
 		}
+
+		if info.IsDir() {
+			return nil
+		}
+
+		if filepath.Ext(path) != ".yaml" && filepath.Ext(path) != ".yml" {
+			return nil
+		}
+
+		rt, err := readRuleTypeFromFile(path)
+		if err != nil {
+			errors = append(errors, fmt.Errorf("error reading rule type from file %s: %w", path, err))
+			return nil
+		}
+
+		if err := rt.Validate(); err != nil {
+			errors = append(errors, fmt.Errorf("error validating rule type: %w", err))
+			return nil
+		}
+
+		// get file name without extension
+		ruleName := strings.TrimSuffix(filepath.Base(path), filepath.Ext(path))
+		if rt.Name != ruleName {
+			errors = append(errors, fmt.Errorf("rule type name does not match file name: %s != %s", rt.Name, ruleName))
+			return nil
+		}
+
+		if rt.Def.Eval.Type == rego.RegoEvalType && !skipRego {
+			if err := validateRegoRule(ctx, rt.Def.Eval.Rego, rtpathStr, cmd.OutOrStdout()); err != nil {
+				errors = append(errors, fmt.Errorf("failed validating rego rule: %w", err))
+				return nil
+			}
+		}
+
+		return nil
+	})
+
+	if walkerr != nil {
+		return fmt.Errorf("error walking path %s: %w", rtpathStr, walkerr)
+	}
+
+	if len(errors) > 0 {
+		for _, err := range errors {
+			fmt.Fprintln(cmd.ErrOrStderr(), err)
+		}
+		return fmt.Errorf("failed linting rule type")
 	}
 
 	return nil


### PR DESCRIPTION
# Summary

In order to allow us to use `mindev` in CI, this adds the ability for the
`ruletype lint` subcommand to walk through a directory and read multiple files.

This then aggregates the errors and prints them out.

To begin somewhere, it also adds the ability to skip rego validations which are quite verbose. We
can fix those little by little and enable them in CI later. They are enabled by default in
the sub-command.

## Change Type

***Mark the type of change your PR introduces:***

- [ ] Bug fix (resolves an issue without affecting existing features)
- [x] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [ ] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

***Outline how the changes were tested, including steps to reproduce and any relevant configurations. 
Attach screenshots if helpful.***

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [ ] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [ ] Included tests that validate the fix or feature.
- [ ] Checked that related changes are merged.
