### PR TITLE
Prevent modification/deletion of rules belonging to a subscription

### DIFF
--- a/database/query/profiles.sql
+++ b/database/query/profiles.sql
@@ -5,8 +5,9 @@ INSERT INTO profiles (
     remediate,
     alert,
     name,
-    provider_id
-    ) VALUES ($1, $2, $3, $4, $5, sqlc.arg(provider_id)) RETURNING *;
+    provider_id,
+    subscription_id
+) VALUES ($1, $2, $3, $4, $5, sqlc.arg(provider_id), sqlc.narg(subscription_id)) RETURNING *;
 
 -- name: UpdateProfile :one
 UPDATE profiles SET

--- a/database/query/rule_types.sql
+++ b/database/query/rule_types.sql
@@ -7,8 +7,19 @@ INSERT INTO rule_type (
     guidance,
     definition,
     severity_value,
-    provider_id
-    ) VALUES ($1, $2, $3, $4, $5, sqlc.arg(definition)::jsonb, sqlc.arg(severity_value), sqlc.arg(provider_id)) RETURNING *;
+    provider_id,
+    subscription_id
+) VALUES (
+    $1,
+    $2,
+    $3,
+    $4,
+    $5,
+    sqlc.arg(definition)::jsonb,
+    sqlc.arg(severity_value),
+    sqlc.arg(provider_id),
+    sqlc.narg(subscription_id)
+) RETURNING *;
 
 -- name: ListRuleTypesByProviderAndProject :many
 SELECT * FROM rule_type WHERE provider = $1 AND project_id = $2;

--- a/internal/controlplane/handlers_profile.go
+++ b/internal/controlplane/handlers_profile.go
@@ -102,6 +102,13 @@ func (s *Server) DeleteProfile(ctx context.Context,
 		return nil, status.Errorf(codes.Internal, "failed to get profile: %s", err)
 	}
 
+	// TEMPORARY HACK: Since we do not need to support the deletion of bundle
+	// profile yet, reject deletion requests in the API
+	// TODO: Move this deletion logic to ProfileService
+	if profile.SubscriptionID.Valid {
+		return nil, status.Errorf(codes.InvalidArgument, "cannot delete profile from bundle")
+	}
+
 	err = s.store.DeleteProfile(ctx, db.DeleteProfileParams{
 		ID:        profile.ID,
 		ProjectID: entityCtx.Project.ID,
@@ -549,6 +556,13 @@ func (s *Server) PatchProfile(ctx context.Context, ppr *minderv1.PatchProfileReq
 			return nil, util.UserVisibleError(codes.NotFound, "profile not found")
 		}
 		return nil, status.Errorf(codes.Internal, "failed to get profile: %s", err)
+	}
+
+	// TEMPORARY HACK: Since we do not need to support this patch logic in the
+	// bundles yet, just reject any attempt to patch a profile from a bundle
+	// TODO: Move this patch logic to ProfileService
+	if oldProfile.SubscriptionID.Valid {
+		return nil, status.Errorf(codes.InvalidArgument, "cannot patch profile from bundle")
 	}
 
 	params := db.UpdateProfileParams{ID: profileID, ProjectID: entityCtx.Project.ID}

--- a/internal/controlplane/handlers_profile_test.go
+++ b/internal/controlplane/handlers_profile_test.go
@@ -268,7 +268,7 @@ func TestCreateProfile(t *testing.T) {
 				Name: "colon:invalid",
 			},
 		},
