### PR TITLE
Use basic auth for container verifier

### DIFF
--- a/internal/verifier/sigstore/container/container.go
+++ b/internal/verifier/sigstore/container/container.go
@@ -49,8 +49,6 @@ var (
 	// ErrProvenanceNotFoundOrIncomplete is returned when there's no provenance info (missing .sig or attestation) or
 	// has incomplete data
 	ErrProvenanceNotFoundOrIncomplete = errors.New("provenance not found or incomplete")
-	// ErrAuthNotProvided is returned when the selected authentication is not provided
-	ErrAuthNotProvided = errors.New("selected auth method not provided")
 )
 
 // AuthMethod is an option for containerAuth
@@ -164,8 +162,8 @@ func getSigstoreBundles(
 ) ([]sigstoreBundle, error) {
 	imageRef := BuildImageRef(registry, owner, artifact, version)
 	// Try to build a bundle from the OCI image reference
-	bundles, err := bundleFromOCIImage(ctx, imageRef, newGithubAuthenticator(owner, auth.ghClient.GetToken()))
-	if errors.Is(err, ErrProvenanceNotFoundOrIncomplete) || errors.Is(err, ErrAuthNotProvided) {
+	bundles, err := bundleFromOCIImage(ctx, imageRef, &authn.Basic{Username: owner, Password: auth.ghClient.GetToken()})
+	if errors.Is(err, ErrProvenanceNotFoundOrIncomplete) {
 		// If we failed to find the signature in the OCI image, try to build a bundle from the GitHub attestation endpoint
 		return bundleFromGHAttestationEndpoint(ctx, auth.ghClient, owner, version)
 	}
@@ -230,7 +228,7 @@ func bundleFromGHAttestationEndpoint(
 
 func getAttestationReply(ctx context.Context, ghCli provifv1.GitHub, owner, version string) (*AttestationReply, error) {
 	if ghCli == nil {
-		return nil, fmt.Errorf("%w: no github client available", ErrAuthNotProvided)
+		return nil, fmt.Errorf("no github client available")
 	}
 
 	url := fmt.Sprintf("orgs/%s/attestations/%s", owner, version)
@@ -292,7 +290,7 @@ func getDigestFromVersion(version string) ([]byte, error) {
 
 // bundleFromOCIImage returns a ProtobufBundle based on OCI image reference.
 func bundleFromOCIImage(ctx context.Context,
-	imageRef string, auth githubAuthenticator) ([]sigstoreBundle, error) {
+	imageRef string, auth authn.Authenticator) ([]sigstoreBundle, error) {
 	logger := zerolog.Ctx(ctx)
 
 	// Get the signature manifest from the OCI image reference
@@ -362,7 +360,7 @@ func bundleFromOCIImage(ctx context.Context,
 }
 
 // getSignatureReferenceFromOCIImage returns the simple signing layer from the OCI image reference
-func getSignatureReferenceFromOCIImage(imageRef string, auth githubAuthenticator) (string, error) {
+func getSignatureReferenceFromOCIImage(imageRef string, auth authn.Authenticator) (string, error) {
 	// 0. Get the auth options
 	opts := []remote.Option{remote.WithAuth(auth)}
 
@@ -393,7 +391,7 @@ func getSignatureReferenceFromOCIImage(imageRef string, auth githubAuthenticator
 }
 
 // getSimpleSigningLayersFromSignatureManifest returns the identity and issuer from the certificate
-func getSimpleSigningLayersFromSignatureManifest(manifestRef string, auth githubAuthenticator) ([]v1.Descriptor, error) {
+func getSimpleSigningLayersFromSignatureManifest(manifestRef string, auth authn.Authenticator) ([]v1.Descriptor, error) {
 	craneOpts := []crane.Option{crane.WithAuth(auth)}
 
 	// Get the manifest of the signature
@@ -568,26 +566,6 @@ func getBundleMsgSignature(simpleSigningLayer v1.Descriptor) (*protobundle.Bundl
 			Signature: sig,
 		},
 	}, nil
-}
-
-// githubAuthenticator is an authenticator for GitHub
-type githubAuthenticator struct{ username, password string }
-
-// Authorization returns the username and password for the githubAuthenticator
-func (g githubAuthenticator) Authorization() (*authn.AuthConfig, error) {
-	if len(g.password) == 0 || len(g.username) == 0 {
-		return nil, ErrAuthNotProvided
-	}
-
-	return &authn.AuthConfig{
-		Username: g.username,
-		Password: g.password,
-	}, nil
-}
-
-// newGithubAuthenticator returns a new githubAuthenticator
-func newGithubAuthenticator(username, password string) githubAuthenticator {
-	return githubAuthenticator{username, password}
 }
 
 // BuildImageRef returns the OCI image reference


### PR DESCRIPTION
# Summary

Instead of creating a custom GitHub authenticator, use the built-in Basic auth Authenticator.
The difference is in the returned error, where the custom authenticator returned `ErrAuthNotProvided` if the owner or token was empty. 

## Change Type

***Mark the type of change your PR introduces:***

- [ ] Bug fix (resolves an issue without affecting existing features)
- [ ] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [x] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

***Outline how the changes were tested, including steps to reproduce and any relevant configurations. 
Attach screenshots if helpful.***

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [ ] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [ ] Included tests that validate the fix or feature.
- [ ] Checked that related changes are merged.
