### PR TITLE
[DRAFT] Turn ProviderBuilder into interface

### DIFF
--- a/cmd/dev/app/rule_type/rttst.go
+++ b/cmd/dev/app/rule_type/rttst.go
@@ -121,20 +121,21 @@ func testCmdRun(cmd *cobra.Command, _ []string) error {
 	}
 
 	// TODO: Read this from a providers file instead so we can make it pluggable
-	eng, err := engine.NewRuleTypeEngine(context.Background(), p, rt, providers.NewProviderBuilder(
-		&db.Provider{
-			Name:    "test",
-			Version: "v1",
-			Implements: []db.ProviderType{
-				"rest",
-				"git",
-				"github",
-			},
-			Definition: json.RawMessage(`{
-				"rest": {},
-				"github": {}
-			}`),
+	prov := &db.Provider{
+		Name:    "test",
+		Version: "v1",
+		Implements: []db.ProviderType{
+			"rest",
+			"git",
+			"github",
 		},
+		Definition: json.RawMessage(`{
+			"rest": {},
+			"github": {}
+		}`),
+	}
+	eng, err := engine.NewRuleTypeEngine(context.Background(), p, rt, providers.NewTraitInstantiator
+		,
 		sql.NullString{},
 		credentials.NewGitHubTokenCredential(token),
 		&serverconfig.ProviderConfig{},

--- a/cmd/server/app/webhook_update.go
+++ b/cmd/server/app/webhook_update.go
@@ -96,14 +96,13 @@ func runCmdWebhookUpdate(cmd *cobra.Command, _ []string) error {
 		return fmt.Errorf("unable to parse webhook url: %w", err)
 	}
 
+	// TODO: Fill me in
+	instantiator := providers.NewTraitInstantiator(nil, nil, &cfg.Provider, store, cryptoEng)
+
 	for _, provider := range allProviders {
 		zerolog.Ctx(ctx).Info().Str("name", provider.Name).Str("uuid", provider.ID.String()).Msg("provider")
-		pb, err := providers.GetProviderBuilder(ctx, provider, store, cryptoEng, &cfg.Provider)
-		if err != nil {
-			return fmt.Errorf("unable to get provider builder: %w", err)
-		}
 
-		if !pb.Implements(db.ProviderType(providerName)) {
+		if !provider.CanImplement(db.ProviderType(providerName)) {
 			zerolog.Ctx(ctx).Info().
 				Str("name", provider.Name).
 				Str("uuid", provider.ID.String()).
@@ -112,9 +111,8 @@ func runCmdWebhookUpdate(cmd *cobra.Command, _ []string) error {
 		}
 
 		var updateErr error
-
 		if db.ProviderType(providerName) == db.ProviderTypeGithub {
-			ghCli, err := pb.GetGitHub()
+			ghCli, err := instantiator.GetGitHub(ctx, &provider)
 			if err != nil {
 				zerolog.Ctx(ctx).Err(err).Msg("cannot get github client")
 			}

--- a/internal/controlplane/server.go
+++ b/internal/controlplane/server.go
@@ -88,11 +88,12 @@ type Server struct {
 	// We may want to start breaking up the server struct if we use it to
 	// inject more entity-specific interfaces. For example, we may want to
 	// consider having a struct per grpc service
-	ruleTypes   ruletypes.RuleTypeService
-	repos       github.RepositoryService
-	profiles    profiles.ProfileService
-	providers   providers.ProviderService
-	marketplace marketplaces.Marketplace
+	ruleTypes    ruletypes.RuleTypeService
+	repos        github.RepositoryService
+	profiles     profiles.ProfileService
+	providers    providers.ProviderService
+	marketplace  marketplaces.Marketplace
+	instantiator providers.TraitInstantiator
 
 	// Implementations for service registration
 	pb.UnimplementedHealthServiceServer
@@ -174,6 +175,7 @@ func NewServer(
 		ruleTypes:           ruleSvc,
 		repos:               github.NewRepositoryService(whManager, store, evt),
 		marketplace:         marketplace,
+		instantiator:        nil, // TODO: FILL ME IN
 		// TODO: this currently always returns authorized as a transitionary measure.
 		// When OpenFGA is fully rolled out, we may want to make this a hard error or set to false.
 		authzClient: &mock.NoopClient{Authorized: true},
@@ -184,7 +186,7 @@ func NewServer(
 	}
 
 	// Moved here because we have a dependency on s.restClientCache
-	s.providers = providers.NewProviderService(store, eng, mt, provMt, &cfg.Provider, s.restClientCache)
+	s.providers = providers.NewProviderService(store, eng, mt, nil) // TODO: DEFINE ME
 
 	return s, nil
 }

--- a/internal/db/domain.go
+++ b/internal/db/domain.go
@@ -1,0 +1,24 @@
+// Copyright 2023 Stacklok, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package db
+
+import "slices"
+
+// This file contains domain-level methods for db structs
+
+// CanImplement returns true if the provider implements the given type.
+func (p *Provider) CanImplement(impl ProviderType) bool {
+	return slices.Contains(p.Implements, impl)
+}

--- a/internal/engine/actions/actions.go
+++ b/internal/engine/actions/actions.go
@@ -22,6 +22,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	v1 "github.com/stacklok/minder/pkg/providers/v1"
 
 	"github.com/rs/zerolog"
 	"github.com/sqlc-dev/pqtype"
@@ -33,7 +34,6 @@ import (
 	"github.com/stacklok/minder/internal/engine/actions/remediate/pull_request"
 	enginerr "github.com/stacklok/minder/internal/engine/errors"
 	engif "github.com/stacklok/minder/internal/engine/interfaces"
-	"github.com/stacklok/minder/internal/providers"
 	minderv1 "github.com/stacklok/minder/pkg/api/protobuf/go/minder/v1"
 )
 
@@ -44,16 +44,16 @@ type RuleActionsEngine struct {
 }
 
 // NewRuleActions creates a new rule actions engine
-func NewRuleActions(p *minderv1.Profile, rt *minderv1.RuleType, pbuild *providers.ProviderBuilder,
+func NewRuleActions(p *minderv1.Profile, rt *minderv1.RuleType, ghClient v1.GitHub,
 ) (*RuleActionsEngine, error) {
 	// Create the remediation engine
-	remEngine, err := remediate.NewRuleRemediator(rt, pbuild)
+	remEngine, err := remediate.NewRuleRemediator(rt, ghClient)
 	if err != nil {
 		return nil, fmt.Errorf("cannot create rule remediator: %w", err)
 	}
 
 	// Create the alert engine
-	alertEngine, err := alert.NewRuleAlert(rt, pbuild)
+	alertEngine, err := alert.NewRuleAlert(rt, ghClient)
 	if err != nil {
 		return nil, fmt.Errorf("cannot create rule alerter: %w", err)
 	}

--- a/internal/engine/actions/alert/alert.go
+++ b/internal/engine/actions/alert/alert.go
@@ -19,11 +19,11 @@ package alert
 
 import (
 	"fmt"
+	v1 "github.com/stacklok/minder/pkg/providers/v1"
 
 	"github.com/stacklok/minder/internal/engine/actions/alert/noop"
 	"github.com/stacklok/minder/internal/engine/actions/alert/security_advisory"
 	engif "github.com/stacklok/minder/internal/engine/interfaces"
-	"github.com/stacklok/minder/internal/providers"
 	pb "github.com/stacklok/minder/pkg/api/protobuf/go/minder/v1"
 )
 
@@ -31,7 +31,7 @@ import (
 const ActionType engif.ActionType = "alert"
 
 // NewRuleAlert creates a new rule alert engine
-func NewRuleAlert(rt *pb.RuleType, pbuild *providers.ProviderBuilder) (engif.Action, error) {
+func NewRuleAlert(rt *pb.RuleType, ghClient v1.GitHub) (engif.Action, error) {
 	alertCfg := rt.Def.GetAlert()
 	if alertCfg == nil {
 		return noop.NewNoopAlert(ActionType)
@@ -43,7 +43,7 @@ func NewRuleAlert(rt *pb.RuleType, pbuild *providers.ProviderBuilder) (engif.Act
 		if alertCfg.GetSecurityAdvisory() == nil {
 			return nil, fmt.Errorf("alert engine missing security-advisory configuration")
 		}
-		return security_advisory.NewSecurityAdvisoryAlert(ActionType, rt.GetSeverity(), alertCfg.GetSecurityAdvisory(), pbuild)
+		return security_advisory.NewSecurityAdvisoryAlert(ActionType, rt.GetSeverity(), alertCfg.GetSecurityAdvisory(), ghClient)
 	}
 
 	return nil, fmt.Errorf("unknown alert type: %s", alertCfg.GetType())

--- a/internal/engine/actions/alert/security_advisory/security_advisory.go
+++ b/internal/engine/actions/alert/security_advisory/security_advisory.go
@@ -31,7 +31,6 @@ import (
 
 	enginerr "github.com/stacklok/minder/internal/engine/errors"
 	"github.com/stacklok/minder/internal/engine/interfaces"
-	"github.com/stacklok/minder/internal/providers"
 	"github.com/stacklok/minder/internal/util"
 	pb "github.com/stacklok/minder/pkg/api/protobuf/go/minder/v1"
 	provifv1 "github.com/stacklok/minder/pkg/providers/v1"
@@ -133,7 +132,7 @@ func NewSecurityAdvisoryAlert(
 	actionType interfaces.ActionType,
 	sev *pb.Severity,
 	saCfg *pb.RuleType_Definition_Alert_AlertTypeSA,
-	pbuild *providers.ProviderBuilder,
+	cli provifv1.GitHub,
 ) (*Alert, error) {
 	if actionType == "" {
 		return nil, fmt.Errorf("action type cannot be empty")
@@ -153,11 +152,7 @@ func NewSecurityAdvisoryAlert(
 	if err != nil {
 		return nil, fmt.Errorf("cannot parse description template: %w", err)
 	}
-	// Get the GitHub client
-	cli, err := pbuild.GetGitHub()
-	if err != nil {
-		return nil, fmt.Errorf("cannot get http client: %w", err)
-	}
+
 	// Create the alert action
 	return &Alert{
 		actionType:           actionType,

--- a/internal/engine/actions/remediate/gh_branch_protect/gh_branch_protect.go
+++ b/internal/engine/actions/remediate/gh_branch_protect/gh_branch_protect.go
@@ -31,7 +31,6 @@ import (
 	"google.golang.org/protobuf/reflect/protoreflect"
 
 	"github.com/stacklok/minder/internal/engine/interfaces"
-	"github.com/stacklok/minder/internal/providers"
 	"github.com/stacklok/minder/internal/util"
 	pb "github.com/stacklok/minder/pkg/api/protobuf/go/minder/v1"
 	provifv1 "github.com/stacklok/minder/pkg/providers/v1"
@@ -53,7 +52,7 @@ type GhBranchProtectRemediator struct {
 func NewGhBranchProtectRemediator(
 	actionType interfaces.ActionType,
 	ghp *pb.RuleType_Definition_Remediate_GhBranchProtectionType,
-	pbuild *providers.ProviderBuilder,
+	cli provifv1.GitHub,
 ) (*GhBranchProtectRemediator, error) {
 	if actionType == "" {
 		return nil, fmt.Errorf("action type cannot be empty")
@@ -64,10 +63,6 @@ func NewGhBranchProtectRemediator(
 		return nil, fmt.Errorf("cannot parse patch template: %w", err)
 	}
 
-	cli, err := pbuild.GetGitHub()
-	if err != nil {
-		return nil, fmt.Errorf("cannot get http client: %w", err)
-	}
 	return &GhBranchProtectRemediator{
 		actionType:    actionType,
 		cli:           cli,

--- a/internal/engine/actions/remediate/pull_request/pull_request.go
+++ b/internal/engine/actions/remediate/pull_request/pull_request.go
@@ -38,7 +38,6 @@ import (
 	"google.golang.org/protobuf/reflect/protoreflect"
 
 	"github.com/stacklok/minder/internal/engine/interfaces"
-	"github.com/stacklok/minder/internal/providers"
 	"github.com/stacklok/minder/internal/util"
 	pb "github.com/stacklok/minder/pkg/api/protobuf/go/minder/v1"
 	provifv1 "github.com/stacklok/minder/pkg/providers/v1"
@@ -80,7 +79,7 @@ type Remediator struct {
 func NewPullRequestRemediate(
 	actionType interfaces.ActionType,
 	prCfg *pb.RuleType_Definition_Remediate_PullRequestRemediation,
-	pbuild *providers.ProviderBuilder,
+	ghClient provifv1.GitHub,
 ) (*Remediator, error) {
 	err := prCfg.Validate()
 	if err != nil {
@@ -97,16 +96,11 @@ func NewPullRequestRemediate(
 		return nil, fmt.Errorf("cannot parse body template: %w", err)
 	}
 
-	ghCli, err := pbuild.GetGitHub()
-	if err != nil {
-		return nil, fmt.Errorf("failed to get github client: %w", err)
-	}
-
 	modRegistry := newModificationRegistry()
 	modRegistry.registerBuiltIn()
 
 	return &Remediator{
-		ghCli:                ghCli,
+		ghCli:                ghClient,
 		prCfg:                prCfg,
 		actionType:           actionType,
 		modificationRegistry: modRegistry,

--- a/internal/engine/actions/remediate/rest/rest.go
+++ b/internal/engine/actions/remediate/rest/rest.go
@@ -31,7 +31,6 @@ import (
 
 	engerrors "github.com/stacklok/minder/internal/engine/errors"
 	"github.com/stacklok/minder/internal/engine/interfaces"
-	"github.com/stacklok/minder/internal/providers"
 	"github.com/stacklok/minder/internal/util"
 	pb "github.com/stacklok/minder/pkg/api/protobuf/go/minder/v1"
 	provifv1 "github.com/stacklok/minder/pkg/providers/v1"
@@ -53,7 +52,7 @@ type Remediator struct {
 
 // NewRestRemediate creates a new REST rule data ingest engine
 func NewRestRemediate(actionType interfaces.ActionType, restCfg *pb.RestType,
-	pbuild *providers.ProviderBuilder,
+	cli provifv1.REST,
 ) (*Remediator, error) {
 	if actionType == "" {
 		return nil, fmt.Errorf("action type cannot be empty")
@@ -73,11 +72,6 @@ func NewRestRemediate(actionType interfaces.ActionType, restCfg *pb.RestType,
 	}
 
 	method := util.HttpMethodFromString(restCfg.Method, http.MethodPatch)
-
-	cli, err := pbuild.GetHTTP()
-	if err != nil {
-		return nil, fmt.Errorf("cannot get http client: %w", err)
-	}
 
 	return &Remediator{
 		cli:              cli,

--- a/internal/engine/eval/eval.go
+++ b/internal/engine/eval/eval.go
@@ -20,6 +20,7 @@ package eval
 import (
 	"context"
 	"fmt"
+	v1 "github.com/stacklok/minder/pkg/providers/v1"
 
 	"github.com/stacklok/minder/internal/engine/eval/homoglyphs/application"
 	"github.com/stacklok/minder/internal/engine/eval/jq"
@@ -27,7 +28,6 @@ import (
 	"github.com/stacklok/minder/internal/engine/eval/trusty"
 	"github.com/stacklok/minder/internal/engine/eval/vulncheck"
 	engif "github.com/stacklok/minder/internal/engine/interfaces"
-	"github.com/stacklok/minder/internal/providers"
 	pb "github.com/stacklok/minder/pkg/api/protobuf/go/minder/v1"
 )
 
@@ -35,7 +35,7 @@ import (
 func NewRuleEvaluator(
 	ctx context.Context,
 	rt *pb.RuleType,
-	cli *providers.ProviderBuilder,
+	cli v1.GitHub,
 ) (engif.Evaluator, error) {
 	e := rt.Def.GetEval()
 	if e == nil {
@@ -52,7 +52,7 @@ func NewRuleEvaluator(
 	case rego.RegoEvalType:
 		return rego.NewRegoEvaluator(e.GetRego())
 	case vulncheck.VulncheckEvalType:
-		return vulncheck.NewVulncheckEvaluator(e.GetVulncheck(), cli)
+		return vulncheck.NewVulncheckEvaluator(cli)
 	case trusty.TrustyEvalType:
 		return trusty.NewTrustyEvaluator(ctx, cli)
 	case application.HomoglyphsEvalType:

--- a/internal/engine/eval/homoglyphs/application/homoglyphs_service.go
+++ b/internal/engine/eval/homoglyphs/application/homoglyphs_service.go
@@ -18,6 +18,7 @@ package application
 import (
 	"context"
 	"fmt"
+	v1 "github.com/stacklok/minder/pkg/providers/v1"
 	"strings"
 
 	"github.com/google/go-github/v60/github"
@@ -25,7 +26,6 @@ import (
 	"github.com/stacklok/minder/internal/engine/eval/homoglyphs/communication"
 	"github.com/stacklok/minder/internal/engine/eval/homoglyphs/domain"
 	engif "github.com/stacklok/minder/internal/engine/interfaces"
-	"github.com/stacklok/minder/internal/providers"
 	pb "github.com/stacklok/minder/pkg/api/protobuf/go/minder/v1"
 )
 
@@ -40,20 +40,17 @@ const (
 // NewHomoglyphsEvaluator creates a new homoglyphs evaluator
 func NewHomoglyphsEvaluator(
 	reh *pb.RuleType_Definition_Eval_Homoglyphs,
-	pbuild *providers.ProviderBuilder,
+	ghClient v1.GitHub,
 ) (engif.Evaluator, error) {
-	if pbuild == nil {
-		return nil, fmt.Errorf("provider builder is nil")
-	}
 	if reh == nil {
 		return nil, fmt.Errorf("homoglyphs configuration is nil")
 	}
 
 	switch reh.Type {
 	case invisibleCharacters:
-		return NewInvisibleCharactersEvaluator(pbuild)
+		return NewInvisibleCharactersEvaluator(ghClient)
 	case mixedScript:
-		return NewMixedScriptEvaluator(pbuild)
+		return NewMixedScriptEvaluator(ghClient)
 	default:
 		return nil, fmt.Errorf("unsupported homoglyphs type: %s", reh.Type)
 	}

--- a/internal/engine/eval/homoglyphs/application/invisible_characters_eval.go
+++ b/internal/engine/eval/homoglyphs/application/invisible_characters_eval.go
@@ -16,13 +16,12 @@ package application
 
 import (
 	"context"
-	"fmt"
+	v1 "github.com/stacklok/minder/pkg/providers/v1"
 
 	evalerrors "github.com/stacklok/minder/internal/engine/errors"
 	"github.com/stacklok/minder/internal/engine/eval/homoglyphs/communication"
 	"github.com/stacklok/minder/internal/engine/eval/homoglyphs/domain"
 	engif "github.com/stacklok/minder/internal/engine/interfaces"
-	"github.com/stacklok/minder/internal/providers"
 )
 
 // InvisibleCharactersEvaluator is an evaluator for the invisible characters rule type
@@ -32,16 +31,7 @@ type InvisibleCharactersEvaluator struct {
 }
 
 // NewInvisibleCharactersEvaluator creates a new invisible characters evaluator
-func NewInvisibleCharactersEvaluator(pbuild *providers.ProviderBuilder) (*InvisibleCharactersEvaluator, error) {
-	if pbuild == nil {
-		return nil, fmt.Errorf("provider builder is nil")
-	}
-
-	ghClient, err := pbuild.GetGitHub()
-	if err != nil {
-		return nil, fmt.Errorf("could not fetch GitHub client: %w", err)
-	}
-
+func NewInvisibleCharactersEvaluator(ghClient v1.GitHub) (*InvisibleCharactersEvaluator, error) {
 	return &InvisibleCharactersEvaluator{
 		processor:     domain.NewInvisibleCharactersProcessor(),
 		reviewHandler: communication.NewGhReviewPrHandler(ghClient),

--- a/internal/engine/eval/homoglyphs/application/mixed_scripts_eval.go
+++ b/internal/engine/eval/homoglyphs/application/mixed_scripts_eval.go
@@ -17,12 +17,12 @@ package application
 import (
 	"context"
 	"fmt"
+	v1 "github.com/stacklok/minder/pkg/providers/v1"
 
 	evalerrors "github.com/stacklok/minder/internal/engine/errors"
 	"github.com/stacklok/minder/internal/engine/eval/homoglyphs/communication"
 	"github.com/stacklok/minder/internal/engine/eval/homoglyphs/domain"
 	engif "github.com/stacklok/minder/internal/engine/interfaces"
-	"github.com/stacklok/minder/internal/providers"
 )
 
 // MixedScriptsEvaluator is the evaluator for the mixed scripts rule type
@@ -32,16 +32,7 @@ type MixedScriptsEvaluator struct {
 }
 
 // NewMixedScriptEvaluator creates a new mixed scripts evaluator
-func NewMixedScriptEvaluator(pbuild *providers.ProviderBuilder) (*MixedScriptsEvaluator, error) {
-	if pbuild == nil {
-		return nil, fmt.Errorf("provider builder is nil")
-	}
-
-	ghClient, err := pbuild.GetGitHub()
-	if err != nil {
-		return nil, fmt.Errorf("could not fetch GitHub client: %w", err)
-	}
-
+func NewMixedScriptEvaluator(ghClient v1.GitHub) (*MixedScriptsEvaluator, error) {
 	msProcessor, err := domain.NewMixedScriptsProcessor()
 	if err != nil {
 		return nil, fmt.Errorf("could not create mixed scripts processor: %w", err)

--- a/internal/engine/eval/trusty/trusty.go
+++ b/internal/engine/eval/trusty/trusty.go
@@ -26,7 +26,6 @@ import (
 	evalerrors "github.com/stacklok/minder/internal/engine/errors"
 	"github.com/stacklok/minder/internal/engine/eval/pr_actions"
 	engif "github.com/stacklok/minder/internal/engine/interfaces"
-	"github.com/stacklok/minder/internal/providers"
 	pb "github.com/stacklok/minder/pkg/api/protobuf/go/minder/v1"
 	provifv1 "github.com/stacklok/minder/pkg/providers/v1"
 )
@@ -45,11 +44,8 @@ type Evaluator struct {
 }
 
 // NewTrustyEvaluator creates a new trusty evaluator
-func NewTrustyEvaluator(ctx context.Context, pbuild *providers.ProviderBuilder) (*Evaluator, error) {
-	if pbuild == nil {
-		return nil, fmt.Errorf("provider builder is nil")
-	}
-
+// TODO: needs a trait which is not Github specific
+func NewTrustyEvaluator(ctx context.Context, ghClient provifv1.GitHub) (*Evaluator, error) {
 	// Read the trusty endpoint from the environment
 	trustyEndpoint := os.Getenv(trustyEndpointEnvVar)
 	// If the environment variable is not set, use the default endpoint
@@ -60,13 +56,8 @@ func NewTrustyEvaluator(ctx context.Context, pbuild *providers.ProviderBuilder) 
 		zerolog.Ctx(ctx).Info().Str("trusty-endpoint", trustyEndpoint).Msg("using trusty endpoint from environment")
 	}
 
-	ghcli, err := pbuild.GetGitHub()
-	if err != nil {
-		return nil, fmt.Errorf("failed to get github client: %w", err)
-	}
-
 	return &Evaluator{
-		cli:      ghcli,
+		cli:      ghClient,
 		endpoint: trustyEndpoint,
 	}, nil
 }

--- a/internal/engine/eval/vulncheck/vulncheck.go
+++ b/internal/engine/eval/vulncheck/vulncheck.go
@@ -25,7 +25,6 @@ import (
 
 	evalerrors "github.com/stacklok/minder/internal/engine/errors"
 	engif "github.com/stacklok/minder/internal/engine/interfaces"
-	"github.com/stacklok/minder/internal/providers"
 	pb "github.com/stacklok/minder/pkg/api/protobuf/go/minder/v1"
 	provifv1 "github.com/stacklok/minder/pkg/providers/v1"
 )
@@ -41,16 +40,7 @@ type Evaluator struct {
 }
 
 // NewVulncheckEvaluator creates a new vulncheck evaluator
-func NewVulncheckEvaluator(_ *pb.RuleType_Definition_Eval_Vulncheck, pbuild *providers.ProviderBuilder) (*Evaluator, error) {
-	if pbuild == nil {
-		return nil, fmt.Errorf("provider builder is nil")
-	}
-
-	ghcli, err := pbuild.GetGitHub()
-	if err != nil {
-		return nil, fmt.Errorf("failed to get github client: %w", err)
-	}
-
+func NewVulncheckEvaluator(ghcli provifv1.GitHub) (*Evaluator, error) {
 	return &Evaluator{
 		cli: ghcli,
 	}, nil

--- a/internal/engine/ingester/artifact/artifact.go
+++ b/internal/engine/ingester/artifact/artifact.go
@@ -29,7 +29,6 @@ import (
 
 	evalerrors "github.com/stacklok/minder/internal/engine/errors"
 	engif "github.com/stacklok/minder/internal/engine/interfaces"
-	"github.com/stacklok/minder/internal/providers"
 	"github.com/stacklok/minder/internal/verifier"
 	"github.com/stacklok/minder/internal/verifier/sigstore/container"
 	"github.com/stacklok/minder/internal/verifier/verifyif"
@@ -64,15 +63,8 @@ type verification struct {
 
 // NewArtifactDataIngest creates a new artifact rule data ingest engine
 func NewArtifactDataIngest(
-	_ *pb.ArtifactType,
-	pbuild *providers.ProviderBuilder,
+	ghCli provifv1.GitHub,
 ) (*Ingest, error) {
-
-	ghCli, err := pbuild.GetGitHub()
-	if err != nil {
-		return nil, fmt.Errorf("failed to get github client: %w", err)
-	}
-
 	return &Ingest{
 		ghCli: ghCli,
 	}, nil

--- a/internal/engine/ingester/builtin/builtin.go
+++ b/internal/engine/ingester/builtin/builtin.go
@@ -29,7 +29,6 @@ import (
 
 	evalerrors "github.com/stacklok/minder/internal/engine/errors"
 	engif "github.com/stacklok/minder/internal/engine/interfaces"
-	"github.com/stacklok/minder/internal/providers"
 	"github.com/stacklok/minder/internal/util"
 	pb "github.com/stacklok/minder/pkg/api/protobuf/go/minder/v1"
 	"github.com/stacklok/minder/pkg/rule_methods"
@@ -50,7 +49,6 @@ type BuiltinRuleDataIngest struct {
 // NewBuiltinRuleDataIngest creates a new builtin rule data ingest engine
 func NewBuiltinRuleDataIngest(
 	builtinCfg *pb.BuiltinType,
-	_ *providers.ProviderBuilder,
 ) (*BuiltinRuleDataIngest, error) {
 	return &BuiltinRuleDataIngest{
 		builtinCfg:  builtinCfg,

--- a/internal/engine/ingester/diff/diff.go
+++ b/internal/engine/ingester/diff/diff.go
@@ -28,7 +28,6 @@ import (
 	"google.golang.org/protobuf/reflect/protoreflect"
 
 	engif "github.com/stacklok/minder/internal/engine/interfaces"
-	"github.com/stacklok/minder/internal/providers"
 	pb "github.com/stacklok/minder/pkg/api/protobuf/go/minder/v1"
 	provifv1 "github.com/stacklok/minder/pkg/providers/v1"
 )
@@ -49,19 +48,10 @@ type Diff struct {
 // NewDiffIngester creates a new diff ingester
 func NewDiffIngester(
 	cfg *pb.DiffType,
-	pbuild *providers.ProviderBuilder,
+	cli provifv1.GitHub,
 ) (*Diff, error) {
 	if cfg == nil {
 		cfg = &pb.DiffType{}
-	}
-
-	if pbuild == nil {
-		return nil, fmt.Errorf("provider builder is nil")
-	}
-
-	cli, err := pbuild.GetGitHub()
-	if err != nil {
-		return nil, fmt.Errorf("failed to get github client: %w", err)
 	}
 
 	return &Diff{

--- a/internal/engine/ingester/git/git.go
+++ b/internal/engine/ingester/git/git.go
@@ -24,10 +24,8 @@ import (
 	"github.com/mitchellh/mapstructure"
 	"google.golang.org/protobuf/reflect/protoreflect"
 
-	"github.com/stacklok/minder/internal/db"
 	engerrors "github.com/stacklok/minder/internal/engine/errors"
 	engif "github.com/stacklok/minder/internal/engine/interfaces"
-	"github.com/stacklok/minder/internal/providers"
 	pb "github.com/stacklok/minder/pkg/api/protobuf/go/minder/v1"
 	provifv1 "github.com/stacklok/minder/pkg/providers/v1"
 )
@@ -45,22 +43,9 @@ type Git struct {
 }
 
 // NewGitIngester creates a new git rule data ingest engine
-func NewGitIngester(cfg *pb.GitType, pbuild *providers.ProviderBuilder) (*Git, error) {
-	if pbuild == nil {
-		return nil, fmt.Errorf("provider builder is nil")
-	}
-
-	if !pbuild.Implements(db.ProviderTypeGit) {
-		return nil, fmt.Errorf("provider builder does not implement git")
-	}
-
+func NewGitIngester(cfg *pb.GitType, gitprov provifv1.Git) (*Git, error) {
 	if cfg == nil {
 		cfg = &pb.GitType{}
-	}
-
-	gitprov, err := pbuild.GetGit()
-	if err != nil {
-		return nil, fmt.Errorf("could not get git provider: %w", err)
 	}
 
 	return &Git{

--- a/internal/engine/ingester/ingester.go
+++ b/internal/engine/ingester/ingester.go
@@ -19,6 +19,7 @@ package ingester
 
 import (
 	"fmt"
+	v1 "github.com/stacklok/minder/pkg/providers/v1"
 
 	"github.com/stacklok/minder/internal/engine/ingester/artifact"
 	"github.com/stacklok/minder/internal/engine/ingester/builtin"
@@ -26,7 +27,6 @@ import (
 	"github.com/stacklok/minder/internal/engine/ingester/git"
 	"github.com/stacklok/minder/internal/engine/ingester/rest"
 	engif "github.com/stacklok/minder/internal/engine/interfaces"
-	"github.com/stacklok/minder/internal/providers"
 	pb "github.com/stacklok/minder/pkg/api/protobuf/go/minder/v1"
 )
 
@@ -38,7 +38,7 @@ var _ engif.Ingester = (*rest.Ingestor)(nil)
 
 // NewRuleDataIngest creates a new rule data ingest based no the given rule
 // type definition.
-func NewRuleDataIngest(rt *pb.RuleType, pbuild *providers.ProviderBuilder) (engif.Ingester, error) {
+func NewRuleDataIngest(rt *pb.RuleType, ghClient v1.GitHub) (engif.Ingester, error) {
 	ing := rt.Def.GetIngest()
 
 	switch ing.GetType() {
@@ -47,23 +47,23 @@ func NewRuleDataIngest(rt *pb.RuleType, pbuild *providers.ProviderBuilder) (engi
 			return nil, fmt.Errorf("rule type engine missing rest configuration")
 		}
 
-		return rest.NewRestRuleDataIngest(ing.GetRest(), pbuild)
+		return rest.NewRestRuleDataIngest(ing.GetRest(), ghClient)
 	case builtin.BuiltinRuleDataIngestType:
 		if rt.Def.Ingest.GetBuiltin() == nil {
 			return nil, fmt.Errorf("rule type engine missing internal configuration")
 		}
-		return builtin.NewBuiltinRuleDataIngest(ing.GetBuiltin(), pbuild)
+		return builtin.NewBuiltinRuleDataIngest(ing.GetBuiltin())
 
 	case artifact.ArtifactRuleDataIngestType:
 		if rt.Def.Ingest.GetArtifact() == nil {
 			return nil, fmt.Errorf("rule type engine missing artifact configuration")
 		}
-		return artifact.NewArtifactDataIngest(ing.GetArtifact(), pbuild)
+		return artifact.NewArtifactDataIngest(ghClient)
 
 	case git.GitRuleDataIngestType:
-		return git.NewGitIngester(ing.GetGit(), pbuild)
+		return git.NewGitIngester(ing.GetGit(), ghClient)
 	case diff.DiffRuleDataIngestType:
-		return diff.NewDiffIngester(ing.GetDiff(), pbuild)
+		return diff.NewDiffIngester(ing.GetDiff(), ghClient)
 	default:
 		return nil, fmt.Errorf("unsupported rule type engine: %s", rt.Def.Ingest.Type)
 	}

--- a/internal/engine/ingester/rest/rest.go
+++ b/internal/engine/ingester/rest/rest.go
@@ -32,7 +32,6 @@ import (
 	"google.golang.org/protobuf/reflect/protoreflect"
 
 	engif "github.com/stacklok/minder/internal/engine/interfaces"
-	"github.com/stacklok/minder/internal/providers"
 	"github.com/stacklok/minder/internal/util"
 	pb "github.com/stacklok/minder/pkg/api/protobuf/go/minder/v1"
 	provifv1 "github.com/stacklok/minder/pkg/providers/v1"
@@ -62,7 +61,7 @@ type Ingestor struct {
 // NewRestRuleDataIngest creates a new REST rule data ingest engine
 func NewRestRuleDataIngest(
 	restCfg *pb.RestType,
-	pbuild *providers.ProviderBuilder,
+	cli provifv1.REST,
 ) (*Ingestor, error) {
 	if len(restCfg.Endpoint) == 0 {
 		return nil, fmt.Errorf("missing endpoint")
@@ -74,12 +73,6 @@ func NewRestRuleDataIngest(
 	}
 
 	method := util.HttpMethodFromString(restCfg.Method, http.MethodGet)
-
-	cli, err := pbuild.GetHTTP()
-	if err != nil {
-		return nil, fmt.Errorf("cannot get http client: %w", err)
-	}
-
 	fallback := make([]ingestorFallback, len(restCfg.Fallback))
 	for _, fb := range restCfg.Fallback {
 		fb := fb

--- a/internal/engine/rule_type_engine.go
+++ b/internal/engine/rule_type_engine.go
@@ -18,6 +18,7 @@ package engine
 import (
 	"context"
 	"fmt"
+	v1 "github.com/stacklok/minder/pkg/providers/v1"
 	"strings"
 
 	"github.com/rs/zerolog/log"
@@ -31,7 +32,6 @@ import (
 	"github.com/stacklok/minder/internal/engine/ingestcache"
 	"github.com/stacklok/minder/internal/engine/ingester"
 	engif "github.com/stacklok/minder/internal/engine/interfaces"
-	"github.com/stacklok/minder/internal/providers"
 	minderv1 "github.com/stacklok/minder/pkg/api/protobuf/go/minder/v1"
 )
 
@@ -75,7 +75,7 @@ type RuleTypeEngine struct {
 
 	rt *minderv1.RuleType
 
-	cli *providers.ProviderBuilder
+	cli v1.GitHub
 
 	ingestCache ingestcache.Cache
 }
@@ -85,7 +85,7 @@ func NewRuleTypeEngine(
 	ctx context.Context,
 	p *minderv1.Profile,
 	rt *minderv1.RuleType,
-	cli *providers.ProviderBuilder,
+	cli v1.GitHub,
 ) (*RuleTypeEngine, error) {
 	rval, err := NewRuleValidator(rt)
 	if err != nil {

--- a/internal/providers/factory.go
+++ b/internal/providers/factory.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+
 	serverconfig "github.com/stacklok/minder/internal/config/server"
 	"github.com/stacklok/minder/internal/crypto"
 	"github.com/stacklok/minder/internal/db"
@@ -48,7 +49,7 @@ type traitInstantiator struct {
 	crypteng        crypto.Engine
 }
 
-func NewTraitInstanceFactory(
+func NewTraitInstantiator(
 	restClientCache ratecache.RestClientCache,
 	metrics telemetry.ProviderMetrics,
 	cfg *serverconfig.ProviderConfig,

--- a/internal/providers/factory.go
+++ b/internal/providers/factory.go
@@ -1,0 +1,157 @@
+// Copyright 2024 Stacklok, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package providers
+
+import (
+	"fmt"
+	"github.com/stacklok/minder/internal/db"
+	gitclient "github.com/stacklok/minder/internal/providers/git"
+	githubapp "github.com/stacklok/minder/internal/providers/github/app"
+	ghclient "github.com/stacklok/minder/internal/providers/github/oauth"
+	httpclient "github.com/stacklok/minder/internal/providers/http"
+	provinfv1 "github.com/stacklok/minder/pkg/providers/v1"
+	"slices"
+)
+
+type ProviderFactory interface {
+	GetGit() (provinfv1.Git, error)
+	GetHTTP() (provinfv1.REST, error)
+	GetGitHub() (provinfv1.GitHub, error)
+	GetRepoLister() (provinfv1.RepoLister, error)
+}
+
+type providerFactory struct {
+}
+
+// GetGit returns a git client for the provider.
+func (p *providerFactory) GetGit() (provinfv1.Git, error) {
+	if !p.Implements(db.ProviderTypeGit) {
+		return nil, fmt.Errorf("provider does not implement git")
+	}
+
+	if p.Implements(db.ProviderTypeGithub) {
+		return p.GetGitHub()
+	}
+
+	gitCredential, ok := pb.credential.(provinfv1.GitCredential)
+	if !ok {
+		return nil, ErrInvalidCredential
+	}
+
+	return gitclient.NewGit(gitCredential), nil
+}
+
+// GetHTTP returns a github client for the provider.
+func (p *providerFactory) GetHTTP() (provinfv1.REST, error) {
+	if !pb.Implements(db.ProviderTypeRest) {
+		return nil, fmt.Errorf("provider does not implement rest")
+	}
+
+	// We can re-use the GitHub provider in case it also implements GitHub.
+	// The client gives us the ability to handle rate limiting and other
+	// things.
+	if pb.Implements(db.ProviderTypeGithub) {
+		return pb.GetGitHub()
+	}
+
+	if pb.p.Version != provinfv1.V1 {
+		return nil, fmt.Errorf("provider version not supported")
+	}
+
+	// TODO: Parsing will change based on version
+	cfg, err := httpclient.ParseV1Config(pb.p.Definition)
+	if err != nil {
+		return nil, fmt.Errorf("error parsing http config: %w", err)
+	}
+
+	restCredential, ok := pb.credential.(provinfv1.RestCredential)
+	if !ok {
+		return nil, ErrInvalidCredential
+	}
+
+	return httpclient.NewREST(cfg, pb.metrics, restCredential)
+}
+
+// GetGitHub returns a github client for the provider.
+func (p *providerFactory) GetGitHub() (provinfv1.GitHub, error) {
+	if !pb.Implements(db.ProviderTypeGithub) {
+		return nil, fmt.Errorf("provider does not implement github")
+	}
+
+	if pb.p.Version != provinfv1.V1 {
+		return nil, fmt.Errorf("provider version not supported")
+	}
+
+	gitHubCredential, ok := pb.credential.(provinfv1.GitHubCredential)
+	if !ok {
+		return nil, ErrInvalidCredential
+	}
+
+	if pb.restClientCache != nil {
+		client, ok := pb.restClientCache.Get(pb.ownerFilter.String, gitHubCredential.GetCacheKey(), db.ProviderTypeGithub)
+		if ok {
+			return client.(provinfv1.GitHub), nil
+		}
+	}
+
+	// TODO: use provider class once it's available
+	if pb.p.Name == ghclient.Github {
+		// TODO: Parsing will change based on version
+		cfg, err := ghclient.ParseV1Config(pb.p.Definition)
+		if err != nil {
+			return nil, fmt.Errorf("error parsing github config: %w", err)
+		}
+
+		cli, err := ghclient.NewRestClient(cfg, pb.metrics, pb.restClientCache, gitHubCredential, pb.ownerFilter.String)
+		if err != nil {
+			return nil, fmt.Errorf("error creating github client: %w", err)
+		}
+		return cli, nil
+	}
+
+	cfg, err := githubapp.ParseV1Config(pb.p.Definition)
+	if err != nil {
+		return nil, fmt.Errorf("error parsing github app config: %w", err)
+	}
+
+	cli, err := githubapp.NewGitHubAppProvider(cfg, pb.cfg.GitHubApp, pb.metrics, pb.restClientCache, gitHubCredential)
+	if err != nil {
+		return nil, fmt.Errorf("error creating github app client: %w", err)
+	}
+	return cli, nil
+}
+
+// GetRepoLister returns a repo lister for the provider.
+func (p *providerFactory) GetRepoLister() (provinfv1.RepoLister, error) {
+	if !pb.Implements(db.ProviderTypeRepoLister) {
+		return nil, fmt.Errorf("provider does not implement repo lister")
+	}
+
+	if pb.p.Version != provinfv1.V1 {
+		return nil, fmt.Errorf("provider version not supported")
+	}
+
+	if pb.Implements(db.ProviderTypeGithub) {
+		return pb.GetGitHub()
+	}
+
+	// TODO: We'll need to add support for other providers here
+	return nil, fmt.Errorf("provider does not implement repo lister")
+}
+
+// Implements returns true if the provider implements the given type.
+func (p *providerFactory) Implements(impl db.ProviderType) bool {
+	return slices.Contains(p.p.Implements, impl)
+}

--- a/internal/providers/providers.go
+++ b/internal/providers/providers.go
@@ -31,12 +31,7 @@ import (
 	"github.com/stacklok/minder/internal/crypto"
 	"github.com/stacklok/minder/internal/db"
 	"github.com/stacklok/minder/internal/providers/credentials"
-	gitclient "github.com/stacklok/minder/internal/providers/git"
 	githubapp "github.com/stacklok/minder/internal/providers/github/app"
-	ghclient "github.com/stacklok/minder/internal/providers/github/oauth"
-	httpclient "github.com/stacklok/minder/internal/providers/http"
-	"github.com/stacklok/minder/internal/providers/ratecache"
-	"github.com/stacklok/minder/internal/providers/telemetry"
 	minderv1 "github.com/stacklok/minder/pkg/api/protobuf/go/minder/v1"
 	provinfv1 "github.com/stacklok/minder/pkg/providers/v1"
 )
@@ -46,7 +41,7 @@ var ErrInvalidCredential = errors.New("invalid credential type")
 
 // GetProviderBuilder is a utility function which allows for the creation of
 // a provider factory.
-func GetProviderBuilder(
+/*func GetProviderBuilder(
 	ctx context.Context,
 	prov db.Provider,
 	store db.Store,
@@ -244,6 +239,7 @@ func (pb *ProviderBuilder) GetRepoLister() (provinfv1.RepoLister, error) {
 	// TODO: We'll need to add support for other providers here
 	return nil, fmt.Errorf("provider does not implement repo lister")
 }
+*/
 
 // DBToPBType converts a database provider type to a protobuf provider type.
 func DBToPBType(t db.ProviderType) (minderv1.ProviderType, bool) {

--- a/internal/reconcilers/artifacts.go
+++ b/internal/reconcilers/artifacts.go
@@ -30,7 +30,6 @@ import (
 
 	"github.com/stacklok/minder/internal/db"
 	"github.com/stacklok/minder/internal/engine/entities"
-	"github.com/stacklok/minder/internal/providers"
 	"github.com/stacklok/minder/internal/providers/github"
 	"github.com/stacklok/minder/internal/util"
 	"github.com/stacklok/minder/internal/verifier/verifyif"
@@ -103,14 +102,19 @@ func (r *Reconciler) handleArtifactsReconcilerEvent(ctx context.Context, evt *Re
 		return fmt.Errorf("error retrieving provider: %w", err)
 	}
 
-	pbOpts := []providers.ProviderBuilderOption{
+	cli, err := r.instantiator.GetGitHub(ctx, &prov)
+	if err != nil {
+		return err // TODO: fill me in
+	}
+
+	/*pbOpts := []providers.ProviderBuilderOption{
 		providers.WithProviderMetrics(r.provMt),
 		providers.WithRestClientCache(r.restClientCache),
 	}
 	p, err := providers.GetProviderBuilder(ctx, prov, r.store, r.crypteng, r.provCfg, pbOpts...)
 	if err != nil {
 		return fmt.Errorf("error building client: %w", err)
-	}
+	}*/
 
 	// evaluate profile for repo
 	repo := util.PBRepositoryFromDB(repository)
@@ -125,7 +129,7 @@ func (r *Reconciler) handleArtifactsReconcilerEvent(ctx context.Context, evt *Re
 		return fmt.Errorf("error publishing message: %w", err)
 	}
 
-	if !p.Implements(db.ProviderTypeGithub) {
+	/*if !p.Implements(db.ProviderTypeGithub) {
 		log.Printf("provider %s is not supported for artifacts reconciler", prov.Name)
 		return nil
 	}
@@ -133,9 +137,9 @@ func (r *Reconciler) handleArtifactsReconcilerEvent(ctx context.Context, evt *Re
 	cli, err := p.GetGitHub()
 	if err != nil {
 		return fmt.Errorf("error getting github client: %w", err)
-	}
+	}*/
 
-	isOrg := (cli.GetOwner() != "")
+	isOrg := cli.GetOwner() != ""
 	// todo: add another type of artifacts
 	artifacts, err := cli.ListPackagesByRepository(ctx, isOrg, repository.RepoOwner,
 		string(verifyif.ArtifactTypeContainer), int64(repository.RepoID), 1, 100)

--- a/internal/reconcilers/reconcilers.go
+++ b/internal/reconcilers/reconcilers.go
@@ -21,6 +21,7 @@ import (
 	"github.com/stacklok/minder/internal/crypto"
 	"github.com/stacklok/minder/internal/db"
 	"github.com/stacklok/minder/internal/events"
+	"github.com/stacklok/minder/internal/providers"
 	"github.com/stacklok/minder/internal/providers/ratecache"
 	providertelemetry "github.com/stacklok/minder/internal/providers/telemetry"
 )
@@ -40,6 +41,7 @@ type Reconciler struct {
 	restClientCache ratecache.RestClientCache
 	provCfg         *serverconfig.ProviderConfig
 	provMt          providertelemetry.ProviderMetrics
+	instantiator    providers.TraitInstantiator
 }
 
 // ReconcilerOption is a function that modifies a reconciler


### PR DESCRIPTION
# Summary

Currently, there are functions within the controlplane which create instances of `db.Provider` from request context. When unit testing the controlplane, it becomes necessary to stub out some of the DB queries needed to create the providers, and these stubs can change as the logic around providers is changed.

This PR introduces a `ProviderFactory` which encapsulates this logic. Once this is fully wired in, tests for the controlplane will only need to stub a single method, and the logic around provider creation can vary independently of the implementation and testing of the controlplane methods.

Fixes #(related issue)

## Change Type

***Mark the type of change your PR introduces:***

- [ ] Bug fix (resolves an issue without affecting existing features)
- [ ] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [ ] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

***Outline how the changes were tested, including steps to reproduce and any relevant configurations. 
Attach screenshots if helpful.***

# Review Checklist:

- [ ] Reviewed my own code for quality and clarity.
- [ ] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [ ] Included tests that validate the fix or feature.
- [ ] Checked that related changes are merged.
