### PR TITLE
Use project ID from entity context for ruletypes

### DIFF
--- a/internal/controlplane/handlers_ruletype.go
+++ b/internal/controlplane/handlers_ruletype.go
@@ -166,7 +166,7 @@ func (s *Server) CreateRuleType(
 		return nil, providerError(err)
 	}
 
-	newRuleType, err := s.ruleTypes.CreateRuleType(ctx, provider, crt.GetRuleType())
+	newRuleType, err := s.ruleTypes.CreateRuleType(ctx, entityCtx, provider, crt.GetRuleType())
 	if err != nil {
 		if errors.Is(err, ruletypes.ErrRuleTypeInvalid) {
 			return nil, status.Errorf(codes.InvalidArgument, "invalid rule type definition: %s", err)
@@ -198,7 +198,7 @@ func (s *Server) UpdateRuleType(
 		return nil, providerError(err)
 	}
 
-	updatedRuleType, err := s.ruleTypes.UpdateRuleType(ctx, provider, urt.GetRuleType())
+	updatedRuleType, err := s.ruleTypes.UpdateRuleType(ctx, entityCtx, provider, urt.GetRuleType())
 	if err != nil {
 		if errors.Is(err, ruletypes.ErrRuleTypeInvalid) {
 			return nil, status.Errorf(codes.InvalidArgument, "invalid rule type definition: %s", err)

--- a/internal/ruletypes/service.go
+++ b/internal/ruletypes/service.go
@@ -39,6 +39,7 @@ type RuleTypeService interface {
 	// returns the pb definition of the new rule type on success
 	CreateRuleType(
 		ctx context.Context,
+		entityCtx engine.EntityContext,
 		provider db.Provider,
 		ruleType *pb.RuleType,
 	) (*pb.RuleType, error)
@@ -49,6 +50,7 @@ type RuleTypeService interface {
 	// returns the pb definition of the updated rule type on success
 	UpdateRuleType(
 		ctx context.Context,
+		entityCtx engine.EntityContext,
 		provider db.Provider,
 		ruleType *pb.RuleType,
 	) (*pb.RuleType, error)
@@ -77,6 +79,7 @@ var (
 
 func (r *ruleTypeService) CreateRuleType(
 	ctx context.Context,
+	entityCtx engine.EntityContext,
 	provider db.Provider,
 	ruleType *pb.RuleType,
 ) (*pb.RuleType, error) {
@@ -113,7 +116,7 @@ func (r *ruleTypeService) CreateRuleType(
 		Name:          ruleTypeName,
 		Provider:      provider.Name,
 		ProviderID:    provider.ID,
-		ProjectID:     provider.ProjectID,
+		ProjectID:     entityCtx.Project.ID,
 		Description:   ruleType.GetDescription(),
 		Definition:    serializedRule,
 		Guidance:      ruleType.GetGuidance(),
@@ -138,6 +141,7 @@ func (r *ruleTypeService) CreateRuleType(
 
 func (r *ruleTypeService) UpdateRuleType(
 	ctx context.Context,
+	entityCtx engine.EntityContext,
 	provider db.Provider,
 	ruleType *pb.RuleType,
 ) (*pb.RuleType, error) {
@@ -150,7 +154,7 @@ func (r *ruleTypeService) UpdateRuleType(
 
 	existingRuleType, err := r.store.GetRuleTypeByName(ctx, db.GetRuleTypeByNameParams{
 		Provider:  provider.Name,
-		ProjectID: provider.ProjectID,
+		ProjectID: entityCtx.Project.ID,
 		Name:      ruleTypeName,
 	})
 	if err != nil {

--- a/internal/ruletypes/service_test.go
+++ b/internal/ruletypes/service_test.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/stacklok/minder/internal/db"
 	dbf "github.com/stacklok/minder/internal/db/fixtures"
+	"github.com/stacklok/minder/internal/engine"
 	"github.com/stacklok/minder/internal/providers/github"
 	"github.com/stacklok/minder/internal/ruletypes"
 	"github.com/stacklok/minder/internal/util/ptr"
@@ -155,10 +156,11 @@ func TestRuleTypeService(t *testing.T) {
 			var err error
 			var res *pb.RuleType
 			svc := ruletypes.NewRuleTypeService(store)
+			ectx := engine.EntityContext{}
 			if scenario.TestMethod == create {
-				res, err = svc.CreateRuleType(ctx, provider, scenario.RuleType)
+				res, err = svc.CreateRuleType(ctx, ectx, provider, scenario.RuleType)
 			} else if scenario.TestMethod == update {
-				res, err = svc.UpdateRuleType(ctx, provider, scenario.RuleType)
+				res, err = svc.UpdateRuleType(ctx, ectx, provider, scenario.RuleType)
 			} else {
 				t.Fatal("unexpected method value")
 			}


### PR DESCRIPTION
# Summary

https://github.com/stacklok/minder/pull/2622 changed the project from coming from the context
to coming from the provider. This broke heirarchical rule type creation.

This PR fixes that.

## Change Type

***Mark the type of change your PR introduces:***

- [x] Bug fix (resolves an issue without affecting existing features)
- [ ] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [ ] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

***Outline how the changes were tested, including steps to reproduce and any relevant configurations. 
Attach screenshots if helpful.***

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [ ] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [ ] Included tests that validate the fix or feature.
- [ ] Checked that related changes are merged.
