### PR TITLE
Minder resource names should be case-insensitive

### DIFF
--- a/database/migrations/000031_case_insensitive_names.down.sql
+++ b/database/migrations/000031_case_insensitive_names.down.sql
@@ -1,0 +1,37 @@
+-- Copyright 2024 Stacklok, Inc
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--      http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+DROP INDEX bundles_namespace_name_lower_idx;
+
+CREATE UNIQUE INDEX IF NOT EXISTS features_name_idx ON features (name);
+DROP INDEX features_name_lower_idx;
+
+CREATE UNIQUE INDEX IF NOT EXISTS rule_evaluations_results_idx
+  ON rule_evaluations (profile_id, repository_id, COALESCE(artifact_id, '00000000-0000-0000-0000-000000000000'::UUID),
+                       entity, rule_type_id, COALESCE(pull_request_id, '00000000-0000-0000-0000-000000000000'::UUID),
+                       rule_name) NULLS NOT DISTINCT;
+DROP INDEX rule_evaluations_results_name_lower_idx;
+
+DROP INDEX rule_type_project_name_idx;
+
+CREATE UNIQUE INDEX IF NOT EXISTS profiles_project_id_name_idx ON profiles (project_id, name);
+DROP INDEX profiles_project_name_lower_idx;
+
+CREATE UNIQUE INDEX IF NOT EXISTS provider_name_project_id_idx ON providers (name, project_id);
+DROP INDEX providers_project_name_lower_idx;
+
+CREATE UNIQUE INDEX IF NOT EXISTS projects_parent_id_name_idx ON projects (parent_id, name) WHERE parent_id IS NOT NULL;
+DROP INDEX projects_parent_id_name_lower_idx;
+CREATE UNIQUE INDEX IF NOT EXISTS projects_name_idx ON projects (name) WHERE parent_id IS NULL;
+DROP INDEX project_name_lower_idx;

--- a/database/migrations/000031_case_insensitive_names.up.sql
+++ b/database/migrations/000031_case_insensitive_names.up.sql
@@ -1,0 +1,51 @@
+-- Copyright 2024 Stacklok, Inc
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--      http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+-- We want case-insensitive-but-preserving names, in general.  The first step
+-- is to replace UNIQUE indexes on names with UNIQUE indexes on lower(name).
+
+CREATE UNIQUE INDEX project_name_lower_idx ON projects (lower(name)) WHERE parent_id IS NULL;
+DROP INDEX IF EXISTS projects_name_idx;
+CREATE UNIQUE INDEX projects_parent_id_name_lower_idx ON projects (parent_id, lower(name)) WHERE parent_id IS NOT NULL;
+DROP INDEX IF EXISTS projects_parent_id_name_idx;
+
+CREATE UNIQUE INDEX providers_project_name_lower_idx ON providers (project_id, lower(name));
+DROP INDEX IF EXISTS provider_name_project_id_idx;
+
+CREATE UNIQUE INDEX profiles_project_name_lower_idx ON profiles (project_id, lower(name));
+DROP INDEX IF EXISTS profiles_project_id_name_idx;
+
+CREATE UNIQUE INDEX rule_type_project_name_idx ON rule_type (project_id, lower(name));
+-- We have an existing index on (provider, project_id, name) that we're not
+-- going to remove yet, but we want detach rules from specific providers in
+-- a future PR, and will delete that index then.
+
+-- artifact_name_lower_idx already exists and enforces unique lowercase names
+-- on artifacts for a given repo.
+
+CREATE UNIQUE INDEX rule_evaluations_results_name_lower_idx ON rule_evaluations
+    (
+        profile_id, lower(rule_name), repository_id, 
+        COALESCE(artifact_id, '00000000-0000-0000-0000-000000000000'::UUID),
+        entity, rule_type_id,
+        COALESCE(pull_request_id, '00000000-0000-0000-0000-000000000000'::UUID)
+    ) NULLS NOT DISTINCT;
+DROP INDEX IF EXISTS rule_evaluations_results_idx;
+
+-- features name is a primary key, add a unique index on lower(name), other tables
+-- have a foreign key to features, so we need to keep the primary key on name
+CREATE UNIQUE INDEX features_name_lower_idx ON features (lower(name));
+DROP INDEX features_name_idx;
+
+CREATE UNIQUE INDEX bundles_namespace_name_lower_idx ON bundles (lower(namespace), lower(name));

