### PR TITLE
Make `repo-lister` interface more general

### DIFF
--- a/internal/controlplane/handlers_repositories.go
+++ b/internal/controlplane/handlers_repositories.go
@@ -343,11 +343,10 @@ func (s *Server) ListRemoteRepositoriesFromProvider(
 	tmoutCtx, cancel := context.WithTimeout(ctx, github.ExpensiveRestCallTimeout)
 	defer cancel()
 
-	remoteGhRepos, err := client.ListAllRepositories(tmoutCtx)
+	remoteRepos, err := client.ListAllRepositories(tmoutCtx)
 	if err != nil {
 		return nil, util.UserVisibleError(codes.Internal, "cannot list repositories: %v", err)
 	}
-	remoteRepos := github.ConvertRepositories(remoteGhRepos)
 
 	out := &pb.ListRemoteRepositoriesFromProviderResponse{
 		Results: make([]*pb.UpstreamRepositoryRef, 0, len(remoteRepos)),

--- a/internal/controlplane/handlers_repositories_test.go
+++ b/internal/controlplane/handlers_repositories_test.go
@@ -496,7 +496,7 @@ func (*StubGitHub) GetCredential() provinfv1.GitHubCredential {
 }
 
 // ListAllRepositories implements v1.GitHub.
-func (*StubGitHub) ListAllRepositories(context.Context) ([]*github.Repository, error) {
+func (*StubGitHub) ListAllRepositories(context.Context) ([]*pb.Repository, error) {
 	panic("unimplemented")
 }
 

--- a/internal/providers/github/app/app.go
+++ b/internal/providers/github/app/app.go
@@ -28,6 +28,7 @@ import (
 	"github.com/stacklok/minder/internal/config/server"
 	"github.com/stacklok/minder/internal/db"
 	"github.com/stacklok/minder/internal/providers/github"
+	ghcommon "github.com/stacklok/minder/internal/providers/github/common"
 	"github.com/stacklok/minder/internal/providers/ratecache"
 	"github.com/stacklok/minder/internal/providers/telemetry"
 	minderv1 "github.com/stacklok/minder/pkg/api/protobuf/go/minder/v1"
@@ -143,7 +144,7 @@ func (_ *GitHubAppDelegate) GetOwner() string {
 }
 
 // ListAllRepositories returns a list of all repositories accessible to the GitHub App installation
-func (g *GitHubAppDelegate) ListAllRepositories(ctx context.Context) ([]*gogithub.Repository, error) {
+func (g *GitHubAppDelegate) ListAllRepositories(ctx context.Context) ([]*minderv1.Repository, error) {
 	listOpt := &gogithub.ListOptions{
 		PerPage: 100,
 	}
@@ -158,7 +159,7 @@ func (g *GitHubAppDelegate) ListAllRepositories(ctx context.Context) ([]*gogithu
 		repos, resp, err = g.client.Apps.ListRepos(ctx, listOpt)
 
 		if err != nil {
-			return allRepos, err
+			return ghcommon.ConvertRepositories(allRepos), fmt.Errorf("error listing repositories: %w", err)
 		}
 		allRepos = append(allRepos, repos.Repositories...)
 		if resp.NextPage == 0 {
@@ -168,7 +169,7 @@ func (g *GitHubAppDelegate) ListAllRepositories(ctx context.Context) ([]*gogithu
 		listOpt.Page = resp.NextPage
 	}
 
-	return allRepos, nil
+	return ghcommon.ConvertRepositories(allRepos), nil
 }
 
 // GetUserId returns the user id for the GitHub App user

--- a/internal/providers/github/common.go
+++ b/internal/providers/github/common.go
@@ -68,7 +68,7 @@ var _ provifv1.GitHub = (*GitHub)(nil)
 // Delegate is the interface that contains operations that differ between different GitHub actors (user vs app)
 type Delegate interface {
 	GetCredential() provifv1.GitHubCredential
-	ListAllRepositories(context.Context) ([]*github.Repository, error)
+	ListAllRepositories(context.Context) ([]*minderv1.Repository, error)
 	GetUserId(ctx context.Context) (int64, error)
 	GetName(ctx context.Context) (string, error)
 	GetLogin(ctx context.Context) (string, error)
@@ -636,7 +636,7 @@ func (c *GitHub) AddAuthToPushOptions(ctx context.Context, pushOptions *git.Push
 }
 
 // ListAllRepositories lists all repositories the credential has access to
-func (c *GitHub) ListAllRepositories(ctx context.Context) ([]*github.Repository, error) {
+func (c *GitHub) ListAllRepositories(ctx context.Context) ([]*minderv1.Repository, error) {
 	return c.delegate.ListAllRepositories(ctx)
 }
 
@@ -791,29 +791,6 @@ func isRateLimitError(err error) bool {
 	isAbuseRateLimitErr := errors.As(err, &abuseRateLimitError)
 
 	return isRateLimitErr || isAbuseRateLimitErr
-}
-
-// ConvertRepositories converts a list of GitHub repositories to a list of minder repositories
-func ConvertRepositories(repos []*github.Repository) []*minderv1.Repository {
-	var converted []*minderv1.Repository
-	for _, repo := range repos {
-		converted = append(converted, convertRepository(repo))
-	}
-	return converted
-}
-
-// ConvertRepository converts a GitHub repository to a minder repository
-func convertRepository(repo *github.Repository) *minderv1.Repository {
-	return &minderv1.Repository{
-		Name:      repo.GetName(),
-		Owner:     repo.GetOwner().GetLogin(),
-		RepoId:    repo.GetID(),
-		HookUrl:   repo.GetHooksURL(),
-		DeployUrl: repo.GetDeploymentsURL(),
-		CloneUrl:  repo.GetCloneURL(),
-		IsPrivate: *repo.Private,
-		IsFork:    *repo.Fork,
-	}
 }
 
 // IsMinderHook checks if a GitHub hook is a Minder hook

--- a/internal/providers/github/common/common.go
+++ b/internal/providers/github/common/common.go
@@ -1,0 +1,45 @@
+// Copyright 2024 Stacklok, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package common provides common utilities for the GitHub provider
+package common
+
+import (
+	gogithub "github.com/google/go-github/v56/github"
+
+	minderv1 "github.com/stacklok/minder/pkg/api/protobuf/go/minder/v1"
+)
+
+// ConvertRepositories converts a list of GitHub repositories to a list of minder repositories
+func ConvertRepositories(repos []*gogithub.Repository) []*minderv1.Repository {
+	var converted []*minderv1.Repository
+	for _, repo := range repos {
+		converted = append(converted, ConvertRepository(repo))
+	}
+	return converted
+}
+
+// ConvertRepository converts a GitHub repository to a minder repository
+func ConvertRepository(repo *gogithub.Repository) *minderv1.Repository {
+	return &minderv1.Repository{
+		Name:      repo.GetName(),
+		Owner:     repo.GetOwner().GetLogin(),
+		RepoId:    repo.GetID(),
+		HookUrl:   repo.GetHooksURL(),
+		DeployUrl: repo.GetDeploymentsURL(),
+		CloneUrl:  repo.GetCloneURL(),
+		IsPrivate: *repo.Private,
+		IsFork:    *repo.Fork,
+	}
+}

--- a/internal/providers/github/mock/github.go
+++ b/internal/providers/github/mock/github.go
@@ -16,7 +16,8 @@ import (
 
 	git "github.com/go-git/go-git/v5"
 	github "github.com/google/go-github/v56/github"
-	v1 "github.com/stacklok/minder/pkg/providers/v1"
+	v1 "github.com/stacklok/minder/pkg/api/protobuf/go/minder/v1"
+	v10 "github.com/stacklok/minder/pkg/providers/v1"
 	gomock "go.uber.org/mock/gomock"
 )
 
@@ -172,10 +173,10 @@ func (m *MockRepoLister) EXPECT() *MockRepoListerMockRecorder {
 }
 
 // ListAllRepositories mocks base method.
-func (m *MockRepoLister) ListAllRepositories(arg0 context.Context) ([]*github.Repository, error) {
+func (m *MockRepoLister) ListAllRepositories(arg0 context.Context) ([]*v1.Repository, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListAllRepositories", arg0)
-	ret0, _ := ret[0].([]*github.Repository)
+	ret0, _ := ret[0].([]*v1.Repository)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -417,10 +418,10 @@ func (mr *MockGitHubMockRecorder) GetBranchProtection(arg0, arg1, arg2, arg3 any
 }
 
 // GetCredential mocks base method.
-func (m *MockGitHub) GetCredential() v1.GitHubCredential {
+func (m *MockGitHub) GetCredential() v10.GitHubCredential {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetCredential")
-	ret0, _ := ret[0].(v1.GitHubCredential)
+	ret0, _ := ret[0].(v10.GitHubCredential)
 	return ret0
 }
 
@@ -595,10 +596,10 @@ func (mr *MockGitHubMockRecorder) GetUserId(ctx any) *gomock.Call {
 }
 
 // ListAllRepositories mocks base method.
-func (m *MockGitHub) ListAllRepositories(arg0 context.Context) ([]*github.Repository, error) {
+func (m *MockGitHub) ListAllRepositories(arg0 context.Context) ([]*v1.Repository, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListAllRepositories", arg0)
-	ret0, _ := ret[0].([]*github.Repository)
+	ret0, _ := ret[0].([]*v1.Repository)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }

--- a/internal/providers/github/oauth/oauth.go
+++ b/internal/providers/github/oauth/oauth.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/stacklok/minder/internal/db"
 	"github.com/stacklok/minder/internal/providers/github"
+	ghcommon "github.com/stacklok/minder/internal/providers/github/common"
 	"github.com/stacklok/minder/internal/providers/ratecache"
 	"github.com/stacklok/minder/internal/providers/telemetry"
 	minderv1 "github.com/stacklok/minder/pkg/api/protobuf/go/minder/v1"
@@ -139,7 +140,7 @@ func (o *GitHubOAuthDelegate) GetOwner() string {
 
 // ListAllRepositories returns a list of all repositories for the authenticated user
 // Two APIs are available, contigent on whether the token is for a user or an organization
-func (o *GitHubOAuthDelegate) ListAllRepositories(ctx context.Context) ([]*gogithub.Repository, error) {
+func (o *GitHubOAuthDelegate) ListAllRepositories(ctx context.Context) ([]*minderv1.Repository, error) {
 	opt := &gogithub.RepositoryListOptions{
 		ListOptions: gogithub.ListOptions{
 			PerPage: 100,
@@ -167,7 +168,7 @@ func (o *GitHubOAuthDelegate) ListAllRepositories(ctx context.Context) ([]*gogit
 		}
 
 		if err != nil {
-			return allRepos, err
+			return ghcommon.ConvertRepositories(allRepos), fmt.Errorf("error listing repositories: %w", err)
 		}
 		allRepos = append(allRepos, repos...)
 		if resp.NextPage == 0 {
@@ -181,7 +182,7 @@ func (o *GitHubOAuthDelegate) ListAllRepositories(ctx context.Context) ([]*gogit
 		}
 	}
 
-	return allRepos, nil
+	return ghcommon.ConvertRepositories(allRepos), nil
 }
 
 // GetUserId returns the user id for the authenticated user

--- a/pkg/providers/v1/providers.go
+++ b/pkg/providers/v1/providers.go
@@ -26,6 +26,8 @@ import (
 	"github.com/go-git/go-git/v5"
 	"github.com/go-playground/validator/v10"
 	"github.com/google/go-github/v56/github"
+
+	minderv1 "github.com/stacklok/minder/pkg/api/protobuf/go/minder/v1"
 )
 
 // V1 is the version of the providers interface
@@ -63,7 +65,7 @@ type REST interface {
 type RepoLister interface {
 	Provider
 
-	ListAllRepositories(context.Context) ([]*github.Repository, error)
+	ListAllRepositories(context.Context) ([]*minderv1.Repository, error)
 }
 
 // GitHub is the interface for interacting with the GitHub REST API


### PR DESCRIPTION
# Summary

Instead of returning a github-specific struct, it now returns minder's
`Repository` protobuf, which is a more portable format for us.

The intention is that other repository providers will be able to leverage this
and hook more easily to minder.

Related-to: https://github.com/stacklok/minder/issues/2769

## Change Type

***Mark the type of change your PR introduces:***

- [ ] Bug fix (resolves an issue without affecting existing features)
- [ ] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [x] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

***Outline how the changes were tested, including steps to reproduce and any relevant configurations. 
Attach screenshots if helpful.***

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [ ] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [ ] Included tests that validate the fix or feature.
- [ ] Checked that related changes are merged.
