### PR TITLE
Allow setting project ID via environment variable

### DIFF
--- a/cmd/cli/app/artifact/artifact.go
+++ b/cmd/cli/app/artifact/artifact.go
@@ -18,9 +18,11 @@ package artifact
 
 import (
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 
 	"github.com/stacklok/minder/cmd/cli/app"
 	ghclient "github.com/stacklok/minder/internal/providers/github"
+	"github.com/stacklok/minder/internal/util/cli"
 )
 
 // ArtifactCmd is the artifact subcommand
@@ -37,5 +39,5 @@ func init() {
 	app.RootCmd.AddCommand(ArtifactCmd)
 	// Flags for all subcommands
 	ArtifactCmd.PersistentFlags().StringP("provider", "p", ghclient.Github, "Name of the provider, i.e. github")
-	ArtifactCmd.PersistentFlags().StringP("project", "j", "", "ID of the project")
+	cli.UseProjectFlag(ArtifactCmd.PersistentFlags(), viper.GetViper())
 }

--- a/cmd/cli/app/profile/profile.go
+++ b/cmd/cli/app/profile/profile.go
@@ -18,9 +18,11 @@ package profile
 
 import (
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 
 	"github.com/stacklok/minder/cmd/cli/app"
 	ghclient "github.com/stacklok/minder/internal/providers/github"
+	"github.com/stacklok/minder/internal/util/cli"
 )
 
 // ProfileCmd is the root command for the profile subcommands
@@ -37,5 +39,5 @@ func init() {
 	app.RootCmd.AddCommand(ProfileCmd)
 	// Flags for all subcommands
 	ProfileCmd.PersistentFlags().StringP("provider", "p", ghclient.Github, "Name of the provider, i.e. github")
-	ProfileCmd.PersistentFlags().StringP("project", "j", "", "ID of the project")
+	cli.UseProjectFlag(ProfileCmd.PersistentFlags(), viper.GetViper())
 }

--- a/cmd/cli/app/project/role/role.go
+++ b/cmd/cli/app/project/role/role.go
@@ -18,8 +18,10 @@ package role
 
 import (
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 
 	"github.com/stacklok/minder/cmd/cli/app/project"
+	"github.com/stacklok/minder/internal/util/cli"
 )
 
 // RoleCmd is the root command for the project subcommands
