### PR TITLE
Use static token source for GitHub provider

### DIFF
--- a/internal/providers/github/github.go
+++ b/internal/providers/github/github.go
@@ -88,14 +88,12 @@ func NewRestClient(
 ) (*GitHub, error) {
 	var err error
 
-	ts := oauth2.StaticTokenSource(
-		&oauth2.Token{AccessToken: token},
-	)
-
 	tc := &http.Client{
 		Transport: &oauth2.Transport{
-			Base:   http.DefaultClient.Transport,
-			Source: oauth2.ReuseTokenSource(nil, ts),
+			Base: http.DefaultClient.Transport,
+			Source: oauth2.StaticTokenSource(
+				&oauth2.Token{AccessToken: token},
+			),
 		},
 	}
 


### PR DESCRIPTION
# Summary
Wrapping a `StaticTokenSource` in a `ReuseTokenSource` behaves the same as simply using a `StaticTokenSource`.
The `ReuseTokenSource` will reuse a token until it's invalid and then fetch a new one from the provided source.
Since `StaticTokenSource` always returns the same token, the result was that `ReuseTokenSource` was behaving as a `StaticTokenSource`.

Fixes #(related issue)

## Change Type

***Mark the type of change your PR introduces:***

- [ ] Bug fix (resolves an issue without affecting existing features)
- [ ] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [x] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

***Outline how the changes were tested, including steps to reproduce and any relevant configurations. 
Attach screenshots if helpful.***

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [ ] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [ ] Included tests that validate the fix or feature.
- [ ] Checked that related changes are merged.
