### PR TITLE
Add provider authorization flow types to database

### DIFF
--- a/database/migrations/000025_provider_auth.down.sql
+++ b/database/migrations/000025_provider_auth.down.sql
@@ -1,0 +1,16 @@
+-- Copyright 2024 Stacklok, Inc
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--      http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+ALTER TABLE providers DROP COLUMN auth_flows;
+DROP TYPE authorization_flow;

--- a/database/migrations/000025_provider_auth.up.sql
+++ b/database/migrations/000025_provider_auth.up.sql
@@ -1,0 +1,27 @@
+-- Copyright 2024 Stacklok, Inc
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--      http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+CREATE TYPE authorization_flow AS ENUM ('user_input', 'oauth2_authorization_code_flow', 'github_app_flow', 'none');
+
+ALTER TABLE providers ADD COLUMN auth_flows authorization_flow ARRAY NOT NULL DEFAULT '{}';
+
+-- Iterate providers that implement github and add the `github_app_flow` and `user_input` to their auth_flows
+DO $$
+DECLARE
+  provider_name TEXT;
+BEGIN
+    FOR provider_name IN SELECT name FROM providers WHERE name = 'github' LOOP
+        UPDATE providers SET auth_flows = ARRAY['github_app_flow'::authorization_flow, 'user_input'::authorization_flow] WHERE name = provider_name;
+    END LOOP;
+END $$;

--- a/internal/db/models.go
+++ b/internal/db/models.go
@@ -102,6 +102,50 @@ func (ns NullAlertStatusTypes) Value() (driver.Value, error) {
 	return string(ns.AlertStatusTypes), nil
 }
 