--- a/database/query/artifacts.sql
+++ b/database/query/artifacts.sql
@@ -31,7 +31,7 @@ SELECT artifacts.id, artifacts.repository_id, artifacts.artifact_name, artifacts
        artifacts.artifact_visibility, artifacts.created_at,
        repositories.provider, repositories.project_id, repositories.repo_owner, repositories.repo_name
 FROM artifacts INNER JOIN repositories ON repositories.id = artifacts.repository_id
-WHERE artifacts.artifact_name = $1 AND artifacts.repository_id = $2;
+WHERE lower(artifacts.artifact_name) = lower(sqlc.arg(artifact_name)) AND artifacts.repository_id = $1;
 
 -- name: ListArtifactsByRepoID :many
 SELECT * FROM artifacts

--- a/database/query/profile_status.sql
+++ b/database/query/profile_status.sql
@@ -3,7 +3,7 @@
 INSERT INTO rule_evaluations (
     profile_id, repository_id, artifact_id, pull_request_id, rule_type_id, entity, rule_name
 ) VALUES ($1, $2, $3, $4, $5, $6, $7)
-ON CONFLICT (profile_id, repository_id, COALESCE(artifact_id, '00000000-0000-0000-0000-000000000000'::UUID), COALESCE(pull_request_id, '00000000-0000-0000-0000-000000000000'::UUID), entity, rule_type_id, rule_name)
+ON CONFLICT (profile_id, repository_id, COALESCE(artifact_id, '00000000-0000-0000-0000-000000000000'::UUID), COALESCE(pull_request_id, '00000000-0000-0000-0000-000000000000'::UUID), entity, rule_type_id, lower(rule_name))
   DO UPDATE SET profile_id = $1
 RETURNING id;
 
@@ -65,7 +65,7 @@ WHERE p.id = $1 AND p.project_id = $2;
 -- name: GetProfileStatusByNameAndProject :one
 SELECT p.id, p.name, ps.profile_status, ps.last_updated FROM profile_status ps
 INNER JOIN profiles p ON p.id = ps.profile_id
-WHERE p.name = $1 AND p.project_id = $2;
+WHERE lower(p.name) = lower(sqlc.arg(name)) AND p.project_id = $1;
 
 -- name: GetProfileStatusByProject :many
 SELECT p.id, p.name, ps.profile_status, ps.last_updated FROM profile_status ps
@@ -145,5 +145,5 @@ WHERE res.profile_id = $1 AND
             ELSE false
             END
         ) AND (rt.name = sqlc.narg(rule_type_name) OR sqlc.narg(rule_type_name) IS NULL)
-          AND (res.rule_name = sqlc.narg(rule_name) OR sqlc.narg(rule_name) IS NULL)
+          AND (lower(res.rule_name) = lower(sqlc.narg(rule_name)) OR sqlc.narg(rule_name) IS NULL)
 ;

--- a/database/query/profiles.sql
+++ b/database/query/profiles.sql
@@ -47,11 +47,11 @@ SELECT * FROM profiles WHERE id = $1 AND project_id = $2;
 SELECT * FROM profiles WHERE id = $1 AND project_id = $2 FOR UPDATE;
 
 -- name: GetProfileByNameAndLock :one
-SELECT * FROM profiles WHERE name = $1 AND project_id = $2 FOR UPDATE;
+SELECT * FROM profiles WHERE lower(name) = lower(sqlc.arg(name)) AND project_id = $1 FOR UPDATE;
 
 -- name: GetEntityProfileByProjectAndName :many
 SELECT * FROM profiles JOIN entity_profiles ON profiles.id = entity_profiles.profile_id
