### PR TITLE
Clean up provider enroll, provide error message on failure

### DIFF
--- a/cmd/cli/app/provider/provider_enroll.go
+++ b/cmd/cli/app/provider/provider_enroll.go
@@ -87,7 +87,7 @@ func EnrollProviderCommand(ctx context.Context, cmd *cobra.Command, conn *grpc.C
 		}
 	}
 
-	oAuthCallbackCtx, oAuthCancel := context.WithTimeout(context.Background(), MAX_WAIT + 5 * time.Second)
+	oAuthCallbackCtx, oAuthCancel := context.WithTimeout(context.Background(), MAX_WAIT+5*time.Second)
 	defer oAuthCancel()
 
 	if token != "" {
@@ -169,9 +169,8 @@ func callBackServer(ctx context.Context, cmd *cobra.Command, provider string, pr
 		}
 		close(done)
 	}()
-	stopServer := false
 
-	for stopServer == false {
+	for {
 		time.Sleep(time.Second)
 
 		// create a shorter lived context for any client calls
@@ -190,12 +189,12 @@ func callBackServer(ctx context.Context, cmd *cobra.Command, provider string, pr
 		if err != nil || res.Status == "OK" {
 			cmd.Printf("Error calling server: %s\n", err)
 			done <- false
-			stopServer = true
+			break
 		}
 		if time.Now().After(openTime.Add(MAX_WAIT)) {
 			cmd.Printf("Timeout waiting for OAuth flow to complete...\n")
 			done <- false
-			stopServer = true
+			break
 		}
 	}
 }

--- a/cmd/cli/app/provider/provider_enroll.go
+++ b/cmd/cli/app/provider/provider_enroll.go
@@ -20,7 +20,6 @@ import (
 	"fmt"
 	"net/http"
 	"os"
-	"sync"
 	"time"
 
 	"github.com/pkg/browser"
@@ -40,8 +39,8 @@ type Response struct {
 	Status string `json:"status"`
 }
 
-// MAX_CALLS is the maximum number of calls to the gRPC server before stopping.
-const MAX_CALLS = 300
+// MAX_WAIT is the maximum number of calls to the gRPC server before stopping.
+const MAX_WAIT = time.Duration(5 * time.Minute)
 
 var enrollCmd = &cobra.Command{
 	Use:   "enroll",
@@ -88,7 +87,7 @@ func EnrollProviderCommand(ctx context.Context, cmd *cobra.Command, conn *grpc.C
 		}
 	}
 
-	oAuthCallbackCtx, oAuthCancel := context.WithTimeout(context.Background(), MAX_CALLS*time.Second)
+	oAuthCallbackCtx, oAuthCancel := context.WithTimeout(context.Background(), MAX_WAIT + 5 * time.Second)
 	defer oAuthCancel()
 
 	if token != "" {
@@ -131,35 +130,30 @@ func EnrollProviderCommand(ctx context.Context, cmd *cobra.Command, conn *grpc.C
 		fmt.Fprintf(os.Stderr, "Error opening browser: %s\n", err)
 		cmd.Println("Please copy and paste the URL into a browser.")
 	}
-	openTime := time.Now().Unix()
+	openTime := time.Now()
 
-	var wg sync.WaitGroup
-	wg.Add(1)
+	done := make(chan bool)
 
-	go callBackServer(oAuthCallbackCtx, cmd, provider, project, fmt.Sprintf("%d", port), &wg, client, openTime)
-	wg.Wait()
+	go callBackServer(oAuthCallbackCtx, cmd, provider, project, fmt.Sprintf("%d", port), done, client, openTime)
 
-	cmd.Println("Provider enrolled successfully")
+	success := <-done
+
+	if success {
+		cmd.Println("Provider enrolled successfully")
+	} else {
+		cmd.Println("Failed to enroll provider")
+	}
 	return nil
 }
 
 // callBackServer starts a server and handler to listen for the OAuth callback.
 // It will wait for either a success or failure response from the server.
 func callBackServer(ctx context.Context, cmd *cobra.Command, provider string, project string, port string,
-	wg *sync.WaitGroup, client minderv1.OAuthServiceClient, since int64) {
+	done chan bool, client minderv1.OAuthServiceClient, openTime time.Time) {
 	server := &http.Server{
 		Addr:              fmt.Sprintf(":%s", port),
 		ReadHeaderTimeout: time.Second * 10, // Set an appropriate timeout value
 	}
-
-	go func() {
-		wg.Wait()
-		err := server.Close()
-		if err != nil {
-			// Handle the error appropriately, such as logging or returning an error message.
-			cmd.Printf("Error closing server: %s", err)
-		}
-	}()
 
 	// Start the server in a goroutine
 	cmd.Println("Listening for OAuth Login flow to complete on port", port)
@@ -167,41 +161,43 @@ func callBackServer(ctx context.Context, cmd *cobra.Command, provider string, pr
 		_ = server.ListenAndServe()
 	}()
 
-	var stopServer bool
 	// Start a goroutine for periodic gRPC calls
-	go func() {
-		defer wg.Done()
-		calls := 0
-
-		for {
-			// Perform periodic gRPC calls
-			if stopServer {
-				// Check the stop condition and break the loop if necessary
-				break
-			}
-
-			time.Sleep(time.Second)
-			t := time.Unix(since, 0)
-			calls++
-
-			// create a shorter lived context for any client calls
-			clientCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
-			defer cancel()
-
-			// todo: check if token has been created. We need an endpoint to pass an state and check if token is created
-			res, err := client.VerifyProviderTokenFrom(clientCtx, &minderv1.VerifyProviderTokenFromRequest{
-				Context:   &minderv1.Context{Provider: &provider, Project: &project},
-				Timestamp: timestamppb.New(t),
-			})
-			if err == nil && res.Status == "OK" {
-				return
-			}
-			if err != nil || res.Status == "OK" || calls >= MAX_CALLS {
-				stopServer = true
-			}
+	defer func() {
+		if err := server.Close(); err != nil {
+			// Handle the error appropriately, such as logging or returning an error message.
+			cmd.Printf("Error closing server: %s", err)
 		}
+		close(done)
 	}()
+	stopServer := false
 
+	for stopServer == false {
+		time.Sleep(time.Second)
+
+		// create a shorter lived context for any client calls
+		clientCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+		defer cancel()
+
+		// todo: check if token has been created. We need an endpoint to pass an state and check if token is created
+		res, err := client.VerifyProviderTokenFrom(clientCtx, &minderv1.VerifyProviderTokenFromRequest{
+			Context:   &minderv1.Context{Provider: &provider, Project: &project},
+			Timestamp: timestamppb.New(openTime),
+		})
+		if err == nil && res.Status == "OK" {
+			done <- true
+			return
+		}
+		if err != nil || res.Status == "OK" {
+			cmd.Printf("Error calling server: %s\n", err)
+			done <- false
+			stopServer = true
+		}
+		if time.Now().After(openTime.Add(MAX_WAIT)) {
+			cmd.Printf("Timeout waiting for OAuth flow to complete...\n")
+			done <- false
+			stopServer = true
+		}
+	}
 }
 
 func init() {


### PR DESCRIPTION
# Summary

While testing #2566, I noticed that we always reported successful enrollment, even when the enrollment timed out or failed.  Also, the code seemed overly complicated (4 goroutines and a WaitGroup).

Refactored to use 2 goroutines and a channel, and cleaned up error reporting.

Switched from both a timeout _and_ a call limit to only a timeout.

## Change Type

***Mark the type of change your PR introduces:***

- [x] Bug fix (resolves an issue without affecting existing features)
- [ ] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [x] Refactoring or test improvements (no bug fixes or new functionality)

(Sorry, the bug fixes and refactoring sort of go hand-in-hand)

# Testing

Manual testing alongside #2566

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [x] Added comments to complex or tricky code sections.
- [x] Updated any affected documentation.
- [ ] Included tests that validate the fix or feature.
- [x] Checked that related changes are merged.
