### PR TITLE
Make GitHub provider interface more generic

### DIFF
--- a/internal/controlplane/handlers_repositories_test.go
+++ b/internal/controlplane/handlers_repositories_test.go
@@ -340,11 +340,6 @@ func (*StubGitHub) Do(context.Context, *http.Request) (*http.Response, error) {
 	panic("unimplemented")
 }
 
-// GetAuthenticatedUser implements v1.GitHub.
-func (*StubGitHub) GetAuthenticatedUser(context.Context) (*github.User, error) {
-	panic("unimplemented")
-}
-
 // GetBaseURL implements v1.GitHub.
 func (*StubGitHub) GetBaseURL() string {
 	panic("unimplemented")
@@ -414,11 +409,6 @@ func (*StubGitHub) ListAllRepositories(context.Context, bool, string) ([]*github
 	panic("unimplemented")
 }
 
-// ListEmails implements v1.GitHub.
-func (*StubGitHub) ListEmails(context.Context, *github.ListOptions) ([]*github.UserEmail, error) {
-	panic("unimplemented")
-}
-
 // ListFiles implements v1.GitHub.
 func (*StubGitHub) ListFiles(context.Context, string, string, int, int, int) ([]*github.CommitFile, *github.Response, error) {
 	panic("unimplemented")
@@ -466,5 +456,20 @@ func (*StubGitHub) SetCommitStatus(context.Context, string, string, string, *git
 
 // UpdateBranchProtection implements v1.GitHub.
 func (*StubGitHub) UpdateBranchProtection(context.Context, string, string, string, *github.ProtectionRequest) error {
+	panic("unimplemented")
+}
+
+// GetUserId implements v1.GitHub.
+func (*StubGitHub) GetUserId(context.Context) (int64, error) {
+	panic("unimplemented")
+}
+
+// GetUsername implements v1.GitHub.
+func (*StubGitHub) GetUsername(context.Context) (string, error) {
+	panic("unimplemented")
+}
+
+// GetPrimaryEmail implements v1.GitHub.
+func (*StubGitHub) GetPrimaryEmail(context.Context) (string, error) {
 	panic("unimplemented")
 }

--- a/internal/engine/actions/remediate/pull_request/pull_request_test.go
+++ b/internal/engine/actions/remediate/pull_request/pull_request_test.go
@@ -196,17 +196,9 @@ func happyPathMockSetup(mockGitHub *mock_ghclient.MockGitHub) {
 	mockGitHub.EXPECT().
 		ListPullRequests(gomock.Any(), repoOwner, repoName, gomock.Any()).Return([]*github.PullRequest{}, nil)
 	mockGitHub.EXPECT().
-		GetAuthenticatedUser(gomock.Any()).Return(&github.User{
-		Email: github.String("test@stacklok.com"),
-		Login: github.String("stacklok-bot"),
-	}, nil)
+		GetUsername(gomock.Any()).Return("stacklok-bot", nil)
 	mockGitHub.EXPECT().
-		ListEmails(gomock.Any(), gomock.Any()).Return([]*github.UserEmail{
-		{
-			Email:   github.String("test@stacklok.com"),
-			Primary: github.Bool(true),
-		},
-	}, nil)
+		GetPrimaryEmail(gomock.Any()).Return("test@stacklok.com", nil)
 	mockGitHub.EXPECT().
 		GetToken().Return("token")
 	mockGitHub.EXPECT().
@@ -467,18 +459,10 @@ func TestPullRequestRemediate(t *testing.T) {
 					ListPullRequests(gomock.Any(), repoOwner, repoName, gomock.Any()).Return([]*github.PullRequest{}, nil)
 				// we need to get the user information and update the branch
 				mockGitHub.EXPECT().
-					GetAuthenticatedUser(gomock.Any()).Return(&github.User{
-					Email: github.String("test@stacklok.com"),
-					Login: github.String("stacklok-bot"),
-				}, nil)
+					GetUsername(gomock.Any()).Return("stacklok-bot", nil)
 				// likewise we need to update the branch with a valid e-mail
 				mockGitHub.EXPECT().
-					ListEmails(gomock.Any(), gomock.Any()).Return([]*github.UserEmail{
-					{
-						Email:   github.String("test@stacklok.com"),
-						Primary: github.Bool(true),
-					},
-				}, nil)
+					GetPrimaryEmail(gomock.Any()).Return("test@stacklok.com", nil)
 				mockGitHub.EXPECT().
 					GetToken().Return("token")
 				// this is the last call we expect to make. It returns existing PRs from this branch, so we

--- a/internal/engine/eval/vulncheck/review.go
+++ b/internal/engine/eval/vulncheck/review.go
@@ -189,8 +189,7 @@ func newReviewPrHandler(
 		Str("repo-owner", pr.RepoOwner).
 		Str("repo-name", pr.RepoName).
 		Logger()
-
-	cliUser, err := cli.GetAuthenticatedUser(ctx)
+	cliUserId, err := cli.GetUserId(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("could not get authenticated user: %w", err)
 	}
@@ -198,7 +197,7 @@ func newReviewPrHandler(
 	// if the user wants minder to request changes on a pull request, they need to
 	// be different identities
 	var failStatus *string
-	if pr.AuthorId == cliUser.GetID() {
+	if pr.AuthorId == cliUserId {
 		failStatus = github.String("COMMENT")
 		logger.Debug().Msg("author is the same as the authenticated user, can only comment")
 	} else {

--- a/internal/engine/eval/vulncheck/review_test.go
+++ b/internal/engine/eval/vulncheck/review_test.go
@@ -58,9 +58,7 @@ func TestReviewPrHandlerNoVulnerabilities(t *testing.T) {
 		AuthorId:  githubSubmitterID,
 	}
 
-	mockClient.EXPECT().GetAuthenticatedUser(gomock.Any()).Return(&github.User{
-		ID: github.Int64(githubSubmitterID),
-	}, nil)
+	mockClient.EXPECT().GetUserId(gomock.Any()).Return(int64(githubSubmitterID), nil)
 	handler, err := newReviewPrHandler(context.TODO(), pr, mockClient)
 	require.NoError(t, err)
 	require.NotNil(t, handler)
@@ -98,9 +96,7 @@ func TestReviewPrHandlerVulnerabilitiesDifferentIdentities(t *testing.T) {
 		AuthorId:  githubSubmitterID,
 	}
 
-	mockClient.EXPECT().GetAuthenticatedUser(gomock.Any()).Return(&github.User{
-		ID: github.Int64(githubMinderID),
-	}, nil)
+	mockClient.EXPECT().GetUserId(gomock.Any()).Return(int64(githubMinderID), nil)
 	handler, err := newReviewPrHandler(context.TODO(), pr, mockClient)
 	require.NoError(t, err)
 	require.NotNil(t, handler)
@@ -191,9 +187,7 @@ func TestReviewPrHandlerVulnerabilitiesWithNoPatchVersion(t *testing.T) {
 		AuthorId:  githubSubmitterID,
 	}
 
-	mockClient.EXPECT().GetAuthenticatedUser(gomock.Any()).Return(&github.User{
-		ID: github.Int64(githubMinderID),
-	}, nil)
+	mockClient.EXPECT().GetUserId(gomock.Any()).Return(int64(githubMinderID), nil)
 	handler, err := newReviewPrHandler(context.TODO(), pr, mockClient)
 	require.NoError(t, err)
 	require.NotNil(t, handler)
@@ -273,9 +267,7 @@ func TestReviewPrHandlerVulnerabilitiesDismissReview(t *testing.T) {
 		AuthorId:  githubSubmitterID,
 	}
 
-	mockClient.EXPECT().GetAuthenticatedUser(gomock.Any()).Return(&github.User{
-		ID: github.Int64(githubSubmitterID),
-	}, nil)
+	mockClient.EXPECT().GetUserId(gomock.Any()).Return(int64(githubSubmitterID), nil)
 	handler, err := newReviewPrHandler(context.TODO(), pr, mockClient)
 	require.NoError(t, err)
 	require.NotNil(t, handler)
@@ -324,9 +316,7 @@ func TestCommitStatusHandlerNoVulnerabilities(t *testing.T) {
 		AuthorId:  githubSubmitterID,
 	}
 
-	mockClient.EXPECT().GetAuthenticatedUser(gomock.Any()).Return(&github.User{
-		ID: github.Int64(githubSubmitterID),
-	}, nil)
+	mockClient.EXPECT().GetUserId(gomock.Any()).Return(int64(githubSubmitterID), nil)
 	handler, err := newCommitStatusPrHandler(context.TODO(), pr, mockClient)
 	require.NoError(t, err)
 	require.NotNil(t, handler)
@@ -371,9 +361,7 @@ func TestCommitStatusPrHandlerWithVulnerabilities(t *testing.T) {
 		AuthorId:  githubSubmitterID,
 	}
 
-	mockClient.EXPECT().GetAuthenticatedUser(gomock.Any()).Return(&github.User{
-		ID: github.Int64(githubMinderID),
-	}, nil)
+	mockClient.EXPECT().GetUserId(gomock.Any()).Return(int64(githubMinderID), nil)
 	handler, err := newCommitStatusPrHandler(context.TODO(), pr, mockClient)
 	require.NoError(t, err)
 	require.NotNil(t, handler)

--- a/internal/providers/github/github_rest.go
+++ b/internal/providers/github/github_rest.go
@@ -475,15 +475,6 @@ func (c *RestClient) UpdateBranchProtection(
 	return err
 }
 
-// GetAuthenticatedUser returns the authenticated user
-func (c *RestClient) GetAuthenticatedUser(ctx context.Context) (*github.User, error) {
-	user, _, err := c.client.Users.Get(ctx, "")
-	if err != nil {
-		return nil, err
-	}
-	return user, nil
-}
-
 // GetBaseURL returns the base URL for the REST API.
 func (c *RestClient) GetBaseURL() string {
 	return c.client.BaseURL.String()
@@ -665,11 +656,40 @@ func (c *RestClient) CreateComment(ctx context.Context, owner, repo string, numb
 	return err
 }
 
-// ListEmails lists all emails for the authenticated user.
-func (c *RestClient) ListEmails(ctx context.Context, opts *github.ListOptions) ([]*github.UserEmail, error) {
-	emails, _, err := c.client.Users.ListEmails(ctx, opts)
+// GetUserId returns the user id for the authenticated user
+func (c *RestClient) GetUserId(ctx context.Context) (int64, error) {
+	user, _, err := c.client.Users.Get(ctx, "")
 	if err != nil {
-		return nil, err
+		return 0, err
 	}
-	return emails, nil
+	return user.GetID(), nil
+}
+
+// GetUsername returns the username for the authenticated user
+func (c *RestClient) GetUsername(ctx context.Context) (string, error) {
+	user, _, err := c.client.Users.Get(ctx, "")
+	if err != nil {
+		return "", err
+	}
+	return user.GetName(), nil
+}
+
+// GetPrimaryEmail returns the primary email for the authenticated user.
+func (c *RestClient) GetPrimaryEmail(ctx context.Context) (string, error) {
+	emails, _, err := c.client.Users.ListEmails(ctx, &github.ListOptions{})
+	if err != nil {
+		return "", fmt.Errorf("cannot get email: %w", err)
+	}
+
+	fallback := ""
+	for _, email := range emails {
+		if fallback == "" {
+			fallback = email.GetEmail()
+		}
+		if email.GetPrimary() {
+			return email.GetEmail(), nil
+		}
+	}
+
+	return fallback, nil
 }

--- a/internal/providers/github/mock/github.go
+++ b/internal/providers/github/mock/github.go
@@ -413,21 +413,6 @@ func (mr *MockGitHubMockRecorder) Do(ctx, req any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Do", reflect.TypeOf((*MockGitHub)(nil).Do), ctx, req)
 }
 
-// GetAuthenticatedUser mocks base method.
-func (m *MockGitHub) GetAuthenticatedUser(arg0 context.Context) (*github.User, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetAuthenticatedUser", arg0)
-	ret0, _ := ret[0].(*github.User)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetAuthenticatedUser indicates an expected call of GetAuthenticatedUser.
-func (mr *MockGitHubMockRecorder) GetAuthenticatedUser(arg0 any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAuthenticatedUser", reflect.TypeOf((*MockGitHub)(nil).GetAuthenticatedUser), arg0)
-}
-
 // GetBaseURL mocks base method.
 func (m *MockGitHub) GetBaseURL() string {
 	m.ctrl.T.Helper()
@@ -531,6 +516,21 @@ func (mr *MockGitHubMockRecorder) GetPackageVersions(arg0, arg1, arg2, arg3, arg
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPackageVersions", reflect.TypeOf((*MockGitHub)(nil).GetPackageVersions), arg0, arg1, arg2, arg3, arg4)
 }
 
+// GetPrimaryEmail mocks base method.
+func (m *MockGitHub) GetPrimaryEmail(ctx context.Context) (string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetPrimaryEmail", ctx)
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetPrimaryEmail indicates an expected call of GetPrimaryEmail.
+func (mr *MockGitHubMockRecorder) GetPrimaryEmail(ctx any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPrimaryEmail", reflect.TypeOf((*MockGitHub)(nil).GetPrimaryEmail), ctx)
+}
+
 // GetPullRequest mocks base method.
 func (m *MockGitHub) GetPullRequest(arg0 context.Context, arg1, arg2 string, arg3 int) (*github.PullRequest, error) {
 	m.ctrl.T.Helper()
@@ -575,6 +575,36 @@ func (mr *MockGitHubMockRecorder) GetToken() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetToken", reflect.TypeOf((*MockGitHub)(nil).GetToken))
 }
 
+// GetUserId mocks base method.
+func (m *MockGitHub) GetUserId(ctx context.Context) (int64, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetUserId", ctx)
+	ret0, _ := ret[0].(int64)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetUserId indicates an expected call of GetUserId.
+func (mr *MockGitHubMockRecorder) GetUserId(ctx any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetUserId", reflect.TypeOf((*MockGitHub)(nil).GetUserId), ctx)
+}
+
+// GetUsername mocks base method.
+func (m *MockGitHub) GetUsername(ctx context.Context) (string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetUsername", ctx)
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetUsername indicates an expected call of GetUsername.
+func (mr *MockGitHubMockRecorder) GetUsername(ctx any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetUsername", reflect.TypeOf((*MockGitHub)(nil).GetUsername), ctx)
+}
+
 // ListAllPackages mocks base method.
 func (m *MockGitHub) ListAllPackages(arg0 context.Context, arg1 bool, arg2, arg3 string, arg4, arg5 int) ([]*github.Package, error) {
 	m.ctrl.T.Helper()
@@ -603,21 +633,6 @@ func (m *MockGitHub) ListAllRepositories(arg0 context.Context, arg1 bool, arg2 s
 func (mr *MockGitHubMockRecorder) ListAllRepositories(arg0, arg1, arg2 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListAllRepositories", reflect.TypeOf((*MockGitHub)(nil).ListAllRepositories), arg0, arg1, arg2)
-}
-
-// ListEmails mocks base method.
-func (m *MockGitHub) ListEmails(ctx context.Context, opts *github.ListOptions) ([]*github.UserEmail, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListEmails", ctx, opts)
-	ret0, _ := ret[0].([]*github.UserEmail)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// ListEmails indicates an expected call of ListEmails.
-func (mr *MockGitHubMockRecorder) ListEmails(ctx, opts any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListEmails", reflect.TypeOf((*MockGitHub)(nil).ListEmails), ctx, opts)
 }
 
 // ListFiles mocks base method.

--- a/pkg/providers/v1/providers.go
+++ b/pkg/providers/v1/providers.go
@@ -78,7 +78,6 @@ type GitHub interface {
 	RepoLister
 	REST
 
-	GetAuthenticatedUser(context.Context) (*github.User, error)
 	GetRepository(context.Context, string, string) (*github.Repository, error)
 	ListAllRepositories(context.Context, bool, string) ([]*github.Repository, error)
 	GetBranchProtection(context.Context, string, string, string) (*github.Protection, error)
@@ -107,7 +106,9 @@ type GitHub interface {
 	CreatePullRequest(ctx context.Context, owner, repo, title, body, head, base string) (*github.PullRequest, error)
 	ListPullRequests(ctx context.Context, owner, repo string, opt *github.PullRequestListOptions) ([]*github.PullRequest, error)
 	CreateComment(ctx context.Context, owner, repo string, number int, comment string) error
-	ListEmails(ctx context.Context, opts *github.ListOptions) ([]*github.UserEmail, error)
+	GetUserId(ctx context.Context) (int64, error)
+	GetUsername(ctx context.Context) (string, error)
+	GetPrimaryEmail(ctx context.Context) (string, error)
 }
 
 // ParseAndValidate parses the given provider configuration and validates it.


### PR DESCRIPTION

Ref https://github.com/stacklok/epics/issues/154

# Summary
Make the GitHub provider interface more generic, in preparation for the GitHub app implementation.
Some methods were specific to the OAuth app implementation, for example getting the authenticated user.

## Change Type

***Mark the type of change your PR introduces:***

- [ ] Bug fix (resolves an issue without affecting existing features)
- [ ] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [x] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

***Outline how the changes were tested, including steps to reproduce and any relevant configurations. 
Attach screenshots if helpful.***

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [x] Added comments to complex or tricky code sections.
- [x] Updated any affected documentation.
- [x] Included tests that validate the fix or feature.
- [x] Checked that related changes are merged.
