### PR TITLE
Ensure we actually set the default auth flows for the github provider

### DIFF
--- a/cmd/server/app/migrate_up.go
+++ b/cmd/server/app/migrate_up.go
@@ -32,7 +32,9 @@ import (
 	"github.com/stacklok/minder/internal/authz"
 	"github.com/stacklok/minder/internal/config"
 	serverconfig "github.com/stacklok/minder/internal/config/server"
+	"github.com/stacklok/minder/internal/db"
 	"github.com/stacklok/minder/internal/logger"
+	"github.com/stacklok/minder/internal/providers/github"
 )
 
 // upCmd represents the up command
@@ -127,10 +129,36 @@ var upCmd = &cobra.Command{
 			return fmt.Errorf("error preparing authz client: %w", err)
 		}
 
-		return nil
+		store := db.NewStore(dbConn)
+		return ensureGitHubProvidersHaveAuthFlows(ctx, cmd, store)
 	},
 }
 
 func init() {
 	migrateCmd.AddCommand(upCmd)
+}
+
+func ensureGitHubProvidersHaveAuthFlows(ctx context.Context, cmd *cobra.Command, store db.Store) error {
+	providers, err := store.GlobalListProvidersByName(ctx, "github")
+	if err != nil {
+		return fmt.Errorf("error while listing providers: %w", err)
+	}
+
+	for _, p := range providers {
+		if len(p.AuthFlows) == 0 {
+			cmd.Printf("Provider %s does not have any auth flows. Adding default auth flows...\n", p.ID)
+			p.AuthFlows = []db.AuthorizationFlow{db.AuthorizationFlowUserInput}
+			if err := store.UpdateProvider(ctx, db.UpdateProviderParams{
+				Implements: p.Implements,
+				Definition: p.Definition,
+				AuthFlows:  github.AuthorizationFlows, // This is what we are adding
+				ID:         p.ID,
+				ProjectID:  p.ProjectID,
+			}); err != nil {
+				return fmt.Errorf("error while updating provider: %w", err)
+			}
+		}
+	}
+
+	return nil
 }

--- a/database/mock/store.go
+++ b/database/mock/store.go
@@ -1107,6 +1107,21 @@ func (mr *MockStoreMockRecorder) GlobalListProviders(arg0 any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GlobalListProviders", reflect.TypeOf((*MockStore)(nil).GlobalListProviders), arg0)
 }
 
