### PR TITLE
Rename GetUsername to GetName, use GetLogin as fallback when opening a PR

### DIFF
--- a/internal/controlplane/handlers_repositories_test.go
+++ b/internal/controlplane/handlers_repositories_test.go
@@ -649,7 +649,12 @@ func (s *StubGitHub) GetUserId(context.Context) (int64, error) {
 }
 
 // GetUsername implements v1.GitHub.
-func (*StubGitHub) GetUsername(context.Context) (string, error) {
+func (*StubGitHub) GetName(context.Context) (string, error) {
+	panic("unimplemented")
+}
+
+// GetLogin implements v1.GitHub.
+func (*StubGitHub) GetLogin(context.Context) (string, error) {
 	panic("unimplemented")
 }
 

--- a/internal/engine/actions/remediate/pull_request/pull_request_test.go
+++ b/internal/engine/actions/remediate/pull_request/pull_request_test.go
@@ -198,7 +198,7 @@ func happyPathMockSetup(mockGitHub *mock_ghclient.MockGitHub) {
 	mockGitHub.EXPECT().
 		ListPullRequests(gomock.Any(), repoOwner, repoName, gomock.Any()).Return([]*github.PullRequest{}, nil)
 	mockGitHub.EXPECT().
-		GetUsername(gomock.Any()).Return("stacklok-bot", nil)
+		GetName(gomock.Any()).Return("stacklok-bot", nil)
 	mockGitHub.EXPECT().
 		GetPrimaryEmail(gomock.Any()).Return("test@stacklok.com", nil)
 	mockGitHub.EXPECT().
@@ -461,7 +461,7 @@ func TestPullRequestRemediate(t *testing.T) {
 					ListPullRequests(gomock.Any(), repoOwner, repoName, gomock.Any()).Return([]*github.PullRequest{}, nil)
 				// we need to get the user information and update the branch
 				mockGitHub.EXPECT().
-					GetUsername(gomock.Any()).Return("stacklok-bot", nil)
+					GetName(gomock.Any()).Return("stacklok-bot", nil)
 				// likewise we need to update the branch with a valid e-mail
 				mockGitHub.EXPECT().
 					GetPrimaryEmail(gomock.Any()).Return("test@stacklok.com", nil)

--- a/internal/providers/github/github_rest.go
+++ b/internal/providers/github/github_rest.go
@@ -664,8 +664,8 @@ func (c *GitHub) GetUserId(ctx context.Context) (int64, error) {
 	return user.GetID(), nil
 }
 
-// GetUsername returns the username for the authenticated user
-func (c *GitHub) GetUsername(ctx context.Context) (string, error) {
+// GetName returns the username for the authenticated user
+func (c *GitHub) GetName(ctx context.Context) (string, error) {
 	user, _, err := c.client.Users.Get(ctx, "")
 	if err != nil {
 		return "", err

--- a/internal/providers/github/mock/github.go
+++ b/internal/providers/github/mock/github.go
@@ -431,6 +431,36 @@ func (mr *MockGitHubMockRecorder) GetCredential() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCredential", reflect.TypeOf((*MockGitHub)(nil).GetCredential))
 }
 
+// GetLogin mocks base method.
+func (m *MockGitHub) GetLogin(ctx context.Context) (string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetLogin", ctx)
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetLogin indicates an expected call of GetLogin.
+func (mr *MockGitHubMockRecorder) GetLogin(ctx any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetLogin", reflect.TypeOf((*MockGitHub)(nil).GetLogin), ctx)
+}
+
+// GetName mocks base method.
+func (m *MockGitHub) GetName(ctx context.Context) (string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetName", ctx)
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetName indicates an expected call of GetName.
+func (mr *MockGitHubMockRecorder) GetName(ctx any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetName", reflect.TypeOf((*MockGitHub)(nil).GetName), ctx)
+}
+
 // GetOwner mocks base method.
 func (m *MockGitHub) GetOwner() string {
 	m.ctrl.T.Helper()
@@ -563,21 +593,6 @@ func (m *MockGitHub) GetUserId(ctx context.Context) (int64, error) {
 func (mr *MockGitHubMockRecorder) GetUserId(ctx any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetUserId", reflect.TypeOf((*MockGitHub)(nil).GetUserId), ctx)
-}
-
-// GetUsername mocks base method.
-func (m *MockGitHub) GetUsername(ctx context.Context) (string, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetUsername", ctx)
-	ret0, _ := ret[0].(string)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetUsername indicates an expected call of GetUsername.
-func (mr *MockGitHubMockRecorder) GetUsername(ctx any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetUsername", reflect.TypeOf((*MockGitHub)(nil).GetUsername), ctx)
 }
 
 // ListAllRepositories mocks base method.

--- a/pkg/providers/v1/providers.go
+++ b/pkg/providers/v1/providers.go
@@ -106,7 +106,8 @@ type GitHub interface {
 	CreatePullRequest(ctx context.Context, owner, repo, title, body, head, base string) (*github.PullRequest, error)
 	ListPullRequests(ctx context.Context, owner, repo string, opt *github.PullRequestListOptions) ([]*github.PullRequest, error)
 	GetUserId(ctx context.Context) (int64, error)
-	GetUsername(ctx context.Context) (string, error)
+	GetName(ctx context.Context) (string, error)
+	GetLogin(ctx context.Context) (string, error)
 	GetPrimaryEmail(ctx context.Context) (string, error)
 	CreateIssueComment(ctx context.Context, owner, repo string, number int, comment string) (*github.IssueComment, error)
 	ListIssueComments(ctx context.Context, owner, repo string, number int,


### PR DESCRIPTION
# Summary

A follow-up to an earlier commit, renames the confusing GetUsername
github interface method to GetName to convey better that it's just the
name. Since the name can be empty and we'd still like to use "something"
for the PRs as an identifier, we use the login as a fallback

Fixes #(related issue)

## Change Type

***Mark the type of change your PR introduces:***

- [ ] Bug fix (resolves an issue without affecting existing features)
- [ ] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [x] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

just manually

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [x] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [ ] Included tests that validate the fix or feature.
- [ ] Checked that related changes are merged.
