### PR TITLE
Introduce provider Credential interface

### DIFF
--- a/cmd/dev/app/container/cmd_verify.go
+++ b/cmd/dev/app/container/cmd_verify.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/stacklok/minder/internal/db"
 	"github.com/stacklok/minder/internal/providers"
+	"github.com/stacklok/minder/internal/providers/credentials"
 	"github.com/stacklok/minder/internal/verifier"
 	"github.com/stacklok/minder/internal/verifier/sigstore"
 	"github.com/stacklok/minder/internal/verifier/sigstore/container"
@@ -123,7 +124,7 @@ func buildGitHubClient(token string) (provifv1.GitHub, error) {
 			}`),
 		},
 		sql.NullString{},
-		token,
+		credentials.NewGitHubTokenCredential(token),
 	)
 
 	return pbuild.GetGitHub()

--- a/cmd/dev/app/rule_type/rttst.go
+++ b/cmd/dev/app/rule_type/rttst.go
@@ -35,6 +35,7 @@ import (
 	"github.com/stacklok/minder/internal/engine/eval/rego"
 	engif "github.com/stacklok/minder/internal/engine/interfaces"
 	"github.com/stacklok/minder/internal/providers"
+	"github.com/stacklok/minder/internal/providers/credentials"
 	"github.com/stacklok/minder/internal/util/jsonyaml"
 	minderv1 "github.com/stacklok/minder/pkg/api/protobuf/go/minder/v1"
 )
@@ -134,7 +135,7 @@ func testCmdRun(cmd *cobra.Command, _ []string) error {
 			}`),
 		},
 		sql.NullString{},
-		token,
+		credentials.NewGitHubTokenCredential(token),
 	))
 	inf := &entities.EntityInfoWrapper{
 		Entity: ent,

--- a/internal/controlplane/handlers_oauth.go
+++ b/internal/controlplane/handlers_oauth.go
@@ -42,6 +42,7 @@ import (
 	"github.com/stacklok/minder/internal/engine"
 	"github.com/stacklok/minder/internal/logger"
 	"github.com/stacklok/minder/internal/providers"
+	"github.com/stacklok/minder/internal/providers/credentials"
 	"github.com/stacklok/minder/internal/util"
 	pb "github.com/stacklok/minder/pkg/api/protobuf/go/minder/v1"
 )
@@ -287,7 +288,7 @@ func (s *Server) verifyProviderTokenIdentity(
 		providers.WithProviderMetrics(s.provMt),
 		providers.WithRestClientCache(s.restClientCache),
 	}
-	builder := providers.NewProviderBuilder(&dbProvider, sql.NullString{}, token, pbOpts...)
+	builder := providers.NewProviderBuilder(&dbProvider, sql.NullString{}, credentials.NewGitHubTokenCredential(token), pbOpts...)
 	// NOTE: this is github-specific at the moment.  We probably need to generally
 	// re-think token enrollment when we add more providers.
 	ghClient, err := builder.GetGitHub()

--- a/internal/controlplane/handlers_repositories_test.go
+++ b/internal/controlplane/handlers_repositories_test.go
@@ -359,8 +359,8 @@ func (s *StubGitHub) GetRepository(_ context.Context, owner string, repo string)
 	return s.Repo, nil
 }
 
-// GetToken implements v1.GitHub.
-func (*StubGitHub) GetToken() string {
+// GetCredential implements v1.GitHub.
+func (*StubGitHub) GetCredential() provinfv1.GitHubCredential {
 	panic("unimplemented")
 }
 
@@ -441,4 +441,9 @@ func (*StubGitHub) GetPrimaryEmail(context.Context) (string, error) {
 
 func (*StubGitHub) Clone(context.Context, string, string) (*git.Repository, error) {
 	panic("unimplemented")
+}
+
+func (*StubGitHub) AddAuthToPushOptions(context.Context, *git.PushOptions) error {
+	panic("unimplemented")
+
 }

--- a/internal/engine/actions/remediate/gh_branch_protect/gh_branch_protect_test.go
+++ b/internal/engine/actions/remediate/gh_branch_protect/gh_branch_protect_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/stacklok/minder/internal/db"
 	"github.com/stacklok/minder/internal/engine/interfaces"
 	"github.com/stacklok/minder/internal/providers"
+	"github.com/stacklok/minder/internal/providers/credentials"
 	mock_ghclient "github.com/stacklok/minder/internal/providers/github/mock"
 	pb "github.com/stacklok/minder/pkg/api/protobuf/go/minder/v1"
 	provifv1 "github.com/stacklok/minder/pkg/providers/v1"
@@ -66,7 +67,7 @@ func testGithubProviderBuilder(baseURL string) *providers.ProviderBuilder {
 			Definition: json.RawMessage(definitionJSON),
 		},
 		sql.NullString{},
-		"token",
+		credentials.NewGitHubTokenCredential("token"),
 	)
 }
 

