### PR TITLE
Disable ingestcache for artifacts

### DIFF
--- a/internal/engine/executor.go
+++ b/internal/engine/executor.go
@@ -226,7 +226,12 @@ func (e *Executor) evalEntityEvent(
 	// this is a cache so we can avoid querying the ingester upstream
 	// for every rule. We use a sync.Map because it's safe for concurrent
 	// access.
-	ingestCache := ingestcache.NewCache()
+	var ingestCache ingestcache.Cache
+	if inf.Type == pb.Entity_ENTITY_ARTIFACTS {
+		ingestCache = ingestcache.NewNoopCache()
+	} else {
+		ingestCache = ingestcache.NewCache()
+	}
 
 	defer e.releaseLockAndFlush(ctx, inf)
 


### PR DESCRIPTION
# Summary

Due to the implementation of the artifact signature rule (lacking ingest
parameters) the ingestcache is caching tags that it shouldn't. While
this is fixed, let's disable caching for artifacts.

Related-to: https://github.com/stacklok/minder/issues/2600

## Change Type

***Mark the type of change your PR introduces:***

- [x] Bug fix (resolves an issue without affecting existing features)
- [ ] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [ ] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [ ] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [ ] Included tests that validate the fix or feature.
- [ ] Checked that related changes are merged.