-		wantErr: `Couldn't create profile: validation failed: profile names may only contain letters, numbers, hyphens and underscores`,
+		wantErr: `Couldn't create profile: validation failed: name may only contain letters, numbers, hyphens and underscores`,
 	}, {
 		name: "Create profile with no rules",
 		profile: &minderv1.CreateProfileRequest{

--- a/internal/db/profiles.sql.go
+++ b/internal/db/profiles.sql.go
@@ -66,17 +66,19 @@ INSERT INTO profiles (
     remediate,
     alert,
     name,
-    provider_id
-    ) VALUES ($1, $2, $3, $4, $5, $6) RETURNING id, name, provider, project_id, remediate, alert, created_at, updated_at, provider_id, subscription_id
+    provider_id,
+    subscription_id
+) VALUES ($1, $2, $3, $4, $5, $6, $7) RETURNING id, name, provider, project_id, remediate, alert, created_at, updated_at, provider_id, subscription_id
 `
 
 type CreateProfileParams struct {
-	Provider   string         `json:"provider"`
-	ProjectID  uuid.UUID      `json:"project_id"`
-	Remediate  NullActionType `json:"remediate"`
-	Alert      NullActionType `json:"alert"`
-	Name       string         `json:"name"`
-	ProviderID uuid.UUID      `json:"provider_id"`
+	Provider       string         `json:"provider"`
+	ProjectID      uuid.UUID      `json:"project_id"`
+	Remediate      NullActionType `json:"remediate"`
+	Alert          NullActionType `json:"alert"`
+	Name           string         `json:"name"`
+	ProviderID     uuid.UUID      `json:"provider_id"`
+	SubscriptionID uuid.NullUUID  `json:"subscription_id"`
 }
 
 func (q *Queries) CreateProfile(ctx context.Context, arg CreateProfileParams) (Profile, error) {
@@ -87,6 +89,7 @@ func (q *Queries) CreateProfile(ctx context.Context, arg CreateProfileParams) (P
 		arg.Alert,
 		arg.Name,
 		arg.ProviderID,
+		arg.SubscriptionID,
 	)
 	var i Profile
 	err := row.Scan(

--- a/internal/db/rule_types.sql.go
+++ b/internal/db/rule_types.sql.go
@@ -21,19 +21,31 @@ INSERT INTO rule_type (
     guidance,
     definition,
     severity_value,
-    provider_id
-    ) VALUES ($1, $2, $3, $4, $5, $6::jsonb, $7, $8) RETURNING id, name, provider, project_id, description, guidance, definition, created_at, updated_at, severity_value, provider_id, subscription_id
+    provider_id,
+    subscription_id
+) VALUES (
+    $1,
+    $2,
+    $3,
+    $4,
+    $5,
+    $6::jsonb,
+    $7,
+    $8,
+    $9
+) RETURNING id, name, provider, project_id, description, guidance, definition, created_at, updated_at, severity_value, provider_id, subscription_id
 `
 
 type CreateRuleTypeParams struct {
-	Name          string          `json:"name"`
-	Provider      string          `json:"provider"`
-	ProjectID     uuid.UUID       `json:"project_id"`
-	Description   string          `json:"description"`
-	Guidance      string          `json:"guidance"`
-	Definition    json.RawMessage `json:"definition"`
-	SeverityValue Severity        `json:"severity_value"`
-	ProviderID    uuid.UUID       `json:"provider_id"`
+	Name           string          `json:"name"`
+	Provider       string          `json:"provider"`
+	ProjectID      uuid.UUID       `json:"project_id"`
+	Description    string          `json:"description"`
+	Guidance       string          `json:"guidance"`
+	Definition     json.RawMessage `json:"definition"`
+	SeverityValue  Severity        `json:"severity_value"`
+	ProviderID     uuid.UUID       `json:"provider_id"`
+	SubscriptionID uuid.NullUUID   `json:"subscription_id"`
 }
 
 func (q *Queries) CreateRuleType(ctx context.Context, arg CreateRuleTypeParams) (RuleType, error) {
@@ -46,6 +58,7 @@ func (q *Queries) CreateRuleType(ctx context.Context, arg CreateRuleTypeParams) 
 		arg.Definition,
 		arg.SeverityValue,
 		arg.ProviderID,
+		arg.SubscriptionID,
 	)
 	var i RuleType
 	err := row.Scan(

--- a/internal/marketplace/namespaces/validation.go
+++ b/internal/marketplace/namespaces/validation.go
@@ -1,0 +1,70 @@
+// Copyright 2024 Stacklok, Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package namespaces contains logic relating to the namespacing of Rule Types
+// and Profiles
+package namespaces
+
+import (
+	"errors"
+	"strings"
+
+	"github.com/google/uuid"
+)
+
+// these functions are tested through the tests for RuleTypeService
+
+// ValidateNamespacedNameRules takes a name for a new profile or rule type and
+// asserts that:
+// A) If the subscriptionID is empty, there name should not be namespaced
+// B) If subscriptionID is not empty, the name must be namespaced
+// This assumes the name has already been validated against the other
+// validation rules for profile and rule type names.
+func ValidateNamespacedNameRules(name string, subscriptionID uuid.UUID) error {
+	hasNamespace := strings.Contains(name, "/")
+	if hasNamespace && subscriptionID == uuid.Nil {
+		return errors.New("cannot create a rule type or profile with a namespace through the API")
+	} else if !hasNamespace && subscriptionID != uuid.Nil {
+		return errors.New("rule types and profiles from subscriptions must have namespaced names")
+	}
+
+	// in future, we may want to check that the namespace in the profile/rule
+	// name is the same as the one in the subscription bundle
+	return nil
+}
+
+// DoesSubscriptionIDMatch takes a subscription ID from the database, and
+// compares it with the subscriptionID parameter. It asserts that:
+// A) If the subscription ID from the DB is not null, that it is equal to
+//
+//	subscription ID.
+//
+// B) If the subscription ID from the DB is null, the subscriptionID parameter
+//
+//	must be equal to uuid.Nil
+//
+// This logic is intended to check if the subscription ID associated with a
+// rule type or profile matches a given subscription ID.
+func DoesSubscriptionIDMatch(subscriptionID uuid.UUID, dbSubscriptionID uuid.NullUUID) error {
+	// In theory, we could include the subscription ID in the GetRuleType query
+	// but this would mean that we would not be able to differentiate between
+	// a row which does not exist, and this case where the subscription ID is
+	// wrong. This distinction is useful for error reporting purposes.
+	if dbSubscriptionID.Valid && dbSubscriptionID.UUID != subscriptionID {
+		return errors.New("attempted to edit a rule type or profile which belongs to a bundle")
+	} else if !dbSubscriptionID.Valid && subscriptionID != uuid.Nil {
+		return errors.New("attempted to edit a customer rule type or profile with bundle operation")
+	}
+	return nil
+}

--- a/internal/ruletypes/service_test.go
+++ b/internal/ruletypes/service_test.go
@@ -39,11 +39,12 @@ func TestRuleTypeService(t *testing.T) {
 	t.Parallel()
 
 	scenarios := []struct {
-		Name          string
-		RuleType      *pb.RuleType
-		DBSetup       dbf.DBMockBuilder
-		ExpectedError string
-		TestMethod    method
+		Name           string
+		RuleType       *pb.RuleType
+		DBSetup        dbf.DBMockBuilder
+		ExpectedError  string
+		TestMethod     method
+		SubscriptionID uuid.UUID
 	}{
 		{
 			Name:          "CreateRuleType rejects nil rule",
@@ -51,17 +52,45 @@ func TestRuleTypeService(t *testing.T) {
 			ExpectedError: ruletypes.ErrRuleTypeInvalid.Error(),
 			TestMethod:    create,
 		},
+		// TODO: these tests should live with the validator, not this service
 		{
-			Name:          "CreateRuleType rule with empty name",
+			Name:          "CreateRuleType rejects rule with empty name",
 			RuleType:      newRuleType(withBasicStructure, withRuleName("")),
 			ExpectedError: ruletypes.ErrRuleTypeInvalid.Error(),
 			TestMethod:    create,
 		},
 		{
-			Name:          "CreateRuleType rule with invalid  name",
+			Name:          "CreateRuleType rejects rule with invalid name",
 			RuleType:      newRuleType(withBasicStructure, withRuleName("I'm a little teapot")),
 			ExpectedError: ruletypes.ErrRuleTypeInvalid.Error(),
 			TestMethod:    create,
+		},
+		{
+			Name:          "CreateRuleType rejects rule with multiple slashes",
+			RuleType:      newRuleType(withBasicStructure, withRuleName("I'm a little teapot")),
+			ExpectedError: ruletypes.ErrRuleTypeInvalid.Error(),
+			TestMethod:    create,
+		},
+		{
+			Name:          "CreateRuleType rejects rule where part of a namespaced name is invalid",
+			RuleType:      newRuleType(withBasicStructure, withRuleName("validnamespace/I'm a little teapot")),
+			ExpectedError: ruletypes.ErrRuleTypeInvalid.Error(),
+			TestMethod:    create,
+		},
+		{
+			Name:          "CreateRuleType rejects attempt to create a namespaced rule",
+			RuleType:      newRuleType(withBasicStructure, withRuleName(namespacedRuleName)),
+			ExpectedError: "cannot create a rule type or profile with a namespace through the API",
+			DBSetup:       dbf.NewDBMock(),
+			TestMethod:    create,
+		},
+		{
+			Name:           "CreateSubscriptionRuleType rejects attempt to create a non-namespaced rule",
+			RuleType:       newRuleType(withBasicStructure),
+			ExpectedError:  "rule types and profiles from subscriptions must have namespaced names",
+			DBSetup:        dbf.NewDBMock(),
+			SubscriptionID: subscriptionID,
+			TestMethod:     create,
 		},
 		{
 			Name:          "CreateRuleType rejects attempt to overwrite an existing rule",
@@ -91,6 +120,13 @@ func TestRuleTypeService(t *testing.T) {
 			TestMethod: create,
 		},
 		{
+			Name:           "CreateRuleType successfully creates a new namespaced rule type",
+			RuleType:       newRuleType(withBasicStructure, withRuleName(namespacedRuleName)),
+			DBSetup:        dbf.NewDBMock(withNotFoundGet, withSuccessfulNamespaceCreate),
+			SubscriptionID: subscriptionID,
+			TestMethod:     create,
+		},
+		{
 			Name:          "UpdateRuleType rejects malformed rule",
 			RuleType:      newRuleType(),
 			ExpectedError: ruletypes.ErrRuleTypeInvalid.Error(),
@@ -109,6 +145,29 @@ func TestRuleTypeService(t *testing.T) {
 			ExpectedError: "failed to get rule type",
 			DBSetup:       dbf.NewDBMock(withFailedGet),
 			TestMethod:    update,
+		},
+		{
+			Name:          "UpdateRuleType rejects attempt to update a rule type from a bundle",
+			RuleType:      newRuleType(withBasicStructure, withRuleName(namespacedRuleName)),
+			ExpectedError: "attempted to edit a rule type or profile which belongs to a bundle",
+			DBSetup:       dbf.NewDBMock(withSuccessfulNamespaceGet),
+			TestMethod:    update,
+		},
+		{
+			Name:           "UpdateSubscriptionRuleType rejects attempt to another subscription's rule types",
+			RuleType:       newRuleType(withBasicStructure, withRuleName(namespacedRuleName)),
+			ExpectedError:  "attempted to edit a rule type or profile which belongs to a bundle",
+			DBSetup:        dbf.NewDBMock(withSuccessfulNamespaceGet),
+			SubscriptionID: uuid.New(),
+			TestMethod:     update,
+		},
+		{
+			Name:           "UpdateSubscriptionRuleType rejects attempt to update a customer rule",
+			RuleType:       newRuleType(withBasicStructure),
+			ExpectedError:  "attempted to edit a customer rule type or profile with bundle operation",
+			DBSetup:        dbf.NewDBMock(withSuccessfulGet),
+			SubscriptionID: subscriptionID,
+			TestMethod:     update,
 		},
 		{
 			Name:          "UpdateRuleType rejects update with incompatible rule schema",
@@ -137,6 +196,13 @@ func TestRuleTypeService(t *testing.T) {
 			DBSetup:    dbf.NewDBMock(withSuccessfulGet, withSuccessfulUpdate),
 			TestMethod: update,
 		},
+		{
+			Name:           "UpdateSubscriptionRuleType successfully updates an existing rule",
+			RuleType:       newRuleType(withBasicStructure),
+			DBSetup:        dbf.NewDBMock(withSuccessfulNamespaceGet, withSuccessfulUpdate),
+			TestMethod:     update,
+			SubscriptionID: subscriptionID,
+		},
 	}
 
 	for i := range scenarios {
@@ -156,9 +222,29 @@ func TestRuleTypeService(t *testing.T) {
 			var res *pb.RuleType
 			svc := ruletypes.NewRuleTypeService(store)
 			if scenario.TestMethod == create {
-				res, err = svc.CreateRuleType(ctx, projectID, provider, scenario.RuleType)
+				if scenario.SubscriptionID != uuid.Nil {
+					res, err = svc.CreateSubscriptionRuleType(
+						ctx,
+						projectID,
+						&provider,
+						scenario.SubscriptionID,
+						scenario.RuleType,
+					)
+				} else {
+					res, err = svc.CreateRuleType(ctx, projectID, &provider, scenario.RuleType)
+				}
 			} else if scenario.TestMethod == update {
-				res, err = svc.UpdateRuleType(ctx, projectID, provider, scenario.RuleType)
+				if scenario.SubscriptionID != uuid.Nil {
+					res, err = svc.UpdateSubscriptionRuleType(
+						ctx,
+						projectID,
+						&provider,
+						scenario.SubscriptionID,
+						scenario.RuleType,
+					)
+				} else {
+					res, err = svc.UpdateRuleType(ctx, projectID, &provider, scenario.RuleType)
+				}
 			} else {
 				t.Fatal("unexpected method value")
 			}
@@ -166,11 +252,11 @@ func TestRuleTypeService(t *testing.T) {
 			if scenario.ExpectedError == "" {
 				// due to the presence of autogenerated UUIDs and timestamps,
 				// limit our assertions to the subset we deliberately set
+				require.Nil(t, err)
 				require.Equal(t, scenario.RuleType.Id, res.Id)
 				require.Equal(t, scenario.RuleType.Description, res.Description)
 				require.Equal(t, scenario.RuleType.Name, res.Name)
 				require.Equal(t, scenario.RuleType.Severity.Value, res.Severity.Value)
-				require.Nil(t, err)
 			} else {
 				require.Nil(t, res)
 				require.ErrorContains(t, err, scenario.ExpectedError)
@@ -184,32 +270,25 @@ type method int
 const (
 	create method = iota
 	update
-	ruleName    = "rule_type"
-	description = "this is my awesome rule"
+	ruleName           = "rule_type"
+	namespacedRuleName = "namespace/rule_type"
+	description        = "this is my awesome rule"
 )
 
 var (
-	ruleTypeID = uuid.New()
-	projectID  = uuid.New()
-	provider   = db.Provider{
+	ruleTypeID     = uuid.New()
+	projectID      = uuid.New()
+	subscriptionID = uuid.New()
+	provider       = db.Provider{
 		ID:   uuid.New(),
 		Name: oauth.Github,
 	}
-	errDefault  = errors.New("oh no")
-	oldRuleType = db.RuleType{
-		ID:            ruleTypeID,
-		Name:          ruleName,
-		Definition:    []byte(`{}`),
-		SeverityValue: "low",
-	}
-	expectation = db.RuleType{
-		ID:            ruleTypeID,
-		Name:          ruleName,
-		Definition:    []byte(`{}`),
-		SeverityValue: "high",
-		Description:   description,
-	}
-	incompatibleSchema = &structpb.Struct{
+	errDefault            = errors.New("oh no")
+	oldRuleType           = newDBRuleType("low", uuid.Nil)
+	namespacedOldRuleType = newDBRuleType("low", subscriptionID)
+	expectation           = newDBRuleType("high", uuid.Nil)
+	namespacedExpectation = newDBRuleType("high", subscriptionID)
+	incompatibleSchema    = &structpb.Struct{
 		Fields: map[string]*structpb.Value{
 			"required": {
 				Kind: &structpb.Value_StringValue{
@@ -261,6 +340,12 @@ func withSuccessfulGet(mock dbf.DBMock) {
 		Return(oldRuleType, nil)
 }
 
+func withSuccessfulNamespaceGet(mock dbf.DBMock) {
+	mock.EXPECT().
+		GetRuleTypeByName(gomock.Any(), gomock.Any()).
+		Return(namespacedOldRuleType, nil)
+}
+
 func withNotFoundGet(mock dbf.DBMock) {
 	mock.EXPECT().
 		GetRuleTypeByName(gomock.Any(), gomock.Any()).
@@ -279,6 +364,12 @@ func withSuccessfulCreate(mock dbf.DBMock) {
 		Return(expectation, nil)
 }
 
+func withSuccessfulNamespaceCreate(mock dbf.DBMock) {
+	mock.EXPECT().
+		CreateRuleType(gomock.Any(), gomock.Any()).
+		Return(namespacedExpectation, nil)
+}
+
 func withFailedCreate(mock dbf.DBMock) {
 	mock.EXPECT().
 		CreateRuleType(gomock.Any(), gomock.Any()).
@@ -295,4 +386,19 @@ func withFailedUpdate(mock dbf.DBMock) {
 	mock.EXPECT().
 		UpdateRuleType(gomock.Any(), gomock.Any()).
 		Return(db.RuleType{}, errDefault)
+}
+
+func newDBRuleType(severity db.Severity, subscriptionID uuid.UUID) db.RuleType {
+	name := ruleName
+	if subscriptionID != uuid.Nil {
+		name = namespacedRuleName
+	}
+	return db.RuleType{
+		ID:             ruleTypeID,
+		Name:           name,
+		Definition:     []byte(`{}`),
+		SeverityValue:  severity,
+		Description:    description,
+		SubscriptionID: uuid.NullUUID{Valid: subscriptionID != uuid.Nil, UUID: subscriptionID},
+	}
 }


### PR DESCRIPTION
# Summary

Relates to https://github.com/stacklok/minder/issues/2543

These methods ensure that it's not possible to create/update/delete
bundle/namespaced profiles or rule types through the API.

Dedicated methods are supplied for creating these entities with a
subscription ID. These methods will be called by the bundle
management code which will be implemented in a follow up PR.

Patch and delete methods which have not yet been migrated to the
respective service interfaces have been modified to prevent modification
of bundle rule types/profiles.

Rules
---

1. Rules and profiles belonging to bundles must have namespaced names.
2. A namespaced name consists of two DNS-like IDs separated by a slash
3. Rules and profiles which were created from a bundle have a foreign key reference back to the subscription they were created from.
4. It is not possible to create a rule/profile with a namespaced name through the API.
5. It is not possible to update or delete a profile/rule with a reference to a subscription through the API.

## Change Type

***Mark the type of change your PR introduces:***

- [ ] Bug fix (resolves an issue without affecting existing features)
- [x] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [ ] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

***Outline how the changes were tested, including steps to reproduce and any relevant configurations. 
Attach screenshots if helpful.***

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [x] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [x] Included tests that validate the fix or feature.
- [x] Checked that related changes are merged.
