### PR TITLE
Eval Status: Return repository UUID, populate entity info

### DIFF
--- a/internal/controlplane/handlers_evalstatus.go
+++ b/internal/controlplane/handlers_evalstatus.go
@@ -278,6 +278,14 @@ func buildRuleEvaluationStatusFromDBEvaluation(
 			Msg("error converting severity will use defaults")
 	}
 
+	entityInfo := map[string]string{}
+	if eval.Entity == db.EntitiesRepository {
+		entityInfo["provider"] = eval.Provider
+		entityInfo["repo_owner"] = eval.RepoOwner
+		entityInfo["repo_name"] = eval.RepoName
+		entityInfo["repository_id"] = eval.RepositoryID.UUID.String()
+	}
+
 	return &minderv1.RuleEvaluationStatus{
 		RuleEvaluationId:       eval.RuleEvaluationID.String(),
 		RuleId:                 eval.RuleTypeID.String(),
@@ -286,7 +294,7 @@ func buildRuleEvaluationStatusFromDBEvaluation(
 		Entity:                 string(eval.Entity),
 		Status:                 string(eval.EvalStatus.EvalStatusTypes),
 		LastUpdated:            timestamppb.New(eval.EvalLastUpdated.Time),
-		EntityInfo:             map[string]string{},
+		EntityInfo:             entityInfo,
 		Details:                eval.EvalDetails.String,
 		Guidance:               guidance,
 		RemediationStatus:      string(eval.RemStatus.RemediationStatusTypes),
@@ -304,7 +312,7 @@ func buildEntityFromEvaluation(eval db.ListRuleEvaluationsByProfileIdRow) *minde
 	}
 
 	if ent.Type == minderv1.Entity_ENTITY_REPOSITORIES && eval.RepoOwner != "" && eval.RepoName != "" {
-		ent.Id = fmt.Sprintf("%s/%s", eval.RepoOwner, eval.RepoName)
+		ent.Id = eval.RepositoryID.UUID.String()
 	}
 	return ent
 }


### PR DESCRIPTION
# Summary

This change modifies the evaluation status response to return the repository UUID instead of the slug. It also populates the entity info map with the repository details.


/cc @jhrozek 

Fixes #(related issue)

## Change Type

***Mark the type of change your PR introduces:***

- [x] Bug fix (resolves an issue without affecting existing features)
- [ ] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [ ] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

***Outline how the changes were tested, including steps to reproduce and any relevant configurations. 
Attach screenshots if helpful.***

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [ ] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [ ] Included tests that validate the fix or feature.
- [ ] Checked that related changes are merged.
