### PR TITLE
Refactor enrolment to be more flexible with provider class

### DIFF
--- a/cmd/cli/app/provider/provider_enroll.go
+++ b/cmd/cli/app/provider/provider_enroll.go
@@ -53,7 +53,6 @@ actions such as adding repositories.`,
 // EnrollProviderCommand is the command for enrolling a provider
 func EnrollProviderCommand(ctx context.Context, cmd *cobra.Command, conn *grpc.ClientConn) error {
 	client := minderv1.NewOAuthServiceClient(conn)
-	provcli := minderv1.NewProvidersServiceClient(conn)
 
 	provider := viper.GetString("provider")
 	project := viper.GetString("project")
@@ -83,25 +82,8 @@ func EnrollProviderCommand(ctx context.Context, cmd *cobra.Command, conn *grpc.C
 		}
 	}
 
-	prov, err := provcli.GetProvider(ctx, &minderv1.GetProviderRequest{
-		Context: &minderv1.Context{Provider: &provider, Project: &project},
-		Name:    provider,
-	})
-	if err != nil {
-		return cli.MessageAndError("Error getting provider", err)
-	}
-
 	if token != "" {
-		if !prov.Provider.SupportsAuthFlow(minderv1.AuthorizationFlow_AUTHORIZATION_FLOW_USER_INPUT) {
-			return fmt.Errorf("provider %s does not support token enrollment", provider)
-		}
-
 		return enrollUsingToken(ctx, cmd, client, provider, project, token, owner)
-	}
-
-	if !prov.Provider.SupportsAuthFlow(
-		minderv1.AuthorizationFlow_AUTHORIZATION_FLOW_OAUTH2_AUTHORIZATION_CODE_FLOW) {
-		return fmt.Errorf("provider %s does not support OAuth2 enrollment", provider)
 	}
 
 	// This will have a different timeout

--- a/database/migrations/000037_session_state_foreign_key.down.sql
+++ b/database/migrations/000037_session_state_foreign_key.down.sql
@@ -1,0 +1,23 @@
+-- Copyright 2024 Stacklok, Inc
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--      http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+-- Drop the existing foreign key constraint on provider
+ALTER TABLE session_store DROP CONSTRAINT session_store_project_id_fkey;
+
+-- Add a new foreign key constraint just for project_id
+ALTER TABLE session_store
+    ADD CONSTRAINT session_store_project_id_provider_fkey
+    FOREIGN KEY (project_id, provider)
+    REFERENCES providers(project_id, name)
+    ON DELETE CASCADE;

--- a/database/migrations/000037_session_state_foreign_key.up.sql
+++ b/database/migrations/000037_session_state_foreign_key.up.sql
@@ -1,0 +1,23 @@
+-- Copyright 2024 Stacklok, Inc
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--      http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+-- Drop the existing foreign key constraint on provider
+ALTER TABLE session_store DROP CONSTRAINT session_store_project_id_provider_fkey;
+
+-- Add a new foreign key constraint just for project_id
+ALTER TABLE session_store
+    ADD CONSTRAINT session_store_project_id_fkey
+    FOREIGN KEY (project_id)
+    REFERENCES projects(id)
+    ON DELETE CASCADE;

--- a/internal/controlplane/server_test.go
+++ b/internal/controlplane/server_test.go
@@ -67,7 +67,7 @@ func init() {
 	// It would be nice if we could Close() the httpServer, but we leak it in the test instead
 }
 
-func newDefaultServer(t *testing.T, mockStore *mockdb.MockStore) (*Server, events.Interface) {
+func newDefaultServer(t *testing.T, mockStore *mockdb.MockStore, opts ...ServerOption) (*Server, events.Interface) {
 	t.Helper()
 
 	evt, err := events.Setup(context.Background(), &serverconfig.EventConfig{
@@ -87,7 +87,7 @@ func newDefaultServer(t *testing.T, mockStore *mockdb.MockStore) (*Server, event
 	defer ctrl.Finish()
 	mockJwt := mockjwt.NewMockJwtValidator(ctrl)
 
-	server, err := NewServer(mockStore, evt, c, mockJwt)
+	server, err := NewServer(mockStore, evt, c, mockJwt, opts...)
 	require.NoError(t, err, "failed to create server")
 	return server, evt
 }

--- a/internal/providers/provider_definitions.go
+++ b/internal/providers/provider_definitions.go
@@ -1,0 +1,49 @@
+// Copyright 2024 Stacklok, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package providers
+
+import (
+	"fmt"
+
+	"github.com/stacklok/minder/internal/db"
+	githubapp "github.com/stacklok/minder/internal/providers/github/app"
+	ghclient "github.com/stacklok/minder/internal/providers/github/oauth"
+)
+
+// ProviderClassDefinition contains the static fields needed when creating a provider
+type ProviderClassDefinition struct {
+	Traits             []db.ProviderType
+	AuthorizationFlows []db.AuthorizationFlow
+}
+
+var supportedProviderClassDefinitions = map[string]ProviderClassDefinition{
+	githubapp.GithubApp: {
+		Traits:             githubapp.Implements,
+		AuthorizationFlows: githubapp.AuthorizationFlows,
+	},
+	ghclient.Github: {
+		Traits:             ghclient.Implements,
+		AuthorizationFlows: ghclient.AuthorizationFlows,
+	},
+}
+
+// GetProviderClassDefinition returns the provider definition for the given provider class
+func GetProviderClassDefinition(class string) (ProviderClassDefinition, error) {
+	def, ok := supportedProviderClassDefinitions[class]
+	if !ok {
+		return ProviderClassDefinition{}, fmt.Errorf("provider %s not found", class)
+	}
+	return def, nil
+}

--- a/internal/providers/service.go
+++ b/internal/providers/service.go
@@ -1,0 +1,182 @@
+//
+// Copyright 2024 Stacklok, Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package providers
+
+import (
+	"context"
+	"database/sql"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strconv"
+
+	"github.com/google/uuid"
+	"github.com/rs/zerolog"
+	"golang.org/x/oauth2"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"github.com/stacklok/minder/internal/config/server"
+	"github.com/stacklok/minder/internal/controlplane/metrics"
+	"github.com/stacklok/minder/internal/crypto"
+	"github.com/stacklok/minder/internal/db"
+	"github.com/stacklok/minder/internal/providers/credentials"
+	"github.com/stacklok/minder/internal/providers/ratecache"
+	provtelemetry "github.com/stacklok/minder/internal/providers/telemetry"
+)
+
+// ProviderService encapsulates methods for creating and updating providers
+type ProviderService interface {
+	CreateGitHubOAuthProvider(ctx context.Context, providerName string, providerClass db.ProviderClass,
+		token oauth2.Token, stateData db.GetProjectIDBySessionStateRow) (*db.Provider, error)
+}
+
+// ErrInvalidTokenIdentity is returned when the user identity in the token does not match the expected user identity
+// from the state
+var ErrInvalidTokenIdentity = errors.New("invalid token identity")
+
+type providerService struct {
+	store           db.Store
+	cryptoEngine    crypto.Engine
+	mt              metrics.Metrics
+	provMt          provtelemetry.ProviderMetrics
+	config          *server.ProviderConfig
+	restClientCache ratecache.RestClientCache
+}
+
+// NewProviderService creates an instance of ProviderService
+func NewProviderService(store db.Store, cryptoEngine crypto.Engine, mt metrics.Metrics,
+	provMt provtelemetry.ProviderMetrics, config *server.ProviderConfig, restClientCache ratecache.RestClientCache) ProviderService {
+	return &providerService{
+		store:           store,
+		cryptoEngine:    cryptoEngine,
+		mt:              mt,
+		provMt:          provMt,
+		config:          config,
+		restClientCache: restClientCache,
+	}
+}
+
+// CreateGitHubOAuthProvider creates a GitHub OAuth provider with an access token credential
+func (p *providerService) CreateGitHubOAuthProvider(ctx context.Context, providerName string, providerClass db.ProviderClass,
+	token oauth2.Token, stateData db.GetProjectIDBySessionStateRow) (*db.Provider, error) {
+	tx, err := p.store.BeginTransaction()
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "error starting transaction: %v", err)
+	}
+	defer p.store.Rollback(tx)
+
+	qtx := p.store.GetQuerierWithTransaction(tx)
+
+	// Check if the provider exists
+	provider, err := qtx.GetProviderByName(ctx, db.GetProviderByNameParams{
+		Name:     providerName,
+		Projects: []uuid.UUID{stateData.ProjectID},
+	})
+	if errors.Is(err, sql.ErrNoRows) {
+
+		// If the provider does not exist, create it
+		providerDef, err := GetProviderClassDefinition(providerName)
+		if err != nil {
+			return nil, fmt.Errorf("error getting provider definition: %w", err)
+		}
+
+		createdProvider, err := qtx.CreateProvider(ctx, db.CreateProviderParams{
+			Name:       providerName,
+			ProjectID:  stateData.ProjectID,
+			Class:      db.NullProviderClass{ProviderClass: providerClass, Valid: true},
+			Implements: providerDef.Traits,
+			Definition: json.RawMessage(`{"github": {}}`),
+			AuthFlows:  providerDef.AuthorizationFlows,
+		})
+		if err != nil {
+			return nil, fmt.Errorf("error creating provider: %w", err)
+		}
+		provider = createdProvider
+	} else if err != nil {
+		return nil, fmt.Errorf("error getting provider from DB: %w", err)
+	}
+
+	// Older enrollments may not have a RemoteUser stored; these should age out fairly quickly.
+	p.mt.AddTokenOpCount(ctx, "check", stateData.RemoteUser.Valid)
+	if stateData.RemoteUser.Valid {
+		if err := p.verifyProviderTokenIdentity(ctx, stateData, provider, token.AccessToken); err != nil {
+			return nil, ErrInvalidTokenIdentity
+		}
+	} else {
+		zerolog.Ctx(ctx).Warn().Msg("RemoteUser not found in session state")
+	}
+
+	ftoken := &oauth2.Token{
+		AccessToken:  token.AccessToken,
+		TokenType:    token.TokenType,
+		RefreshToken: "",
+	}
+
+	// Convert token to JSON
+	jsonData, err := json.Marshal(ftoken)
+	if err != nil {
+		return nil, fmt.Errorf("error marshaling token: %w", err)
+	}
+
+	// encode token
+	encryptedToken, err := p.cryptoEngine.EncryptOAuthToken(jsonData)
+	if err != nil {
+		return nil, fmt.Errorf("error encoding token: %w", err)
+	}
+
+	encodedToken := base64.StdEncoding.EncodeToString(encryptedToken)
+
+	_, err = qtx.UpsertAccessToken(ctx, db.UpsertAccessTokenParams{
+		ProjectID:      stateData.ProjectID,
+		Provider:       providerName,
+		EncryptedToken: encodedToken,
+		OwnerFilter:    stateData.OwnerFilter,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("error inserting access token: %w", err)
+	}
+	if err := p.store.Commit(tx); err != nil {
+
+		return nil, status.Errorf(codes.Internal, "error committing transaction: %v", err)
+	}
+	return &provider, nil
+}
+
+func (p *providerService) verifyProviderTokenIdentity(
+	ctx context.Context, stateData db.GetProjectIDBySessionStateRow, provider db.Provider, token string) error {
+	pbOpts := []ProviderBuilderOption{
+		WithProviderMetrics(p.provMt),
+		WithRestClientCache(p.restClientCache),
+	}
+	builder := NewProviderBuilder(&provider, sql.NullString{}, credentials.NewGitHubTokenCredential(token),
+		p.config, pbOpts...)
+	// NOTE: this is github-specific at the moment.  We probably need to generally
+	// re-think token enrollment when we add more providers.
+	ghClient, err := builder.GetGitHub()
+	if err != nil {
+		return fmt.Errorf("error creating GitHub client: %w", err)
+	}
+	userId, err := ghClient.GetUserId(ctx)
+	if err != nil {
+		return fmt.Errorf("error getting user ID: %w", err)
+	}
+	if strconv.FormatInt(userId, 10) != stateData.RemoteUser.String {
+		return fmt.Errorf("user ID mismatch: %d != %s", userId, stateData.RemoteUser.String)
+	}
+	return nil
+}


### PR DESCRIPTION
# Summary

This is a subset of https://github.com/stacklok/minder/pull/2750, which does not actually remove the built-in provider.

This creates a provider on successful enrolment, if the provider does not already exist.
It also allows makes enrolment less GitHub specific.

Ref #2520

## Change Type

***Mark the type of change your PR introduces:***

- [ ] Bug fix (resolves an issue without affecting existing features)
- [ ] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [x] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

***Outline how the changes were tested, including steps to reproduce and any relevant configurations. 
Attach screenshots if helpful.***

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [x] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [x] Included tests that validate the fix or feature.
- [ ] Checked that related changes are merged.
