### PR TITLE
Add new pending remediation status and implement in pull_request

### DIFF
--- a/cmd/cli/app/profile/table_render.go
+++ b/cmd/cli/app/profile/table_render.go
@@ -211,6 +211,8 @@ func getRemediationStatusText(status string) string {
 		return "Skipped" // visually empty as we didn't have to remediate
 	case notAvailableStatus:
 		return "Not Available"
+	case pendingStatus:
+		return "Pending"
 	default:
 		return "Unknown"
 	}

--- a/database/migrations/000029_remediation_alter_statuses.down.sql
+++ b/database/migrations/000029_remediation_alter_statuses.down.sql
@@ -1,0 +1,15 @@
+-- Copyright 2024 Stacklok, Inc
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--      http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+-- It is not possible to drop added values from enums

--- a/database/migrations/000029_remediation_alter_statuses.up.sql
+++ b/database/migrations/000029_remediation_alter_statuses.up.sql
@@ -1,0 +1,21 @@
+-- Copyright 2024 Stacklok, Inc
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--      http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+-- Add pending and unknown to the remediation status types enum
+ALTER TYPE remediation_status_types add value 'pending';
+ALTER TYPE remediation_status_types add value 'unknown';
+
+-- Add pending and unknown to the alert status types enum
+ALTER TYPE alert_status_types add value 'pending';
+ALTER TYPE alert_status_types add value 'unknown';

--- a/internal/db/models.go
+++ b/internal/db/models.go
@@ -288,6 +288,7 @@ const (
 	RemediationStatusTypesError        RemediationStatusTypes = "error"
 	RemediationStatusTypesSkipped      RemediationStatusTypes = "skipped"
 	RemediationStatusTypesNotAvailable RemediationStatusTypes = "not_available"
+	RemediationStatusTypesPending      RemediationStatusTypes = "pending"
 )
 
 func (e *RemediationStatusTypes) Scan(src interface{}) error {

--- a/internal/db/models.go
+++ b/internal/db/models.go
@@ -65,6 +65,8 @@ const (
 	AlertStatusTypesError        AlertStatusTypes = "error"
 	AlertStatusTypesSkipped      AlertStatusTypes = "skipped"
 	AlertStatusTypesNotAvailable AlertStatusTypes = "not_available"
+	AlertStatusTypesPending      AlertStatusTypes = "pending"
+	AlertStatusTypesUnknown      AlertStatusTypes = "unknown"
 )
 
 func (e *AlertStatusTypes) Scan(src interface{}) error {

--- a/internal/db/models.go
+++ b/internal/db/models.go
@@ -289,6 +289,7 @@ const (
 	RemediationStatusTypesSkipped      RemediationStatusTypes = "skipped"
 	RemediationStatusTypesNotAvailable RemediationStatusTypes = "not_available"
 	RemediationStatusTypesPending      RemediationStatusTypes = "pending"
+	RemediationStatusTypesUnknown      RemediationStatusTypes = "unknown"
 )
 
 func (e *RemediationStatusTypes) Scan(src interface{}) error {

--- a/internal/engine/actions/remediate/pull_request/pull_request.go
+++ b/internal/engine/actions/remediate/pull_request/pull_request.go
@@ -40,6 +40,7 @@ import (
 	"google.golang.org/protobuf/reflect/protoreflect"
 
 	"github.com/stacklok/minder/internal/db"
+	enginerr "github.com/stacklok/minder/internal/engine/errors"
 	"github.com/stacklok/minder/internal/engine/interfaces"
 	"github.com/stacklok/minder/internal/providers"
 	"github.com/stacklok/minder/internal/util"
@@ -251,9 +252,9 @@ func (r *Remediator) Do(
 			zerolog.Ctx(ctx).Info().Msgf("PR %s already exists, won't create a new one", slug)
 		}
 
-		return json.Marshal(map[string]any{
-			"status":      db.RemediationStatusTypesPending,
-			"status_data": slug,
+		return json.Marshal(enginerr.RemediationMetadata{
+			Status:     db.RemediationStatusTypesPending,
+			StatusData: slug,
 		})
 
 	case interfaces.ActionOptDryRun:

--- a/internal/engine/actions/remediate/pull_request/pull_request_test.go
+++ b/internal/engine/actions/remediate/pull_request/pull_request_test.go
@@ -626,3 +626,40 @@ func TestPullRequestRemediate(t *testing.T) {
 		})
 	}
 }
+
+func TestRepoSlug(t *testing.T) {
+	t.Parallel()
+	const (
+		example = "example"
+		repo    = "repo"
+		githubs = "github"
+	)
+	for _, tc := range []struct {
+		name      string
+		sut       prSlug
+		eProvider string
+		eOrg      string
+		eRepo     string
+		eNumber   string
+	}{
+		{"normal", prSlug("github:example/repo#34"), githubs, example, repo, "34"},
+		{"one_char", prSlug("github:e/r#34"), githubs, "e", "r", "34"},
+		{"uppercase", prSlug("github:eXamPle/REPO#34"), githubs, "eXamPle", "REPO", "34"},
+		{"no_number", prSlug("github:example/repo"), githubs, example, repo, ""},
+		{"numbers", prSlug("github:example1234567890zzz/repo1234567890#123"), githubs, "example1234567890zzz", "repo1234567890", "123"},
+		{"org_only", prSlug("github:example"), githubs, example, "", ""},
+		{"no_repo", prSlug("github:example/#123"), "", "", "", ""},
+		{"no_org", prSlug("github:/repo#123"), "github", "", "repo", "123"},
+		{"not_github", prSlug("gitlab:example/repo#123"), "gitlab", example, repo, "123"},
+	} {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			parts := tc.sut.Parse()
+			require.Equal(t, tc.eProvider, parts[0])
+			require.Equal(t, tc.eOrg, parts[1])
+			require.Equal(t, tc.eRepo, parts[2])
+			require.Equal(t, tc.eNumber, parts[3])
+		})
+	}
+}

--- a/internal/engine/errors/errors_test.go
+++ b/internal/engine/errors/errors_test.go
@@ -1,0 +1,100 @@
+// Copyright 2023 Stacklok, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// Package rule provides the CLI subcommand for managing rules
+
+package errors
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/stacklok/minder/internal/db"
+)
+
+func TestAsRemediationStatus(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		name           string
+		err            ActionsError
+		shouldErr      bool
+		expectedStatus db.RemediationStatusTypes
+	}{
+		{
+			name: "set-pending",
+			err: ActionsError{
+				RemediateErr:  nil,
+				RemediateMeta: []byte(`{"status":"pending"}`),
+			},
+			expectedStatus: db.RemediationStatusTypesPending,
+		},
+		{
+			name: "error-trumps-status",
+			err: ActionsError{
+				RemediateErr:  ErrActionFailed,
+				RemediateMeta: []byte(`{"status":"pending"}`),
+			},
+			expectedStatus: db.RemediationStatusTypesFailure,
+		},
+		{
+			name: "invalid-meta",
+			err: ActionsError{
+				RemediateMeta: []byte(`{"status":1}`),
+			},
+			expectedStatus: db.RemediationStatusTypesUnknown,
+		},
+		{
+			name:           "no-meta",
+			err:            ActionsError{},
+			expectedStatus: db.RemediationStatusTypesSuccess,
+		},
+		{
+			name: "custom-status",
+			err: ActionsError{
+				RemediateMeta: []byte(`{"status":"hello"}`),
+			},
+			expectedStatus: db.RemediationStatusTypes("hello"),
+		},
+	} {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			s := tc.err.AsRemediationStatus()
+			require.Equal(t, tc.expectedStatus, s)
+		})
+	}
+}
+
+func TestErrorAsRemediationStatus(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		name           string
+		err            error
+		expectedStatus db.RemediationStatusTypes
+	}{
+		{"no-error", nil, db.RemediationStatusTypesSuccess},
+		{"action-failed", ErrActionFailed, db.RemediationStatusTypesFailure},
+		{"action-skipped", ErrActionSkipped, db.RemediationStatusTypesSkipped},
+		{"action-not-available", ErrActionNotAvailable, db.RemediationStatusTypesNotAvailable},
+		{"other-error", fmt.Errorf("custom error"), db.RemediationStatusTypesError},
+	} {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			s := ErrorAsRemediationStatus(tc.err)
+			require.Equal(t, tc.expectedStatus, s)
+		})
+	}
+}

