### PR TITLE
Add unordered message handler wrapper for performance

### DIFF
--- a/internal/events/unordered/unordered.go
+++ b/internal/events/unordered/unordered.go
@@ -1,0 +1,129 @@
+//
+// Copyright 2024 Stacklok, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package unordered providers a handler wrapper that will handle events in an unordered fashion.
+// This means that events will be acked immediately, and the handler will not wait for the event to be processed.
+// If a retry is needed, the event will be requeued and processed again.
+package unordered
+
+import (
+	"context"
+	"strconv"
+	"sync"
+
+	"github.com/ThreeDotsLabs/watermill/message"
+	"github.com/rs/zerolog"
+
+	"github.com/stacklok/minder/internal/events"
+)
+
+const (
+	// MessageRepublishedMetadataKey is the key used to store the republished metadata
+	MessageRepublishedMetadataKey = "unordered_processor_republished"
+	// MetadataRepublishRetriesKey is the key used to store the number of times the message has been republished
+	MetadataRepublishRetriesKey = "unordered_processor_republish_retries"
+
+	// DefaultMaxRetries is the default number of times a message will be retried
+	DefaultMaxRetries = 3
+)
+
+// Retrier is a handler wrapper that will handle event retries in an unordered fashion.
+type Retrier struct {
+	pub events.Publisher
+	wg  sync.WaitGroup
+}
+
+// New creates a new UnorderedProcessor
+func New(pub events.Publisher) *Retrier {
+	return &Retrier{pub: pub}
+}
+
+// Wrap wraps the handler with the unordered processor
+func (up *Retrier) Wrap(topic string, h events.Handler) events.Handler {
+	return func(msg *message.Message) error {
+		ctx := msg.Context()
+		newMsg := msg.Copy()
+
+		up.wg.Add(1)
+		go func() {
+			defer up.wg.Done()
+
+			err := h(newMsg)
+			if err == nil {
+				return
+			}
+
+			newMsg = setMetadata(newMsg)
+			republishIfRequired(topic, newMsg, up.pub,
+				buildLogger(ctx, topic, msg.UUID, err))
+		}()
+		return nil
+	}
+}
+
+// Wait waits for all the messages to be processed
+func (up *Retrier) Wait() {
+	up.wg.Wait()
+}
+
+func setMetadata(msg *message.Message) *message.Message {
+	msg.Metadata.Set(MessageRepublishedMetadataKey, "true")
+	if retries := msg.Metadata.Get(MetadataRepublishRetriesKey); retries != "" {
+		r, err := strconv.Atoi(retries)
+		if err != nil {
+			r = 0
+		}
+
+		msg.Metadata.Set(MetadataRepublishRetriesKey, strconv.Itoa(r+1))
+	} else {
+		msg.Metadata.Set(MetadataRepublishRetriesKey, "1")
+	}
+
+	return msg
+}
+
+func republishIfRequired(topic string, msg *message.Message, pub events.Publisher, l zerolog.Logger) {
+	if !retriable(msg) {
+		l.Error().Msg("message not retriable. dropping message")
+		return
+	}
+
+	republish(topic, msg, pub, l)
+}
+
+func republish(topic string, msg *message.Message, pub events.Publisher, l zerolog.Logger) {
+	// republish the message
+	if err := pub.Publish(topic, msg); err != nil {
+		l.Error().Msg("failed to republish message")
+	}
+}
+
+func retriable(msg *message.Message) bool {
+	r, err := strconv.Atoi(msg.Metadata.Get(MetadataRepublishRetriesKey))
+	if err != nil {
+		return false
+	}
+
+	return r <= DefaultMaxRetries
+}
+
+func buildLogger(ctx context.Context, topic string, msgID string, upstreamErr error) zerolog.Logger {
+	return zerolog.Ctx(ctx).With().
+		Str("component", "unordered-processor").
+		Str("topic", topic).
+		Str("message-id", msgID).
+		Err(upstreamErr).
+		Logger()
+}