@@ -34,5 +36,5 @@ var RoleCmd = &cobra.Command{
 
 func init() {
 	project.ProjectCmd.AddCommand(RoleCmd)
-	RoleCmd.PersistentFlags().StringP("project", "j", "", "ID of the project")
+	cli.UseProjectFlag(RoleCmd.PersistentFlags(), viper.GetViper())
 }

--- a/cmd/cli/app/provider/provider.go
+++ b/cmd/cli/app/provider/provider.go
@@ -18,9 +18,11 @@ package provider
 
 import (
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 
 	"github.com/stacklok/minder/cmd/cli/app"
 	ghclient "github.com/stacklok/minder/internal/providers/github"
+	"github.com/stacklok/minder/internal/util/cli"
 )
 
 // ProviderCmd is the root command for the provider subcommands
@@ -37,5 +39,5 @@ func init() {
 	app.RootCmd.AddCommand(ProviderCmd)
 	// Flags for all subcommands
 	ProviderCmd.PersistentFlags().StringP("provider", "p", ghclient.Github, "Name of the provider, i.e. github")
-	ProviderCmd.PersistentFlags().StringP("project", "j", "", "ID of the project")
+	cli.UseProjectFlag(ProviderCmd.PersistentFlags(), viper.GetViper())
 }

--- a/cmd/cli/app/quickstart/quickstart.go
+++ b/cmd/cli/app/quickstart/quickstart.go
@@ -384,7 +384,9 @@ func init() {
 	app.RootCmd.AddCommand(cmd)
 	// Flags
 	cmd.Flags().StringP("provider", "p", ghclient.Github, "Name of the provider, i.e. github")
-	cmd.Flags().StringP("project", "j", "", "ID of the project")
+
+	cli.UseProjectFlag(cmd.Flags(), viper.GetViper())
+
 	cmd.Flags().StringP("token", "t", "", "Personal Access Token (PAT) to use for enrollment")
 	cmd.Flags().StringP("owner", "o", "", "Owner to filter on for provider resources")
 	// Bind flags

--- a/cmd/cli/app/repo/repo.go
+++ b/cmd/cli/app/repo/repo.go
@@ -18,9 +18,11 @@ package repo
 
 import (
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 
 	"github.com/stacklok/minder/cmd/cli/app"
 	ghclient "github.com/stacklok/minder/internal/providers/github"
+	"github.com/stacklok/minder/internal/util/cli"
 )
 
 // RepoCmd is the root command for the repo subcommands
@@ -37,5 +39,5 @@ func init() {
 	app.RootCmd.AddCommand(RepoCmd)
 	// Flags for all subcommands
 	RepoCmd.PersistentFlags().StringP("provider", "p", ghclient.Github, "Name of the provider, i.e. github")
-	RepoCmd.PersistentFlags().StringP("project", "j", "", "ID of the project")
+	cli.UseProjectFlag(RepoCmd.PersistentFlags(), viper.GetViper())
 }

--- a/cmd/cli/app/ruletype/ruletype.go
+++ b/cmd/cli/app/ruletype/ruletype.go
@@ -18,9 +18,11 @@ package ruletype
 
 import (
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 
 	"github.com/stacklok/minder/cmd/cli/app"
 	ghclient "github.com/stacklok/minder/internal/providers/github"
+	"github.com/stacklok/minder/internal/util/cli"
 )
 
 // ruleTypeCmd is the root command for the rule subcommands
@@ -37,5 +39,5 @@ func init() {
 	app.RootCmd.AddCommand(ruleTypeCmd)
 	// Flags for all subcommands
 	ruleTypeCmd.PersistentFlags().StringP("provider", "p", ghclient.Github, "Name of the provider, i.e. github")
-	ruleTypeCmd.PersistentFlags().StringP("project", "j", "", "ID of the project")
+	cli.UseProjectFlag(ruleTypeCmd.PersistentFlags(), viper.GetViper())
 }

--- a/internal/util/cli/project.go
+++ b/internal/util/cli/project.go
@@ -1,0 +1,37 @@
+//
+// Copyright 2024 Stacklok, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cli
+
+import (
+	"fmt"
+
+	"github.com/spf13/pflag"
+	"github.com/spf13/viper"
+)
+
+// StringArgSetter is an interface for setting string arguments
+type StringArgSetter interface {
+	StringP(string, string, string, string) *string
+	Lookup(string) *pflag.Flag
+}
+
+// UseProjectFlag adds a project flag to the provided flag set and binds it to the viper instance
+func UseProjectFlag(s StringArgSetter, v *viper.Viper) {
+	s.StringP("project", "j", "", "ID of the project")
+	if err := v.BindPFlag("project", s.Lookup("project")); err != nil {
+		panic(fmt.Sprintf("Error binding project flag: %s", err))
+	}
+}


### PR DESCRIPTION
# Summary

This allows for setting the project ID to work on via an environment variable.

One would set the `MINDER_PROJECT` environment variable as follows:

```
export MINDER_PROJECT=$(minder project list -o json | jq -r '.projects | map(select(.name == "foo"))[0].projectId')
```

Where `foo` is the project ID.

Then, one could simply do `minder repo list` or any other project-scoped operation
without needing to pass in the `-j` or `--project` flag.

This could be enhanced further by having a dedicated CLI command to get the ID, but let's enhance that
in further PRs.

## Change Type

***Mark the type of change your PR introduces:***

- [ ] Bug fix (resolves an issue without affecting existing features)
- [x] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [ ] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

***Outline how the changes were tested, including steps to reproduce and any relevant configurations. 
Attach screenshots if helpful.***

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [x] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [ ] Included tests that validate the fix or feature.
- [ ] Checked that related changes are merged.