+// GlobalListProvidersByName mocks base method.
+func (m *MockStore) GlobalListProvidersByName(arg0 context.Context, arg1 string) ([]db.Provider, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GlobalListProvidersByName", arg0, arg1)
+	ret0, _ := ret[0].([]db.Provider)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GlobalListProvidersByName indicates an expected call of GlobalListProvidersByName.
+func (mr *MockStoreMockRecorder) GlobalListProvidersByName(arg0, arg1 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GlobalListProvidersByName", reflect.TypeOf((*MockStore)(nil).GlobalListProvidersByName), arg0, arg1)
+}
+
 // ListArtifactsByRepoID mocks base method.
 func (m *MockStore) ListArtifactsByRepoID(arg0 context.Context, arg1 uuid.UUID) ([]db.Artifact, error) {
 	m.ctrl.T.Helper()
@@ -1402,6 +1417,20 @@ func (m *MockStore) UpdateProjectMeta(arg0 context.Context, arg1 db.UpdateProjec
 func (mr *MockStoreMockRecorder) UpdateProjectMeta(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateProjectMeta", reflect.TypeOf((*MockStore)(nil).UpdateProjectMeta), arg0, arg1)
+}
+
+// UpdateProvider mocks base method.
+func (m *MockStore) UpdateProvider(arg0 context.Context, arg1 db.UpdateProviderParams) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpdateProvider", arg0, arg1)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// UpdateProvider indicates an expected call of UpdateProvider.
+func (mr *MockStoreMockRecorder) UpdateProvider(arg0, arg1 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateProvider", reflect.TypeOf((*MockStore)(nil).UpdateProvider), arg0, arg1)
 }
 
 // UpdateRuleType mocks base method.

--- a/database/query/providers.sql
+++ b/database/query/providers.sql
@@ -3,7 +3,9 @@ INSERT INTO providers (
     name,
     project_id,
     implements,
-    definition) VALUES ($1, $2, $3, sqlc.arg(definition)::jsonb) RETURNING *;
+    definition,
+    auth_flows
+    ) VALUES ($1, $2, $3, sqlc.arg(definition)::jsonb, sqlc.arg(auth_flows)) RETURNING *;
 
 -- name: GetProviderByName :one
 SELECT * FROM providers WHERE name = $1 AND project_id = $2;
@@ -29,6 +31,14 @@ LIMIT sqlc.arg('limit');
 
 -- name: GlobalListProviders :many
 SELECT * FROM providers;
+
+-- name: GlobalListProvidersByName :many
+SELECT * FROM providers WHERE name = $1;
+
+-- name: UpdateProvider :exec
+UPDATE providers
+    SET implements = sqlc.arg(implements), definition = sqlc.arg(definition)::jsonb, auth_flows = sqlc.arg('auth_flows')
+    WHERE id = sqlc.arg('id') AND project_id = sqlc.arg('project_id');
 
 -- name: DeleteProvider :exec
 DELETE FROM providers WHERE id = $1 AND project_id = $2;

--- a/internal/controlplane/handlers_profile_test.go
+++ b/internal/controlplane/handlers_profile_test.go
@@ -228,6 +228,7 @@ func TestCreateProfile(t *testing.T) {
 		Name:       "github",
 		ProjectID:  dbproj.ID,
 		Implements: []db.ProviderType{db.ProviderTypeGithub},
+		AuthFlows:  []db.AuthorizationFlow{db.AuthorizationFlowUserInput},
 		Definition: []byte(`{}`),
 	})
 	if err != nil {

--- a/internal/controlplane/handlers_ruletype_test.go
+++ b/internal/controlplane/handlers_ruletype_test.go
@@ -55,6 +55,7 @@ func TestCreateRuleType(t *testing.T) {
 		Name:       "github",
 		ProjectID:  dbproj.ID,
 		Implements: []db.ProviderType{db.ProviderTypeGithub},
+		AuthFlows:  []db.AuthorizationFlow{db.AuthorizationFlowUserInput},
 		Definition: []byte(`{}`),
 	})
 	if err != nil {

--- a/internal/db/providers_test.go
+++ b/internal/db/providers_test.go
@@ -36,6 +36,7 @@ func createRandomProvider(t *testing.T, projectID uuid.UUID) Provider {
 		Name:       rand.RandomName(seed),
 		ProjectID:  projectID,
 		Implements: []ProviderType{ProviderTypeGithub, ProviderTypeGit},
+		AuthFlows:  []AuthorizationFlow{AuthorizationFlowUserInput},
 		Definition: json.RawMessage("{}"),
 	})
 	require.NoError(t, err, "Error creating provider")

--- a/internal/db/querier.go
+++ b/internal/db/querier.go
@@ -83,6 +83,7 @@ type Querier interface {
 	GetUserByID(ctx context.Context, id int32) (User, error)
 	GetUserBySubject(ctx context.Context, identitySubject string) (User, error)
 	GlobalListProviders(ctx context.Context) ([]Provider, error)
+	GlobalListProvidersByName(ctx context.Context, name string) ([]Provider, error)
 	ListArtifactsByRepoID(ctx context.Context, repositoryID uuid.UUID) ([]Artifact, error)
 	ListFlushCache(ctx context.Context) ([]FlushCache, error)
 	// ListNonOrgProjects is a query that lists all non-organization projects.
@@ -123,6 +124,7 @@ type Querier interface {
 	UpdateLease(ctx context.Context, arg UpdateLeaseParams) error
 	UpdateProfile(ctx context.Context, arg UpdateProfileParams) (Profile, error)
 	UpdateProjectMeta(ctx context.Context, arg UpdateProjectMetaParams) (Project, error)
+	UpdateProvider(ctx context.Context, arg UpdateProviderParams) error
 	UpdateRuleType(ctx context.Context, arg UpdateRuleTypeParams) error
 	UpsertAccessToken(ctx context.Context, arg UpsertAccessTokenParams) (ProviderAccessToken, error)
 	UpsertArtifact(ctx context.Context, arg UpsertArtifactParams) (Artifact, error)

--- a/internal/eea/eea_test.go
+++ b/internal/eea/eea_test.go
@@ -161,6 +161,7 @@ func createNeededEntities(ctx context.Context, t *testing.T, testQueries db.Stor
 		Name:       providerName,
 		ProjectID:  proj.ID,
 		Implements: []db.ProviderType{db.ProviderTypeRest},
+		AuthFlows:  []db.AuthorizationFlow{db.AuthorizationFlowUserInput},
 		Definition: json.RawMessage(`{}`),
 	})
 	require.NoError(t, err, "expected no error when creating provider")

--- a/internal/projects/create.go
+++ b/internal/projects/create.go
@@ -87,6 +87,7 @@ func ProvisionSelfEnrolledProject(
 		ProjectID:  project.ID,
 		Implements: github.Implements,
 		Definition: json.RawMessage(`{"github": {}}`),
+		AuthFlows:  github.AuthorizationFlows,
 	})
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "failed to create provider: %v", err)


### PR DESCRIPTION
# Summary

A recent PR added the "authorization flows" concept to the database ( https://github.com/stacklok/minder/pull/2570 ). It even added a migration
to ensure existing entries had an appropriate default. However, it did not change the default
provider created in each project to actually contain the aforementioned default flows.

This PR fixes that.

***Mark the type of change your PR introduces:***

- [x] Bug fix (resolves an issue without affecting existing features)
- [ ] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [ ] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

***Outline how the changes were tested, including steps to reproduce and any relevant configurations. 
Attach screenshots if helpful.***

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [ ] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [ ] Included tests that validate the fix or feature.
- [ ] Checked that related changes are merged.
