### PR TITLE
Detect project deletion while `ListProjects` gathers projects

### DIFF
--- a/internal/controlplane/handlers_projects.go
+++ b/internal/controlplane/handlers_projects.go
@@ -57,6 +57,10 @@ func (s *Server) ListProjects(
 	for _, projectID := range projs {
 		project, err := s.store.GetProjectByID(ctx, projectID)
 		if err != nil {
+			// project was deleted while we were iterating
+			if errors.Is(err, sql.ErrNoRows) {
+				continue
+			}
 			return nil, status.Errorf(codes.Internal, "error getting project: %v", err)
 		}
 

--- a/internal/controlplane/handlers_projects_test.go
+++ b/internal/controlplane/handlers_projects_test.go
@@ -16,6 +16,7 @@ package controlplane
 
 import (
 	"context"
+	"database/sql"
 	"testing"
 
 	"github.com/google/uuid"
@@ -61,4 +62,42 @@ func TestListProjects(t *testing.T) {
 
 	assert.Len(t, resp.Projects, 1)
 	assert.Equal(t, authzClient.Allowed[0].String(), resp.Projects[0].ProjectId)
+}
+
+func TestListProjectsWithOneDeletedWhileIterating(t *testing.T) {
+	t.Parallel()
+
+	user := openid.New()
+	assert.NoError(t, user.Set("sub", "testuser"))
+
+	authzClient := &mock.SimpleClient{
+		Allowed: []uuid.UUID{uuid.New(), uuid.New(), uuid.New()},
+	}
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockStore := mockdb.NewMockStore(ctrl)
+	mockStore.EXPECT().GetUserBySubject(gomock.Any(), user.Subject()).Return(db.User{ID: 1}, nil)
+	mockStore.EXPECT().GetProjectByID(gomock.Any(), authzClient.Allowed[0]).Return(
+		db.Project{ID: authzClient.Allowed[0]}, nil)
+	mockStore.EXPECT().GetProjectByID(gomock.Any(), authzClient.Allowed[1]).Return(
+		db.Project{}, sql.ErrNoRows)
+	mockStore.EXPECT().GetProjectByID(gomock.Any(), authzClient.Allowed[2]).Return(
+		db.Project{ID: authzClient.Allowed[2]}, nil)
+
+	server := Server{
+		store:       mockStore,
+		authzClient: authzClient,
+	}
+
+	ctx := context.Background()
+	ctx = auth.WithAuthTokenContext(ctx, user)
+
+	resp, err := server.ListProjects(ctx, &minder.ListProjectsRequest{})
+	assert.NoError(t, err)
+
+	assert.Len(t, resp.Projects, 2)
+	assert.Equal(t, authzClient.Allowed[0].String(), resp.Projects[0].ProjectId)
+	assert.Equal(t, authzClient.Allowed[2].String(), resp.Projects[1].ProjectId)
 }


### PR DESCRIPTION
# Summary

This detects the `ErrNoRows` error when getting project information
in the ListProjects call to detect if a project was deleted while the RPC
was being executed. Thus, no longer erroring out.

Fixes #2751

## Change Type

***Mark the type of change your PR introduces:***

- [x] Bug fix (resolves an issue without affecting existing features)
- [ ] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [ ] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

Added a unit test

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [x] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [x] Included tests that validate the fix or feature.
- [x] Checked that related changes are merged.
