### PR TITLE
Add test server `mindev` command

### DIFF
--- a/cmd/dev/app/root.go
+++ b/cmd/dev/app/root.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/stacklok/minder/cmd/dev/app/container"
 	"github.com/stacklok/minder/cmd/dev/app/rule_type"
+	"github.com/stacklok/minder/cmd/dev/app/testserver"
 	"github.com/stacklok/minder/internal/util/cli"
 )
 
@@ -37,6 +38,7 @@ https://docs.stacklok.com/minder`,
 
 	cmd.AddCommand(rule_type.CmdRuleType())
 	cmd.AddCommand(container.CmdContainer())
+	cmd.AddCommand(testserver.CmdTestServer())
 
 	return cmd
 }

--- a/cmd/dev/app/testserver/testserver.go
+++ b/cmd/dev/app/testserver/testserver.go
@@ -1,0 +1,84 @@
+// Copyright 2023 Stacklok, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package testserver spawns a test server useful for integration testing.
+package testserver
+
+import (
+	"fmt"
+	"os"
+	"os/signal"
+
+	"github.com/rs/zerolog"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+
+	noopauth "github.com/stacklok/minder/internal/auth/noop"
+	mockauthz "github.com/stacklok/minder/internal/authz/mock"
+	"github.com/stacklok/minder/internal/config"
+	serverconfig "github.com/stacklok/minder/internal/config/server"
+	"github.com/stacklok/minder/internal/controlplane"
+	"github.com/stacklok/minder/internal/db/embedded"
+	"github.com/stacklok/minder/internal/engine"
+	"github.com/stacklok/minder/internal/logger"
+	"github.com/stacklok/minder/internal/reconcilers"
+	"github.com/stacklok/minder/internal/service"
+)
+
+// CmdTestServer starts a test server for integration testing.
+func CmdTestServer() *cobra.Command {
+	var rtCmd = &cobra.Command{
+		Use:   "testserver",
+		Short: "testserver starts a test server for integration testing",
+		RunE:  runTestServer,
+	}
+
+	return rtCmd
+}
+
+func runTestServer(cmd *cobra.Command, _ []string) error {
+	v := viper.GetViper()
+	serverconfig.SetViperDefaults(v)
+	cfg, err := config.ReadConfigFromViper[serverconfig.Config](v)
+	if err != nil {
+		return fmt.Errorf("unable to read config: %w", err)
+	}
+
+	ctx, cancel := signal.NotifyContext(cmd.Context(), os.Interrupt)
+	defer cancel()
+
+	ctx = logger.FromFlags(cfg.LoggingConfig).WithContext(ctx)
+	l := zerolog.Ctx(ctx)
+	l.Info().Msgf("Initializing logger in level: %s", cfg.LoggingConfig.Level)
+
+	store, td, err := embedded.GetFakeStore("file://database/migrations")
+	if err != nil {
+		return fmt.Errorf("unable to spawn embedded store: %w", err)
+	}
+	defer td()
+
+	cfg.Events.Driver = "go-channel"
+	cfg.Events.RouterCloseTimeout = 10
+	cfg.Events.Aggregator.LockInterval = 30
+
+	vldtr := noopauth.NewJwtValidator("mindev")
+
+	return service.AllInOneServerService(ctx, cfg, store, vldtr,
+		[]controlplane.ServerOption{
+			controlplane.WithAuthzClient(&mockauthz.SimpleClient{}),
+		},
+		[]engine.ExecutorOption{},
+		[]reconcilers.ReconcilerOption{},
+	)
+}