-WHERE profiles.project_id = $1 AND profiles.name = $2;
+WHERE profiles.project_id = $1 AND lower(profiles.name) = lower(sqlc.arg(name));
 
 -- name: ListProfilesByProjectID :many
 SELECT * FROM profiles JOIN entity_profiles ON profiles.id = entity_profiles.profile_id
@@ -87,4 +87,4 @@ FROM profiles AS p
 GROUP BY ep.entity;
 
 -- name: CountProfilesByName :one
-SELECT COUNT(*) AS num_named_profiles FROM profiles WHERE name = $1;
+SELECT COUNT(*) AS num_named_profiles FROM profiles WHERE lower(name) = lower(sqlc.arg(name));

--- a/database/query/projects.sql
+++ b/database/query/projects.sql
@@ -22,7 +22,7 @@ WHERE id = $1 AND is_organization = FALSE LIMIT 1;
 
 -- name: GetProjectByName :one
 SELECT * FROM projects
-WHERE name = $1 AND is_organization = FALSE LIMIT 1;
+WHERE lower(name) = lower(sqlc.arg(name)) AND is_organization = FALSE LIMIT 1;
 
 -- name: GetParentProjects :many
 WITH RECURSIVE get_parents AS (

--- a/database/query/providers.sql
+++ b/database/query/providers.sql
@@ -13,7 +13,7 @@ INSERT INTO providers (
 -- provider that matches the name.
 
 -- name: GetProviderByName :one
-SELECT * FROM providers WHERE name = $1 AND project_id = ANY(sqlc.arg(projects)::uuid[])
+SELECT * FROM providers WHERE lower(name) = lower(sqlc.arg(name)) AND project_id = ANY(sqlc.arg(projects)::uuid[])
 LIMIT 1;
 
 -- name: GetProviderByID :one
@@ -40,7 +40,7 @@ LIMIT sqlc.arg('limit');
 SELECT * FROM providers;
 
 -- name: GlobalListProvidersByName :many
-SELECT * FROM providers WHERE name = $1;
+SELECT * FROM providers WHERE lower(name) = lower(sqlc.arg(name));
 
 -- name: UpdateProvider :exec
 UPDATE providers

--- a/database/query/rule_types.sql
+++ b/database/query/rule_types.sql
@@ -17,7 +17,7 @@ SELECT * FROM rule_type WHERE provider = $1 AND project_id = $2;
 SELECT * FROM rule_type WHERE id = $1;
 
 -- name: GetRuleTypeByName :one
-SELECT * FROM rule_type WHERE provider = $1 AND project_id = $2 AND name = $3;
+SELECT * FROM rule_type WHERE provider = $1 AND project_id = $2 AND lower(name) = lower(sqlc.arg(name));
 
 -- name: DeleteRuleType :exec
 DELETE FROM rule_type WHERE id = $1;

--- a/internal/db/artifacts.sql.go
+++ b/internal/db/artifacts.sql.go
@@ -101,12 +101,12 @@ SELECT artifacts.id, artifacts.repository_id, artifacts.artifact_name, artifacts
        artifacts.artifact_visibility, artifacts.created_at,
        repositories.provider, repositories.project_id, repositories.repo_owner, repositories.repo_name
 FROM artifacts INNER JOIN repositories ON repositories.id = artifacts.repository_id
-WHERE artifacts.artifact_name = $1 AND artifacts.repository_id = $2
+WHERE lower(artifacts.artifact_name) = lower($2) AND artifacts.repository_id = $1
 `
 
 type GetArtifactByNameParams struct {
-	ArtifactName string    `json:"artifact_name"`
 	RepositoryID uuid.UUID `json:"repository_id"`
+	ArtifactName string    `json:"artifact_name"`
 }
 
 type GetArtifactByNameRow struct {
@@ -123,7 +123,7 @@ type GetArtifactByNameRow struct {
 }
 
 func (q *Queries) GetArtifactByName(ctx context.Context, arg GetArtifactByNameParams) (GetArtifactByNameRow, error) {
-	row := q.db.QueryRowContext(ctx, getArtifactByName, arg.ArtifactName, arg.RepositoryID)
+	row := q.db.QueryRowContext(ctx, getArtifactByName, arg.RepositoryID, arg.ArtifactName)
 	var i GetArtifactByNameRow
 	err := row.Scan(
 		&i.ID,

--- a/internal/db/projects.sql.go
+++ b/internal/db/projects.sql.go
@@ -290,7 +290,7 @@ func (q *Queries) GetProjectByID(ctx context.Context, id uuid.UUID) (Project, er
 
 const getProjectByName = `-- name: GetProjectByName :one
 SELECT id, name, is_organization, metadata, parent_id, created_at, updated_at FROM projects
-WHERE name = $1 AND is_organization = FALSE LIMIT 1
+WHERE lower(name) = lower($1) AND is_organization = FALSE LIMIT 1
 `
 
 func (q *Queries) GetProjectByName(ctx context.Context, name string) (Project, error) {

--- a/internal/db/providers.sql.go
+++ b/internal/db/providers.sql.go
@@ -92,7 +92,7 @@ func (q *Queries) GetProviderByID(ctx context.Context, id uuid.UUID) (Provider, 
 
 const getProviderByName = `-- name: GetProviderByName :one
 
-SELECT id, name, version, project_id, implements, definition, created_at, updated_at, auth_flows FROM providers WHERE name = $1 AND project_id = ANY($2::uuid[])
+SELECT id, name, version, project_id, implements, definition, created_at, updated_at, auth_flows FROM providers WHERE lower(name) = lower($1) AND project_id = ANY($2::uuid[])
 LIMIT 1
 `
 
@@ -160,7 +160,7 @@ func (q *Queries) GlobalListProviders(ctx context.Context) ([]Provider, error) {
 }
 
 const globalListProvidersByName = `-- name: GlobalListProvidersByName :many
-SELECT id, name, version, project_id, implements, definition, created_at, updated_at, auth_flows FROM providers WHERE name = $1
+SELECT id, name, version, project_id, implements, definition, created_at, updated_at, auth_flows FROM providers WHERE lower(name) = lower($1)
 `
 
 func (q *Queries) GlobalListProvidersByName(ctx context.Context, name string) ([]Provider, error) {

--- a/internal/db/rule_types.sql.go
+++ b/internal/db/rule_types.sql.go
@@ -99,7 +99,7 @@ func (q *Queries) GetRuleTypeByID(ctx context.Context, id uuid.UUID) (RuleType, 
 }
 
 const getRuleTypeByName = `-- name: GetRuleTypeByName :one
-SELECT id, name, provider, project_id, description, guidance, definition, created_at, updated_at, severity_value, provider_id, subscription_id FROM rule_type WHERE provider = $1 AND project_id = $2 AND name = $3
+SELECT id, name, provider, project_id, description, guidance, definition, created_at, updated_at, severity_value, provider_id, subscription_id FROM rule_type WHERE provider = $1 AND project_id = $2 AND lower(name) = lower($3)
 `
 
 type GetRuleTypeByNameParams struct {


### PR DESCRIPTION
# Summary

Fixes #2682

Per discussion elsewhere today, it was noticed that most of our names are stored as TEXT with exact-match UNIQUE indexes.  It's potentially confusing to be able to have both `Important-rule` and `important-rule` in the same project, so we should switch the indexes to case-insensitive on the `name`.

## Change Type

***Mark the type of change your PR introduces:***

- [x] Bug fix (resolves an issue without affecting existing features)
- [ ] Feature (adds new functionality without breaking changes)
- [x] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [ ] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

`go test ./...` plus manual testing attempting to register a rule named `codeql_enabled` and `CodeQL_Enabled`.

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [x] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [x] Included tests that validate the fix or feature.
- [x] Checked that related changes are merged.
