### PR TITLE
OpenFGA: change playground port to 8085

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -141,17 +141,19 @@ services:
   openfga:
     container_name: openfga
     image: openfga/openfga:v1.5.0
-    command:
-      - "run"
+    command: [
+      "run",
+      "--playground-port=8085"
+    ]
     healthcheck:
       test:
         - CMD
         - grpc_health_probe
         - "-addr=:8081"
     ports:
-      - 3000:3000
       - 8082:8080
       - 8083:8081
+      - 8085:8085
     networks:
       - app_net
 networks:


### PR DESCRIPTION
# Summary

Currently the OpenFGA playground is run by default in a local run (via `make run-docker`). The default port for OpenFGA playground is 3000, which also happens to be the default port for Next.js (used by a great many sites).

Avoid contention for this port by moving OpenFGA playground to 8085. You can now access it as http://localhost:8085/playground

## Change Type

***Mark the type of change your PR introduces:***

- [x] Bug fix (resolves an issue without affecting existing features)
- [ ] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [ ] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

<img width="1263" alt="Screenshot 2024-03-07 at 4 45 43 PM" src="https://github.com/stacklok/minder/assets/1130014/c7423b44-8fd0-4d2f-90f2-e22b44b36a91">

# Review Checklist:

- [ ] Reviewed my own code for quality and clarity.
- [ ] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [ ] Included tests that validate the fix or feature.
- [ ] Checked that related changes are merged.
