### PR TITLE
Use the Login field as the user name, not Username

### DIFF
--- a/internal/providers/github/github_rest.go
+++ b/internal/providers/github/github_rest.go
@@ -673,6 +673,15 @@ func (c *GitHub) GetUsername(ctx context.Context) (string, error) {
 	return user.GetName(), nil
 }
 
+// GetLogin returns the login for the authenticated user
+func (c *GitHub) GetLogin(ctx context.Context) (string, error) {
+	user, _, err := c.client.Users.Get(ctx, "")
+	if err != nil {
+		return "", err
+	}
+	return user.GetLogin(), nil
+}
+
 // GetPrimaryEmail returns the primary email for the authenticated user.
 func (c *GitHub) GetPrimaryEmail(ctx context.Context) (string, error) {
 	emails, _, err := c.client.Users.ListEmails(ctx, &github.ListOptions{})
@@ -701,11 +710,11 @@ func (c *GitHub) Clone(ctx context.Context, cloneUrl string, branch string) (*gi
 
 // AddAuthToPushOptions adds authorization to the push options
 func (c *GitHub) AddAuthToPushOptions(ctx context.Context, pushOptions *git.PushOptions) error {
-	username, err := c.GetUsername(ctx)
+	login, err := c.GetLogin(ctx)
 	if err != nil {
-		return fmt.Errorf("cannot get username: %w", err)
+		return fmt.Errorf("cannot get login: %w", err)
 	}
-	c.credential.AddToPushOptions(pushOptions, username)
+	c.credential.AddToPushOptions(pushOptions, login)
 	return nil
 }
 


### PR DESCRIPTION
# Summary

Apparently the Username in github is optional and different from the
Login field. We should use the login field to prevent authentication
issues e.g. when opening pull requests.

Fixes: https://github.com/stacklok/epics/issues/252


## Change Type

***Mark the type of change your PR introduces:***

- [x] Bug fix (resolves an issue without affecting existing features)
- [ ] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [ ] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

local testing with the stackloktest account

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [ ] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [ ] Included tests that validate the fix or feature.
- [ ] Checked that related changes are merged.