--- a/cmd/server/app/serve.go
+++ b/cmd/server/app/serve.go
@@ -26,7 +26,6 @@ import (
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
-	"golang.org/x/sync/errgroup"
 
 	"github.com/stacklok/minder/internal/auth"
 	"github.com/stacklok/minder/internal/authz"
@@ -35,13 +34,12 @@ import (
 	"github.com/stacklok/minder/internal/controlplane"
 	cpmetrics "github.com/stacklok/minder/internal/controlplane/metrics"
 	"github.com/stacklok/minder/internal/db"
-	"github.com/stacklok/minder/internal/eea"
 	"github.com/stacklok/minder/internal/engine"
-	"github.com/stacklok/minder/internal/events"
 	"github.com/stacklok/minder/internal/logger"
 	"github.com/stacklok/minder/internal/providers/ratecache"
 	provtelemetry "github.com/stacklok/minder/internal/providers/telemetry"
 	"github.com/stacklok/minder/internal/reconcilers"
+	"github.com/stacklok/minder/internal/service"
 )
 
 var serveCmd = &cobra.Command{
@@ -49,7 +47,6 @@ var serveCmd = &cobra.Command{
 	Short: "Start the minder platform",
 	Long:  `Starts the minder platform, which includes the gRPC server and the HTTP gateway.`,
 	RunE: func(cmd *cobra.Command, _ []string) error {
-
 		ctx, cancel := signal.NotifyContext(cmd.Context(), os.Interrupt)
 		defer cancel()
 
@@ -79,14 +76,6 @@ var serveCmd = &cobra.Command{
 		}(dbConn)
 
 		store := db.NewStore(dbConn)
-
-		errg, ctx := errgroup.WithContext(ctx)
-
-		evt, err := events.Setup(ctx, &cfg.Events)
-		if err != nil {
-			log.Printf("Failed to set up eventer: %v", err)
-			return err
-		}
 
 		// webhook config validation
 		webhookURL := cfg.WebhookConfig.ExternalWebhookURL
@@ -126,66 +115,27 @@ var serveCmd = &cobra.Command{
 		restClientCache := ratecache.NewRestClientCache(ctx)
 		defer restClientCache.Close()
 
-		s, err := controlplane.NewServer(
-			store, evt, cfg, vldtr,
+		serverOpts := []controlplane.ServerOption{
 			controlplane.WithServerMetrics(cpmetrics.NewMetrics()),
 			controlplane.WithProviderMetrics(providerMetrics),
 			controlplane.WithAuthzClient(authzc),
 			controlplane.WithRestClientCache(restClientCache),
-		)
-		if err != nil {
-			return fmt.Errorf("unable to create server: %w", err)
 		}
-
-		aggr := eea.NewEEA(store, evt, &cfg.Events.Aggregator)
-
-		s.ConsumeEvents(aggr)
 
 		tsmdw := logger.NewTelemetryStoreWMMiddleware(l)
-
-		exec, err := engine.NewExecutor(ctx, store, &cfg.Auth, evt,
+		executorOpts := []engine.ExecutorOption{
 			engine.WithProviderMetrics(providerMetrics),
-			engine.WithMiddleware(aggr.AggregateMiddleware),
 			engine.WithMiddleware(tsmdw.TelemetryStoreMiddleware),
 			engine.WithRestClientCache(restClientCache),
-		)
-		if err != nil {
-			return fmt.Errorf("unable to create executor: %w", err)
 		}
 
-		s.ConsumeEvents(exec)
-
-		rec, err := reconcilers.NewReconciler(store, evt, &cfg.Auth,
+		reconcilerOpts := []reconcilers.ReconcilerOption{
 			reconcilers.WithProviderMetrics(providerMetrics),
-			reconcilers.WithRestClientCache(restClientCache))
-		if err != nil {
-			return fmt.Errorf("unable to create reconciler: %w", err)
+			reconcilers.WithRestClientCache(restClientCache),
 		}
 
-		s.ConsumeEvents(rec)
-
-		// Start the gRPC and HTTP server in separate goroutines
-		errg.Go(func() error {
-			return s.StartGRPCServer(ctx)
-		})
-
-		errg.Go(func() error {
-			return s.StartHTTPServer(ctx)
-		})
-
-		errg.Go(s.HandleEvents(ctx))
-
-		// Wait for event handlers to start running
-		<-evt.Running()
-
-		if err := aggr.FlushAll(ctx); err != nil {
-			return fmt.Errorf("error flushing cache: %w", err)
-		}
-
-		// Wait for all entity events to be executed
-		exec.Wait()
-
-		return errg.Wait()
+		return service.AllInOneServerService(ctx, cfg, store, vldtr,
+			serverOpts, executorOpts, reconcilerOpts)
 	},
 }
 

--- a/internal/auth/noop/jwtauth.go
+++ b/internal/auth/noop/jwtauth.go
@@ -1,0 +1,45 @@
+//
+// Copyright 2024 Stacklok, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package noop provides a no-op implementation of the JwtValidator interface
+package noop
+
+import (
+	"github.com/lestrrat-go/jwx/v2/jwt/openid"
+
+	"github.com/stacklok/minder/internal/auth"
+)
+
+type noopJwtValidator struct {
+	// Subject is the subject of the token that will be returned by ParseAndValidate
+	Subject string
+}
+
+// NewJwtValidator returns a new instance of the no-op JWT validator
+func NewJwtValidator(subject string) auth.JwtValidator {
+	return &noopJwtValidator{
+		Subject: subject,
+	}
+}
+
+// ParseAndValidate returns a token with the subject set to the subject of the no-op JWT validator
+func (n *noopJwtValidator) ParseAndValidate(_ string) (openid.Token, error) {
+	tok := openid.New()
+	if err := tok.Set("sub", n.Subject); err != nil {
+		return nil, err
+	}
+
+	return tok, nil
+}

--- a/internal/controlplane/server.go
+++ b/internal/controlplane/server.go
@@ -22,7 +22,6 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/ThreeDotsLabs/watermill/message"
 	"github.com/gorilla/handlers"
 	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
@@ -167,8 +166,6 @@ func NewServer(
 	return s, nil
 }
 
-var _ (events.Registrar) = (*Server)(nil)
-
 func (s *Server) initTracer() (*sdktrace.TracerProvider, error) {
 	// create a stdout exporter to show collected spans out to stdout.
 	exporter, err := stdout.New(stdout.WithPrettyPrint())
@@ -186,16 +183,6 @@ func (s *Server) initTracer() (*sdktrace.TracerProvider, error) {
 	otel.SetTextMapPropagator(propagation.TraceContext{})
 
 	return tp, nil
-}
-
-// Register implements events.Registrar
-func (s *Server) Register(topic string, handler events.Handler, mdw ...message.HandlerMiddleware) {
-	s.evt.Register(topic, handler, mdw...)
-}
-
-// ConsumeEvents implements events.Registrar
-func (s *Server) ConsumeEvents(c ...events.Consumer) {
-	s.evt.ConsumeEvents(c...)
 }
 
 func initMetrics(r sdkmetric.Reader) *sdkmetric.MeterProvider {
@@ -456,14 +443,6 @@ func (s *Server) startMetricServer(ctx context.Context) error {
 		log.Printf("shutting down 'Metric server'")
 
 		return server.Shutdown(shutdownCtx)
-	}
-}
-
-// HandleEvents starts the event handler and blocks while handling events.
-func (s *Server) HandleEvents(ctx context.Context) func() error {
-	return func() error {
-		defer s.evt.Close()
-		return s.evt.Run(ctx)
 	}
 }
 

--- a/internal/events/eventer.go
+++ b/internal/events/eventer.go
@@ -81,10 +81,6 @@ type Registrar interface {
 	// handler function.  It's allowed to call Register with both argument the same, but
 	// then events will be delivered twice to the handler, which is probably not what you want.
 	Register(topic string, handler Handler, mdw ...message.HandlerMiddleware)
-
-	// HandleAll registers all the consumers with the registrar
-	// TODO: should this be a different interface?
-	ConsumeEvents(consumers ...Consumer)
 }
 
 // Consumer is an interface implemented by components which wish to consume events.

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -1,0 +1,111 @@
+//
+// Copyright 2023 Stacklok, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package service contains the business logic for the minder services.
+package service
+
+import (
+	"context"
+	"fmt"
+
+	"golang.org/x/sync/errgroup"
+
+	"github.com/stacklok/minder/internal/auth"
+	serverconfig "github.com/stacklok/minder/internal/config/server"
+	"github.com/stacklok/minder/internal/controlplane"
+	"github.com/stacklok/minder/internal/db"
+	"github.com/stacklok/minder/internal/eea"
+	"github.com/stacklok/minder/internal/engine"
+	"github.com/stacklok/minder/internal/events"
+	"github.com/stacklok/minder/internal/reconcilers"
+)
+
+// AllInOneServerService is a helper function that starts the gRPC and HTTP servers,
+// the eventer, aggregator, the executor, and the reconciler.
+func AllInOneServerService(
+	ctx context.Context,
+	cfg *serverconfig.Config,
+	store db.Store,
+	vldtr auth.JwtValidator,
+	serverOpts []controlplane.ServerOption,
+	executorOpts []engine.ExecutorOption,
+	reconcilerOpts []reconcilers.ReconcilerOption,
+
+) error {
+	errg, ctx := errgroup.WithContext(ctx)
+
+	evt, err := events.Setup(ctx, &cfg.Events)
+	if err != nil {
+		return fmt.Errorf("unable to setup eventer: %w", err)
+	}
+
+	s, err := controlplane.NewServer(
+		store, evt, cfg, vldtr,
+		serverOpts...,
+	)
+	if err != nil {
+		return fmt.Errorf("unable to create server: %w", err)
+	}
+
+	aggr := eea.NewEEA(store, evt, &cfg.Events.Aggregator)
+
+	// consume flush-all events
+	evt.ConsumeEvents(aggr)
+
+	// prepend the aggregator to the executor options
+	executorOpts = append([]engine.ExecutorOption{engine.WithMiddleware(aggr.AggregateMiddleware)},
+		executorOpts...)
+
+	exec, err := engine.NewExecutor(ctx, store, &cfg.Auth, evt, executorOpts...)
+	if err != nil {
+		return fmt.Errorf("unable to create executor: %w", err)
+	}
+
+	evt.ConsumeEvents(exec)
+
+	rec, err := reconcilers.NewReconciler(store, evt, &cfg.Auth, reconcilerOpts...)
+	if err != nil {
+		return fmt.Errorf("unable to create reconciler: %w", err)
+	}
+
+	evt.ConsumeEvents(rec)
+
+	// Start the gRPC and HTTP server in separate goroutines
+	errg.Go(func() error {
+		return s.StartGRPCServer(ctx)
+	})
+
+	errg.Go(func() error {
+		return s.StartHTTPServer(ctx)
+	})
+
+	errg.Go(func() error {
+		defer evt.Close()
+		return evt.Run(ctx)
+	})
+
+	// Wait for event handlers to start running
+	<-evt.Running()
+
+	// Flush all cache
+	if err := aggr.FlushAll(ctx); err != nil {
+		return fmt.Errorf("error flushing cache: %w", err)
+	}
+
+	// Wait for all entity events to be executed
+	exec.Wait()
+
+	return errg.Wait()
+}


### PR DESCRIPTION
# Summary

This adds the ability for `mindev` to spawn an all-in-one minder test server.

This server has noop authn/z and uses an embedded postgres database to operate.

This is meant for integration testing and is not for production, hence why it was
added in mindev.

Note that user provisioning needs to be done with:

```
grpcurl -plaintext -H "Authorization: Bearer foo" localhost:8090 minder.v1.UserService/CreateUser
```

## Change Type

***Mark the type of change your PR introduces:***

- [ ] Bug fix (resolves an issue without affecting existing features)
- [x] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [ ] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

***Outline how the changes were tested, including steps to reproduce and any relevant configurations. 
Attach screenshots if helpful.***

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [ ] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [ ] Included tests that validate the fix or feature.
- [ ] Checked that related changes are merged.
