### PR TITLE
Remove token from builtin rules

### DIFF
--- a/internal/engine/ingester/builtin/builtin.go
+++ b/internal/engine/ingester/builtin/builtin.go
@@ -45,17 +45,15 @@ type BuiltinRuleDataIngest struct {
 	builtinCfg  *pb.BuiltinType
 	ruleMethods rule_methods.Methods
 	method      string
-	accessToken string
 }
 
 // NewBuiltinRuleDataIngest creates a new builtin rule data ingest engine
 func NewBuiltinRuleDataIngest(
 	builtinCfg *pb.BuiltinType,
-	pbuild *providers.ProviderBuilder,
+	_ *providers.ProviderBuilder,
 ) (*BuiltinRuleDataIngest, error) {
 	return &BuiltinRuleDataIngest{
 		builtinCfg:  builtinCfg,
-		accessToken: pbuild.GetToken(),
 		method:      builtinCfg.GetMethod(),
 		ruleMethods: &rule_methods.RuleMethods{},
 	}, nil
@@ -98,8 +96,7 @@ func (idi *BuiltinRuleDataIngest) Ingest(ctx context.Context, ent protoreflect.P
 
 	// call method
 	// Call the method (empty parameter list)
-	result := method.Call([]reflect.Value{reflect.ValueOf(ctx),
-		reflect.ValueOf(idi.accessToken), reflect.ValueOf(ent)})
+	result := method.Call([]reflect.Value{reflect.ValueOf(ctx), reflect.ValueOf(ent)})
 	if len(result) != 2 {
 		return nil, fmt.Errorf("rule method should return 3 values")
 	}

--- a/pkg/rule_methods/rule_methods.go
+++ b/pkg/rule_methods/rule_methods.go
@@ -47,6 +47,6 @@ func (r *RuleMethods) GetMethod(mName string) (reflect.Value, error) {
 }
 
 // Passthrough is a method that passes the entity through, just marshalling it
-func (_ *RuleMethods) Passthrough(_ context.Context, _ string, ent protoreflect.ProtoMessage) (json.RawMessage, error) {
+func (_ *RuleMethods) Passthrough(_ context.Context, ent protoreflect.ProtoMessage) (json.RawMessage, error) {
 	return protojson.Marshal(ent)
 }


### PR DESCRIPTION
# Summary

From what I can tell, the only built in rule is the passthough, which doesn't use the token.
Additionally, as we add more providers we can't assume that they will all have a token.

Fixes #(related issue)

## Change Type

***Mark the type of change your PR introduces:***

- [ ] Bug fix (resolves an issue without affecting existing features)
- [ ] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [x] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

***Outline how the changes were tested, including steps to reproduce and any relevant configurations. 
Attach screenshots if helpful.***

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [ ] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [ ] Included tests that validate the fix or feature.
- [ ] Checked that related changes are merged.
