### PR TITLE
Only run transaction rollback for deleting user when there's an error

### DIFF
--- a/internal/controlplane/handlers_user_test.go
+++ b/internal/controlplane/handlers_user_test.go
@@ -275,7 +275,6 @@ func TestDeleteUserDBMock(t *testing.T) {
 		DeleteUser(gomock.Any(), gomock.Any()).
 		Return(nil)
 	mockStore.EXPECT().Commit(gomock.Any())
-	mockStore.EXPECT().Rollback(gomock.Any())
 
 	crypeng := mockcrypto.NewMockEngine(ctrl)
 
@@ -330,7 +329,6 @@ func TestDeleteUser_gRPC(t *testing.T) {
 					DeleteUser(gomock.Any(), gomock.Any()).
 					Return(nil)
 				store.EXPECT().Commit(gomock.Any())
-				store.EXPECT().Rollback(gomock.Any())
 			},
 			checkResponse: func(t *testing.T, res *pb.DeleteUserResponse, err error) {
 				t.Helper()

--- a/internal/controlplane/identity_events_test.go
+++ b/internal/controlplane/identity_events_test.go
@@ -70,7 +70,6 @@ func TestHandleEvents(t *testing.T) {
 		DeleteUser(gomock.Any(), gomock.Any()).
 		Return(nil)
 	mockStore.EXPECT().Commit(gomock.Any())
-	mockStore.EXPECT().Rollback(gomock.Any())
 
 	mockStore.EXPECT().BeginTransaction().Return(&tx, nil)
 	mockStore.EXPECT().GetQuerierWithTransaction(gomock.Any()).Return(mockStore)
@@ -78,7 +77,6 @@ func TestHandleEvents(t *testing.T) {
 		GetUserBySubject(gomock.Any(), "alreadyDeletedUserId").
 		Return(db.User{}, sql.ErrNoRows)
 	mockStore.EXPECT().Commit(gomock.Any())
-	mockStore.EXPECT().Rollback(gomock.Any())
 
 	c := serverconfig.Config{
 		Identity: serverconfig.IdentityConfigWrapper{


### PR DESCRIPTION
# Summary

The transaction is not being executed for some reason, this
only executes the rollback if there's an error and logs a rollback
error too.

## Change Type

***Mark the type of change your PR introduces:***

- [x] Bug fix (resolves an issue without affecting existing features)
- [ ] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [ ] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

***Outline how the changes were tested, including steps to reproduce and any relevant configurations. 
Attach screenshots if helpful.***

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [ ] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [ ] Included tests that validate the fix or feature.
- [ ] Checked that related changes are merged.
