### PR TITLE
Fix error message when instantiating alerter

### DIFF
--- a/internal/engine/actions/actions.go
+++ b/internal/engine/actions/actions.go
@@ -55,7 +55,7 @@ func NewRuleActions(p *minderv1.Profile, rt *minderv1.RuleType, pbuild *provider
 	// Create the alert engine
 	alertEngine, err := alert.NewRuleAlert(rt, pbuild)
 	if err != nil {
-		return nil, fmt.Errorf("cannot create rule remediator: %w", err)
+		return nil, fmt.Errorf("cannot create rule alerter: %w", err)
 	}
 
 	return &RuleActionsEngine{


### PR DESCRIPTION
# Summary

When working on the OCI registry, I noticed we were issues a funky error message
when the alerter cannot be instantiated. This fixes that.

## Change Type

***Mark the type of change your PR introduces:***

- [x] Bug fix (resolves an issue without affecting existing features)
- [ ] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [ ] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

***Outline how the changes were tested, including steps to reproduce and any relevant configurations. 
Attach screenshots if helpful.***

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [ ] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [ ] Included tests that validate the fix or feature.
- [ ] Checked that related changes are merged.
