### PR TITLE
Show user facing error when credential is invalid

### DIFF
--- a/internal/controlplane/handlers_repositories.go
+++ b/internal/controlplane/handlers_repositories.go
@@ -333,6 +333,10 @@ func (s *Server) ListRemoteRepositoriesFromProvider(
 
 	client, err := p.GetRepoLister()
 	if err != nil {
+		if errors.Is(err, providers.ErrInvalidCredential) {
+			return nil, util.UserVisibleError(codes.PermissionDenied,
+				"cannot get credential for provider: did you run `minder provider enroll`?")
+		}
 		return nil, status.Errorf(codes.Internal, "cannot create github client: %v", err)
 	}
 

--- a/internal/providers/providers.go
+++ b/internal/providers/providers.go
@@ -41,6 +41,9 @@ import (
 	provinfv1 "github.com/stacklok/minder/pkg/providers/v1"
 )
 
+// ErrInvalidCredential is returned when the credential is not of the required type
+var ErrInvalidCredential = errors.New("invalid credential type")
+
 // GetProviderBuilder is a utility function which allows for the creation of
 // a provider factory.
 func GetProviderBuilder(
@@ -138,7 +141,7 @@ func (pb *ProviderBuilder) GetGit() (provinfv1.Git, error) {
 
 	gitCredential, ok := pb.credential.(provinfv1.GitCredential)
 	if !ok {
-		return nil, fmt.Errorf("credential is not a git credential")
+		return nil, ErrInvalidCredential
 	}
 
 	return gitclient.NewGit(gitCredential), nil
@@ -169,7 +172,7 @@ func (pb *ProviderBuilder) GetHTTP() (provinfv1.REST, error) {
 
 	restCredential, ok := pb.credential.(provinfv1.RestCredential)
 	if !ok {
-		return nil, fmt.Errorf("credential is not a rest credential")
+		return nil, ErrInvalidCredential
 	}
 
 	return httpclient.NewREST(cfg, pb.metrics, restCredential)
@@ -187,7 +190,7 @@ func (pb *ProviderBuilder) GetGitHub() (provinfv1.GitHub, error) {
 
 	gitHubCredential, ok := pb.credential.(provinfv1.GitHubCredential)
 	if !ok {
-		return nil, fmt.Errorf("credential is not a GitHub credential")
+		return nil, ErrInvalidCredential
 	}
 
 	if pb.restClientCache != nil {


### PR DESCRIPTION
# Summary
This fixes a recently introduced bug, where we weren't showing the user a descriptive error message when they tried to register repos before enrolling a provider.
With this fix, the user now sees the message: `cannot get credential for provider: did you run `minder provider enroll`?` if they run `minder repo register` without having an enrolled provider.


## Change Type

***Mark the type of change your PR introduces:***

- [x] Bug fix (resolves an issue without affecting existing features)
- [ ] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [ ] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

***Outline how the changes were tested, including steps to reproduce and any relevant configurations. 
Attach screenshots if helpful.***

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [ ] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [ ] Included tests that validate the fix or feature.
- [ ] Checked that related changes are merged.