+type AuthorizationFlow string
+
+const (
+	AuthorizationFlowUserInput                   AuthorizationFlow = "user_input"
+	AuthorizationFlowOauth2AuthorizationCodeFlow AuthorizationFlow = "oauth2_authorization_code_flow"
+	AuthorizationFlowGithubAppFlow               AuthorizationFlow = "github_app_flow"
+	AuthorizationFlowNone                        AuthorizationFlow = "none"
+)
+
+func (e *AuthorizationFlow) Scan(src interface{}) error {
+	switch s := src.(type) {
+	case []byte:
+		*e = AuthorizationFlow(s)
+	case string:
+		*e = AuthorizationFlow(s)
+	default:
+		return fmt.Errorf("unsupported scan type for AuthorizationFlow: %T", src)
+	}
+	return nil
+}
+
+type NullAuthorizationFlow struct {
+	AuthorizationFlow AuthorizationFlow `json:"authorization_flow"`
+	Valid             bool              `json:"valid"` // Valid is true if AuthorizationFlow is not NULL
+}
+
+// Scan implements the Scanner interface.
+func (ns *NullAuthorizationFlow) Scan(value interface{}) error {
+	if value == nil {
+		ns.AuthorizationFlow, ns.Valid = "", false
+		return nil
+	}
+	ns.Valid = true
+	return ns.AuthorizationFlow.Scan(value)
+}
+
+// Value implements the driver Valuer interface.
+func (ns NullAuthorizationFlow) Value() (driver.Value, error) {
+	if !ns.Valid {
+		return nil, nil
+	}
+	return string(ns.AuthorizationFlow), nil
+}
+
 type Entities string
 
 const (
@@ -419,14 +463,15 @@ type Project struct {
 }
 
 type Provider struct {
-	ID         uuid.UUID       `json:"id"`
-	Name       string          `json:"name"`
-	Version    string          `json:"version"`
-	ProjectID  uuid.UUID       `json:"project_id"`
-	Implements []ProviderType  `json:"implements"`
-	Definition json.RawMessage `json:"definition"`
-	CreatedAt  time.Time       `json:"created_at"`
-	UpdatedAt  time.Time       `json:"updated_at"`
+	ID         uuid.UUID           `json:"id"`
+	Name       string              `json:"name"`
+	Version    string              `json:"version"`
+	ProjectID  uuid.UUID           `json:"project_id"`
+	Implements []ProviderType      `json:"implements"`
+	Definition json.RawMessage     `json:"definition"`
+	CreatedAt  time.Time           `json:"created_at"`
+	UpdatedAt  time.Time           `json:"updated_at"`
+	AuthFlows  []AuthorizationFlow `json:"auth_flows"`
 }
 
 type ProviderAccessToken struct {

--- a/internal/db/providers.sql.go
+++ b/internal/db/providers.sql.go
@@ -19,7 +19,7 @@ INSERT INTO providers (
     name,
     project_id,
     implements,
-    definition) VALUES ($1, $2, $3, $4::jsonb) RETURNING id, name, version, project_id, implements, definition, created_at, updated_at
+    definition) VALUES ($1, $2, $3, $4::jsonb) RETURNING id, name, version, project_id, implements, definition, created_at, updated_at, auth_flows
 `
 
 type CreateProviderParams struct {
@@ -46,6 +46,7 @@ func (q *Queries) CreateProvider(ctx context.Context, arg CreateProviderParams) 
 		&i.Definition,
 		&i.CreatedAt,
 		&i.UpdatedAt,
+		pq.Array(&i.AuthFlows),
 	)
 	return i, err
 }
@@ -65,7 +66,7 @@ func (q *Queries) DeleteProvider(ctx context.Context, arg DeleteProviderParams) 
 }
 
 const getProviderByID = `-- name: GetProviderByID :one
-SELECT id, name, version, project_id, implements, definition, created_at, updated_at FROM providers WHERE id = $1 AND project_id = $2
+SELECT id, name, version, project_id, implements, definition, created_at, updated_at, auth_flows FROM providers WHERE id = $1 AND project_id = $2
 `
 
 type GetProviderByIDParams struct {
@@ -85,12 +86,13 @@ func (q *Queries) GetProviderByID(ctx context.Context, arg GetProviderByIDParams
 		&i.Definition,
 		&i.CreatedAt,
 		&i.UpdatedAt,
+		pq.Array(&i.AuthFlows),
 	)
 	return i, err
 }
 
 const getProviderByName = `-- name: GetProviderByName :one
-SELECT id, name, version, project_id, implements, definition, created_at, updated_at FROM providers WHERE name = $1 AND project_id = $2
+SELECT id, name, version, project_id, implements, definition, created_at, updated_at, auth_flows FROM providers WHERE name = $1 AND project_id = $2
 `
 
 type GetProviderByNameParams struct {
@@ -110,12 +112,13 @@ func (q *Queries) GetProviderByName(ctx context.Context, arg GetProviderByNamePa
 		&i.Definition,
 		&i.CreatedAt,
 		&i.UpdatedAt,
+		pq.Array(&i.AuthFlows),
 	)
 	return i, err
 }
 
 const globalListProviders = `-- name: GlobalListProviders :many
-SELECT id, name, version, project_id, implements, definition, created_at, updated_at FROM providers
+SELECT id, name, version, project_id, implements, definition, created_at, updated_at, auth_flows FROM providers
 `
 
 func (q *Queries) GlobalListProviders(ctx context.Context) ([]Provider, error) {
@@ -136,6 +139,7 @@ func (q *Queries) GlobalListProviders(ctx context.Context) ([]Provider, error) {
 			&i.Definition,
 			&i.CreatedAt,
 			&i.UpdatedAt,
+			pq.Array(&i.AuthFlows),
 		); err != nil {
 			return nil, err
 		}
@@ -152,7 +156,7 @@ func (q *Queries) GlobalListProviders(ctx context.Context) ([]Provider, error) {
 
 const listProvidersByProjectID = `-- name: ListProvidersByProjectID :many
 
-SELECT id, name, version, project_id, implements, definition, created_at, updated_at FROM providers WHERE project_id = $1
+SELECT id, name, version, project_id, implements, definition, created_at, updated_at, auth_flows FROM providers WHERE project_id = $1
 `
 
 // ListProvidersByProjectID allows us to lits all providers for a given project.
@@ -174,6 +178,7 @@ func (q *Queries) ListProvidersByProjectID(ctx context.Context, projectID uuid.U
 			&i.Definition,
 			&i.CreatedAt,
 			&i.UpdatedAt,
+			pq.Array(&i.AuthFlows),
 		); err != nil {
 			return nil, err
 		}
@@ -190,7 +195,7 @@ func (q *Queries) ListProvidersByProjectID(ctx context.Context, projectID uuid.U
 
 const listProvidersByProjectIDPaginated = `-- name: ListProvidersByProjectIDPaginated :many
 
-SELECT id, name, version, project_id, implements, definition, created_at, updated_at FROM providers
+SELECT id, name, version, project_id, implements, definition, created_at, updated_at, auth_flows FROM providers
 WHERE project_id = $1
     AND (created_at > $2 OR $2 IS NULL)
 ORDER BY created_at DESC, id
@@ -223,6 +228,7 @@ func (q *Queries) ListProvidersByProjectIDPaginated(ctx context.Context, arg Lis
 			&i.Definition,
 			&i.CreatedAt,
 			&i.UpdatedAt,
+			pq.Array(&i.AuthFlows),
 		); err != nil {
 			return nil, err
 		}

--- a/internal/providers/github/github.go
+++ b/internal/providers/github/github.go
@@ -58,6 +58,12 @@ var Implements = []db.ProviderType{
 	db.ProviderTypeRepoLister,
 }
 
+// AuthorizationFlows is the list of authorization flows that the GitHub provider supports
+var AuthorizationFlows = []db.AuthorizationFlow{
+	db.AuthorizationFlowUserInput,
+	db.AuthorizationFlowOauth2AuthorizationCodeFlow,
+}
+
 // RestClient is the struct that contains the GitHub REST API client
 type RestClient struct {
 	client *github.Client


### PR DESCRIPTION
# Summary

This adds an authorization_flow enum to the minder database. This is then used by providers.

GitHub will use two, which are enforced via a migration script. Any new projects
will get these two authorization flows set up.

Fixes #2517

## Change Type

***Mark the type of change your PR introduces:***

- [ ] Bug fix (resolves an issue without affecting existing features)
- [x] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [ ] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [ ] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [ ] Included tests that validate the fix or feature.
- [ ] Checked that related changes are merged.