--- a/internal/engine/actions/remediate/pull_request/pull_request_test.go
+++ b/internal/engine/actions/remediate/pull_request/pull_request_test.go
@@ -42,6 +42,7 @@ import (
 	"github.com/stacklok/minder/internal/db"
 	"github.com/stacklok/minder/internal/engine/interfaces"
 	"github.com/stacklok/minder/internal/providers"
+	"github.com/stacklok/minder/internal/providers/credentials"
 	mock_ghclient "github.com/stacklok/minder/internal/providers/github/mock"
 	pb "github.com/stacklok/minder/pkg/api/protobuf/go/minder/v1"
 	provifv1 "github.com/stacklok/minder/pkg/providers/v1"
@@ -109,7 +110,7 @@ func testGithubProviderBuilder() *providers.ProviderBuilder {
 			Definition: json.RawMessage(definitionJSON),
 		},
 		sql.NullString{},
-		"token",
+		credentials.NewGitHubTokenCredential("token"),
 	)
 }
 
@@ -201,7 +202,7 @@ func happyPathMockSetup(mockGitHub *mock_ghclient.MockGitHub) {
 	mockGitHub.EXPECT().
 		GetPrimaryEmail(gomock.Any()).Return("test@stacklok.com", nil)
 	mockGitHub.EXPECT().
-		GetToken().Return("token")
+		AddAuthToPushOptions(gomock.Any(), gomock.Any()).Return(nil)
 	mockGitHub.EXPECT().
 		ListPullRequests(gomock.Any(), repoOwner, repoName, gomock.Any()).Return([]*github.PullRequest{}, nil)
 }
@@ -465,7 +466,7 @@ func TestPullRequestRemediate(t *testing.T) {
 				mockGitHub.EXPECT().
 					GetPrimaryEmail(gomock.Any()).Return("test@stacklok.com", nil)
 				mockGitHub.EXPECT().
-					GetToken().Return("token")
+					AddAuthToPushOptions(gomock.Any(), gomock.Any()).Return(nil)
 				// this is the last call we expect to make. It returns existing PRs from this branch, so we
 				// stop after having updated the branch
 				mockGitHub.EXPECT().

--- a/internal/engine/actions/remediate/remediate_test.go
+++ b/internal/engine/actions/remediate/remediate_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/stacklok/minder/internal/engine/actions/remediate/rest"
 	engif "github.com/stacklok/minder/internal/engine/interfaces"
 	"github.com/stacklok/minder/internal/providers"
+	"github.com/stacklok/minder/internal/providers/credentials"
 	pb "github.com/stacklok/minder/pkg/api/protobuf/go/minder/v1"
 	provifv1 "github.com/stacklok/minder/pkg/providers/v1"
 )
@@ -50,7 +51,7 @@ var (
 }`),
 		},
 		sql.NullString{},
-		"token",
+		credentials.NewGitHubTokenCredential("token"),
 	)
 )
 

--- a/internal/engine/actions/remediate/rest/rest_test.go
+++ b/internal/engine/actions/remediate/rest/rest_test.go
@@ -34,6 +34,7 @@ import (
 	"github.com/stacklok/minder/internal/db"
 	"github.com/stacklok/minder/internal/engine/interfaces"
 	"github.com/stacklok/minder/internal/providers"
+	"github.com/stacklok/minder/internal/providers/credentials"
 	pb "github.com/stacklok/minder/pkg/api/protobuf/go/minder/v1"
 	provifv1 "github.com/stacklok/minder/pkg/providers/v1"
 )
@@ -56,7 +57,7 @@ var (
 }`),
 		},
 		sql.NullString{},