--- a/internal/engine/eval_status.go
+++ b/internal/engine/eval_status.go
@@ -162,7 +162,7 @@ func (e *Executor) createOrUpdateEvalStatus(
 	// Upsert remediation details
 	_, err = e.querier.UpsertRuleDetailsRemediate(ctx, db.UpsertRuleDetailsRemediateParams{
 		RuleEvalID: id,
-		Status:     evalerrors.ErrorAsRemediationStatus(params.GetActionsErr().RemediateErr),
+		Status:     params.GetActionsErr().AsRemediationStatus(),
 		Details:    errorAsActionDetails(params.GetActionsErr().RemediateErr),
 	})
 	if err != nil {

--- a/internal/engine/executor.go
+++ b/internal/engine/executor.go
@@ -427,7 +427,7 @@ func logEval(
 	// log remediation
 	logger.Err(filterActionErrorForLogging(params.GetActionsErr().RemediateErr)).
 		Str("action", "remediate").
-		Str("action_status", string(evalerrors.ErrorAsRemediationStatus(params.GetActionsErr().RemediateErr))).
+		Str("action_status", string(params.GetActionsErr().AsRemediationStatus())).
 		Msg("result - action")
 
 	// log alert


### PR DESCRIPTION
# Summary

***Provide a brief overview of the changes and the issue being addressed. 

This PR introduces a new remediation status "pending" intended to add an intermediate status to remediation processes. 

The status is implemented in the pull_request remediation and wired all the way to the database store.

To propagate the new status, in b3e44bea2e5ecd14e417f1cb92e65476824bf18f the pull request remediation `Do` method now populates its metadata with a status and details about the PR (which will be used to build a better remediation details line).

Fixes https://github.com/stacklok/minder/issues/2526

## Change Type

***Mark the type of change your PR introduces:***

- [x] Bug fix (resolves an issue without affecting existing features)
- [x] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [ ] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

***Outline how the changes were tested, including steps to reproduce and any relevant configurations. 
Attach screenshots if helpful.***

# Review Checklist:

- [ ] Reviewed my own code for quality and clarity.
- [ ] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [ ] Included tests that validate the fix or feature.
- [ ] Checked that related changes are merged.
