### PR TITLE
Reuse token from GitHub client in container verifier

### DIFF
--- a/cmd/dev/app/container/cmd_verify.go
+++ b/cmd/dev/app/container/cmd_verify.go
@@ -91,7 +91,7 @@ func runCmdVerify(cmd *cobra.Command, _ []string) error {
 	artifactVerifier, err := verifier.NewVerifier(
 		verifier.VerifierSigstore,
 		tufRoot.Value.String(),
-		container.WithAccessToken(token), container.WithGitHubClient(ghcli))
+		container.WithGitHubClient(ghcli))
 	if err != nil {
 		return fmt.Errorf("error getting sigstore verifier: %w", err)
 	}

--- a/internal/engine/ingester/artifact/artifact.go
+++ b/internal/engine/ingester/artifact/artifact.go
@@ -223,7 +223,7 @@ func getVerifier(i *Ingest, cfg *ingesterConfig) (verifyif.ArtifactVerifier, err
 	artifactVerifier, err := verifier.NewVerifier(
 		verifier.VerifierSigstore,
 		cfg.Sigstore,
-		container.WithAccessToken(i.ghCli.GetToken()), container.WithGitHubClient(i.ghCli))
+		container.WithGitHubClient(i.ghCli))
 	if err != nil {
 		return nil, fmt.Errorf("error getting sigstore verifier: %w", err)
 	}

--- a/internal/verifier/sigstore/container/container.go
+++ b/internal/verifier/sigstore/container/container.go
@@ -58,8 +58,7 @@ type AuthMethod func(auth *containerAuth)
 
 // containerAuth is the authentication for the container
 type containerAuth struct {
-	accessToken string
-	ghClient    provifv1.GitHub
+	ghClient provifv1.GitHub
 }
 
 func newContainerAuth(authOpts ...AuthMethod) *containerAuth {
@@ -68,13 +67,6 @@ func newContainerAuth(authOpts ...AuthMethod) *containerAuth {
 		opt(&auth)
 	}
 	return &auth
-}
-
-// WithAccessToken sets the access token as an authentication option we want to use during verification
-func WithAccessToken(accessToken string) AuthMethod {
-	return func(auth *containerAuth) {
-		auth.accessToken = accessToken
-	}
 }
 
 // WithGitHubClient sets the GitHub client as an authentication option we want to use during verification
@@ -172,7 +164,7 @@ func getSigstoreBundles(
 ) ([]sigstoreBundle, error) {
 	imageRef := BuildImageRef(registry, owner, artifact, version)
 	// Try to build a bundle from the OCI image reference
-	bundles, err := bundleFromOCIImage(ctx, imageRef, newGithubAuthenticator(owner, auth.accessToken))
+	bundles, err := bundleFromOCIImage(ctx, imageRef, newGithubAuthenticator(owner, auth.ghClient.GetToken()))
 	if errors.Is(err, ErrProvenanceNotFoundOrIncomplete) || errors.Is(err, ErrAuthNotProvided) {
 		// If we failed to find the signature in the OCI image, try to build a bundle from the GitHub attestation endpoint
 		return bundleFromGHAttestationEndpoint(ctx, auth.ghClient, owner, version)


### PR DESCRIPTION
# Summary

The access token set in `containerAuth` always comes from the GitHub client. Instead of passing in both the token and the client, only pass in the client and then fetch the access token from the client.

## Change Type

***Mark the type of change your PR introduces:***

- [ ] Bug fix (resolves an issue without affecting existing features)
- [ ] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [x] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

***Outline how the changes were tested, including steps to reproduce and any relevant configurations. 
Attach screenshots if helpful.***

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [ ] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [ ] Included tests that validate the fix or feature.
- [ ] Checked that related changes are merged.
