### PR TITLE
Explicitly specify owner when listing packages

### DIFF
--- a/internal/providers/github/github_rest.go
+++ b/internal/providers/github/github_rest.go
@@ -148,7 +148,7 @@ func (c *GitHub) ListPackagesByRepository(ctx context.Context, isOrg bool, owner
 		if isOrg {
 			artifacts, resp, err = c.client.Organizations.ListPackages(ctx, owner, opt)
 		} else {
-			artifacts, resp, err = c.client.Users.ListPackages(ctx, "", opt)
+			artifacts, resp, err = c.client.Users.ListPackages(ctx, owner, opt)
 		}
 		if err != nil {
 			if resp.StatusCode == http.StatusNotFound {


### PR DESCRIPTION
# Summary

When listing packages by repository, we were relying on the repository owner being the same user that generated the token being used.
Currently the token user and repo owner will always be the same, but to be safer we should use the explicit owner parameter that this function is called with.

note: I validated that we store always store the repo owner, both when the owner is a user and when the owner is an organization.

## Change Type

***Mark the type of change your PR introduces:***

- [ ] Bug fix (resolves an issue without affecting existing features)
- [ ] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [x] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

***Outline how the changes were tested, including steps to reproduce and any relevant configurations. 
Attach screenshots if helpful.***

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [ ] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [ ] Included tests that validate the fix or feature.
- [ ] Checked that related changes are merged.
