### PR TITLE
Remove unused 'port' from session state queries

### DIFF
--- a/database/mock/store.go
+++ b/database/mock/store.go
@@ -838,19 +838,19 @@ func (mr *MockStoreMockRecorder) GetProjectByName(arg0, arg1 any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetProjectByName", reflect.TypeOf((*MockStore)(nil).GetProjectByName), arg0, arg1)
 }
 
-// GetProjectIDPortBySessionState mocks base method.
-func (m *MockStore) GetProjectIDPortBySessionState(arg0 context.Context, arg1 string) (db.GetProjectIDPortBySessionStateRow, error) {
+// GetProjectIDBySessionState mocks base method.
+func (m *MockStore) GetProjectIDBySessionState(arg0 context.Context, arg1 string) (db.GetProjectIDBySessionStateRow, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetProjectIDPortBySessionState", arg0, arg1)
-	ret0, _ := ret[0].(db.GetProjectIDPortBySessionStateRow)
+	ret := m.ctrl.Call(m, "GetProjectIDBySessionState", arg0, arg1)
+	ret0, _ := ret[0].(db.GetProjectIDBySessionStateRow)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// GetProjectIDPortBySessionState indicates an expected call of GetProjectIDPortBySessionState.
-func (mr *MockStoreMockRecorder) GetProjectIDPortBySessionState(arg0, arg1 any) *gomock.Call {
+// GetProjectIDBySessionState indicates an expected call of GetProjectIDBySessionState.
+func (mr *MockStoreMockRecorder) GetProjectIDBySessionState(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetProjectIDPortBySessionState", reflect.TypeOf((*MockStore)(nil).GetProjectIDPortBySessionState), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetProjectIDBySessionState", reflect.TypeOf((*MockStore)(nil).GetProjectIDBySessionState), arg0, arg1)
 }
 
 // GetProviderByID mocks base method.

--- a/database/query/session_store.sql
+++ b/database/query/session_store.sql
@@ -1,5 +1,5 @@
 -- name: CreateSessionState :one
-INSERT INTO session_store (provider, project_id, port, session_state, owner_filter, redirect_url) VALUES ($1, $2, $3, $4, $5, $6) RETURNING *;
+INSERT INTO session_store (provider, project_id, session_state, owner_filter, redirect_url) VALUES ($1, $2, $3, $4, $5) RETURNING *;
 
 -- name: GetSessionState :one
 SELECT * FROM session_store WHERE id = $1;
@@ -7,8 +7,8 @@ SELECT * FROM session_store WHERE id = $1;
 -- name: GetSessionStateByProjectID :one
 SELECT * FROM session_store WHERE project_id = $1;
 
--- name: GetProjectIDPortBySessionState :one
-SELECT provider, project_id, port, owner_filter, redirect_url FROM session_store WHERE session_state = $1;
+-- name: GetProjectIDBySessionState :one
+SELECT provider, project_id, owner_filter, redirect_url FROM session_store WHERE session_state = $1;
 
 -- name: DeleteSessionState :exec
 DELETE FROM session_store WHERE id = $1;

--- a/internal/controlplane/handlers_oauth.go
+++ b/internal/controlplane/handlers_oauth.go
@@ -75,12 +75,6 @@ func (s *Server) GetAuthorizationURL(ctx context.Context,
 		return nil, err
 	}
 
-	// Format the port number
-	port := sql.NullInt32{
-		Int32: req.Port,
-		Valid: true,
-	}
-
 	// Delete any existing session state for the project
 	err = s.store.DeleteSessionStateByProjectID(ctx, db.DeleteSessionStateByProjectIDParams{
 		Provider:  provider.Name,
@@ -112,7 +106,6 @@ func (s *Server) GetAuthorizationURL(ctx context.Context,
 	_, err = s.store.CreateSessionState(ctx, db.CreateSessionStateParams{
 		Provider:     provider.Name,
 		ProjectID:    projectID,
-		Port:         port,
 		SessionState: state,
 		OwnerFilter:  owner,
 		RedirectUrl:  redirectUrl,
@@ -173,7 +166,7 @@ func (s *Server) processCallback(ctx context.Context, w http.ResponseWriter, r *
 	}
 
 	// get projectID from session along with state nonce from the database
-	stateData, err := s.store.GetProjectIDPortBySessionState(ctx, state)
+	stateData, err := s.store.GetProjectIDBySessionState(ctx, state)
 	if err != nil {
 		return fmt.Errorf("error getting project ID by session state: %w", err)
 	}
@@ -210,7 +203,7 @@ func (s *Server) processCallback(ctx context.Context, w http.ResponseWriter, r *
 }
 
 func (s *Server) generateOAuthToken(ctx context.Context, provider string, code string,
-	stateData db.GetProjectIDPortBySessionStateRow) error {
+	stateData db.GetProjectIDBySessionStateRow) error {
 	// generate a new OAuth2 config for the given provider
 	oauthConfig, err := auth.NewOAuthConfig(provider, true)
 	if err != nil {

--- a/internal/controlplane/handlers_oauth_test.go
+++ b/internal/controlplane/handlers_oauth_test.go
@@ -16,7 +16,6 @@ package controlplane
 
 import (
 	"context"
-	"database/sql"
 	"testing"
 
 	"github.com/google/uuid"
@@ -84,9 +83,7 @@ func TestNewOAuthConfig(t *testing.T) {
 func TestGetAuthorizationURL(t *testing.T) {
 	t.Parallel()
 
-	state := "test"
 	projectID := uuid.New()
-	port := sql.NullInt32{Int32: 8080, Valid: true}
 	providerID := uuid.New()
 	providerName := "github"
 	projectIdStr := projectID.String()
@@ -117,11 +114,7 @@ func TestGetAuthorizationURL(t *testing.T) {
 					}}, nil)
 				store.EXPECT().
 					CreateSessionState(gomock.Any(), gomock.Any()).
-					Return(db.SessionStore{
-						ProjectID:    projectID,
-						Port:         port,
-						SessionState: state,
-					}, nil)
+					Return(db.SessionStore{}, nil)
 				store.EXPECT().
 					DeleteSessionStateByProjectID(gomock.Any(), gomock.Any()).
 					Return(nil)

--- a/internal/db/querier.go
+++ b/internal/db/querier.go
@@ -67,7 +67,7 @@ type Querier interface {
 	GetProfileStatusByProject(ctx context.Context, projectID uuid.UUID) ([]GetProfileStatusByProjectRow, error)
 	GetProjectByID(ctx context.Context, id uuid.UUID) (Project, error)
 	GetProjectByName(ctx context.Context, name string) (Project, error)
-	GetProjectIDPortBySessionState(ctx context.Context, sessionState string) (GetProjectIDPortBySessionStateRow, error)
+	GetProjectIDBySessionState(ctx context.Context, sessionState string) (GetProjectIDBySessionStateRow, error)
 	GetProviderByID(ctx context.Context, arg GetProviderByIDParams) (Provider, error)
 	GetProviderByName(ctx context.Context, arg GetProviderByNameParams) (Provider, error)
 	GetPullRequest(ctx context.Context, arg GetPullRequestParams) (PullRequest, error)

--- a/internal/db/session_store.sql.go
+++ b/internal/db/session_store.sql.go
@@ -13,13 +13,12 @@ import (
 )
 
 const createSessionState = `-- name: CreateSessionState :one
-INSERT INTO session_store (provider, project_id, port, session_state, owner_filter, redirect_url) VALUES ($1, $2, $3, $4, $5, $6) RETURNING id, provider, project_id, port, owner_filter, session_state, created_at, redirect_url
+INSERT INTO session_store (provider, project_id, session_state, owner_filter, redirect_url) VALUES ($1, $2, $3, $4, $5) RETURNING id, provider, project_id, port, owner_filter, session_state, created_at, redirect_url
 `
 
 type CreateSessionStateParams struct {
 	Provider     string         `json:"provider"`
 	ProjectID    uuid.UUID      `json:"project_id"`
-	Port         sql.NullInt32  `json:"port"`
 	SessionState string         `json:"session_state"`
 	OwnerFilter  sql.NullString `json:"owner_filter"`
 	RedirectUrl  sql.NullString `json:"redirect_url"`
@@ -29,7 +28,6 @@ func (q *Queries) CreateSessionState(ctx context.Context, arg CreateSessionState
 	row := q.db.QueryRowContext(ctx, createSessionState,
 		arg.Provider,
 		arg.ProjectID,
-		arg.Port,
 		arg.SessionState,
 		arg.OwnerFilter,
 		arg.RedirectUrl,
@@ -80,25 +78,23 @@ func (q *Queries) DeleteSessionStateByProjectID(ctx context.Context, arg DeleteS
 	return err
 }
 
-const getProjectIDPortBySessionState = `-- name: GetProjectIDPortBySessionState :one
-SELECT provider, project_id, port, owner_filter, redirect_url FROM session_store WHERE session_state = $1
+const getProjectIDBySessionState = `-- name: GetProjectIDBySessionState :one
+SELECT provider, project_id, owner_filter, redirect_url FROM session_store WHERE session_state = $1
 `
 
-type GetProjectIDPortBySessionStateRow struct {
+type GetProjectIDBySessionStateRow struct {
 	Provider    string         `json:"provider"`
 	ProjectID   uuid.UUID      `json:"project_id"`
-	Port        sql.NullInt32  `json:"port"`
 	OwnerFilter sql.NullString `json:"owner_filter"`
 	RedirectUrl sql.NullString `json:"redirect_url"`
 }
 
-func (q *Queries) GetProjectIDPortBySessionState(ctx context.Context, sessionState string) (GetProjectIDPortBySessionStateRow, error) {
-	row := q.db.QueryRowContext(ctx, getProjectIDPortBySessionState, sessionState)
-	var i GetProjectIDPortBySessionStateRow
+func (q *Queries) GetProjectIDBySessionState(ctx context.Context, sessionState string) (GetProjectIDBySessionStateRow, error) {
+	row := q.db.QueryRowContext(ctx, getProjectIDBySessionState, sessionState)
+	var i GetProjectIDBySessionStateRow
 	err := row.Scan(
 		&i.Provider,
 		&i.ProjectID,
-		&i.Port,
 		&i.OwnerFilter,
 		&i.RedirectUrl,
 	)


### PR DESCRIPTION
# Summary

I noticed that the `port` field from `GetProjectIDPortBySessionState` isn't used anywhere in the response.  Removing it in preparation for some other refactoring.

Note: I did _not_ remove the column from the database _yet_, as I expect to have more substantial migrations in the future that I'll roll it into.  I could add a "currently unused" comment, but I think that would break our "no changes to existing migrations" check.

## Change Type

***Mark the type of change your PR introduces:***

- [ ] Bug fix (resolves an issue without affecting existing features)
- [ ] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [x] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

***Outline how the changes were tested, including steps to reproduce and any relevant configurations. 
Attach screenshots if helpful.***

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [x] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [x] Included tests that validate the fix or feature.
- [x] Checked that related changes are merged.