-		"token",
+		credentials.NewGitHubTokenCredential("token"),
 	)
 	invalidProviderBuilder = providers.NewProviderBuilder(
 		&db.Provider{
@@ -71,7 +72,7 @@ var (
 }`),
 		},
 		sql.NullString{},
-		"token",
+		credentials.NewGitHubTokenCredential("token"),
 	)
 	TestActionTypeValid interfaces.ActionType = "remediate-test"
 )
@@ -95,7 +96,7 @@ func testGithubProviderBuilder(baseURL string) *providers.ProviderBuilder {
 			Definition: json.RawMessage(definitionJSON),
 		},
 		sql.NullString{},
-		"token",
+		credentials.NewGitHubTokenCredential("token"),
 	)
 }
 

--- a/internal/engine/ingester/artifact/artifact_test.go
+++ b/internal/engine/ingester/artifact/artifact_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/stacklok/minder/internal/db"
 	evalerrors "github.com/stacklok/minder/internal/engine/errors"
 	"github.com/stacklok/minder/internal/providers"
+	"github.com/stacklok/minder/internal/providers/credentials"
 	mock_ghclient "github.com/stacklok/minder/internal/providers/github/mock"
 	mockverify "github.com/stacklok/minder/internal/verifier/mock"
 	"github.com/stacklok/minder/internal/verifier/verifyif"
@@ -57,7 +58,7 @@ func testGithubProviderBuilder() *providers.ProviderBuilder {
 			Definition: json.RawMessage(definitionJSON),
 		},
 		sql.NullString{},
-		"token",
+		credentials.NewGitHubTokenCredential("token"),
 	)
 }
 

--- a/internal/engine/ingester/git/git_test.go
+++ b/internal/engine/ingester/git/git_test.go
@@ -26,6 +26,7 @@ import (
 	engerrors "github.com/stacklok/minder/internal/engine/errors"
 	gitengine "github.com/stacklok/minder/internal/engine/ingester/git"
 	"github.com/stacklok/minder/internal/providers"
+	"github.com/stacklok/minder/internal/providers/credentials"
 	pb "github.com/stacklok/minder/pkg/api/protobuf/go/minder/v1"
 	provifv1 "github.com/stacklok/minder/pkg/providers/v1"
 )
@@ -44,7 +45,7 @@ func TestGitIngestWithCloneURLFromRepo(t *testing.T) {
 			},
 		},
 		sql.NullString{},
-		"",
+		credentials.NewEmptyCredential(),
 	))
 	require.NoError(t, err, "expected no error")
 
@@ -81,7 +82,7 @@ func TestGitIngestWithCloneURLFromParams(t *testing.T) {
 			},
 		},
 		sql.NullString{},
-		"",
+		credentials.NewEmptyCredential(),
 	))
 	require.NoError(t, err, "expected no error")
 
@@ -118,7 +119,7 @@ func TestGitIngestWithCustomBranchFromParams(t *testing.T) {
 			},
 		},
 		sql.NullString{},
-		"",
+		credentials.NewEmptyCredential(),
 	))
 	require.NoError(t, err, "expected no error")
 
@@ -155,7 +156,7 @@ func TestGitIngestWithBranchFromRepoEntity(t *testing.T) {
 				},
 			},
 			sql.NullString{},
-			"",
+			credentials.NewEmptyCredential(),
 		))
 	require.NoError(t, err, "expected no error")
 
@@ -194,7 +195,7 @@ func TestGitIngestWithUnexistentBranchFromParams(t *testing.T) {
 			},
 		},
 		sql.NullString{},
-		"",
+		credentials.NewEmptyCredential(),
 	))
 	require.NoError(t, err, "expected no error")
 
@@ -222,7 +223,7 @@ func TestGitIngestFailsBecauseOfAuthorization(t *testing.T) {
 			},
 		},
 		sql.NullString{},
-		"foobar",
+		credentials.NewGitHubTokenCredential("foobar"),
 	),
 	)
 	require.NoError(t, err, "expected no error")
@@ -248,7 +249,7 @@ func TestGitIngestFailsBecauseOfUnexistentCloneUrl(t *testing.T) {
 		},
 		sql.NullString{},
 		// No authentication is the right thing in this case.
-		"",
+		credentials.NewEmptyCredential(),
 	))
 	require.NoError(t, err, "expected no error")
 

--- a/internal/engine/ingester/ingester_test.go
+++ b/internal/engine/ingester/ingester_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/stacklok/minder/internal/engine/ingester/git"
 	"github.com/stacklok/minder/internal/engine/ingester/rest"
 	"github.com/stacklok/minder/internal/providers"
+	"github.com/stacklok/minder/internal/providers/credentials"
 	pb "github.com/stacklok/minder/pkg/api/protobuf/go/minder/v1"
 	provifv1 "github.com/stacklok/minder/pkg/providers/v1"
 )
@@ -177,7 +178,7 @@ func TestNewRuleDataIngest(t *testing.T) {
 }`),
 				},
 				sql.NullString{},
-				"token",
+				credentials.NewGitHubTokenCredential("token"),
 			))
 			if tt.wantErr {
 				require.Error(t, err, "Expected error")

--- a/internal/engine/ingester/rest/rest_test.go
+++ b/internal/engine/ingester/rest/rest_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/stacklok/minder/internal/db"
 	engif "github.com/stacklok/minder/internal/engine/interfaces"
 	"github.com/stacklok/minder/internal/providers"
+	"github.com/stacklok/minder/internal/providers/credentials"
 	pb "github.com/stacklok/minder/pkg/api/protobuf/go/minder/v1"
 	provifv1 "github.com/stacklok/minder/pkg/providers/v1"
 )
