### PR TITLE
Add the ruletype severity when returning the list of evaluations

### DIFF
--- a/database/query/profile_status.sql
+++ b/database/query/profile_status.sql
@@ -128,6 +128,7 @@ SELECT
     repo.repo_owner,
     repo.provider,
     rt.name AS rule_type_name,
+    rt.severity_value as rule_type_severity_value,
     rt.id AS rule_type_id,
     rt.guidance as rule_type_guidance
 FROM rule_evaluations res

--- a/internal/controlplane/handlers_evalstatus.go
+++ b/internal/controlplane/handlers_evalstatus.go
@@ -280,6 +280,7 @@ func buildRuleEvaluationStatusFromDBEvaluation(
 
 	return &minderv1.RuleEvaluationStatus{
 		RuleEvaluationId:       eval.RuleEvaluationID.String(),
+		RuleId:                 eval.RuleTypeID.String(),
 		ProfileId:              profile.ID.String(),
 		RuleName:               eval.RuleName,
 		Entity:                 string(eval.Entity),

--- a/internal/db/profile_status.sql.go
+++ b/internal/db/profile_status.sql.go
@@ -184,6 +184,7 @@ SELECT
     repo.repo_owner,
     repo.provider,
     rt.name AS rule_type_name,
+    rt.severity_value as rule_type_severity_value,
     rt.id AS rule_type_id,
     rt.guidance as rule_type_guidance
 FROM rule_evaluations res
@@ -215,26 +216,27 @@ type ListRuleEvaluationsByProfileIdParams struct {
 }
 
 type ListRuleEvaluationsByProfileIdRow struct {
-	EvalStatus       NullEvalStatusTypes        `json:"eval_status"`
-	EvalLastUpdated  sql.NullTime               `json:"eval_last_updated"`
-	EvalDetails      sql.NullString             `json:"eval_details"`
-	RemStatus        NullRemediationStatusTypes `json:"rem_status"`
-	RemDetails       sql.NullString             `json:"rem_details"`
-	RemLastUpdated   sql.NullTime               `json:"rem_last_updated"`
-	AlertStatus      NullAlertStatusTypes       `json:"alert_status"`
-	AlertDetails     sql.NullString             `json:"alert_details"`
-	AlertMetadata    pqtype.NullRawMessage      `json:"alert_metadata"`
-	AlertLastUpdated sql.NullTime               `json:"alert_last_updated"`
-	RuleEvaluationID uuid.UUID                  `json:"rule_evaluation_id"`
-	RepositoryID     uuid.NullUUID              `json:"repository_id"`
-	Entity           Entities                   `json:"entity"`
-	RuleName         string                     `json:"rule_name"`
-	RepoName         string                     `json:"repo_name"`
-	RepoOwner        string                     `json:"repo_owner"`
-	Provider         string                     `json:"provider"`
-	RuleTypeName     string                     `json:"rule_type_name"`
-	RuleTypeID       uuid.UUID                  `json:"rule_type_id"`
-	RuleTypeGuidance string                     `json:"rule_type_guidance"`
+	EvalStatus            NullEvalStatusTypes        `json:"eval_status"`
+	EvalLastUpdated       sql.NullTime               `json:"eval_last_updated"`
+	EvalDetails           sql.NullString             `json:"eval_details"`
+	RemStatus             NullRemediationStatusTypes `json:"rem_status"`
+	RemDetails            sql.NullString             `json:"rem_details"`
+	RemLastUpdated        sql.NullTime               `json:"rem_last_updated"`
+	AlertStatus           NullAlertStatusTypes       `json:"alert_status"`
+	AlertDetails          sql.NullString             `json:"alert_details"`
+	AlertMetadata         pqtype.NullRawMessage      `json:"alert_metadata"`
+	AlertLastUpdated      sql.NullTime               `json:"alert_last_updated"`
+	RuleEvaluationID      uuid.UUID                  `json:"rule_evaluation_id"`
+	RepositoryID          uuid.NullUUID              `json:"repository_id"`
+	Entity                Entities                   `json:"entity"`
+	RuleName              string                     `json:"rule_name"`
+	RepoName              string                     `json:"repo_name"`
+	RepoOwner             string                     `json:"repo_owner"`
+	Provider              string                     `json:"provider"`
+	RuleTypeName          string                     `json:"rule_type_name"`
+	RuleTypeSeverityValue Severity                   `json:"rule_type_severity_value"`
+	RuleTypeID            uuid.UUID                  `json:"rule_type_id"`
+	RuleTypeGuidance      string                     `json:"rule_type_guidance"`
 }
 
 func (q *Queries) ListRuleEvaluationsByProfileId(ctx context.Context, arg ListRuleEvaluationsByProfileIdParams) ([]ListRuleEvaluationsByProfileIdRow, error) {
@@ -271,6 +273,7 @@ func (q *Queries) ListRuleEvaluationsByProfileId(ctx context.Context, arg ListRu
 			&i.RepoOwner,
 			&i.Provider,
 			&i.RuleTypeName,
+			&i.RuleTypeSeverityValue,
 			&i.RuleTypeID,
 			&i.RuleTypeGuidance,
 		); err != nil {


### PR DESCRIPTION
- **Extend ListRuleEvaluationsByProfileId to include severity**
- **Add the ruletype severity when returning the list of evaluations**

# Summary

Add the ruletype severity when returning the list of evaluations

Instead of empty severity, let's return the one from the ruletype

Fixes: #2709

## Change Type

***Mark the type of change your PR introduces:***

- [x] Bug fix (resolves an issue without affecting existing features)
- [ ] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [ ] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

```
curl  -H "Authorization: Bearer $MINDER_BEARER_TOKEN" 'http://localhost:8080/api/v1/results?context.project=8f701090-efb9-477e-983a-39a34cb73b42&context.provider=github' | jq
```

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [ ] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [ ] Included tests that validate the fix or feature.
- [ ] Checked that related changes are merged.
