### PR TITLE
Actually check for auth flows in provider enrollment

### DIFF
--- a/pkg/api/protobuf/go/minder/v1/providers.go
+++ b/pkg/api/protobuf/go/minder/v1/providers.go
@@ -14,6 +14,8 @@
 
 package v1
 
+import "slices"
+
 // ToString returns the string representation of the ProviderType
 func (provt ProviderType) ToString() string {
 	return enumToStringViaDescriptor(provt.Descriptor(), provt.Number())
@@ -22,4 +24,9 @@ func (provt ProviderType) ToString() string {
 // ToString returns the string representation of the AuthorizationFlow
 func (a AuthorizationFlow) ToString() string {
 	return enumToStringViaDescriptor(a.Descriptor(), a.Number())
+}
+
+// SupportsAuthFlow returns true if the provider supports the given auth flow
+func (p *Provider) SupportsAuthFlow(flow AuthorizationFlow) bool {
+	return slices.Contains(p.GetAuthFlows(), flow)
 }


### PR DESCRIPTION
# Summary

This modifies the provider enrollment to actually verify that the provider supports the given auth flows before attempting them.

This is enforced both in the CLI and the server.

Closes: https://github.com/stacklok/minder/issues/2518

## Change Type

***Mark the type of change your PR introduces:***

- [ ] Bug fix (resolves an issue without affecting existing features)
- [x] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [ ] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

***Outline how the changes were tested, including steps to reproduce and any relevant configurations. 
Attach screenshots if helpful.***

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [ ] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [ ] Included tests that validate the fix or feature.
- [ ] Checked that related changes are merged.
