### PR TITLE
Make GitHub provider implement Git provider

### DIFF
--- a/internal/controlplane/handlers_repositories_test.go
+++ b/internal/controlplane/handlers_repositories_test.go
@@ -23,6 +23,7 @@ import (
 	"testing"
 
 	"github.com/ThreeDotsLabs/watermill/message"
+	"github.com/go-git/go-git/v5"
 	"github.com/google/go-github/v56/github"
 	"github.com/google/uuid"
 	"go.uber.org/mock/gomock"
@@ -474,5 +475,9 @@ func (*StubGitHub) GetUsername(context.Context) (string, error) {
 
 // GetPrimaryEmail implements v1.GitHub.
 func (*StubGitHub) GetPrimaryEmail(context.Context) (string, error) {
+	panic("unimplemented")
+}
+
+func (*StubGitHub) Clone(context.Context, string, string) (*git.Repository, error) {
 	panic("unimplemented")
 }

--- a/internal/engine/ingester/git/git_test.go
+++ b/internal/engine/ingester/git/git_test.go
@@ -36,12 +36,10 @@ func TestGitIngestWithCloneURLFromRepo(t *testing.T) {
 		Branch: "master",
 	}, providers.NewProviderBuilder(
 		&db.Provider{
-			Name:    "github",
+			Name:    "git-provider",
 			Version: provifv1.V1,
 			Implements: []db.ProviderType{
 				"git",
-				"rest",
-				"github",
 			},
 		},
 		db.ProviderAccessToken{},
@@ -75,12 +73,10 @@ func TestGitIngestWithCloneURLFromParams(t *testing.T) {
 		Branch: "master",
 	}, providers.NewProviderBuilder(
 		&db.Provider{
-			Name:    "github",
+			Name:    "git-provider",
 			Version: provifv1.V1,
 			Implements: []db.ProviderType{
 				"git",
-				"rest",
-				"github",
 			},
 		},
 		db.ProviderAccessToken{},
@@ -114,12 +110,10 @@ func TestGitIngestWithCustomBranchFromParams(t *testing.T) {
 		Branch: "master",
 	}, providers.NewProviderBuilder(
 		&db.Provider{
-			Name:    "github",
+			Name:    "git-provider",
 			Version: provifv1.V1,
 			Implements: []db.ProviderType{
 				"git",
-				"rest",
-				"github",
 			},
 		},
 		db.ProviderAccessToken{},
@@ -153,12 +147,10 @@ func TestGitIngestWithBranchFromRepoEntity(t *testing.T) {
 	gi, err := gitengine.NewGitIngester(&pb.GitType{},
 		providers.NewProviderBuilder(
 			&db.Provider{
-				Name:    "github",
+				Name:    "git-provider",
 				Version: provifv1.V1,
 				Implements: []db.ProviderType{
 					"git",
-					"rest",
-					"github",
 				},
 			},
 			db.ProviderAccessToken{},
@@ -194,12 +186,10 @@ func TestGitIngestWithUnexistentBranchFromParams(t *testing.T) {
 		Branch: "master",
 	}, providers.NewProviderBuilder(
 		&db.Provider{
-			Name:    "github",
+			Name:    "git-provider",
 			Version: provifv1.V1,
 			Implements: []db.ProviderType{
 				"git",
-				"rest",
-				"github",
 			},
 		},
 		db.ProviderAccessToken{},
@@ -224,12 +214,10 @@ func TestGitIngestFailsBecauseOfAuthorization(t *testing.T) {
 		Branch: "master",
 	}, providers.NewProviderBuilder(
 		&db.Provider{
-			Name:    "github",
+			Name:    "git-provider",
 			Version: provifv1.V1,
 			Implements: []db.ProviderType{
 				"git",
-				"rest",
-				"github",
 			},
 		},
 		db.ProviderAccessToken{},
@@ -251,12 +239,10 @@ func TestGitIngestFailsBecauseOfUnexistentCloneUrl(t *testing.T) {
 	// foobar is not a valid token
 	gi, err := gitengine.NewGitIngester(&pb.GitType{}, providers.NewProviderBuilder(
 		&db.Provider{
-			Name:    "github",
+			Name:    "git-provider",
 			Version: provifv1.V1,
 			Implements: []db.ProviderType{
 				"git",
-				"rest",
-				"github",
 			},
 		},
 		db.ProviderAccessToken{},

--- a/internal/providers/github/github_test.go
+++ b/internal/providers/github/github_test.go
@@ -52,7 +52,7 @@ func TestArtifactAPIEscapes(t *testing.T) {
 	tests := []struct {
 		name        string
 		testHandler http.HandlerFunc
-		cliFn       func(cli *RestClient)
+		cliFn       func(cli *GitHub)
 		wantErr     bool
 	}{
 		{
@@ -61,7 +61,7 @@ func TestArtifactAPIEscapes(t *testing.T) {
 				assert.Equal(t, "/orgs/stacklok/packages/container/helm%2Fmediator", r.URL.RequestURI())
 				w.WriteHeader(http.StatusOK)
 			},
-			cliFn: func(cli *RestClient) {
+			cliFn: func(cli *GitHub) {
 				_, err := cli.GetPackageByName(context.Background(), true, "stacklok", "container", "helm/mediator")
 				assert.NoError(t, err)
 			},
@@ -72,7 +72,7 @@ func TestArtifactAPIEscapes(t *testing.T) {
 				assert.Equal(t, "/orgs/stacklok/packages/container/helm%2Fmediator/versions?package_type=container&page=1&per_page=100&state=active", r.URL.RequestURI())
 				w.WriteHeader(http.StatusOK)
 			},
-			cliFn: func(cli *RestClient) {
+			cliFn: func(cli *GitHub) {
 				_, err := cli.GetPackageVersions(context.Background(), true, "stacklok", "container", "helm/mediator")
 				assert.NoError(t, err)
 			},
@@ -83,7 +83,7 @@ func TestArtifactAPIEscapes(t *testing.T) {
 				assert.Equal(t, "/orgs/stacklok/packages/container/helm%2Fmediator/versions?package_type=container&page=1&per_page=100&state=active", r.URL.RequestURI())
 				w.WriteHeader(http.StatusOK)
 			},
-			cliFn: func(cli *RestClient) {
+			cliFn: func(cli *GitHub) {
 				_, err := cli.GetPackageVersionByTag(context.Background(), true, "stacklok", "container", "helm/mediator", "v1.0.0")
 				assert.NoError(t, err)
 			},
@@ -94,7 +94,7 @@ func TestArtifactAPIEscapes(t *testing.T) {
 				assert.Equal(t, "/orgs/stacklok/packages/container/helm%2Fmediator/versions/123", r.URL.RequestURI())
 				w.WriteHeader(http.StatusOK)
 			},
-			cliFn: func(cli *RestClient) {
+			cliFn: func(cli *GitHub) {
 				_, err := cli.GetPackageVersionById(context.Background(), true, "stacklok", "container", "helm/mediator", 123)
 				assert.NoError(t, err)
 			},
@@ -207,7 +207,7 @@ func TestConcurrentWaitForRateLimitReset(t *testing.T) {
 			client, ok := restClientCache.Get(owner, token, db.ProviderTypeGithub)
 			require.True(t, ok)
 
-			ghClient, ok := client.(*RestClient)
+			ghClient, ok := client.(*GitHub)
 			require.True(t, ok)
 
 			_, err := ghClient.CreateIssueComment(ctx, owner, "mockRepo", 1, "Test Comment")

--- a/internal/providers/github/mock/github.go
+++ b/internal/providers/github/mock/github.go
@@ -280,6 +280,21 @@ func (m *MockGitHub) EXPECT() *MockGitHubMockRecorder {
 	return m.recorder
 }
 
+// Clone mocks base method.
+func (m *MockGitHub) Clone(ctx context.Context, url, branch string) (*git.Repository, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Clone", ctx, url, branch)
+	ret0, _ := ret[0].(*git.Repository)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// Clone indicates an expected call of Clone.
+func (mr *MockGitHubMockRecorder) Clone(ctx, url, branch any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Clone", reflect.TypeOf((*MockGitHub)(nil).Clone), ctx, url, branch)
+}
+
 // CloseSecurityAdvisory mocks base method.
 func (m *MockGitHub) CloseSecurityAdvisory(ctx context.Context, owner, repo, id string) error {
 	m.ctrl.T.Helper()

--- a/internal/providers/providers.go
+++ b/internal/providers/providers.go
@@ -128,6 +128,10 @@ func (pb *ProviderBuilder) GetGit() (provinfv1.Git, error) {
 		return nil, fmt.Errorf("provider does not implement git")
 	}
 
+	if pb.Implements(db.ProviderTypeGithub) {
+		return pb.GetGitHub()
+	}
+
 	return gitclient.NewGit(pb.tok), nil
 }
 

--- a/pkg/providers/v1/providers.go
+++ b/pkg/providers/v1/providers.go
@@ -77,6 +77,7 @@ type GitHub interface {
 	Provider
 	RepoLister
 	REST
+	Git
 
 	GetRepository(context.Context, string, string) (*github.Repository, error)
 	ListAllRepositories(context.Context, bool, string) ([]*github.Repository, error)


### PR DESCRIPTION
# Summary

Our implementation of the GitHub provider stated that it implemented the Git provider, but this was not enforced.
This PR updates the GitHub provider interface to inherit from the Git provider interface (see `pkg/providers/v1/providers.go`).

This also renamed the GitHub provider implementation to `GitHub` instead of `RestClient` because it's not REST specific.


## Change Type

***Mark the type of change your PR introduces:***

- [ ] Bug fix (resolves an issue without affecting existing features)
- [ ] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [x] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

***Outline how the changes were tested, including steps to reproduce and any relevant configurations. 
Attach screenshots if helpful.***

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [ ] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [ ] Included tests that validate the fix or feature.
- [x] Checked that related changes are merged.