--- a/internal/events/unordered/unordered_test.go
+++ b/internal/events/unordered/unordered_test.go
@@ -1,0 +1,138 @@
+//
+// Copyright 2024 Stacklok, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package unordered providers a handler wrapper that will handle events in an unordered fashion.
+// This means that events will be acked immediately, and the handler will not wait for the event to be processed.
+// If a retry is needed, the event will be requeued and processed again.
+package unordered
+
+import (
+	"context"
+	"errors"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/ThreeDotsLabs/watermill/message"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	serverconfig "github.com/stacklok/minder/internal/config/server"
+	"github.com/stacklok/minder/internal/events"
+)
+
+func TestUnorderedProcessor_Wrap_HandlesEvent(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	evt, err := events.Setup(ctx, &serverconfig.EventConfig{
+		Driver:    "go-channel",
+		GoChannel: serverconfig.GoChannelEventConfig{},
+	})
+	require.NoError(t, err)
+
+	u := New(evt)
+
+	var counter atomic.Uint32
+
+	h := u.Wrap("test", func(_ *message.Message) error {
+		counter.Add(1)
+		return nil
+	})
+
+	done := make(chan struct{})
+
+	evt.Register("test", h, func(h message.HandlerFunc) message.HandlerFunc {
+		return func(msg *message.Message) ([]*message.Message, error) {
+			msgs, err := h(msg)
+			done <- struct{}{}
+			return msgs, err
+		}
+	})
+
+	go func() {
+		err := evt.Run(ctx)
+		assert.NoError(t, err)
+	}()
+
+	<-evt.Running()
+
+	assert.NoError(t, evt.Publish("test", message.NewMessage(uuid.New().String(), nil)))
+
+	<-done
+
+	require.NoError(t, evt.Close(), "closing eventer")
+
+	u.Wait()
+
+	assert.Equal(t, uint32(1), counter.Load())
+}
+
+func TestUnorderedProcessor_Wrap_HandlesErrors(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	evt, err := events.Setup(ctx, &serverconfig.EventConfig{
+		Driver:    "go-channel",
+		GoChannel: serverconfig.GoChannelEventConfig{},
+	})
+	require.NoError(t, err)
+
+	u := New(evt)
+
+	var counter atomic.Uint32
+
+	h := u.Wrap("test", func(msg *message.Message) error {
+		counter.Add(1)
+		t.Logf("handling message %s", msg.UUID)
+		t.Logf("metadata: %v", msg.Metadata)
+
+		return errors.New("some error")
+	})
+
+	done := make(chan struct{}, 3)
+
+	evt.Register("test", h, func(h message.HandlerFunc) message.HandlerFunc {
+		return func(msg *message.Message) ([]*message.Message, error) {
+			msgs, err := h(msg)
+			done <- struct{}{}
+			return msgs, err
+		}
+	})
+
+	go func() {
+		err := evt.Run(ctx)
+		assert.NoError(t, err)
+	}()
+
+	<-evt.Running()
+
+	assert.NoError(t, evt.Publish("test", message.NewMessage(uuid.New().String(), nil)))
+
+	<-done
+
+	time.Sleep(2 * time.Second)
+
+	u.Wait()
+
+	require.NoError(t, evt.Close(), "closing eventer")
+
+	assert.Equal(t, uint32(4), counter.Load(), "expected 3 retries (A counter of 4)")
+}


### PR DESCRIPTION
# Summary

When looking at our metrics, it seems that the operations that take the most time are
the reconcilers. This is because they are indeed heavy operations which list other entities
such as repos, artifacts and profiles and eventually send more messages for the executor
to run policy on them.

The issue comes for the fact that the event subscriber actually waits for a message to be
processed before moving on to the next one. This is not a problem for the executor as it already
is fairly lightweight and async (when evaluating policy). But this was not the case
for the reconcilers.

This creates a new wrapper that ensures we immediately acknowledge messages, and in case of errors
it'll republish until a certain point; thus making this an unordered message handler. The fact is that
we don't need ordering for reconcilers, we just need to eventually handle them. This helps with that.

This frees up the subscribers to focus on more important processing, such as policy executions.

## Change Type

***Mark the type of change your PR introduces:***

- [ ] Bug fix (resolves an issue without affecting existing features)
- [x] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [ ] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

***Outline how the changes were tested, including steps to reproduce and any relevant configurations. 
Attach screenshots if helpful.***

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [ ] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [ ] Included tests that validate the fix or feature.
- [ ] Checked that related changes are merged.
