### PR TITLE
Sort the list of profiles before returning to clients

### DIFF
--- a/internal/controlplane/handlers_profile.go
+++ b/internal/controlplane/handlers_profile.go
@@ -20,6 +20,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"sort"
 	"strings"
 
 	"github.com/google/uuid"
@@ -274,7 +275,17 @@ func (s *Server) ListProfiles(ctx context.Context,
 
 	var resp minderv1.ListProfilesResponse
 	resp.Profiles = make([]*minderv1.Profile, 0, len(profiles))
-	for _, profile := range engine.MergeDatabaseListIntoProfiles(profiles) {
+	profileMap := engine.MergeDatabaseListIntoProfiles(profiles)
+
+	// Sort the profiles by name to get a consistent order. This is important for UI.
+	profileNames := make([]string, 0, len(profileMap))
+	for prfName := range profileMap {
+		profileNames = append(profileNames, prfName)
+	}
+	sort.Strings(profileNames)
+
+	for _, prfName := range profileNames {
+		profile := profileMap[prfName]
 		resp.Profiles = append(resp.Profiles, profile)
 	}
 


### PR DESCRIPTION
# Summary

Because we internally construct a go map when retrieving the list of
profiles and then iterate over it, the result of ListProfiles is not
ordered. But this is putting a strain on the UI that would have to order
the results or else every refresh might produce a different looking set
of results.

Fixes: #2658

## Change Type

- [x] Bug fix (resolves an issue without affecting existing features)
- [ ] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [ ] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

Running minder profile list in a loop.

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [ ] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [ ] Included tests that validate the fix or feature.
- [ ] Checked that related changes are merged.
