### PR TITLE
Also show display name in `GetProfile` API

### DIFF
--- a/internal/engine/profile.go
+++ b/internal/engine/profile.go
@@ -219,9 +219,16 @@ func MergeDatabaseGetIntoProfiles(ppl []db.GetProfileByProjectAndIDRow) map[stri
 		if _, ok := profiles[p.Name]; !ok {
 			profileID := p.ID.String()
 			project := p.ProjectID.String()
+
+			displayName := p.DisplayName
+			if displayName == "" {
+				displayName = p.Name
+			}
+
 			profiles[p.Name] = &pb.Profile{
-				Id:   &profileID,
-				Name: p.Name,
+				Id:          &profileID,
+				Name:        p.Name,
+				DisplayName: displayName,
 				Context: &pb.Context{
 					Provider: &p.Provider,
 					Project:  &project,


### PR DESCRIPTION
# Summary

The `GET` operation was left out from showing the display name for profiles. This fixes that.

## Change Type

***Mark the type of change your PR introduces:***

- [x] Bug fix (resolves an issue without affecting existing features)
- [ ] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [ ] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [ ] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [ ] Included tests that validate the fix or feature.
- [ ] Checked that related changes are merged.
