### PR TITLE
Provide an array of fallback secrets to allow secret migration

### DIFF
--- a/config/server-config.yaml.example
+++ b/config/server-config.yaml.example
@@ -65,6 +65,7 @@ webhook-config:
   external_webhook_url: "https://example.com/api/v1/webhook/github"
   external_ping_url: "https://example.com/api/v1/health"
   webhook_secret: "your-password"
+# previous_webhook_secret_file: ./previous_secrets
 
 # OAuth2 Configuration (used during enrollment)
 # These values are to be set within the GitHub OAuth2 App page

--- a/docs/docs/run_minder_server/run_the_server.md
+++ b/docs/docs/run_minder_server/run_the_server.md
@@ -249,6 +249,13 @@ webhook-config:
 
 After these steps, your Minder server should be ready to receive webhook events from GitHub, and add webhooks to repositories.
 
+In case you need to update the webhook secret, you can do so by putting the
+new secret in `webhook-config.webhook_secret` and for the duration of the
+migration, the old secret(s) in a file referenced by
+`webhook-config.previous_webhook_secret_file`. The old webhook secrets will
+then only be used to verify incoming webhooks messages, not for creating or
+updating webhooks and can be removed after the migration is complete.
+
 In order to rotate webhook secrets, you can use the `minder-server` CLI tool to update the webhook secret.
 
 ```bash
@@ -256,7 +263,7 @@ minder-server webhook update -p github
 ```
 
 Note that the command simply replaces the webhook secret on the provider
-side. You will need to update the webhook secret in the server configuration
+side. You will still need to update the webhook secret in the server configuration
 to match the provider's secret.
 
 ## Run the application

--- a/internal/config/server/webhook.go
+++ b/internal/config/server/webhook.go
@@ -15,6 +15,12 @@
 
 package server
 
+import (
+	"fmt"
+	"os"
+	"strings"
+)
+
 // WebhookConfig is the configuration for our webhook capabilities
 type WebhookConfig struct {
 	// ExternalWebhookURL is the URL that we will send our webhook to
@@ -22,6 +28,22 @@ type WebhookConfig struct {
 	// ExternalPingURL is the URL that we will send our ping to
 	ExternalPingURL string `mapstructure:"external_ping_url"`
 	// WebhookSecret is the secret that we will use to sign our webhook
-	// TODO: Check if this is actually used and needed
 	WebhookSecret string `mapstructure:"webhook_secret"`
+	// PreviousWebhookSecretFile is a reference to a file that contains previous webhook secrets. This is used
+	// in case we are rotating secrets and the external service is still using the old secret. These will not
+	// be used when creating new webhooks.
+	PreviousWebhookSecretFile string `mapstructure:"previous_webhook_secret_file"`
+}
+
+// GetPreviousWebhookSecrets retrieves the previous webhook secrets from a file specified in the WebhookConfig.
+// It reads the contents of the file, splits the data by whitespace, and returns it as a slice of strings.
+func (wc *WebhookConfig) GetPreviousWebhookSecrets() ([]string, error) {
+	data, err := os.ReadFile(wc.PreviousWebhookSecretFile)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read previous webhook secrets from file: %w", err)
+	}
+
+	// Split the data by whitespace and return it as a slice of strings
+	secrets := strings.Fields(string(data))
+	return secrets, nil
 }


### PR DESCRIPTION
# Summary

In order to provide for a clean webhook secret migration, we need to
provide a window of using the old secret. For this, we add an array of
PreivousWebhookSecrets to the WebhookConfig structure. If validating the
payload with the WebhookConfig.WebhookSecret fails, we fall back to
validating using the previous secrets.

Because validating the request reads the request body, we need to read
the body first and save in a byte slice in case we do have the fallbacks
configured.

Related: #2722


## Change Type

***Mark the type of change your PR introduces:***

- [ ] Bug fix (resolves an issue without affecting existing features)
- [x] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [ ] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

Tested by setting the correct shared secrets in the previousWebhookSecrets
array and junk in WebhookConfig.WebhookSecret as well as the usual case
of WebhookConfig.WebhookSecret containing the correct secret.

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [x] Added comments to complex or tricky code sections.
- [x] Updated any affected documentation.
- [x] Included tests that validate the fix or feature.
- [ ] Checked that related changes are merged.
