### PR TITLE
Separate the eventer into interfaces

### DIFF
--- a/internal/controlplane/handlers_githubwebhooks_test.go
+++ b/internal/controlplane/handlers_githubwebhooks_test.go
@@ -89,20 +89,20 @@ func (s *UnitTestSuite) TestHandleWebHookPing() {
 	defer ctrl.Finish()
 
 	mockStore := mockdb.NewMockStore(ctrl)
-	srv := newDefaultServer(t, mockStore)
-	defer srv.evt.Close()
+	srv, evt := newDefaultServer(t, mockStore)
+	defer evt.Close()
 
 	pq := testqueue.NewPassthroughQueue(t)
 	queued := pq.GetQueue()
 
-	srv.evt.Register(events.ExecuteEntityEventTopic, pq.Pass)
+	evt.Register(events.ExecuteEntityEventTopic, pq.Pass)
 
 	go func() {
-		err := srv.evt.Run(context.Background())
+		err := evt.Run(context.Background())
 		require.NoError(t, err, "failed to run eventer")
 	}()
 
-	<-srv.evt.Running()
+	<-evt.Running()
 
 	hook := srv.HandleGitHubWebHook()
 	port, err := rand.GetRandomPort()
@@ -142,20 +142,20 @@ func (s *UnitTestSuite) TestHandleWebHookUnexistentRepository() {
 	defer ctrl.Finish()
 
 	mockStore := mockdb.NewMockStore(ctrl)
-	srv := newDefaultServer(t, mockStore)
-	defer srv.evt.Close()
+	srv, evt := newDefaultServer(t, mockStore)
+	defer evt.Close()
 
 	pq := testqueue.NewPassthroughQueue(t)
 	queued := pq.GetQueue()
 
-	srv.evt.Register(events.ExecuteEntityEventTopic, pq.Pass)
+	evt.Register(events.ExecuteEntityEventTopic, pq.Pass)
 
 	go func() {
-		err := srv.evt.Run(context.Background())
+		err := evt.Run(context.Background())
 		require.NoError(t, err, "failed to run eventer")
 	}()
 
-	<-srv.evt.Running()
+	<-evt.Running()
 
 	mockStore.EXPECT().
 		GetRepositoryByRepoID(gomock.Any(), gomock.Any()).
@@ -208,20 +208,20 @@ func (s *UnitTestSuite) TestHandleWebHookRepository() {
 	defer ctrl.Finish()
 
 	mockStore := mockdb.NewMockStore(ctrl)
-	srv := newDefaultServer(t, mockStore)
-	defer srv.evt.Close()
+	srv, evt := newDefaultServer(t, mockStore)
+	defer evt.Close()
 
 	pq := testqueue.NewPassthroughQueue(t)
 	queued := pq.GetQueue()
 
-	srv.evt.Register(events.ExecuteEntityEventTopic, pq.Pass)
+	evt.Register(events.ExecuteEntityEventTopic, pq.Pass)
 
 	go func() {
-		err := srv.evt.Run(context.Background())
+		err := evt.Run(context.Background())
 		require.NoError(t, err, "failed to run eventer")
 	}()
 
-	<-srv.evt.Running()
+	<-evt.Running()
 
 	providerName := "github"
 	repositoryID := uuid.New()
@@ -333,20 +333,20 @@ func (s *UnitTestSuite) TestHandleWebHookUnexistentRepoPackage() {
 	defer ctrl.Finish()
 
 	mockStore := mockdb.NewMockStore(ctrl)
-	srv := newDefaultServer(t, mockStore)
-	defer srv.evt.Close()
+	srv, evt := newDefaultServer(t, mockStore)
+	defer evt.Close()
 
 	pq := testqueue.NewPassthroughQueue(t)
 	queued := pq.GetQueue()
 
-	srv.evt.Register(events.ExecuteEntityEventTopic, pq.Pass)
+	evt.Register(events.ExecuteEntityEventTopic, pq.Pass)
 
 	go func() {
-		err := srv.evt.Run(context.Background())
+		err := evt.Run(context.Background())
 		require.NoError(t, err, "failed to run eventer")
 	}()
 
-	<-srv.evt.Running()
+	<-evt.Running()
 
 	mockStore.EXPECT().
 		GetRepositoryByRepoID(gomock.Any(), gomock.Any()).

--- a/internal/controlplane/handlers_oauth_test.go
+++ b/internal/controlplane/handlers_oauth_test.go
@@ -287,7 +287,7 @@ func TestGetAuthorizationURL(t *testing.T) {
 			store := mockdb.NewMockStore(ctrl)
 			tc.buildStubs(store)
 
-			server := newDefaultServer(t, store)
+			server, _ := newDefaultServer(t, store)
 
 			res, err := server.GetAuthorizationURL(ctx, tc.req)
 			tc.checkResponse(t, res, err)
@@ -362,7 +362,7 @@ func TestProviderCallback(t *testing.T) {
 			ctrl := gomock.NewController(t)
 			defer ctrl.Finish()
 			store := mockdb.NewMockStore(ctrl)
-			s := newDefaultServer(t, store)
+			s, _ := newDefaultServer(t, store)
 
 			encryptedUrl := sql.NullString{}
 			if tc.redirectUrl != "" {

--- a/internal/controlplane/handlers_profile_test.go
+++ b/internal/controlplane/handlers_profile_test.go
@@ -438,4 +438,4 @@ func (*StubEventer) Running() chan struct{} {
 	panic("unimplemented")
 }
 
-var _ events.Interface = (*StubEventer)(nil)
+var _ events.Publisher = (*StubEventer)(nil)

--- a/internal/controlplane/server.go
+++ b/internal/controlplane/server.go
@@ -74,7 +74,7 @@ var (
 type Server struct {
 	store               db.Store
 	cfg                 *serverconfig.Config
-	evt                 events.Interface
+	evt                 events.Publisher
 	mt                  metrics.Metrics
 	provMt              provtelemetry.ProviderMetrics
 	grpcServer          *grpc.Server
@@ -140,7 +140,7 @@ func WithServerMetrics(mt metrics.Metrics) ServerOption {
 // NewServer creates a new server instance
 func NewServer(
 	store db.Store,
-	evt *events.Eventer,
+	evt events.Publisher,
 	cfg *serverconfig.Config,
 	vldtr auth.JwtValidator,
 	opts ...ServerOption,

--- a/internal/controlplane/server_test.go
+++ b/internal/controlplane/server_test.go
@@ -67,7 +67,7 @@ func init() {
 	// It would be nice if we could Close() the httpServer, but we leak it in the test instead
 }
 
-func newDefaultServer(t *testing.T, mockStore *mockdb.MockStore) *Server {
+func newDefaultServer(t *testing.T, mockStore *mockdb.MockStore) (*Server, events.Interface) {
 	t.Helper()
 
 	evt, err := events.Setup(context.Background(), &serverconfig.EventConfig{
@@ -89,7 +89,7 @@ func newDefaultServer(t *testing.T, mockStore *mockdb.MockStore) *Server {
 
 	server, err := NewServer(mockStore, evt, c, mockJwt)
 	require.NoError(t, err, "failed to create server")
-	return server
+	return server, evt
 }
 
 func generateTokenKey(t *testing.T) string {

--- a/internal/eea/eea.go
+++ b/internal/eea/eea.go
@@ -39,12 +39,12 @@ import (
 // EEA is the Event Execution Aggregator
 type EEA struct {
 	querier db.Store
-	evt     *events.Eventer
+	evt     events.Publisher
 	cfg     *serverconfig.AggregatorConfig
 }
 
 // NewEEA creates a new EEA
-func NewEEA(querier db.Store, evt *events.Eventer, cfg *serverconfig.AggregatorConfig) *EEA {
+func NewEEA(querier db.Store, evt events.Publisher, cfg *serverconfig.AggregatorConfig) *EEA {
 	return &EEA{
 		querier: querier,
 		evt:     evt,

--- a/internal/engine/entities/entity_event.go
+++ b/internal/engine/entities/entity_event.go
@@ -192,7 +192,7 @@ func (eiw *EntityInfoWrapper) BuildMessage() (*message.Message, error) {
 }
 
 // Publish builds a message.Message and publishes it to the event bus
-func (eiw *EntityInfoWrapper) Publish(evt *events.Eventer) error {
+func (eiw *EntityInfoWrapper) Publish(evt events.Publisher) error {
 	msg, err := eiw.BuildMessage()
 	if err != nil {
 		return err

--- a/internal/engine/executor.go
+++ b/internal/engine/executor.go
@@ -48,7 +48,7 @@ const (
 // Executor is the engine that executes the rules for a given event
 type Executor struct {
 	querier                db.Store
-	evt                    *events.Eventer
+	evt                    events.Publisher
 	crypteng               crypto.Engine
 	provMt                 providertelemetry.ProviderMetrics
 	mdws                   []message.HandlerMiddleware
@@ -88,7 +88,7 @@ func NewExecutor(
 	ctx context.Context,
 	querier db.Store,
 	authCfg *serverconfig.AuthConfig,
-	evt *events.Eventer,
+	evt events.Publisher,
 	opts ...ExecutorOption,
 ) (*Executor, error) {
 	crypteng, err := crypto.EngineFromAuthConfig(authCfg)

--- a/internal/events/common/driver.go
+++ b/internal/events/common/driver.go
@@ -1,0 +1,20 @@
+//
+// Copyright 2024 Stacklok, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package common contains common interfaces and types used by the eventer.
+package common
+
+// DriverCloser is a function that can be used to close an eventer driver
+type DriverCloser func()

--- a/internal/events/constants.go
+++ b/internal/events/constants.go
@@ -1,0 +1,42 @@
+//
+// Copyright 2024 Stacklok, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package events
+
+// Metadata added to Messages
+const (
+	ProviderDeliveryIdKey     = "id"
+	ProviderTypeKey           = "provider"
+	ProviderSourceKey         = "source"
+	GithubWebhookEventTypeKey = "type"
+
+	GoChannelDriver = "go-channel"
+	SQLDriver       = "sql"
+
+	DeadLetterQueueTopic = "dead_letter_queue"
+	PublishedKey         = "published_at"
+)
+
+const (
+	metricsNamespace = "minder"
+	metricsSubsystem = "eventer"
+)
+
+const (
+	// ExecuteEntityEventTopic is the topic for internal webhook events
+	ExecuteEntityEventTopic = "execute.entity.event"
+	// FlushEntityEventTopic is the topic for flushing internal webhook events
+	FlushEntityEventTopic = "flush.entity.event"
+)

--- a/internal/events/eventer.go
+++ b/internal/events/eventer.go
@@ -26,101 +26,24 @@ import (
 	"time"
 
 	"github.com/ThreeDotsLabs/watermill"
-	watermillsql "github.com/ThreeDotsLabs/watermill-sql/v3/pkg/sql"
 	"github.com/ThreeDotsLabs/watermill/components/metrics"
 	"github.com/ThreeDotsLabs/watermill/message"
 	"github.com/ThreeDotsLabs/watermill/message/router/middleware"
-	"github.com/ThreeDotsLabs/watermill/pubsub/gochannel"
 	"github.com/alexdrl/zerowater"
 	promgo "github.com/prometheus/client_golang/prometheus"
 	"github.com/rs/zerolog"
-	"github.com/rs/zerolog/log"
 	"go.opentelemetry.io/otel"
-	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/metric"
 
 	serverconfig "github.com/stacklok/minder/internal/config/server"
+	"github.com/stacklok/minder/internal/events/common"
+	gochannel "github.com/stacklok/minder/internal/events/gochannel"
+	eventersql "github.com/stacklok/minder/internal/events/sql"
 )
 
-// Metadata added to Messages
-const (
-	ProviderDeliveryIdKey     = "id"
-	ProviderTypeKey           = "provider"
-	ProviderSourceKey         = "source"
-	GithubWebhookEventTypeKey = "type"
-
-	GoChannelDriver = "go-channel"
-	SQLDriver       = "sql"
-
-	DeadLetterQueueTopic = "dead_letter_queue"
-	PublishedKey         = "published_at"
-)
-
-const (
-	metricsNamespace = "minder"
-	metricsSubsystem = "eventer"
-)
-
-const (
-	// ExecuteEntityEventTopic is the topic for internal webhook events
-	ExecuteEntityEventTopic = "execute.entity.event"
-	// FlushEntityEventTopic is the topic for flushing internal webhook events
-	FlushEntityEventTopic = "flush.entity.event"
-)
-
-// Handler is an alias for the watermill handler type, which is both wordy and may be
-// detail we don't want to expose.
-type Handler = message.NoPublishHandlerFunc
-
-// Registrar provides an interface which allows an event router to expose
-// itself to event consumers.
-type Registrar interface {
-	// Register requests that the message router calls handler for each message on topic.
-	// It is valid to call Register multiple times with the same topic and different handler
-	// functions, or to call Register multiple times with different topics and the same
-	// handler function.  It's allowed to call Register with both argument the same, but
-	// then events will be delivered twice to the handler, which is probably not what you want.
-	Register(topic string, handler Handler, mdw ...message.HandlerMiddleware)
-}
-
-// Consumer is an interface implemented by components which wish to consume events.
-// Once a component has implemented the consumer interface, it can be registered with an
-// event router using the HandleAll interface.
-type Consumer interface {
-	Register(Registrar)
-}
-
-// AggregatorMiddleware is an interface that allows the eventer to
-// add middleware to the router
-type AggregatorMiddleware interface {
-	AggregateMiddleware(h message.HandlerFunc) message.HandlerFunc
-}
-
-type driverCloser func()
-
-// Interface provides an abstract interface over Eventer (and mocks)
-type Interface interface {
-	// Publish implements message.Publisher
-	Publish(topic string, messages ...*message.Message) error
-
-	// Register subscribes to a topic and handles incoming messages
-	Register(topic string, handler message.NoPublishHandlerFunc, mdw ...message.HandlerMiddleware)
-
-	// ConsumeEvents allows registration of multiple consumers easily
-	ConsumeEvents(consumers ...Consumer)
-	// Close closes the router
-	Close() error
-	// Run runs the router, blocks until the router is closed
-	Run(ctx context.Context) error
-
-	// Running returns a channel which allows you to wait until the
-	// event router has started.
-	Running() chan struct{}
-}
-
-// Eventer is a wrapper over the relevant eventing objects in such
+// eventer is a wrapper over the relevant eventing objects in such
 // a way that they can be easily accessible and configurable.
-type Eventer struct {
+type eventer struct {
 	router *message.Router
 	// webhookPublisher will gather events coming into the webhook and publish them
 	webhookPublisher message.Publisher
@@ -129,21 +52,22 @@ type Eventer struct {
 	// TODO: We'll have a Final publisher that will publish to the final topic
 	msgInstruments *messageInstruments
 
-	closer driverCloser
+	closer common.DriverCloser
 }
 
-var _ Interface = (*Eventer)(nil)
+var _ Publisher = (*eventer)(nil)
+var _ Service = (*eventer)(nil)
 
 type messageInstruments struct {
 	// message processing time duration histogram
 	messageProcessingTimeHistogram metric.Int64Histogram
 }
 
-var _ Registrar = (*Eventer)(nil)
-var _ message.Publisher = (*Eventer)(nil)
+var _ Registrar = (*eventer)(nil)
+var _ message.Publisher = (*eventer)(nil)
 
-// Setup creates an Eventer object which isolates the watermill setup code
-func Setup(ctx context.Context, cfg *serverconfig.EventConfig) (*Eventer, error) {
+// Setup creates an eventer object which isolates the watermill setup code
+func Setup(ctx context.Context, cfg *serverconfig.EventConfig) (Interface, error) {
 	if cfg == nil {
 		return nil, errors.New("event config is nil")
 	}
@@ -202,7 +126,7 @@ func Setup(ctx context.Context, cfg *serverconfig.EventConfig) (*Eventer, error)
 		return nil, fmt.Errorf("failed to decorate subscriber: %w", err)
 	}
 
-	return &Eventer{
+	return &eventer{
 		router:            router,
 		webhookPublisher:  pubWithMetrics,
 		webhookSubscriber: subWithMetrics,
@@ -218,119 +142,40 @@ func Setup(ctx context.Context, cfg *serverconfig.EventConfig) (*Eventer, error)
 	}, nil
 }
 
-func recordMetrics(instruments *messageInstruments) func(h message.HandlerFunc) message.HandlerFunc {
-	metricsFunc := func(h message.HandlerFunc) message.HandlerFunc {
-		return func(msg *message.Message) ([]*message.Message, error) {
-			var processingTime time.Duration
-			if publishedAt := msg.Metadata.Get(PublishedKey); publishedAt != "" {
-				if parsedTime, err := time.Parse(time.RFC3339, publishedAt); err == nil {
-					processingTime = time.Since(parsedTime)
-				}
-			}
-
-			res, err := h(msg)
-
-			// Defer the DLQ tracking logic to after the message has been processed by other middlewares,
-			// including the deferred PoisonQueue middleware functionality,
-			// so that we can check if it has been poisoned or not.
-			isPoisoned := msg.Metadata.Get(middleware.ReasonForPoisonedKey) != ""
-			instruments.messageProcessingTimeHistogram.Record(
-				msg.Context(),
-				processingTime.Milliseconds(),
-				metric.WithAttributes(attribute.Bool("poison", isPoisoned)),
-			)
-
-			return res, err
-		}
-	}
-	return metricsFunc
-}
-
 func instantiateDriver(
 	ctx context.Context,
 	driver string,
 	cfg *serverconfig.EventConfig,
-) (message.Publisher, message.Subscriber, driverCloser, error) {
+) (message.Publisher, message.Subscriber, common.DriverCloser, error) {
 	switch driver {
 	case GoChannelDriver:
-		return buildGoChannelDriver(cfg)
+		return gochannel.BuildGoChannelDriver(cfg)
 	case SQLDriver:
-		return buildPostgreSQLDriver(ctx, cfg)
+		return eventersql.BuildPostgreSQLDriver(ctx, cfg)
 	default:
 		return nil, nil, nil, fmt.Errorf("unknown driver %s", driver)
 	}
 }
 
-func buildGoChannelDriver(cfg *serverconfig.EventConfig) (message.Publisher, message.Subscriber, driverCloser, error) {
-	pubsub := gochannel.NewGoChannel(gochannel.Config{
-		OutputChannelBuffer: cfg.GoChannel.BufferSize,
-		Persistent:          cfg.GoChannel.PersistEvents,
-	}, nil)
-
-	return pubsub, pubsub, func() {}, nil
-}
-
-func buildPostgreSQLDriver(
-	ctx context.Context,
-	cfg *serverconfig.EventConfig,
-) (message.Publisher, message.Subscriber, driverCloser, error) {
-	db, _, err := cfg.SQLPubSub.Connection.GetDBConnection(ctx)
-	if err != nil {
-		return nil, nil, nil, fmt.Errorf("unable to connect to events database: %w", err)
-	}
-
-	publisher, err := watermillsql.NewPublisher(
-		db,
-		watermillsql.PublisherConfig{
-			SchemaAdapter:        watermillsql.DefaultPostgreSQLSchema{},
-			AutoInitializeSchema: true,
-		},
-		watermill.NewStdLogger(false, false),
-	)
-	if err != nil {
-		return nil, nil, nil, fmt.Errorf("failed to create SQL publisher: %w", err)
-	}
-
-	subscriber, err := watermillsql.NewSubscriber(
-		db,
-		watermillsql.SubscriberConfig{
-			SchemaAdapter:    watermillsql.DefaultPostgreSQLSchema{},
-			OffsetsAdapter:   watermillsql.DefaultPostgreSQLOffsetsAdapter{},
-			InitializeSchema: true,
-		},
-		watermill.NewStdLogger(false, false),
-	)
-	if err != nil {
-		return nil, nil, nil, fmt.Errorf("failed to create SQL subscriber: %w", err)
-	}
-
-	return publisher, subscriber, func() {
-		err := db.Close()
-		if err != nil {
-			log.Printf("error closing events database connection: %v", err)
-		}
-	}, nil
-}
-
 // Close closes the router
-func (e *Eventer) Close() error {
+func (e *eventer) Close() error {
 	e.closer()
 	return e.router.Close()
 }
 
 // Run runs the router, blocks until the router is closed
-func (e *Eventer) Run(ctx context.Context) error {
+func (e *eventer) Run(ctx context.Context) error {
 	return e.router.Run(ctx)
 }
 
 // Running returns a channel which allows you to wait until the
 // event router has started.
-func (e *Eventer) Running() chan struct{} {
+func (e *eventer) Running() chan struct{} {
 	return e.router.Running()
 }
 
 // Publish implements message.Publisher
-func (e *Eventer) Publish(topic string, messages ...*message.Message) error {
+func (e *eventer) Publish(topic string, messages ...*message.Message) error {
 	pc, _, _, ok := runtime.Caller(1)
 	details := runtime.FuncForPC(pc)
 
@@ -352,7 +197,7 @@ func (e *Eventer) Publish(topic string, messages ...*message.Message) error {
 }
 
 // Register subscribes to a topic and handles incoming messages
-func (e *Eventer) Register(
+func (e *eventer) Register(
 	topic string,
 	handler message.NoPublishHandlerFunc,
 	mdw ...message.HandlerMiddleware,
@@ -392,32 +237,8 @@ func (e *Eventer) Register(
 }
 
 // ConsumeEvents allows registration of multiple consumers easily
-func (e *Eventer) ConsumeEvents(consumers ...Consumer) {
+func (e *eventer) ConsumeEvents(consumers ...Consumer) {
 	for _, c := range consumers {
 		c.Register(e)
 	}
-}
-
-func initMetricsInstruments(meter metric.Meter) (*messageInstruments, error) {
-	histogram, err := createProcessingLatencyHistogram(meter)
-	if err != nil {
-		return nil, err
-	}
-
-	return &messageInstruments{
-		messageProcessingTimeHistogram: histogram,
-	}, nil
-}
-
-func createProcessingLatencyHistogram(meter metric.Meter) (metric.Int64Histogram, error) {
-	processingLatencyHistogram, err := meter.Int64Histogram("messages.processing_delay",
-		metric.WithDescription("Duration between a message being enqueued and dequeued for processing"),
-		metric.WithUnit("ms"),
-		// Pick a set of bucket boundaries that span out to 10 minutes
-		metric.WithExplicitBucketBoundaries(0, 500, 1000, 2000, 5000, 10000, 30000, 60000, 120000, 300000, 600000),
-	)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create message processing processingLatencyHistogram: %w", err)
-	}
-	return processingLatencyHistogram, nil
 }

--- a/internal/events/eventer_test.go
+++ b/internal/events/eventer_test.go
@@ -235,7 +235,7 @@ var setupMu sync.Mutex
 // We currently use the global meter provider, so reset it for each test.
 // Since this is global, we use a global mutex to ensure we don't enter setup
 // concurrently.
-func setupEventerWithMetricReader(ctx context.Context) (*events.Eventer, *metric.ManualReader, error) {
+func setupEventerWithMetricReader(ctx context.Context) (events.Interface, *metric.ManualReader, error) {
 	setupMu.Lock()
 	defer setupMu.Unlock()
 	oldMeter := otel.GetMeterProvider()

--- a/internal/events/gochannel/gochannel.go
+++ b/internal/events/gochannel/gochannel.go
@@ -1,0 +1,35 @@
+//
+// Copyright 2024 Stacklok, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package gochannel provides a gochannel implementation of the eventer
+package gochannel
+
+import (
+	"github.com/ThreeDotsLabs/watermill/message"
+	"github.com/ThreeDotsLabs/watermill/pubsub/gochannel"
+
+	serverconfig "github.com/stacklok/minder/internal/config/server"
+	"github.com/stacklok/minder/internal/events/common"
+)
+
+// BuildGoChannelDriver creates a gochannel driver for the eventer
+func BuildGoChannelDriver(cfg *serverconfig.EventConfig) (message.Publisher, message.Subscriber, common.DriverCloser, error) {
+	pubsub := gochannel.NewGoChannel(gochannel.Config{
+		OutputChannelBuffer: cfg.GoChannel.BufferSize,
+		Persistent:          cfg.GoChannel.PersistEvents,
+	}, nil)
+
+	return pubsub, pubsub, func() {}, nil
+}

--- a/internal/events/interfaces.go
+++ b/internal/events/interfaces.go
@@ -1,0 +1,80 @@
+//
+// Copyright 2024 Stacklok, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package events
+
+import (
+	"context"
+
+	"github.com/ThreeDotsLabs/watermill/message"
+)
+
+// Handler is an alias for the watermill handler type, which is both wordy and may be
+// detail we don't want to expose.
+type Handler = message.NoPublishHandlerFunc
+
+// Registrar provides an interface which allows an event router to expose
+// itself to event consumers.
+type Registrar interface {
+	// Register requests that the message router calls handler for each message on topic.
+	// It is valid to call Register multiple times with the same topic and different handler
+	// functions, or to call Register multiple times with different topics and the same
+	// handler function.  It's allowed to call Register with both argument the same, but
+	// then events will be delivered twice to the handler, which is probably not what you want.
+	Register(topic string, handler Handler, mdw ...message.HandlerMiddleware)
+}
+
+// Consumer is an interface implemented by components which wish to consume events.
+// Once a component has implemented the consumer interface, it can be registered with an
+// event router using the HandleAll interface.
+type Consumer interface {
+	Register(Registrar)
+}
+
+// AggregatorMiddleware is an interface that allows the eventer to
+// add middleware to the router
+type AggregatorMiddleware interface {
+	AggregateMiddleware(h message.HandlerFunc) message.HandlerFunc
+}
+
+// Publisher is an interface implemented by components which wish to publish events.
+type Publisher interface {
+	// Publish implements message.Publisher
+	Publish(topic string, messages ...*message.Message) error
+}
+
+// Service is an interface that allows the eventer to orchestrate the
+// consumption and publication of events, as well as start and stop the
+// event router.
+type Service interface {
+	// ConsumeEvents allows registration of multiple consumers easily
+	ConsumeEvents(consumers ...Consumer)
+	// Close closes the router
+	Close() error
+	// Run runs the router, blocks until the router is closed
+	Run(ctx context.Context) error
+
+	// Running returns a channel which allows you to wait until the
+	// event router has started.
+	Running() chan struct{}
+}
+
+// Interface is a combination of the Publisher, Registrar, and Service interfaces.
+// This is handy when spawning the eventer in a single function for easy setup.
+type Interface interface {
+	Publisher
+	Registrar
+	Service
+}

--- a/internal/events/metrics.go
+++ b/internal/events/metrics.go
@@ -1,0 +1,78 @@
+//
+// Copyright 2024 Stacklok, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package events
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/ThreeDotsLabs/watermill/message"
+	"github.com/ThreeDotsLabs/watermill/message/router/middleware"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
+)
+
+func recordMetrics(instruments *messageInstruments) func(h message.HandlerFunc) message.HandlerFunc {
+	metricsFunc := func(h message.HandlerFunc) message.HandlerFunc {
+		return func(msg *message.Message) ([]*message.Message, error) {
+			var processingTime time.Duration
+			if publishedAt := msg.Metadata.Get(PublishedKey); publishedAt != "" {
+				if parsedTime, err := time.Parse(time.RFC3339, publishedAt); err == nil {
+					processingTime = time.Since(parsedTime)
+				}
+			}
+
+			res, err := h(msg)
+
+			// Defer the DLQ tracking logic to after the message has been processed by other middlewares,
+			// including the deferred PoisonQueue middleware functionality,
+			// so that we can check if it has been poisoned or not.
+			isPoisoned := msg.Metadata.Get(middleware.ReasonForPoisonedKey) != ""
+			instruments.messageProcessingTimeHistogram.Record(
+				msg.Context(),
+				processingTime.Milliseconds(),
+				metric.WithAttributes(attribute.Bool("poison", isPoisoned)),
+			)
+
+			return res, err
+		}
+	}
+	return metricsFunc
+}
+
+func initMetricsInstruments(meter metric.Meter) (*messageInstruments, error) {
+	histogram, err := createProcessingLatencyHistogram(meter)
+	if err != nil {
+		return nil, err
+	}
+
+	return &messageInstruments{
+		messageProcessingTimeHistogram: histogram,
+	}, nil
+}
+
+func createProcessingLatencyHistogram(meter metric.Meter) (metric.Int64Histogram, error) {
+	processingLatencyHistogram, err := meter.Int64Histogram("messages.processing_delay",
+		metric.WithDescription("Duration between a message being enqueued and dequeued for processing"),
+		metric.WithUnit("ms"),
+		// Pick a set of bucket boundaries that span out to 10 minutes
+		metric.WithExplicitBucketBoundaries(0, 500, 1000, 2000, 5000, 10000, 30000, 60000, 120000, 300000, 600000),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create message processing processingLatencyHistogram: %w", err)
+	}
+	return processingLatencyHistogram, nil
+}

--- a/internal/events/sql/postgres.go
+++ b/internal/events/sql/postgres.go
@@ -1,0 +1,72 @@
+//
+// Copyright 2024 Stacklok, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package sql provides the eventer implementation for the SQL database.
+package sql
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/ThreeDotsLabs/watermill"
+	watermillsql "github.com/ThreeDotsLabs/watermill-sql/v3/pkg/sql"
+	"github.com/ThreeDotsLabs/watermill/message"
+	"github.com/rs/zerolog/log"
+
+	serverconfig "github.com/stacklok/minder/internal/config/server"
+)
+
+// BuildPostgreSQLDriver creates a PostgreSQL driver for the eventer
+func BuildPostgreSQLDriver(
+	ctx context.Context,
+	cfg *serverconfig.EventConfig,
+) (message.Publisher, message.Subscriber, func(), error) {
+	db, _, err := cfg.SQLPubSub.Connection.GetDBConnection(ctx)
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("unable to connect to events database: %w", err)
+	}
+
+	publisher, err := watermillsql.NewPublisher(
+		db,
+		watermillsql.PublisherConfig{
+			SchemaAdapter:        watermillsql.DefaultPostgreSQLSchema{},
+			AutoInitializeSchema: true,
+		},
+		watermill.NewStdLogger(false, false),
+	)
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("failed to create SQL publisher: %w", err)
+	}
+
+	subscriber, err := watermillsql.NewSubscriber(
+		db,
+		watermillsql.SubscriberConfig{
+			SchemaAdapter:    watermillsql.DefaultPostgreSQLSchema{},
+			OffsetsAdapter:   watermillsql.DefaultPostgreSQLOffsetsAdapter{},
+			InitializeSchema: true,
+		},
+		watermill.NewStdLogger(false, false),
+	)
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("failed to create SQL subscriber: %w", err)
+	}
+
+	return publisher, subscriber, func() {
+		err := db.Close()
+		if err != nil {
+			log.Printf("error closing events database connection: %v", err)
+		}
+	}, nil
+}

--- a/internal/profiles/service.go
+++ b/internal/profiles/service.go
@@ -86,14 +86,14 @@ type ProfileService interface {
 
 type profileService struct {
 	store     db.Store
-	publisher events.Interface
+	publisher events.Publisher
 	validator *Validator
 }
 
 // NewProfileService creates an instance of ProfileService
 func NewProfileService(
 	store db.Store,
-	publisher events.Interface,
+	publisher events.Publisher,
 ) ProfileService {
 	return &profileService{
 		store:     store,

--- a/internal/reconcilers/reconcilers.go
+++ b/internal/reconcilers/reconcilers.go
@@ -35,7 +35,7 @@ const (
 // Reconciler is a helper that reconciles entities
 type Reconciler struct {
 	store           db.Store
-	evt             *events.Eventer
+	evt             events.Publisher
 	crypteng        crypto.Engine
 	restClientCache ratecache.RestClientCache
 	provMt          providertelemetry.ProviderMetrics
@@ -61,7 +61,7 @@ func WithRestClientCache(cache ratecache.RestClientCache) ReconcilerOption {
 // NewReconciler creates a new reconciler object
 func NewReconciler(
 	store db.Store,
-	evt *events.Eventer,
+	evt events.Publisher,
 	authCfg *serverconfig.AuthConfig,
 	opts ...ReconcilerOption,
 ) (*Reconciler, error) {

--- a/internal/repositories/github/service.go
+++ b/internal/repositories/github/service.go
@@ -79,14 +79,14 @@ var (
 type repositoryService struct {
 	webhookManager webhooks.WebhookManager
 	store          db.Store
-	eventProducer  events.Interface
+	eventProducer  events.Publisher
 }
 
 // NewRepositoryService creates an instance of the RepositoryService interface
 func NewRepositoryService(
 	webhookManager webhooks.WebhookManager,
 	store db.Store,
-	eventProducer events.Interface,
+	eventProducer events.Publisher,
 ) RepositoryService {
 	return &repositoryService{
 		webhookManager: webhookManager,


### PR DESCRIPTION
# Summary

This makes use of the eventer interfaces in order to make the implementation
more portable. Individual components no longer hold an `Eventer` pointer, and
instead they just use the relevant interface contains the functions they need
to use.

Turns out that most of minder just uses publishers, and we set up the consumers
in a central place. This will be handy to simplify our tests.

The driver implementations of the eventer were also moved to their own packages.

## Change Type

***Mark the type of change your PR introduces:***

- [ ] Bug fix (resolves an issue without affecting existing features)
- [ ] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [x] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

***Outline how the changes were tested, including steps to reproduce and any relevant configurations. 
Attach screenshots if helpful.***

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [ ] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [ ] Included tests that validate the fix or feature.
- [ ] Checked that related changes are merged.