@@ -67,7 +68,7 @@ func TestNewRestRuleDataIngest(t *testing.T) {
 }`),
 					},
 					sql.NullString{},
-					"token",
+					credentials.NewGitHubTokenCredential("token"),
 				),
 			},
 			wantErr: false,
@@ -92,7 +93,7 @@ func TestNewRestRuleDataIngest(t *testing.T) {
 }`),
 					},
 					sql.NullString{},
-					"token",
+					credentials.NewGitHubTokenCredential("token"),
 				),
 			},
 			wantErr: true,
@@ -117,7 +118,7 @@ func TestNewRestRuleDataIngest(t *testing.T) {
 }`),
 					},
 					sql.NullString{},
-					"token",
+					credentials.NewGitHubTokenCredential("token"),
 				),
 			},
 			wantErr: true,
@@ -137,7 +138,7 @@ func TestNewRestRuleDataIngest(t *testing.T) {
 						},
 					},
 					sql.NullString{},
-					"token",
+					credentials.NewGitHubTokenCredential("token"),
 				),
 			},
 			wantErr: true,
@@ -162,7 +163,7 @@ func TestNewRestRuleDataIngest(t *testing.T) {
 }`),
 					},
 					sql.NullString{},
-					"token",
+					credentials.NewGitHubTokenCredential("token"),
 				),
 			},
 			wantErr: true,
