### PR TITLE
Explicitly specify owner in all package operations

### DIFF
--- a/internal/providers/github/github_rest.go
+++ b/internal/providers/github/github_rest.go
@@ -205,7 +205,7 @@ func (c *GitHub) GetPackageVersions(ctx context.Context, isOrg bool, owner strin
 		if isOrg {
 			v, resp, err = c.client.Organizations.PackageGetAllVersions(ctx, owner, package_type, package_name, opt)
 		} else {
-			v, resp, err = c.client.Users.PackageGetAllVersions(ctx, "", package_type, package_name, opt)
+			v, resp, err = c.client.Users.PackageGetAllVersions(ctx, owner, package_type, package_name, opt)
 		}
 		if err != nil {
 			return nil, err
@@ -269,7 +269,7 @@ func (c *GitHub) GetPackageByName(ctx context.Context, isOrg bool, owner string,
 			return nil, err
 		}
 	} else {
-		pkg, _, err = c.client.Users.GetPackage(ctx, "", package_type, package_name)
+		pkg, _, err = c.client.Users.GetPackage(ctx, owner, package_type, package_name)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
# Summary

When querying GitHub packages we should use the `owner` parameter, rather than relying on the user from the token.

Related to #2643

## Change Type

***Mark the type of change your PR introduces:***

- [ ] Bug fix (resolves an issue without affecting existing features)
- [ ] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [x] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

***Outline how the changes were tested, including steps to reproduce and any relevant configurations. 
Attach screenshots if helpful.***

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [ ] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [ ] Included tests that validate the fix or feature.
- [ ] Checked that related changes are merged.
