### PR TITLE
Overlay PatchProfile body with the current profile to avoid reverting to default values

### DIFF
--- a/internal/controlplane/handlers_profile.go
+++ b/internal/controlplane/handlers_profile.go
@@ -603,15 +603,33 @@ func (s *Server) PatchProfile(ctx context.Context, ppr *minderv1.PatchProfileReq
 		return nil, util.UserVisibleError(codes.InvalidArgument, "Malformed UUID")
 	}
 
+	// The UpdateProfile accepts Null values for the remediate and alert fields as "the server default". Until
+	// we fix that, we need to fetch the old profile to get the current values and extend the patch with those
+	oldProfile, err := s.store.GetProfileByID(ctx, db.GetProfileByIDParams{
+		ProjectID: entityCtx.Project.ID,
+		ID:        profileID,
+	})
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, util.UserVisibleError(codes.NotFound, "profile not found")
+		}
+		return nil, status.Errorf(codes.Internal, "failed to get profile: %s", err)
+	}
+
 	params := db.UpdateProfileParams{ID: profileID, ProjectID: entityCtx.Project.ID}
 
 	// we check the pointers explicitly because the zero value of a string is valid
 	// value that means "use default" and we want to distinguish that from "not set in the patch"
 	if patch.Remediate != nil {
 		params.Remediate = validateActionType(patch.GetRemediate())
+	} else {
+		params.Remediate = oldProfile.Remediate
 	}
+
 	if patch.Alert != nil {
 		params.Alert = validateActionType(patch.GetAlert())
+	} else {
+		params.Alert = oldProfile.Alert
 	}
 
 	// Update top-level profile db object


### PR DESCRIPTION
# Summary

if one of the alert/remediate fields is not specified in the patch, but is
specified in the profile, will overwrite the unspecified one to its default
value which is "unset" on the server side.

Fixes: #2672

## Change Type

***Mark the type of change your PR introduces:***

- [x] Bug fix (resolves an issue without affecting existing features)
- [ ] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [ ] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

```
curl -XPATCH -H "Authorization: Bearer $MINDER_BEARER_TOKEN" 'http://localhost:8080/api/v1/profile/af95014a-1184-47ef-a7ca-41b7550e137c?context.project=8f701090-efb9-477e-983a-39a34cb73b42&context.provider=github' -d '{ "remediate": "off" }'

{"profile":{"context":{"provider":"github", "project":"8f701090-efb9-477e-983a-39a34cb73b42"}, "id":"af95014a-1184-47ef-a7ca-41b7550e137c", "name":"python-test-profile", "labels":[], "repository":[{"type":"secret_scanning", "params":null, "def":{"enabled":true}, "name":"secret_scanning"}, {"type":"secret_push_protection", "params":null, "def":{"enabled":true}, "
name":"secret_push_protection"}, {"type":"dependabot_configured", "params":null, "def":{"apply_if_file":"requirements.txt", "package_ecosystem":"pip", "schedule_interval":"weekly"}, "name":"dependabot_configured"}, {"type":"branch_protection_allow_force_pushes", "params":{"branch":"main"}, "def":{"allow_force_pushes":true}, "name":"branch_protection_allow_force_
pushes"}, {"type":"branch_protection_enforce_admins", "params":{"branch":"main"}, "def":{"enforce_admins":false}, "name":"branch_protection_enforce_admins"}], "buildEnvironment":[], "artifact":[{"type":"artifact_signature", "params":{"name":"bad-python", "tags":["main"]}, "def":{"is_signed":true, "is_verified":true}, "name":"artifact_signature"}], "pullRequest":
[{"type":"pr_vulnerability_check", "params":null, "def":{"action":"review", "ecosystem_config":[{"name":"npm", "package_repository":{"url":"https://registry.npmjs.org"}, "vulnerability_database_endpoint":"https://api.osv.dev/v1/query", "vulnerability_database_type":"osv"}, {"name":"go", "package_repository":{"url":"https://proxy.golang.org"}, "sum_repository":{"
url":"https://sum.golang.org"}, "vulnerability_database_endpoint":"https://api.osv.dev/v1/query", "vulnerability_database_type":"osv"}, {"name":"pypi", "package_repository":{"url":"https://pypi.org/pypi"}, "vulnerability_database_endpoint":"https://api.osv.dev/v1/query", "vulnerability_database_type":"osv"}]}, "name":"pr_vulnerability_check"}, {"type":"pr_trusty
_check", "params":null, "def":{"action":"summary", "ecosystem_config":[{"name":"npm", "score":5}, {"name":"pypi", "score":5}]}, "name":"pr_trusty_check"}], "remediate":"off", "alert":"on", "type":"", "version":""}}%
```

before this patch, the patch call would have set the remediate field to off as requested, but also reset the alert field.

# Review Checklist:

- [ ] Reviewed my own code for quality and clarity.
- [ ] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [ ] Included tests that validate the fix or feature.
- [ ] Checked that related changes are merged.