@@ -186,7 +187,7 @@ func TestNewRestRuleDataIngest(t *testing.T) {
 }`),
 					},
 					sql.NullString{},
-					"token",
+					credentials.NewGitHubTokenCredential("token"),
 				),
 			},
 			wantErr: true,
@@ -230,7 +231,7 @@ func testGithubProviderBuilder(baseURL string) *providers.ProviderBuilder {
 			Definition: json.RawMessage(definitionJSON),
 		},
 		sql.NullString{},
-		"token",
+		credentials.NewGitHubTokenCredential("token"),
 	)
 }
 

--- a/internal/providers/credentials/empty_credential.go
+++ b/internal/providers/credentials/empty_credential.go
@@ -1,0 +1,51 @@
+// Copyright 2024 Stacklok, Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package credentials provides the implementations for the credentials
+package credentials
+
+import (
+	"net/http"
+
+	"github.com/go-git/go-git/v5"
+
+	provifv1 "github.com/stacklok/minder/pkg/providers/v1"
+)
+
+// EmptyCredential is an empty credential whose operations are no-ops
+type EmptyCredential struct {
+}
+
+// Ensure that the EmptyCredential implements the GitCredential interface
+var _ provifv1.GitCredential = (*EmptyCredential)(nil)
+
+// Ensure that the EmptyCredential implements the RestCredential interface
+var _ provifv1.RestCredential = (*EmptyCredential)(nil)
+
+// NewEmptyCredential creates a new EmptyCredential
+func NewEmptyCredential() *EmptyCredential {
+	return &EmptyCredential{}
+}
+
+// SetAuthorizationHeader is a no-op
+func (*EmptyCredential) SetAuthorizationHeader(*http.Request) {
+}
+
+// AddToPushOptions is a no-op
+func (*EmptyCredential) AddToPushOptions(*git.PushOptions, string) {
+}
+
+// AddToCloneOptions is a no-op
+func (*EmptyCredential) AddToCloneOptions(*git.CloneOptions) {
+}

--- a/internal/providers/credentials/empty_credential_test.go
+++ b/internal/providers/credentials/empty_credential_test.go
@@ -1,0 +1,59 @@
+// Copyright 2024 Stacklok, Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package credentials
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/go-git/go-git/v5"
+	"github.com/stretchr/testify/require"
+)
+
+var (
+	emptyCredential = NewEmptyCredential()
+)
+
+func TestEmptyCredentialSetAuthorizationHeader(t *testing.T) {
+	t.Parallel()
+
+	expected := &http.Request{
+		Header: http.Header{},
+	}
+	req := &http.Request{
+		Header: http.Header{},
+	}
+	emptyCredential.SetAuthorizationHeader(req)
+	require.Equal(t, expected, req)
+}
+
+func TestEmptyCredentialAddToPushOptions(t *testing.T) {
+	t.Parallel()
+
+	username := "user"
+	expected := &git.PushOptions{}
+	pushOptions := &git.PushOptions{}
+	emptyCredential.AddToPushOptions(pushOptions, username)
+	require.Equal(t, expected, pushOptions)
+}
+
+func TestEmptyCredentialAddToCloneOptions(t *testing.T) {
+	t.Parallel()
+
+	expected := &git.CloneOptions{}
+	cloneOptions := &git.CloneOptions{}
+	emptyCredential.AddToCloneOptions(cloneOptions)
+	require.Equal(t, expected, cloneOptions)
+}

--- a/internal/providers/credentials/github_token_credential.go
+++ b/internal/providers/credentials/github_token_credential.go
@@ -1,0 +1,84 @@
+// Copyright 2024 Stacklok, Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package credentials provides the implementations for the credentials
+package credentials
+
+import (
+	"net/http"
+
+	"github.com/go-git/go-git/v5"
+	githttp "github.com/go-git/go-git/v5/plumbing/transport/http"
+	"github.com/google/go-containerregistry/pkg/authn"
+	"golang.org/x/oauth2"
+
+	provifv1 "github.com/stacklok/minder/pkg/providers/v1"
+)
+
+// GitHubTokenCredential is a credential that uses a token
+type GitHubTokenCredential struct {
+	token string
+}
+
+// Ensure that the GitHubTokenCredential implements the GitHubTokenCredential interface
+var _ provifv1.GitHubCredential = (*GitHubTokenCredential)(nil)
+
+// NewGitHubTokenCredential creates a new GitHubTokenCredential from the token
+func NewGitHubTokenCredential(token string) *GitHubTokenCredential {
+	return &GitHubTokenCredential{
+		token: token,
+	}
+}
+
+// SetAuthorizationHeader sets the authorization header on the request
+func (t *GitHubTokenCredential) SetAuthorizationHeader(req *http.Request) {
+	req.Header.Set("Authorization", "Bearer "+t.token)
+}
+
+// GetAsContainerAuthenticator returns the token as a container registry authenticator
+func (t *GitHubTokenCredential) GetAsContainerAuthenticator(owner string) authn.Authenticator {
+	return &authn.Basic{
+		Username: owner,
+		Password: t.token,
+	}
+}
+
+// AddToPushOptions adds the credential to the git push options
+func (t *GitHubTokenCredential) AddToPushOptions(options *git.PushOptions, owner string) {
+	options.Auth = &githttp.BasicAuth{
+		Username: owner,
+		Password: t.token,
+	}
+}
+
+// AddToCloneOptions adds the credential to the git clone options
+func (t *GitHubTokenCredential) AddToCloneOptions(options *git.CloneOptions) {
+	options.Auth = &githttp.BasicAuth{
+		// the username can be anything, but it can't be empty
+		Username: "minder-user",
+		Password: t.token,
+	}
+}
+
+// GetCacheKey returns the cache key used to look up the REST client
+func (t *GitHubTokenCredential) GetCacheKey() string {
+	return t.token
+}
+
+// GetAsOAuth2TokenSource returns the token as an OAuth2 token source
+func (t *GitHubTokenCredential) GetAsOAuth2TokenSource() oauth2.TokenSource {
+	return oauth2.StaticTokenSource(
+		&oauth2.Token{AccessToken: t.token},
+	)
+}

--- a/internal/providers/credentials/github_token_credential_test.go
+++ b/internal/providers/credentials/github_token_credential_test.go
@@ -1,0 +1,93 @@
+// Copyright 2024 Stacklok, Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package credentials
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/go-git/go-git/v5"
+	githttp "github.com/go-git/go-git/v5/plumbing/transport/http"
+	"github.com/google/go-containerregistry/pkg/authn"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/oauth2"
+)
+
+var (
+	token      = "test_token"
+	credential = NewGitHubTokenCredential(token)
+)
+
+func TestGitHubTokenCredentialSetAuthorizationHeader(t *testing.T) {
+	t.Parallel()
+
+	expected := "Bearer test_token"
+	req := &http.Request{
+		Header: http.Header{},
+	}
+	credential.SetAuthorizationHeader(req)
+	require.Equal(t, expected, req.Header.Get("Authorization"))
+}
+
+func TestGitHubTokenCredentialAddToPushOptions(t *testing.T) {
+	t.Parallel()
+
+	username := "test_user"
+	expected := &githttp.BasicAuth{
+		Username: username,
+		Password: token,
+	}
+	pushOptions := &git.PushOptions{}
+	credential.AddToPushOptions(pushOptions, username)
+	require.Equal(t, expected, pushOptions.Auth)
+}
+
+func TestGitHubTokenCredentialAddToClone(t *testing.T) {
+	t.Parallel()
+
+	expected := &githttp.BasicAuth{
+		Username: "minder-user",
+		Password: token,
+	}
+	cloneOptions := &git.CloneOptions{}
+	credential.AddToCloneOptions(cloneOptions)
+	require.Equal(t, expected, cloneOptions.Auth)
+}
+
+func TestGitHubTokenCredentialGetAsContainerAuthenticator(t *testing.T) {
+	t.Parallel()
+
+	username := "test_user"
+	expected := &authn.Basic{
+		Username: username,
+		Password: token,
+	}
+	require.Equal(t, expected, credential.GetAsContainerAuthenticator(username))
+}
+
+func TestGitHubTokenCredentialGetAsOAuth2TokenSource(t *testing.T) {
+	t.Parallel()
+
+	expected := oauth2.StaticTokenSource(
+		&oauth2.Token{AccessToken: token},
+	)
+	require.Equal(t, expected, credential.GetAsOAuth2TokenSource())
+}
+
+func TestGitHubTokenCredentialGetCacheKey(t *testing.T) {
+	t.Parallel()
+
+	require.Equal(t, token, credential.GetCacheKey())
+}

--- a/internal/providers/github/github_test.go
+++ b/internal/providers/github/github_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/stacklok/minder/internal/db"
+	"github.com/stacklok/minder/internal/providers/credentials"
 	"github.com/stacklok/minder/internal/providers/ratecache"
 	provtelemetry "github.com/stacklok/minder/internal/providers/telemetry"
 	minderv1 "github.com/stacklok/minder/pkg/api/protobuf/go/minder/v1"
@@ -40,7 +41,7 @@ func TestNewRestClient(t *testing.T) {
 		Endpoint: "https://api.github.com",
 	},
 		provtelemetry.NewNoopMetrics(),
-		nil, "token", "")
+		nil, credentials.NewGitHubTokenCredential("token"), "")
 
 	assert.NoError(t, err)
 	assert.NotNil(t, client)
@@ -114,7 +115,7 @@ func TestArtifactAPIEscapes(t *testing.T) {
 				Endpoint: testServer.URL + "/",
 			},
 				provtelemetry.NewNoopMetrics(),
-				nil, "token", "")
+				nil, credentials.NewGitHubTokenCredential("token"), "")
 			assert.NoError(t, err)
 			assert.NotNil(t, client)
 
@@ -142,7 +143,7 @@ func TestWaitForRateLimitReset(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client, err := NewRestClient(&minderv1.GitHubProviderConfig{Endpoint: server.URL + "/"}, provtelemetry.NewNoopMetrics(), ratecache.NewRestClientCache(context.Background()), token, "mockOwner")
+	client, err := NewRestClient(&minderv1.GitHubProviderConfig{Endpoint: server.URL + "/"}, provtelemetry.NewNoopMetrics(), ratecache.NewRestClientCache(context.Background()), credentials.NewGitHubTokenCredential(token), "mockOwner")
 	require.NoError(t, err)
 
 	_, err = client.CreateIssueComment(context.Background(), "mockOwner", "mockRepo", 1, "Test Comment")
@@ -186,7 +187,7 @@ func TestConcurrentWaitForRateLimitReset(t *testing.T) {
 	// Start a goroutine that will make a request to the server, rate limiting the gh client
 	go func() {
 		defer wg.Done()
-		client, err := NewRestClient(&minderv1.GitHubProviderConfig{Endpoint: server.URL + "/"}, provtelemetry.NewNoopMetrics(), restClientCache, token, owner)
+		client, err := NewRestClient(&minderv1.GitHubProviderConfig{Endpoint: server.URL + "/"}, provtelemetry.NewNoopMetrics(), restClientCache, credentials.NewGitHubTokenCredential(token), owner)
 		require.NoError(t, err)
 
 		_, err = client.CreateIssueComment(context.Background(), owner, "mockRepo", 1, "Test Comment")

--- a/internal/providers/github/mock/github.go
+++ b/internal/providers/github/mock/github.go
@@ -17,6 +17,7 @@ import (
 	git "github.com/go-git/go-git/v5"
 	github "github.com/google/go-github/v56/github"
 	v1 "github.com/stacklok/minder/pkg/api/protobuf/go/minder/v1"
+	v10 "github.com/stacklok/minder/pkg/providers/v1"
 	gomock "go.uber.org/mock/gomock"
 )
 
@@ -41,20 +42,6 @@ func NewMockProvider(ctrl *gomock.Controller) *MockProvider {
 // EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockProvider) EXPECT() *MockProviderMockRecorder {
 	return m.recorder
-}
-
-// GetToken mocks base method.
-func (m *MockProvider) GetToken() string {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetToken")
-	ret0, _ := ret[0].(string)
-	return ret0
-}
-
-// GetToken indicates an expected call of GetToken.
-func (mr *MockProviderMockRecorder) GetToken() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetToken", reflect.TypeOf((*MockProvider)(nil).GetToken))
 }
 
 // MockGit is a mock of Git interface.
@@ -93,20 +80,6 @@ func (m *MockGit) Clone(ctx context.Context, url, branch string) (*git.Repositor
 func (mr *MockGitMockRecorder) Clone(ctx, url, branch any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Clone", reflect.TypeOf((*MockGit)(nil).Clone), ctx, url, branch)
-}
-
-// GetToken mocks base method.
-func (m *MockGit) GetToken() string {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetToken")
-	ret0, _ := ret[0].(string)
-	return ret0
-}
-
-// GetToken indicates an expected call of GetToken.
-func (mr *MockGitMockRecorder) GetToken() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetToken", reflect.TypeOf((*MockGit)(nil).GetToken))
 }
 
 // MockREST is a mock of REST interface.
@@ -161,20 +134,6 @@ func (mr *MockRESTMockRecorder) GetBaseURL() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetBaseURL", reflect.TypeOf((*MockREST)(nil).GetBaseURL))
 }
 
-// GetToken mocks base method.
-func (m *MockREST) GetToken() string {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetToken")
-	ret0, _ := ret[0].(string)
-	return ret0
-}
-
-// GetToken indicates an expected call of GetToken.
-func (mr *MockRESTMockRecorder) GetToken() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetToken", reflect.TypeOf((*MockREST)(nil).GetToken))
-}
-
 // NewRequest mocks base method.
 func (m *MockREST) NewRequest(method, url string, body any) (*http.Request, error) {
 	m.ctrl.T.Helper()
@@ -211,20 +170,6 @@ func NewMockRepoLister(ctrl *gomock.Controller) *MockRepoLister {
 // EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockRepoLister) EXPECT() *MockRepoListerMockRecorder {
 	return m.recorder
-}
-
-// GetToken mocks base method.
-func (m *MockRepoLister) GetToken() string {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetToken")
-	ret0, _ := ret[0].(string)
-	return ret0
-}
-
-// GetToken indicates an expected call of GetToken.
-func (mr *MockRepoListerMockRecorder) GetToken() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetToken", reflect.TypeOf((*MockRepoLister)(nil).GetToken))
 }
 
 // ListOrganizationRepsitories mocks base method.
@@ -278,6 +223,20 @@ func NewMockGitHub(ctrl *gomock.Controller) *MockGitHub {
 // EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockGitHub) EXPECT() *MockGitHubMockRecorder {
 	return m.recorder
+}
+
+// AddAuthToPushOptions mocks base method.
+func (m *MockGitHub) AddAuthToPushOptions(ctx context.Context, options *git.PushOptions) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "AddAuthToPushOptions", ctx, options)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// AddAuthToPushOptions indicates an expected call of AddAuthToPushOptions.
+func (mr *MockGitHubMockRecorder) AddAuthToPushOptions(ctx, options any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddAuthToPushOptions", reflect.TypeOf((*MockGitHub)(nil).AddAuthToPushOptions), ctx, options)
 }
 
 // Clone mocks base method.
@@ -458,6 +417,20 @@ func (mr *MockGitHubMockRecorder) GetBranchProtection(arg0, arg1, arg2, arg3 any
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetBranchProtection", reflect.TypeOf((*MockGitHub)(nil).GetBranchProtection), arg0, arg1, arg2, arg3)
 }
 
+// GetCredential mocks base method.
+func (m *MockGitHub) GetCredential() v10.GitHubCredential {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetCredential")
+	ret0, _ := ret[0].(v10.GitHubCredential)
+	return ret0
+}
+
+// GetCredential indicates an expected call of GetCredential.
+func (mr *MockGitHubMockRecorder) GetCredential() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCredential", reflect.TypeOf((*MockGitHub)(nil).GetCredential))
+}
+
 // GetOwner mocks base method.
 func (m *MockGitHub) GetOwner() string {
 	m.ctrl.T.Helper()
@@ -575,20 +548,6 @@ func (m *MockGitHub) GetRepository(arg0 context.Context, arg1, arg2 string) (*gi
 func (mr *MockGitHubMockRecorder) GetRepository(arg0, arg1, arg2 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRepository", reflect.TypeOf((*MockGitHub)(nil).GetRepository), arg0, arg1, arg2)
-}
-
-// GetToken mocks base method.
-func (m *MockGitHub) GetToken() string {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetToken")
-	ret0, _ := ret[0].(string)
-	return ret0
-}
-
-// GetToken indicates an expected call of GetToken.
-func (mr *MockGitHubMockRecorder) GetToken() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetToken", reflect.TypeOf((*MockGitHub)(nil).GetToken))
 }
 
 // GetUserId mocks base method.

--- a/internal/verifier/sigstore/container/container.go
+++ b/internal/verifier/sigstore/container/container.go
@@ -162,7 +162,7 @@ func getSigstoreBundles(
 ) ([]sigstoreBundle, error) {
 	imageRef := BuildImageRef(registry, owner, artifact, version)
 	// Try to build a bundle from the OCI image reference
-	bundles, err := bundleFromOCIImage(ctx, imageRef, &authn.Basic{Username: owner, Password: auth.ghClient.GetToken()})
+	bundles, err := bundleFromOCIImage(ctx, imageRef, auth.ghClient.GetCredential().GetAsContainerAuthenticator(owner))
 	if errors.Is(err, ErrProvenanceNotFoundOrIncomplete) {
 		// If we failed to find the signature in the OCI image, try to build a bundle from the GitHub attestation endpoint
 		return bundleFromGHAttestationEndpoint(ctx, auth.ghClient, owner, version)

--- a/pkg/providers/v1/credentials.go
+++ b/pkg/providers/v1/credentials.go
@@ -1,0 +1,52 @@
+// Copyright 2024 Stacklok, Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package v1 for providers provides the public interfaces for the providers
+// implemented by minder. The providers are the sources of the data
+// that is used by the rules.
+package v1
+
+import (
+	"net/http"
+
+	"github.com/go-git/go-git/v5"
+	"github.com/google/go-containerregistry/pkg/authn"
+	"golang.org/x/oauth2"
+)
+
+// Credential is the general interface for all credentials
+type Credential interface {
+}
+
+// RestCredential is the interface for credentials used in REST requests
+type RestCredential interface {
+	SetAuthorizationHeader(req *http.Request)
+}
+
+// GitCredential is the interface for credentials used when performing git operations
+type GitCredential interface {
+	AddToPushOptions(options *git.PushOptions, owner string)
+	AddToCloneOptions(options *git.CloneOptions)
+}
+
+// GitHubCredential is the interface for credentials used when interacting with GitHub
+type GitHubCredential interface {
+	RestCredential
+	GitCredential
+
+	GetCacheKey() string
+	GetAsOAuth2TokenSource() oauth2.TokenSource
+	// as we add new OCI providers this will change to a procedure / mutator, right now it's GitHub specific
+	GetAsContainerAuthenticator(owner string) authn.Authenticator
+}

--- a/pkg/providers/v1/providers.go
+++ b/pkg/providers/v1/providers.go
@@ -37,8 +37,6 @@ const (
 
 // Provider is the general interface for all providers
 type Provider interface {
-	// GetToken returns the token for the provider
-	GetToken() string
 }
 
 // Git is the interface for git providers
@@ -79,6 +77,7 @@ type GitHub interface {
 	REST
 	Git
 
+	GetCredential() GitHubCredential
 	GetRepository(context.Context, string, string) (*github.Repository, error)
 	ListAllRepositories(context.Context, bool, string) ([]*github.Repository, error)
 	GetBranchProtection(context.Context, string, string, string) (*github.Protection, error)
@@ -115,6 +114,7 @@ type GitHub interface {
 		opts *github.IssueListCommentsOptions,
 	) ([]*github.IssueComment, error)
 	UpdateIssueComment(ctx context.Context, owner, repo string, number int64, comment string) error
+	AddAuthToPushOptions(ctx context.Context, options *git.PushOptions) error
 }
 
 // ParseAndValidate parses the given provider configuration and validates it.


### PR DESCRIPTION
# Summary

Remove the token from the Provider interface, since not all providers will have a token.

Introduce `Credential` interface that represents a credential used when interacting with a provider.

There is a `EmptyCredential` implementation that allows  performing Git operations, like `clone`, and making REST calls without using authentication.

The other implementation is the `GitHubTokenCredential` which is a token credential used when interacting with the GitHub provider.

Fixes #2519

## Change Type

***Mark the type of change your PR introduces:***

- [ ] Bug fix (resolves an issue without affecting existing features)
- [ ] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [x] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

***Outline how the changes were tested, including steps to reproduce and any relevant configurations. 
Attach screenshots if helpful.***

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [x] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [x] Included tests that validate the fix or feature.
- [ ] Checked that related changes are merged. 

This PR will have conflicts with https://github.com/stacklok/minder/pull/2566.
