### PR TITLE
Allow using an environment variable to override the token from the CLI

### DIFF
--- a/internal/util/helpers.go
+++ b/internal/util/helpers.go
@@ -55,6 +55,9 @@ var (
 	PyRequestsVersionRegexp = regexp.MustCompile(`\s*(>=|<=|==|>|<|!=)\s*(\d+(\.\d+)*(\*)?)`)
 	// PyRequestsNameRegexp is a regexp to match a line in a requirements.txt file, parsing out the package name
 	PyRequestsNameRegexp = regexp.MustCompile(`\s*(>=|<=|==|>|<|!=)`)
+	// MinderAuthTokenEnvVar is the environment variable for the minder auth token
+	//nolint:gosec // This is not a hardcoded credential
+	MinderAuthTokenEnvVar = "MINDER_AUTH_TOKEN"
 )
 
 // OpenIdCredentials is a struct to hold the access and refresh tokens
@@ -109,9 +112,13 @@ func GetGrpcConnection(
 
 	// read credentials
 	token := ""
-	t, err := GetToken(issuerUrl, clientId)
-	if err == nil {
-		token = t
+	if os.Getenv(MinderAuthTokenEnvVar) != "" {
+		token = os.Getenv(MinderAuthTokenEnvVar)
+	} else {
+		t, err := GetToken(issuerUrl, clientId)
+		if err == nil {
+			token = t
+		}
 	}
 
 	credentialOpts := credentials.NewTLS(&tls.Config{MinVersion: tls.VersionTLS13})


### PR DESCRIPTION
# Summary

This allows for using the `MINDER_AUTH_TOKEN` environment variable to
set the minder token used for authentication; thus bypassing reading the
credentials.json file and attempting to refresh.

This is mostly meant for usage in testing enviornments where keycloak might be disabled.

## Change Type

***Mark the type of change your PR introduces:***

- [x] Bug fix (resolves an issue without affecting existing features)
- [ ] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [ ] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

***Outline how the changes were tested, including steps to reproduce and any relevant configurations. 
Attach screenshots if helpful.***

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [ ] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [ ] Included tests that validate the fix or feature.
- [ ] Checked that related changes are merged.
