### PR TITLE
Remove isOrg from function calls to GitHub Provider

### DIFF
--- a/internal/controlplane/handlers_oauth.go
+++ b/internal/controlplane/handlers_oauth.go
@@ -306,26 +306,6 @@ func (s *Server) verifyProviderTokenIdentity(
 	return nil
 }
 
-// getProviderAccessToken returns the access token for providers
-func (s *Server) getProviderAccessToken(ctx context.Context, provider string,
-	projectID uuid.UUID) (oauth2.Token, string, error) {
-
-	encToken, err := s.store.GetAccessTokenByProjectID(ctx,
-		db.GetAccessTokenByProjectIDParams{Provider: provider, ProjectID: projectID})
-	if err != nil {
-		return oauth2.Token{}, "", err
-	}
-
-	decryptedToken, err := s.cryptoEngine.DecryptOAuthToken(encToken.EncryptedToken)
-	if err != nil {
-		return oauth2.Token{}, "", err
-	}
-
-	// base64 decode the token
-	decryptedToken.Expiry = encToken.ExpirationTime
-	return decryptedToken, encToken.OwnerFilter.String, nil
-}
-
 // StoreProviderToken stores the provider token for a project
 func (s *Server) StoreProviderToken(ctx context.Context,
 	in *pb.StoreProviderTokenRequest) (*pb.StoreProviderTokenResponse, error) {

--- a/internal/controlplane/handlers_repositories.go
+++ b/internal/controlplane/handlers_repositories.go
@@ -318,14 +318,6 @@ func (s *Server) ListRemoteRepositoriesFromProvider(
 		Str("projectID", projectID.String()).
 		Msg("listing repositories")
 
-	// FIXME: this is a hack to get the owner filter from the request
-	_, owner_filter, err := s.getProviderAccessToken(ctx, provider.Name, provider.ProjectID)
-
-	if err != nil {
-		return nil, util.UserVisibleError(codes.PermissionDenied,
-			"cannot get access token for provider: did you run `minder provider enroll`?")
-	}
-
 	pbOpts := []providers.ProviderBuilderOption{
 		providers.WithProviderMetrics(s.provMt),
 		providers.WithRestClientCache(s.restClientCache),
@@ -347,21 +339,11 @@ func (s *Server) ListRemoteRepositoriesFromProvider(
 	tmoutCtx, cancel := context.WithTimeout(ctx, github.ExpensiveRestCallTimeout)
 	defer cancel()
 
-	var remoteRepos []*pb.Repository
-	isOrg := (owner_filter != "")
-	if isOrg {
-		zerolog.Ctx(ctx).Debug().Msgf("listing repositories for organization")
-		remoteRepos, err = client.ListOrganizationRepsitories(tmoutCtx)
-		if err != nil {
-			return nil, util.UserVisibleError(codes.Internal, "cannot list repositories: %v", err)
-		}
-	} else {
-		zerolog.Ctx(ctx).Debug().Msgf("listing repositories for the user")
-		remoteRepos, err = client.ListUserRepositories(tmoutCtx)
-		if err != nil {
-			return nil, util.UserVisibleError(codes.Internal, "cannot list repositories: %v", err)
-		}
+	remoteGhRepos, err := client.ListAllRepositories(tmoutCtx)
+	if err != nil {
+		return nil, util.UserVisibleError(codes.Internal, "cannot list repositories: %v", err)
 	}
+	remoteRepos := github.ConvertRepositories(remoteGhRepos)
 
 	out := &pb.ListRemoteRepositoriesFromProviderResponse{
 		Results: make([]*pb.UpstreamRepositoryRef, 0, len(remoteRepos)),

--- a/internal/controlplane/handlers_repositories.go
+++ b/internal/controlplane/handlers_repositories.go
@@ -351,13 +351,13 @@ func (s *Server) ListRemoteRepositoriesFromProvider(
 	isOrg := (owner_filter != "")
 	if isOrg {
 		zerolog.Ctx(ctx).Debug().Msgf("listing repositories for organization")
-		remoteRepos, err = client.ListOrganizationRepsitories(tmoutCtx, owner_filter)
+		remoteRepos, err = client.ListOrganizationRepsitories(tmoutCtx)
 		if err != nil {
 			return nil, util.UserVisibleError(codes.Internal, "cannot list repositories: %v", err)
 		}
 	} else {
 		zerolog.Ctx(ctx).Debug().Msgf("listing repositories for the user")
-		remoteRepos, err = client.ListUserRepositories(tmoutCtx, owner_filter)
+		remoteRepos, err = client.ListUserRepositories(tmoutCtx)
 		if err != nil {
 			return nil, util.UserVisibleError(codes.Internal, "cannot list repositories: %v", err)
 		}

--- a/internal/controlplane/handlers_repositories_test.go
+++ b/internal/controlplane/handlers_repositories_test.go
@@ -495,11 +495,6 @@ func (*StubGitHub) GetCredential() provinfv1.GitHubCredential {
 	panic("unimplemented")
 }
 
-// ListAllPackages implements v1.GitHub.
-func (*StubGitHub) ListAllPackages(context.Context, bool, string, string, int, int) ([]*github.Package, error) {
-	panic("unimplemented")
-}
-
 // ListAllRepositories implements v1.GitHub.
 func (*StubGitHub) ListAllRepositories(context.Context) ([]*github.Repository, error) {
 	panic("unimplemented")
@@ -532,11 +527,6 @@ func (*StubGitHub) ListPullRequests(context.Context, string, string, *github.Pul
 
 // ListReviews implements v1.GitHub.
 func (*StubGitHub) ListReviews(context.Context, string, string, int, *github.ListOptions) ([]*github.PullRequestReview, error) {
-	panic("unimplemented")
-}
-
-// ListUserRepositories implements v1.GitHub.
-func (*StubGitHub) ListUserRepositories(context.Context) ([]*pb.Repository, error) {
 	panic("unimplemented")
 }
 

--- a/internal/controlplane/handlers_repositories_test.go
+++ b/internal/controlplane/handlers_repositories_test.go
@@ -501,7 +501,7 @@ func (*StubGitHub) ListAllPackages(context.Context, bool, string, string, int, i
 }
 
 // ListAllRepositories implements v1.GitHub.
-func (*StubGitHub) ListAllRepositories(context.Context, bool, string) ([]*github.Repository, error) {
+func (*StubGitHub) ListAllRepositories(context.Context) ([]*github.Repository, error) {
 	panic("unimplemented")
 }
 
@@ -516,7 +516,7 @@ func (_ *StubGitHub) ListHooks(_ context.Context, _ string, _ string) ([]*github
 }
 
 // ListOrganizationRepsitories implements v1.GitHub.
-func (*StubGitHub) ListOrganizationRepsitories(context.Context, string) ([]*pb.Repository, error) {
+func (*StubGitHub) ListOrganizationRepsitories(context.Context) ([]*pb.Repository, error) {
 	panic("unimplemented")
 }
 
@@ -536,7 +536,7 @@ func (*StubGitHub) ListReviews(context.Context, string, string, int, *github.Lis
 }
 
 // ListUserRepositories implements v1.GitHub.
-func (*StubGitHub) ListUserRepositories(context.Context, string) ([]*pb.Repository, error) {
+func (*StubGitHub) ListUserRepositories(context.Context) ([]*pb.Repository, error) {
 	panic("unimplemented")
 }
 

--- a/internal/providers/github/app/app.go
+++ b/internal/providers/github/app/app.go
@@ -142,26 +142,6 @@ func (_ *GitHubAppDelegate) GetOwner() string {
 	return ""
 }
 
-// ListUserRepositories returns a list of repositories for the owner
-func (g *GitHubAppDelegate) ListUserRepositories(ctx context.Context) ([]*minderv1.Repository, error) {
-	repos, err := g.ListAllRepositories(ctx)
-	if err != nil {
-		return nil, err
-	}
-
-	return github.ConvertRepositories(repos), nil
-}
-
-// ListOrganizationRepositories returns a list of repositories for the organization
-func (g *GitHubAppDelegate) ListOrganizationRepositories(ctx context.Context) ([]*minderv1.Repository, error) {
-	repos, err := g.ListAllRepositories(ctx)
-	if err != nil {
-		return nil, err
-	}
-
-	return github.ConvertRepositories(repos), nil
-}
-
 // ListAllRepositories returns a list of all repositories accessible to the GitHub App installation
 func (g *GitHubAppDelegate) ListAllRepositories(ctx context.Context) ([]*gogithub.Repository, error) {
 	listOpt := &gogithub.ListOptions{

--- a/internal/providers/github/app/app.go
+++ b/internal/providers/github/app/app.go
@@ -105,7 +105,6 @@ func NewGitHubAppProvider(
 
 	return github.NewGitHub(
 		ghClient,
-		"",
 		restClientCache,
 		oauthDelegate,
 	), nil
@@ -136,6 +135,11 @@ var _ github.Delegate = (*GitHubAppDelegate)(nil)
 // GetCredential returns the GitHub App installation credential
 func (g *GitHubAppDelegate) GetCredential() provifv1.GitHubCredential {
 	return g.credential
+}
+
+// GetOwner returns the owner filter
+func (_ *GitHubAppDelegate) GetOwner() string {
+	return ""
 }
 
 // ListUserRepositories returns a list of repositories for the owner

--- a/internal/providers/github/app/app.go
+++ b/internal/providers/github/app/app.go
@@ -139,8 +139,8 @@ func (g *GitHubAppDelegate) GetCredential() provifv1.GitHubCredential {
 }
 
 // ListUserRepositories returns a list of repositories for the owner
-func (g *GitHubAppDelegate) ListUserRepositories(ctx context.Context, owner string) ([]*minderv1.Repository, error) {
-	repos, err := g.ListAllRepositories(ctx, false, owner)
+func (g *GitHubAppDelegate) ListUserRepositories(ctx context.Context) ([]*minderv1.Repository, error) {
+	repos, err := g.ListAllRepositories(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -149,11 +149,8 @@ func (g *GitHubAppDelegate) ListUserRepositories(ctx context.Context, owner stri
 }
 
 // ListOrganizationRepositories returns a list of repositories for the organization
-func (g *GitHubAppDelegate) ListOrganizationRepositories(
-	ctx context.Context,
-	owner string,
-) ([]*minderv1.Repository, error) {
-	repos, err := g.ListAllRepositories(ctx, true, owner)
+func (g *GitHubAppDelegate) ListOrganizationRepositories(ctx context.Context) ([]*minderv1.Repository, error) {
+	repos, err := g.ListAllRepositories(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -162,7 +159,7 @@ func (g *GitHubAppDelegate) ListOrganizationRepositories(
 }
 
 // ListAllRepositories returns a list of all repositories accessible to the GitHub App installation
-func (g *GitHubAppDelegate) ListAllRepositories(ctx context.Context, _ bool, _ string) ([]*gogithub.Repository, error) {
+func (g *GitHubAppDelegate) ListAllRepositories(ctx context.Context) ([]*gogithub.Repository, error) {
 	listOpt := &gogithub.ListOptions{
 		PerPage: 100,
 	}

--- a/internal/providers/github/common.go
+++ b/internal/providers/github/common.go
@@ -69,9 +69,9 @@ var _ provifv1.GitHub = (*GitHub)(nil)
 // Delegate is the interface that contains operations that differ between different GitHub actors (user vs app)
 type Delegate interface {
 	GetCredential() provifv1.GitHubCredential
-	ListUserRepositories(context.Context, string) ([]*minderv1.Repository, error)
-	ListOrganizationRepositories(context.Context, string) ([]*minderv1.Repository, error)
-	ListAllRepositories(context.Context, bool, string) ([]*github.Repository, error)
+	ListUserRepositories(context.Context) ([]*minderv1.Repository, error)
+	ListOrganizationRepositories(context.Context) ([]*minderv1.Repository, error)
+	ListAllRepositories(context.Context) ([]*github.Repository, error)
 	GetUserId(ctx context.Context) (int64, error)
 	GetName(ctx context.Context) (string, error)
 	GetLogin(ctx context.Context) (string, error)
@@ -643,18 +643,18 @@ func (c *GitHub) AddAuthToPushOptions(ctx context.Context, pushOptions *git.Push
 }
 
 // ListUserRepositories lists all repositories for the owner
-func (c *GitHub) ListUserRepositories(ctx context.Context, owner string) ([]*minderv1.Repository, error) {
-	return c.delegate.ListUserRepositories(ctx, owner)
+func (c *GitHub) ListUserRepositories(ctx context.Context) ([]*minderv1.Repository, error) {
+	return c.delegate.ListUserRepositories(ctx)
 }
 
 // ListOrganizationRepsitories lists all repositories for the organization
-func (c *GitHub) ListOrganizationRepsitories(ctx context.Context, owner string) ([]*minderv1.Repository, error) {
-	return c.delegate.ListOrganizationRepositories(ctx, owner)
+func (c *GitHub) ListOrganizationRepsitories(ctx context.Context) ([]*minderv1.Repository, error) {
+	return c.delegate.ListOrganizationRepositories(ctx)
 }
 
 // ListAllRepositories lists all repositories the credential has access to
-func (c *GitHub) ListAllRepositories(ctx context.Context, isOrg bool, owner string) ([]*github.Repository, error) {
-	return c.delegate.ListAllRepositories(ctx, isOrg, owner)
+func (c *GitHub) ListAllRepositories(ctx context.Context) ([]*github.Repository, error) {
+	return c.delegate.ListAllRepositories(ctx)
 }
 
 // GetUserId returns the user id for the acting user

--- a/internal/providers/github/common.go
+++ b/internal/providers/github/common.go
@@ -68,8 +68,6 @@ var _ provifv1.GitHub = (*GitHub)(nil)
 // Delegate is the interface that contains operations that differ between different GitHub actors (user vs app)
 type Delegate interface {
 	GetCredential() provifv1.GitHubCredential
-	ListUserRepositories(context.Context) ([]*minderv1.Repository, error)
-	ListOrganizationRepositories(context.Context) ([]*minderv1.Repository, error)
 	ListAllRepositories(context.Context) ([]*github.Repository, error)
 	GetUserId(ctx context.Context) (int64, error)
 	GetName(ctx context.Context) (string, error)
@@ -635,16 +633,6 @@ func (c *GitHub) AddAuthToPushOptions(ctx context.Context, pushOptions *git.Push
 	}
 	c.delegate.GetCredential().AddToPushOptions(pushOptions, login)
 	return nil
-}
-
-// ListUserRepositories lists all repositories for the owner
-func (c *GitHub) ListUserRepositories(ctx context.Context) ([]*minderv1.Repository, error) {
-	return c.delegate.ListUserRepositories(ctx)
-}
-
-// ListOrganizationRepsitories lists all repositories for the organization
-func (c *GitHub) ListOrganizationRepsitories(ctx context.Context) ([]*minderv1.Repository, error) {
-	return c.delegate.ListOrganizationRepositories(ctx)
 }
 
 // ListAllRepositories lists all repositories the credential has access to

--- a/internal/providers/github/mock/github.go
+++ b/internal/providers/github/mock/github.go
@@ -173,33 +173,33 @@ func (m *MockRepoLister) EXPECT() *MockRepoListerMockRecorder {
 }
 
 // ListOrganizationRepsitories mocks base method.
-func (m *MockRepoLister) ListOrganizationRepsitories(arg0 context.Context, arg1 string) ([]*v1.Repository, error) {
+func (m *MockRepoLister) ListOrganizationRepsitories(arg0 context.Context) ([]*v1.Repository, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListOrganizationRepsitories", arg0, arg1)
+	ret := m.ctrl.Call(m, "ListOrganizationRepsitories", arg0)
 	ret0, _ := ret[0].([]*v1.Repository)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ListOrganizationRepsitories indicates an expected call of ListOrganizationRepsitories.
-func (mr *MockRepoListerMockRecorder) ListOrganizationRepsitories(arg0, arg1 any) *gomock.Call {
+func (mr *MockRepoListerMockRecorder) ListOrganizationRepsitories(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListOrganizationRepsitories", reflect.TypeOf((*MockRepoLister)(nil).ListOrganizationRepsitories), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListOrganizationRepsitories", reflect.TypeOf((*MockRepoLister)(nil).ListOrganizationRepsitories), arg0)
 }
 
 // ListUserRepositories mocks base method.
-func (m *MockRepoLister) ListUserRepositories(arg0 context.Context, arg1 string) ([]*v1.Repository, error) {
+func (m *MockRepoLister) ListUserRepositories(arg0 context.Context) ([]*v1.Repository, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListUserRepositories", arg0, arg1)
+	ret := m.ctrl.Call(m, "ListUserRepositories", arg0)
 	ret0, _ := ret[0].([]*v1.Repository)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ListUserRepositories indicates an expected call of ListUserRepositories.
-func (mr *MockRepoListerMockRecorder) ListUserRepositories(arg0, arg1 any) *gomock.Call {
+func (mr *MockRepoListerMockRecorder) ListUserRepositories(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListUserRepositories", reflect.TypeOf((*MockRepoLister)(nil).ListUserRepositories), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListUserRepositories", reflect.TypeOf((*MockRepoLister)(nil).ListUserRepositories), arg0)
 }
 
 // MockGitHub is a mock of GitHub interface.
@@ -611,18 +611,18 @@ func (mr *MockGitHubMockRecorder) GetUserId(ctx any) *gomock.Call {
 }
 
 // ListAllRepositories mocks base method.
-func (m *MockGitHub) ListAllRepositories(arg0 context.Context, arg1 bool, arg2 string) ([]*github.Repository, error) {
+func (m *MockGitHub) ListAllRepositories(arg0 context.Context) ([]*github.Repository, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListAllRepositories", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "ListAllRepositories", arg0)
 	ret0, _ := ret[0].([]*github.Repository)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ListAllRepositories indicates an expected call of ListAllRepositories.
-func (mr *MockGitHubMockRecorder) ListAllRepositories(arg0, arg1, arg2 any) *gomock.Call {
+func (mr *MockGitHubMockRecorder) ListAllRepositories(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListAllRepositories", reflect.TypeOf((*MockGitHub)(nil).ListAllRepositories), arg0, arg1, arg2)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListAllRepositories", reflect.TypeOf((*MockGitHub)(nil).ListAllRepositories), arg0)
 }
 
 // ListFiles mocks base method.
@@ -672,18 +672,18 @@ func (mr *MockGitHubMockRecorder) ListIssueComments(ctx, owner, repo, number, op
 }
 
 // ListOrganizationRepsitories mocks base method.
-func (m *MockGitHub) ListOrganizationRepsitories(arg0 context.Context, arg1 string) ([]*v1.Repository, error) {
+func (m *MockGitHub) ListOrganizationRepsitories(arg0 context.Context) ([]*v1.Repository, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListOrganizationRepsitories", arg0, arg1)
+	ret := m.ctrl.Call(m, "ListOrganizationRepsitories", arg0)
 	ret0, _ := ret[0].([]*v1.Repository)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ListOrganizationRepsitories indicates an expected call of ListOrganizationRepsitories.
-func (mr *MockGitHubMockRecorder) ListOrganizationRepsitories(arg0, arg1 any) *gomock.Call {
+func (mr *MockGitHubMockRecorder) ListOrganizationRepsitories(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListOrganizationRepsitories", reflect.TypeOf((*MockGitHub)(nil).ListOrganizationRepsitories), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListOrganizationRepsitories", reflect.TypeOf((*MockGitHub)(nil).ListOrganizationRepsitories), arg0)
 }
 
 // ListPackagesByRepository mocks base method.
@@ -732,18 +732,18 @@ func (mr *MockGitHubMockRecorder) ListReviews(arg0, arg1, arg2, arg3, arg4 any) 
 }
 
 // ListUserRepositories mocks base method.
-func (m *MockGitHub) ListUserRepositories(arg0 context.Context, arg1 string) ([]*v1.Repository, error) {
+func (m *MockGitHub) ListUserRepositories(arg0 context.Context) ([]*v1.Repository, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListUserRepositories", arg0, arg1)
+	ret := m.ctrl.Call(m, "ListUserRepositories", arg0)
 	ret0, _ := ret[0].([]*v1.Repository)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ListUserRepositories indicates an expected call of ListUserRepositories.
-func (mr *MockGitHubMockRecorder) ListUserRepositories(arg0, arg1 any) *gomock.Call {
+func (mr *MockGitHubMockRecorder) ListUserRepositories(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListUserRepositories", reflect.TypeOf((*MockGitHub)(nil).ListUserRepositories), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListUserRepositories", reflect.TypeOf((*MockGitHub)(nil).ListUserRepositories), arg0)
 }
 
 // NewRequest mocks base method.

--- a/internal/providers/github/mock/github.go
+++ b/internal/providers/github/mock/github.go
@@ -16,8 +16,7 @@ import (
 
 	git "github.com/go-git/go-git/v5"
 	github "github.com/google/go-github/v56/github"
-	v1 "github.com/stacklok/minder/pkg/api/protobuf/go/minder/v1"
-	v10 "github.com/stacklok/minder/pkg/providers/v1"
+	v1 "github.com/stacklok/minder/pkg/providers/v1"
 	gomock "go.uber.org/mock/gomock"
 )
 
@@ -172,34 +171,19 @@ func (m *MockRepoLister) EXPECT() *MockRepoListerMockRecorder {
 	return m.recorder
 }
 
-// ListOrganizationRepsitories mocks base method.
-func (m *MockRepoLister) ListOrganizationRepsitories(arg0 context.Context) ([]*v1.Repository, error) {
+// ListAllRepositories mocks base method.
+func (m *MockRepoLister) ListAllRepositories(arg0 context.Context) ([]*github.Repository, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListOrganizationRepsitories", arg0)
-	ret0, _ := ret[0].([]*v1.Repository)
+	ret := m.ctrl.Call(m, "ListAllRepositories", arg0)
+	ret0, _ := ret[0].([]*github.Repository)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// ListOrganizationRepsitories indicates an expected call of ListOrganizationRepsitories.
-func (mr *MockRepoListerMockRecorder) ListOrganizationRepsitories(arg0 any) *gomock.Call {
+// ListAllRepositories indicates an expected call of ListAllRepositories.
+func (mr *MockRepoListerMockRecorder) ListAllRepositories(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListOrganizationRepsitories", reflect.TypeOf((*MockRepoLister)(nil).ListOrganizationRepsitories), arg0)
-}
-
-// ListUserRepositories mocks base method.
-func (m *MockRepoLister) ListUserRepositories(arg0 context.Context) ([]*v1.Repository, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListUserRepositories", arg0)
-	ret0, _ := ret[0].([]*v1.Repository)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// ListUserRepositories indicates an expected call of ListUserRepositories.
-func (mr *MockRepoListerMockRecorder) ListUserRepositories(arg0 any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListUserRepositories", reflect.TypeOf((*MockRepoLister)(nil).ListUserRepositories), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListAllRepositories", reflect.TypeOf((*MockRepoLister)(nil).ListAllRepositories), arg0)
 }
 
 // MockGitHub is a mock of GitHub interface.
@@ -433,10 +417,10 @@ func (mr *MockGitHubMockRecorder) GetBranchProtection(arg0, arg1, arg2, arg3 any
 }
 
 // GetCredential mocks base method.
-func (m *MockGitHub) GetCredential() v10.GitHubCredential {
+func (m *MockGitHub) GetCredential() v1.GitHubCredential {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetCredential")
-	ret0, _ := ret[0].(v10.GitHubCredential)
+	ret0, _ := ret[0].(v1.GitHubCredential)
 	return ret0
 }
 
@@ -671,21 +655,6 @@ func (mr *MockGitHubMockRecorder) ListIssueComments(ctx, owner, repo, number, op
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListIssueComments", reflect.TypeOf((*MockGitHub)(nil).ListIssueComments), ctx, owner, repo, number, opts)
 }
 
-// ListOrganizationRepsitories mocks base method.
-func (m *MockGitHub) ListOrganizationRepsitories(arg0 context.Context) ([]*v1.Repository, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListOrganizationRepsitories", arg0)
-	ret0, _ := ret[0].([]*v1.Repository)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// ListOrganizationRepsitories indicates an expected call of ListOrganizationRepsitories.
-func (mr *MockGitHubMockRecorder) ListOrganizationRepsitories(arg0 any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListOrganizationRepsitories", reflect.TypeOf((*MockGitHub)(nil).ListOrganizationRepsitories), arg0)
-}
-
 // ListPackagesByRepository mocks base method.
 func (m *MockGitHub) ListPackagesByRepository(arg0 context.Context, arg1 bool, arg2, arg3 string, arg4 int64, arg5, arg6 int) ([]*github.Package, error) {
 	m.ctrl.T.Helper()
@@ -729,21 +698,6 @@ func (m *MockGitHub) ListReviews(arg0 context.Context, arg1, arg2 string, arg3 i
 func (mr *MockGitHubMockRecorder) ListReviews(arg0, arg1, arg2, arg3, arg4 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListReviews", reflect.TypeOf((*MockGitHub)(nil).ListReviews), arg0, arg1, arg2, arg3, arg4)
-}
-
-// ListUserRepositories mocks base method.
-func (m *MockGitHub) ListUserRepositories(arg0 context.Context) ([]*v1.Repository, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListUserRepositories", arg0)
-	ret0, _ := ret[0].([]*v1.Repository)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// ListUserRepositories indicates an expected call of ListUserRepositories.
-func (mr *MockGitHubMockRecorder) ListUserRepositories(arg0 any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListUserRepositories", reflect.TypeOf((*MockGitHub)(nil).ListUserRepositories), arg0)
 }
 
 // NewRequest mocks base method.

--- a/internal/providers/github/oauth/oauth.go
+++ b/internal/providers/github/oauth/oauth.go
@@ -54,6 +54,7 @@ var AuthorizationFlows = []db.AuthorizationFlow{
 type GitHubOAuthDelegate struct {
 	client     *gogithub.Client
 	credential provifv1.GitHubCredential
+	owner      string
 }
 
 // Ensure that the GitHubOAuthDelegate client implements the GitHub Delegate interface
@@ -97,6 +98,7 @@ func NewRestClient(
 	oauthDelegate := &GitHubOAuthDelegate{
 		client:     ghClient,
 		credential: credential,
+		owner:      owner,
 	}
 
 	return github.NewGitHub(
@@ -132,8 +134,8 @@ func (o *GitHubOAuthDelegate) GetCredential() provifv1.GitHubCredential {
 }
 
 // ListUserRepositories returns a list of all repositories for the authenticated user
-func (o *GitHubOAuthDelegate) ListUserRepositories(ctx context.Context, owner string) ([]*minderv1.Repository, error) {
-	repos, err := o.ListAllRepositories(ctx, false, owner)
+func (o *GitHubOAuthDelegate) ListUserRepositories(ctx context.Context) ([]*minderv1.Repository, error) {
+	repos, err := o.ListAllRepositories(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -142,8 +144,8 @@ func (o *GitHubOAuthDelegate) ListUserRepositories(ctx context.Context, owner st
 }
 
 // ListOrganizationRepositories returns a list of all repositories for the organization
-func (o *GitHubOAuthDelegate) ListOrganizationRepositories(ctx context.Context, owner string) ([]*minderv1.Repository, error) {
-	repos, err := o.ListAllRepositories(ctx, true, owner)
+func (o *GitHubOAuthDelegate) ListOrganizationRepositories(ctx context.Context) ([]*minderv1.Repository, error) {
+	repos, err := o.ListAllRepositories(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -153,7 +155,7 @@ func (o *GitHubOAuthDelegate) ListOrganizationRepositories(ctx context.Context, 
 
 // ListAllRepositories returns a list of all repositories for the authenticated user
 // Two APIs are available, contigent on whether the token is for a user or an organization
-func (o *GitHubOAuthDelegate) ListAllRepositories(ctx context.Context, isOrg bool, owner string) ([]*gogithub.Repository, error) {
+func (o *GitHubOAuthDelegate) ListAllRepositories(ctx context.Context) ([]*gogithub.Repository, error) {
 	opt := &gogithub.RepositoryListOptions{
 		ListOptions: gogithub.ListOptions{
 			PerPage: 100,
@@ -174,8 +176,8 @@ func (o *GitHubOAuthDelegate) ListAllRepositories(ctx context.Context, isOrg boo
 		var resp *gogithub.Response
 		var err error
 
-		if isOrg {
-			repos, resp, err = o.client.Repositories.ListByOrg(ctx, owner, orgOpt)
+		if o.owner != "" {
+			repos, resp, err = o.client.Repositories.ListByOrg(ctx, o.owner, orgOpt)
 		} else {
 			repos, resp, err = o.client.Repositories.List(ctx, "", opt)
 		}
@@ -188,7 +190,7 @@ func (o *GitHubOAuthDelegate) ListAllRepositories(ctx context.Context, isOrg boo
 			break
 		}
 
-		if isOrg {
+		if o.owner != "" {
 			orgOpt.Page = resp.NextPage
 		} else {
 			opt.Page = resp.NextPage

--- a/internal/providers/github/oauth/oauth.go
+++ b/internal/providers/github/oauth/oauth.go
@@ -103,7 +103,6 @@ func NewRestClient(
 
 	return github.NewGitHub(
 		ghClient,
-		owner,
 		restClientCache,
 		oauthDelegate,
 	), nil
@@ -131,6 +130,11 @@ func ParseV1Config(rawCfg json.RawMessage) (*minderv1.GitHubProviderConfig, erro
 // GetCredential returns the GitHub OAuth credential
 func (o *GitHubOAuthDelegate) GetCredential() provifv1.GitHubCredential {
 	return o.credential
+}
+
+// GetOwner returns the owner filter
+func (o *GitHubOAuthDelegate) GetOwner() string {
+	return o.owner
 }
 
 // ListUserRepositories returns a list of all repositories for the authenticated user

--- a/internal/providers/github/oauth/oauth.go
+++ b/internal/providers/github/oauth/oauth.go
@@ -137,26 +137,6 @@ func (o *GitHubOAuthDelegate) GetOwner() string {
 	return o.owner
 }
 
-// ListUserRepositories returns a list of all repositories for the authenticated user
-func (o *GitHubOAuthDelegate) ListUserRepositories(ctx context.Context) ([]*minderv1.Repository, error) {
-	repos, err := o.ListAllRepositories(ctx)
-	if err != nil {
-		return nil, err
-	}
-
-	return github.ConvertRepositories(repos), nil
-}
-
-// ListOrganizationRepositories returns a list of all repositories for the organization
-func (o *GitHubOAuthDelegate) ListOrganizationRepositories(ctx context.Context) ([]*minderv1.Repository, error) {
-	repos, err := o.ListAllRepositories(ctx)
-	if err != nil {
-		return nil, err
-	}
-
-	return github.ConvertRepositories(repos), nil
-}
-
 // ListAllRepositories returns a list of all repositories for the authenticated user
 // Two APIs are available, contigent on whether the token is for a user or an organization
 func (o *GitHubOAuthDelegate) ListAllRepositories(ctx context.Context) ([]*gogithub.Repository, error) {

--- a/pkg/providers/v1/providers.go
+++ b/pkg/providers/v1/providers.go
@@ -65,8 +65,8 @@ type REST interface {
 type RepoLister interface {
 	Provider
 
-	ListUserRepositories(context.Context, string) ([]*minderv1.Repository, error)
-	ListOrganizationRepsitories(context.Context, string) ([]*minderv1.Repository, error)
+	ListUserRepositories(context.Context) ([]*minderv1.Repository, error)
+	ListOrganizationRepsitories(context.Context) ([]*minderv1.Repository, error)
 }
 
 // GitHub is the interface for interacting with the GitHub REST API
@@ -79,7 +79,7 @@ type GitHub interface {
 
 	GetCredential() GitHubCredential
 	GetRepository(context.Context, string, string) (*github.Repository, error)
-	ListAllRepositories(context.Context, bool, string) ([]*github.Repository, error)
+	ListAllRepositories(context.Context) ([]*github.Repository, error)
 	GetBranchProtection(context.Context, string, string, string) (*github.Protection, error)
 	UpdateBranchProtection(context.Context, string, string, string, *github.ProtectionRequest) error
 	ListPackagesByRepository(context.Context, bool, string, string, int64, int, int) ([]*github.Package, error)

--- a/pkg/providers/v1/providers.go
+++ b/pkg/providers/v1/providers.go
@@ -26,8 +26,6 @@ import (
 	"github.com/go-git/go-git/v5"
 	"github.com/go-playground/validator/v10"
 	"github.com/google/go-github/v56/github"
-
-	minderv1 "github.com/stacklok/minder/pkg/api/protobuf/go/minder/v1"
 )
 
 // V1 is the version of the providers interface
@@ -65,8 +63,7 @@ type REST interface {
 type RepoLister interface {
 	Provider
 
-	ListUserRepositories(context.Context) ([]*minderv1.Repository, error)
-	ListOrganizationRepsitories(context.Context) ([]*minderv1.Repository, error)
+	ListAllRepositories(context.Context) ([]*github.Repository, error)
 }
 
 // GitHub is the interface for interacting with the GitHub REST API
@@ -79,7 +76,6 @@ type GitHub interface {
 
 	GetCredential() GitHubCredential
 	GetRepository(context.Context, string, string) (*github.Repository, error)
-	ListAllRepositories(context.Context) ([]*github.Repository, error)
 	GetBranchProtection(context.Context, string, string, string) (*github.Protection, error)
 	UpdateBranchProtection(context.Context, string, string, string, *github.ProtectionRequest) error
 	ListPackagesByRepository(context.Context, bool, string, string, int64, int, int) ([]*github.Package, error)


### PR DESCRIPTION
# Summary

- **Drop is_org and owner parameters from repo listing methods of RepoLister and GitHub interfaces**
- **Move the owner attribute to the delegates**
- **Remove ListUserRepositories and ListOrganizationRepsitories in favour of ListAllRepositories**

Fixes #2756

## Change Type

***Mark the type of change your PR introduces:***

- [ ] Bug fix (resolves an issue without affecting existing features)
- [ ] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [x] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

Tested by calling `repo register` for both an enrolled org an a user account.

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [ ] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [ ] Included tests that validate the fix or feature.
- [ ] Checked that related changes are merged.
