### PR TITLE
Return alert status in profile get

### DIFF
--- a/internal/engine/profile.go
+++ b/internal/engine/profile.go
@@ -222,6 +222,11 @@ func MergeDatabaseGetIntoProfiles(ppl []db.GetProfileByProjectAndIDRow) map[stri
 				sRem := string(p.Remediate.ActionType)
 				profiles[p.Name].Remediate = &sRem
 			}
+
+			if p.Alert.Valid {
+				sAlert := string(p.Alert.ActionType)
+				profiles[p.Name].Alert = &sAlert
+			}
 		}
 		if pm := rowInfoToProfileMap(profiles[p.Name], p.Entity, p.ContextualRules); pm != nil {
 			profiles[p.Name] = pm


### PR DESCRIPTION
# Summary

The get command was only returning remediate status, not alert.

Fixes: https://github.com/stacklok/epics/issues/237

## Change Type

***Mark the type of change your PR introduces:***

- [x] Bug fix (resolves an issue without affecting existing features)
- [ ] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [ ] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

```
curl -H "Authorization: Bearer $MINDER_BEARER_TOKEN" 'http://localhost:8080/api/v1/profile/67c550c7-74cd-4bd6-a6f4-78ffc65d6af9?context.provider=github&context.project=a34dc21e-0164-4508-ada1-32419bc72d65&id=67c550c7-74cd-4bd6-a6f4-78ffc65d6af9'
```

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [ ] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [ ] Included tests that validate the fix or feature.
- [ ] Checked that related changes are merged.
