### PR TITLE
Add "public" metadata section in project's metadata and use it for display name

### DIFF
--- a/internal/projects/create.go
+++ b/internal/projects/create.go
@@ -39,7 +39,7 @@ func ProvisionSelfEnrolledProject(
 	projectName string,
 	userSub string,
 ) (outproj *pb.Project, projerr error) {
-	projectmeta := NewSelfEnrolledMetadata()
+	projectmeta := NewSelfEnrolledMetadata(projectName)
 
 	jsonmeta, err := json.Marshal(&projectmeta)
 	if err != nil {
@@ -76,7 +76,8 @@ func ProvisionSelfEnrolledProject(
 	prj := pb.Project{
 		ProjectId:   project.ID.String(),
 		Name:        project.Name,
-		Description: projectmeta.Description,
+		Description: projectmeta.Public.Description,
+		DisplayName: projectmeta.Public.DisplayName,
 		CreatedAt:   timestamppb.New(project.CreatedAt),
 		UpdatedAt:   timestamppb.New(project.UpdatedAt),
 	}

--- a/internal/projects/meta.go
+++ b/internal/projects/meta.go
@@ -16,6 +16,12 @@
 // Package projects contains utilities for working with projects.
 package projects
 
+import (
+	"encoding/json"
+
+	"github.com/stacklok/minder/internal/db"
+)
+
 const (
 	// MinderMetadataVersion is the version of the metadata format.
 	MinderMetadataVersion = "v1alpha1"
@@ -25,16 +31,48 @@ const (
 type Metadata struct {
 	Version      string `json:"version"`
 	SelfEnrolled bool   `json:"self_enrolled"`
-	Description  string `json:"description"`
+
+	// This will be deprecated in favor of PublicMetadataV1.
+	Description string `json:"description"`
 
 	// TODO: Add more metadata fields here.
 	// e.g. vendor-specific fields
+
+	// Public is a field that is meant to be read by other systems.
+	// It will be exposed to the public, e.g. via a UI.
+	Public PublicMetadataV1 `json:"public"`
+}
+
+// PublicMetadataV1 contains public metadata relevant for a project.
+type PublicMetadataV1 struct {
+	Description string `json:"description"`
+	DisplayName string `json:"display_name"`
 }
 
 // NewSelfEnrolledMetadata returns a new Metadata object with the SelfEnrolled field set to true.
-func NewSelfEnrolledMetadata() Metadata {
+func NewSelfEnrolledMetadata(projectName string) Metadata {
 	return Metadata{
 		Version:      MinderMetadataVersion,
 		SelfEnrolled: true,
+		// These will be editable by the user.
+		Public: PublicMetadataV1{
+			Description: "A self-enrolled project.",
+			DisplayName: projectName,
+		},
 	}
+}
+
+// ParseMetadata parses the given JSON data into a Metadata object.
+func ParseMetadata(proj *db.Project) (*Metadata, error) {
+	var meta Metadata
+	if err := json.Unmarshal(proj.Metadata, &meta); err != nil {
+		return nil, err
+	}
+
+	// default the display name to the project name if it's not set
+	if meta.Public.DisplayName == "" {
+		meta.Public.DisplayName = proj.Name
+	}
+
+	return &meta, nil
 }


### PR DESCRIPTION
# Summary

This adds a `public` metadata key in the project's metadata. This will hold whatever is fine
to display for the project in an API/UI. The first two instances added there are the description
(previously unused) and the "display name".

The display name is always displayed and defaulted to the project's name. It is also defaulted
in all new projects.

It should show up as follows:

```
$ minder project list -o json
WARNING: Running against a test environment (127.0.0.1) and may not be stable
{
  "projects": [
    {
      "projectId": "73460926-70c3-4d7d-bf34-1c224a1ec4d4",
      "name": "jaormx",
      "createdAt": "2024-03-18T16:18:19.521054Z",
      "updatedAt": "2024-03-18T16:18:19.521054Z",
      "displayName": "jaormx"
    }
  ]
}
```

Adding the ability to update a project will come in a subsequent PR.

## Change Type

***Mark the type of change your PR introduces:***

- [ ] Bug fix (resolves an issue without affecting existing features)
- [x] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [ ] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

***Outline how the changes were tested, including steps to reproduce and any relevant configurations. 
Attach screenshots if helpful.***

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [x] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [ ] Included tests that validate the fix or feature.
- [ ] Checked that related changes are merged.
