### PR TITLE
Add label support for ListProfilesByProjectID

### DIFF
--- a/database/mock/store.go
+++ b/database/mock/store.go
@@ -1198,7 +1198,7 @@ func (mr *MockStoreMockRecorder) ListOldOrgProjects(arg0 any) *gomock.Call {
 }
 
 // ListProfilesByProjectID mocks base method.
-func (m *MockStore) ListProfilesByProjectID(arg0 context.Context, arg1 db.ListProfilesByProjectIDParams) ([]db.ListProfilesByProjectIDRow, error) {
+func (m *MockStore) ListProfilesByProjectID(arg0 context.Context, arg1 uuid.UUID) ([]db.ListProfilesByProjectIDRow, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListProfilesByProjectID", arg0, arg1)
 	ret0, _ := ret[0].([]db.ListProfilesByProjectIDRow)
@@ -1210,6 +1210,21 @@ func (m *MockStore) ListProfilesByProjectID(arg0 context.Context, arg1 db.ListPr
 func (mr *MockStoreMockRecorder) ListProfilesByProjectID(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListProfilesByProjectID", reflect.TypeOf((*MockStore)(nil).ListProfilesByProjectID), arg0, arg1)
+}
+
+// ListProfilesByProjectIDAndLabel mocks base method.
+func (m *MockStore) ListProfilesByProjectIDAndLabel(arg0 context.Context, arg1 db.ListProfilesByProjectIDAndLabelParams) ([]db.ListProfilesByProjectIDAndLabelRow, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListProfilesByProjectIDAndLabel", arg0, arg1)
+	ret0, _ := ret[0].([]db.ListProfilesByProjectIDAndLabelRow)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListProfilesByProjectIDAndLabel indicates an expected call of ListProfilesByProjectIDAndLabel.
+func (mr *MockStoreMockRecorder) ListProfilesByProjectIDAndLabel(arg0, arg1 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListProfilesByProjectIDAndLabel", reflect.TypeOf((*MockStore)(nil).ListProfilesByProjectIDAndLabel), arg0, arg1)
 }
 
 // ListProfilesInstantiatingRuleType mocks base method.

--- a/database/mock/store.go
+++ b/database/mock/store.go
@@ -1198,7 +1198,7 @@ func (mr *MockStoreMockRecorder) ListOldOrgProjects(arg0 any) *gomock.Call {
 }
 
 // ListProfilesByProjectID mocks base method.
-func (m *MockStore) ListProfilesByProjectID(arg0 context.Context, arg1 uuid.UUID) ([]db.ListProfilesByProjectIDRow, error) {
+func (m *MockStore) ListProfilesByProjectID(arg0 context.Context, arg1 db.ListProfilesByProjectIDParams) ([]db.ListProfilesByProjectIDRow, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListProfilesByProjectID", arg0, arg1)
 	ret0, _ := ret[0].([]db.ListProfilesByProjectIDRow)

--- a/database/query/profiles.sql
+++ b/database/query/profiles.sql
@@ -60,7 +60,21 @@ WHERE profiles.project_id = $1 AND lower(profiles.name) = lower(sqlc.arg(name));
 
 -- name: ListProfilesByProjectID :many
 SELECT * FROM profiles JOIN entity_profiles ON profiles.id = entity_profiles.profile_id
-WHERE profiles.project_id = $1;
+WHERE profiles.project_id = $1
+AND (
+    -- the most common case first, if the include_labels is empty, we list profiles with no labels
+    -- we use coalesce to handle the case where the include_labels is null
+    (COALESCE(cardinality(sqlc.arg(include_labels)::TEXT[]), 0) = 0 AND profiles.labels = ARRAY[]::TEXT[]) OR
+    -- if the include_labels arg is equal to '*', we list all profiles
+    sqlc.arg(include_labels)::TEXT[] = ARRAY['*'] OR
+    -- if the include_labels arg is not empty and not a wildcard, we list profiles whose labels are a subset of include_labels
+    (COALESCE(cardinality(sqlc.arg(include_labels)::TEXT[]), 0) > 0 AND profiles.labels @> sqlc.arg(include_labels)::TEXT[])
+) AND (
+    -- if the exclude_labels arg is empty, we list all profiles
+    COALESCE(cardinality(sqlc.arg(exclude_labels)::TEXT[]), 0) = 0 OR
+    -- if the exclude_labels arg is not empty, we list profiles whose labels are not a subset of exclude_labels
+    NOT profiles.labels @> sqlc.arg(exclude_labels)::TEXT[]
+);
 
 -- name: DeleteProfile :exec
 DELETE FROM profiles

--- a/database/query/profiles.sql
+++ b/database/query/profiles.sql
@@ -59,7 +59,11 @@ SELECT * FROM profiles JOIN entity_profiles ON profiles.id = entity_profiles.pro
 WHERE profiles.project_id = $1 AND lower(profiles.name) = lower(sqlc.arg(name));
 
 -- name: ListProfilesByProjectID :many
-SELECT * FROM profiles JOIN entity_profiles ON profiles.id = entity_profiles.profile_id
+SELECT sqlc.embed(profiles), sqlc.embed(entity_profiles) FROM profiles JOIN entity_profiles ON profiles.id = entity_profiles.profile_id
+WHERE profiles.project_id = $1;
+
+-- name: ListProfilesByProjectIDAndLabel :many
+SELECT sqlc.embed(profiles), sqlc.embed(entity_profiles) FROM profiles JOIN entity_profiles ON profiles.id = entity_profiles.profile_id
 WHERE profiles.project_id = $1
 AND (
     -- the most common case first, if the include_labels is empty, we list profiles with no labels

--- a/internal/controlplane/handlers_evalstatus.go
+++ b/internal/controlplane/handlers_evalstatus.go
@@ -221,7 +221,7 @@ func buildProjectsProfileList(
 	profileList := []db.ListProfilesByProjectIDRow{}
 
 	for _, projectID := range projects {
-		profiles, err := store.ListProfilesByProjectID(ctx, projectID)
+		profiles, err := store.ListProfilesByProjectID(ctx, db.ListProfilesByProjectIDParams{ProjectID: projectID})
 		if err != nil {
 			return nil, status.Errorf(codes.Internal, "error listing profiles")
 		}

--- a/internal/controlplane/handlers_profile.go
+++ b/internal/controlplane/handlers_profile.go
@@ -137,7 +137,7 @@ func (s *Server) ListProfiles(ctx context.Context,
 		return nil, status.Errorf(codes.InvalidArgument, "error in entity context: %v", err)
 	}
 
-	profiles, err := s.store.ListProfilesByProjectID(ctx, entityCtx.Project.ID)
+	profiles, err := s.store.ListProfilesByProjectID(ctx, db.ListProfilesByProjectIDParams{ProjectID: entityCtx.Project.ID})
 	if err != nil {
 		return nil, status.Errorf(codes.Unknown, "failed to get profiles: %s", err)
 	}

--- a/internal/controlplane/handlers_profile.go
+++ b/internal/controlplane/handlers_profile.go
@@ -129,7 +129,7 @@ func (s *Server) DeleteProfile(ctx context.Context,
 
 // ListProfiles is a method to get all profiles for a project
 func (s *Server) ListProfiles(ctx context.Context,
-	_ *minderv1.ListProfilesRequest) (*minderv1.ListProfilesResponse, error) {
+	req *minderv1.ListProfilesRequest) (*minderv1.ListProfilesResponse, error) {
 	entityCtx := engine.EntityFromContext(ctx)
 
 	err := entityCtx.Validate(ctx, s.store)
@@ -137,11 +137,12 @@ func (s *Server) ListProfiles(ctx context.Context,
 		return nil, status.Errorf(codes.InvalidArgument, "error in entity context: %v", err)
 	}
 
-	profiles, err := s.store.ListProfilesByProjectIDAndLabel(
-		ctx,
-		db.ListProfilesByProjectIDAndLabelParams{
-			ProjectID: entityCtx.Project.ID,
-		})
+	listParams := db.ListProfilesByProjectIDAndLabelParams{
+		ProjectID: entityCtx.Project.ID,
+	}
+	listParams.LabelsFromFilter(req.GetLabelFilter())
+
+	profiles, err := s.store.ListProfilesByProjectIDAndLabel(ctx, listParams)
 	if err != nil {
 		return nil, status.Errorf(codes.Unknown, "failed to get profiles: %s", err)
 	}

--- a/internal/controlplane/handlers_profile.go
+++ b/internal/controlplane/handlers_profile.go
@@ -137,7 +137,11 @@ func (s *Server) ListProfiles(ctx context.Context,
 		return nil, status.Errorf(codes.InvalidArgument, "error in entity context: %v", err)
 	}
 
-	profiles, err := s.store.ListProfilesByProjectID(ctx, db.ListProfilesByProjectIDParams{ProjectID: entityCtx.Project.ID})
+	profiles, err := s.store.ListProfilesByProjectIDAndLabel(
+		ctx,
+		db.ListProfilesByProjectIDAndLabelParams{
+			ProjectID: entityCtx.Project.ID,
+		})
 	if err != nil {
 		return nil, status.Errorf(codes.Unknown, "failed to get profiles: %s", err)
 	}

--- a/internal/db/profiles.sql.go
+++ b/internal/db/profiles.sql.go
@@ -443,7 +443,59 @@ func (q *Queries) GetProfileForEntity(ctx context.Context, arg GetProfileForEnti
 }
 
 const listProfilesByProjectID = `-- name: ListProfilesByProjectID :many
-SELECT profiles.id, name, provider, project_id, remediate, alert, profiles.created_at, profiles.updated_at, provider_id, subscription_id, display_name, labels, entity_profiles.id, entity, profile_id, contextual_rules, entity_profiles.created_at, entity_profiles.updated_at FROM profiles JOIN entity_profiles ON profiles.id = entity_profiles.profile_id
+SELECT profiles.id, profiles.name, profiles.provider, profiles.project_id, profiles.remediate, profiles.alert, profiles.created_at, profiles.updated_at, profiles.provider_id, profiles.subscription_id, profiles.display_name, profiles.labels, entity_profiles.id, entity_profiles.entity, entity_profiles.profile_id, entity_profiles.contextual_rules, entity_profiles.created_at, entity_profiles.updated_at FROM profiles JOIN entity_profiles ON profiles.id = entity_profiles.profile_id
+WHERE profiles.project_id = $1
+`
+
+type ListProfilesByProjectIDRow struct {
+	Profile       Profile       `json:"profile"`
+	EntityProfile EntityProfile `json:"entity_profile"`
+}
+
+func (q *Queries) ListProfilesByProjectID(ctx context.Context, projectID uuid.UUID) ([]ListProfilesByProjectIDRow, error) {
+	rows, err := q.db.QueryContext(ctx, listProfilesByProjectID, projectID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []ListProfilesByProjectIDRow{}
+	for rows.Next() {
+		var i ListProfilesByProjectIDRow
+		if err := rows.Scan(
+			&i.Profile.ID,
+			&i.Profile.Name,
+			&i.Profile.Provider,
+			&i.Profile.ProjectID,
+			&i.Profile.Remediate,
+			&i.Profile.Alert,
+			&i.Profile.CreatedAt,
+			&i.Profile.UpdatedAt,
+			&i.Profile.ProviderID,
+			&i.Profile.SubscriptionID,
+			&i.Profile.DisplayName,
+			pq.Array(&i.Profile.Labels),
+			&i.EntityProfile.ID,
+			&i.EntityProfile.Entity,
+			&i.EntityProfile.ProfileID,
+			&i.EntityProfile.ContextualRules,
+			&i.EntityProfile.CreatedAt,
+			&i.EntityProfile.UpdatedAt,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const listProfilesByProjectIDAndLabel = `-- name: ListProfilesByProjectIDAndLabel :many
+SELECT profiles.id, profiles.name, profiles.provider, profiles.project_id, profiles.remediate, profiles.alert, profiles.created_at, profiles.updated_at, profiles.provider_id, profiles.subscription_id, profiles.display_name, profiles.labels, entity_profiles.id, entity_profiles.entity, entity_profiles.profile_id, entity_profiles.contextual_rules, entity_profiles.created_at, entity_profiles.updated_at FROM profiles JOIN entity_profiles ON profiles.id = entity_profiles.profile_id
 WHERE profiles.project_id = $1
 AND (
     -- the most common case first, if the include_labels is empty, we list profiles with no labels
@@ -461,61 +513,45 @@ AND (
 )
 `
 
-type ListProfilesByProjectIDParams struct {
+type ListProfilesByProjectIDAndLabelParams struct {
 	ProjectID     uuid.UUID `json:"project_id"`
 	IncludeLabels []string  `json:"include_labels"`
 	ExcludeLabels []string  `json:"exclude_labels"`
 }
 
-type ListProfilesByProjectIDRow struct {
-	ID              uuid.UUID       `json:"id"`
-	Name            string          `json:"name"`
-	Provider        string          `json:"provider"`
-	ProjectID       uuid.UUID       `json:"project_id"`
-	Remediate       NullActionType  `json:"remediate"`
-	Alert           NullActionType  `json:"alert"`
-	CreatedAt       time.Time       `json:"created_at"`
-	UpdatedAt       time.Time       `json:"updated_at"`
-	ProviderID      uuid.UUID       `json:"provider_id"`
-	SubscriptionID  uuid.NullUUID   `json:"subscription_id"`
-	DisplayName     string          `json:"display_name"`
-	Labels          []string        `json:"labels"`
-	ID_2            uuid.UUID       `json:"id_2"`
-	Entity          Entities        `json:"entity"`
-	ProfileID       uuid.UUID       `json:"profile_id"`
-	ContextualRules json.RawMessage `json:"contextual_rules"`
-	CreatedAt_2     time.Time       `json:"created_at_2"`
-	UpdatedAt_2     time.Time       `json:"updated_at_2"`
+type ListProfilesByProjectIDAndLabelRow struct {
+	Profile       Profile       `json:"profile"`
+	EntityProfile EntityProfile `json:"entity_profile"`
 }
 
-func (q *Queries) ListProfilesByProjectID(ctx context.Context, arg ListProfilesByProjectIDParams) ([]ListProfilesByProjectIDRow, error) {
-	rows, err := q.db.QueryContext(ctx, listProfilesByProjectID, arg.ProjectID, pq.Array(arg.IncludeLabels), pq.Array(arg.ExcludeLabels))
+func (q *Queries) ListProfilesByProjectIDAndLabel(ctx context.Context, arg ListProfilesByProjectIDAndLabelParams) ([]ListProfilesByProjectIDAndLabelRow, error) {
+	rows, err := q.db.QueryContext(ctx, listProfilesByProjectIDAndLabel, arg.ProjectID, pq.Array(arg.IncludeLabels), pq.Array(arg.ExcludeLabels))
 	if err != nil {
 		return nil, err
 	}
 	defer rows.Close()
-	items := []ListProfilesByProjectIDRow{}
+	items := []ListProfilesByProjectIDAndLabelRow{}
 	for rows.Next() {
-		var i ListProfilesByProjectIDRow
+		var i ListProfilesByProjectIDAndLabelRow
 		if err := rows.Scan(
-			&i.ID,
-			&i.Name,
-			&i.Provider,
-			&i.ProjectID,
-			&i.Remediate,
-			&i.Alert,
-			&i.CreatedAt,
-			&i.UpdatedAt,
-			&i.ProviderID,
-			&i.SubscriptionID,
-			&i.DisplayName,
-			pq.Array(&i.Labels),
-			&i.ID_2,
-			&i.Entity,
-			&i.ProfileID,
-			&i.ContextualRules,
-			&i.CreatedAt_2,
-			&i.UpdatedAt_2,
+			&i.Profile.ID,
+			&i.Profile.Name,
+			&i.Profile.Provider,
+			&i.Profile.ProjectID,
+			&i.Profile.Remediate,
+			&i.Profile.Alert,
+			&i.Profile.CreatedAt,
+			&i.Profile.UpdatedAt,
+			&i.Profile.ProviderID,
+			&i.Profile.SubscriptionID,
+			&i.Profile.DisplayName,
+			pq.Array(&i.Profile.Labels),
+			&i.EntityProfile.ID,
+			&i.EntityProfile.Entity,
+			&i.EntityProfile.ProfileID,
+			&i.EntityProfile.ContextualRules,
+			&i.EntityProfile.CreatedAt,
+			&i.EntityProfile.UpdatedAt,
 		); err != nil {
 			return nil, err
 		}

--- a/internal/db/profiles_test.go
+++ b/internal/db/profiles_test.go
@@ -267,16 +267,17 @@ func TestProfileLabels(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			rows, err := testQueries.ListProfilesByProjectID(context.Background(), ListProfilesByProjectIDParams{
-				ProjectID:     randomEntities.proj.ID,
-				IncludeLabels: tt.includeLabels,
-				ExcludeLabels: tt.excludeLabels,
-			})
+			rows, err := testQueries.ListProfilesByProjectIDAndLabel(
+				context.Background(), ListProfilesByProjectIDAndLabelParams{
+					ProjectID:     randomEntities.proj.ID,
+					IncludeLabels: tt.includeLabels,
+					ExcludeLabels: tt.excludeLabels,
+				})
 			require.NoError(t, err)
 
 			names := make([]string, 0, len(rows))
 			for _, row := range rows {
-				names = append(names, row.Name)
+				names = append(names, row.Profile.Name)
 			}
 			require.True(t, slices.Equal(names, tt.expectedNames), "expected %v, got %v", tt.expectedNames, names)
 		})

--- a/internal/db/profiles_test.go
+++ b/internal/db/profiles_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"encoding/json"
+	"slices"
 	"testing"
 	"time"
 
@@ -13,7 +14,7 @@ import (
 	"github.com/stacklok/minder/internal/util/rand"
 )
 
-func createRandomProfile(t *testing.T, prov Provider, projectID uuid.UUID) Profile {
+func createRandomProfile(t *testing.T, prov Provider, projectID uuid.UUID, labels []string) Profile {
 	t.Helper()
 
 	seed := time.Now().UnixNano()
@@ -27,11 +28,21 @@ func createRandomProfile(t *testing.T, prov Provider, projectID uuid.UUID) Profi
 			ActionType: "on",
 			Valid:      true,
 		},
+		Labels: labels,
 	}
 
 	prof, err := testQueries.CreateProfile(context.Background(), arg)
 	require.NoError(t, err)
 	require.NotEmpty(t, prof)
+
+	// listProfilesLabels doesn't join properly without the entityProfile entries
+	ent, err := testQueries.CreateProfileForEntity(context.Background(), CreateProfileForEntityParams{
+		ProfileID:       prof.ID,
+		Entity:          EntitiesRepository,
+		ContextualRules: json.RawMessage(`{"key": "value"}`),
+	})
+	require.NoError(t, err)
+	require.NotEmpty(t, ent)
 
 	return prof
 }
@@ -176,6 +187,99 @@ func createTestRandomEntities(t *testing.T) *testRandomEntities {
 		repo:      repo,
 		ruleType1: ruleType1,
 		ruleType2: ruleType2,
+	}
+}
+
+func TestProfileLabels(t *testing.T) {
+	t.Parallel()
+
+	randomEntities := createTestRandomEntities(t)
+
+	health1 := createRandomProfile(t, randomEntities.prov, randomEntities.proj.ID, []string{"stacklok:health"})
+	require.NotEmpty(t, health1)
+	health2 := createRandomProfile(t, randomEntities.prov, randomEntities.proj.ID, []string{"stacklok:health", "obsolete"})
+	require.NotEmpty(t, health2)
+	obsolete := createRandomProfile(t, randomEntities.prov, randomEntities.proj.ID, []string{"obsolete"})
+	require.NotEmpty(t, obsolete)
+	p1 := createRandomProfile(t, randomEntities.prov, randomEntities.proj.ID, []string{})
+	require.NotEmpty(t, p1)
+	p2 := createRandomProfile(t, randomEntities.prov, randomEntities.proj.ID, []string{})
+	require.NotEmpty(t, p2)
+
+	tests := []struct {
+		name          string
+		includeLabels []string
+		excludeLabels []string
+		expectedNames []string
+	}{
+		{
+			name:          "list all profiles",
+			includeLabels: []string{"*"},
+			expectedNames: []string{health1.Name, health2.Name, obsolete.Name, p1.Name, p2.Name},
+		},
+		{
+			name:          "list profiles with no labels",
+			includeLabels: []string{},
+			expectedNames: []string{p1.Name, p2.Name},
+		},
+		{
+			name:          "list profiles with no labels using nil - default ",
+			includeLabels: nil,
+			expectedNames: []string{p1.Name, p2.Name},
+		},
+		{
+			name:          "list profiles that have the obsolete label",
+			includeLabels: []string{"obsolete"},
+			expectedNames: []string{health2.Name, obsolete.Name},
+		},
+		{
+			name:          "list profiles with the stacklok:health label",
+			includeLabels: []string{"stacklok:health"},
+			expectedNames: []string{health1.Name, health2.Name},
+		},
+		{
+			name:          "list profile having both obsolete and stacklok:health labels",
+			includeLabels: []string{"stacklok:health", "obsolete"},
+			expectedNames: []string{health2.Name},
+		},
+		{
+			name:          "list profiles with nonexistent labels",
+			includeLabels: []string{"nonexistent"},
+			expectedNames: []string{},
+		},
+		{
+			name:          "both include and exclude",
+			includeLabels: []string{"stacklok:health"},
+			excludeLabels: []string{"obsolete"},
+			expectedNames: []string{health1.Name},
+		},
+		{
+			name:          "include all labels but exclude one",
+			includeLabels: []string{"*"},
+			excludeLabels: []string{"obsolete"},
+			expectedNames: []string{health1.Name, p1.Name, p2.Name},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			rows, err := testQueries.ListProfilesByProjectID(context.Background(), ListProfilesByProjectIDParams{
+				ProjectID:     randomEntities.proj.ID,
+				IncludeLabels: tt.includeLabels,
+				ExcludeLabels: tt.excludeLabels,
+			})
+			require.NoError(t, err)
+
+			names := make([]string, 0, len(rows))
+			for _, row := range rows {
+				names = append(names, row.Name)
+			}
+			require.True(t, slices.Equal(names, tt.expectedNames), "expected %v, got %v", tt.expectedNames, names)
+		})
 	}
 }
 
@@ -366,7 +470,7 @@ func TestCreateProfileStatusStoredProcedure(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			profile := createRandomProfile(t, randomEntities.prov, randomEntities.proj.ID)
+			profile := createRandomProfile(t, randomEntities.prov, randomEntities.proj.ID, []string{})
 			require.NotEmpty(t, profile)
 
 			tt.ruleStatusSetupFn(profile, randomEntities)
@@ -499,7 +603,7 @@ func TestCreateProfileStatusStoredDeleteProcedure(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			profile := createRandomProfile(t, randomEntities.prov, randomEntities.proj.ID)
+			profile := createRandomProfile(t, randomEntities.prov, randomEntities.proj.ID, []string{})
 			require.NotEmpty(t, profile)
 
 			delRepo := createRandomRepository(t, randomEntities.proj.ID, randomEntities.prov)
@@ -724,7 +828,7 @@ func TestListRuleEvaluations(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			tt.profile = createRandomProfile(t, randomEntities.prov, randomEntities.proj.ID)
+			tt.profile = createRandomProfile(t, randomEntities.prov, randomEntities.proj.ID, []string{})
 			require.NotEmpty(t, tt.profile)
 
 			tt.ruleStatusSetupFn(tt.profile, randomEntities)

--- a/internal/db/querier.go
+++ b/internal/db/querier.go
@@ -101,7 +101,8 @@ type Querier interface {
 	// projects have a boolean field is_organization that is set to true if the project is an organization.
 	// this flag is no longer used and will be removed in the future.
 	ListOldOrgProjects(ctx context.Context) ([]Project, error)
-	ListProfilesByProjectID(ctx context.Context, arg ListProfilesByProjectIDParams) ([]ListProfilesByProjectIDRow, error)
+	ListProfilesByProjectID(ctx context.Context, projectID uuid.UUID) ([]ListProfilesByProjectIDRow, error)
+	ListProfilesByProjectIDAndLabel(ctx context.Context, arg ListProfilesByProjectIDAndLabelParams) ([]ListProfilesByProjectIDAndLabelRow, error)
 	// get profile information that instantiate a rule. This is done by joining the profiles with entity_profiles, then correlating those
 	// with entity_profile_rules. The rule_type_id is used to filter the results. Note that we only really care about the overal profile,
 	// so we only return the profile information. We also should group the profiles so that we don't get duplicates.

--- a/internal/db/querier.go
+++ b/internal/db/querier.go
@@ -101,7 +101,7 @@ type Querier interface {
 	// projects have a boolean field is_organization that is set to true if the project is an organization.
 	// this flag is no longer used and will be removed in the future.
 	ListOldOrgProjects(ctx context.Context) ([]Project, error)
-	ListProfilesByProjectID(ctx context.Context, projectID uuid.UUID) ([]ListProfilesByProjectIDRow, error)
+	ListProfilesByProjectID(ctx context.Context, arg ListProfilesByProjectIDParams) ([]ListProfilesByProjectIDRow, error)
 	// get profile information that instantiate a rule. This is done by joining the profiles with entity_profiles, then correlating those
 	// with entity_profile_rules. The rule_type_id is used to filter the results. Note that we only really care about the overal profile,
 	// so we only return the profile information. We also should group the profiles so that we don't get duplicates.

--- a/internal/db/store.go
+++ b/internal/db/store.go
@@ -131,3 +131,29 @@ func WithTransaction[T any](store Store, fn func(querier ExtendQuerier) (T, erro
 	}
 	return result, store.Commit(tx)
 }
+
+// ProfileRow is an interface row in the profiles table
+type ProfileRow interface {
+	GetProfile() Profile
+	GetEntityProfile() EntityProfile
+}
+
+// GetProfile returns the profile
+func (r ListProfilesByProjectIDAndLabelRow) GetProfile() Profile {
+	return r.Profile
+}
+
+// GetEntityProfile returns the entity profile
+func (r ListProfilesByProjectIDAndLabelRow) GetEntityProfile() EntityProfile {
+	return r.EntityProfile
+}
+
+// GetProfile returns the profile
+func (r ListProfilesByProjectIDRow) GetProfile() Profile {
+	return r.Profile
+}
+
+// GetEntityProfile returns the entity profile
+func (r ListProfilesByProjectIDRow) GetEntityProfile() EntityProfile {
+	return r.EntityProfile
+}

--- a/internal/db/store.go
+++ b/internal/db/store.go
@@ -19,6 +19,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"strings"
 
 	"github.com/google/uuid"
 )
@@ -156,4 +157,24 @@ func (r ListProfilesByProjectIDRow) GetProfile() Profile {
 // GetEntityProfile returns the entity profile
 func (r ListProfilesByProjectIDRow) GetEntityProfile() EntityProfile {
 	return r.EntityProfile
+}
+
+// LabelsFromFilter parses the filter string and populates the IncludeLabels and ExcludeLabels fields
+func (lp *ListProfilesByProjectIDAndLabelParams) LabelsFromFilter(filter string) {
+	// otherwise Split would have returned a slice with one empty string
+	if filter == "" {
+		return
+	}
+
+	for _, label := range strings.Split(filter, ",") {
+		switch {
+		case label == "*":
+			lp.IncludeLabels = append(lp.IncludeLabels, label)
+		case strings.HasPrefix(label, "!"):
+			// if the label starts with a "!", it is a negative filter, add it to the negative list
+			lp.ExcludeLabels = append(lp.ExcludeLabels, label[1:])
+		default:
+			lp.IncludeLabels = append(lp.IncludeLabels, label)
+		}
+	}
 }

--- a/internal/engine/executor.go
+++ b/internal/engine/executor.go
@@ -234,7 +234,7 @@ func (e *Executor) evalEntityEvent(
 	defer e.releaseLockAndFlush(ctx, inf)
 
 	// Get profiles relevant to project
-	dbpols, err := e.querier.ListProfilesByProjectID(ctx, db.ListProfilesByProjectIDParams{ProjectID: inf.ProjectID})
+	dbpols, err := e.querier.ListProfilesByProjectID(ctx, inf.ProjectID)
 	if err != nil {
 		return fmt.Errorf("error getting profiles: %w", err)
 	}

--- a/internal/engine/executor.go
+++ b/internal/engine/executor.go
@@ -234,7 +234,7 @@ func (e *Executor) evalEntityEvent(
 	defer e.releaseLockAndFlush(ctx, inf)
 
 	// Get profiles relevant to project
-	dbpols, err := e.querier.ListProfilesByProjectID(ctx, inf.ProjectID)
+	dbpols, err := e.querier.ListProfilesByProjectID(ctx, db.ListProfilesByProjectIDParams{ProjectID: inf.ProjectID})
 	if err != nil {
 		return fmt.Errorf("error getting profiles: %w", err)
 	}

--- a/internal/engine/executor_test.go
+++ b/internal/engine/executor_test.go
@@ -143,17 +143,21 @@ func TestExecutor_handleEntityEvent(t *testing.T) {
 	require.NoError(t, err, "expected no error")
 
 	mockStore.EXPECT().
-		ListProfilesByProjectID(gomock.Any(), db.ListProfilesByProjectIDParams{ProjectID: projectID}).
+		ListProfilesByProjectID(gomock.Any(), projectID).
 		Return([]db.ListProfilesByProjectIDRow{
 			{
-				ID:              profileID,
-				Name:            "test-profile",
-				Entity:          db.EntitiesRepository,
-				Provider:        providerName,
-				ProjectID:       projectID,
-				CreatedAt:       time.Now(),
-				UpdatedAt:       time.Now(),
-				ContextualRules: json.RawMessage(marshalledCRS),
+				Profile: db.Profile{
+					ID:        profileID,
+					Name:      "test-profile",
+					Provider:  providerName,
+					ProjectID: projectID,
+					CreatedAt: time.Now(),
+					UpdatedAt: time.Now(),
+				},
+				EntityProfile: db.EntityProfile{
+					Entity:          db.EntitiesRepository,
+					ContextualRules: json.RawMessage(marshalledCRS),
+				},
 			},
 		}, nil)
 

--- a/internal/engine/executor_test.go
+++ b/internal/engine/executor_test.go
@@ -143,7 +143,7 @@ func TestExecutor_handleEntityEvent(t *testing.T) {
 	require.NoError(t, err, "expected no error")
 
 	mockStore.EXPECT().
-		ListProfilesByProjectID(gomock.Any(), projectID).
+		ListProfilesByProjectID(gomock.Any(), db.ListProfilesByProjectIDParams{ProjectID: projectID}).
 		Return([]db.ListProfilesByProjectIDRow{
 			{
 				ID:              profileID,


### PR DESCRIPTION
# Summary

In order to support listing by labels, let's extend the
`ListProfilesByProjectID` SQL statement with two optional parameters -
`include_labels` and `exclude_labels`. These default to `[]` which is
also the first branch in the SQL statement which would list all profiles
with no labels.

Please refer to the unit tests for more use-cases.

Related: #2759

## Change Type

***Mark the type of change your PR introduces:***

- [ ] Bug fix (resolves an issue without affecting existing features)
- [x] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [ ] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

1. results API - list all the profiles regardless of labels
```shell
curl  -H "Authorization: Bearer $MINDER_BEARER_TOKEN" 'http://localhost:8080/api/v1/results?context.project=2e7e96d2-6cf0-4af0-8f02-c84df2c2dddf&context.provider==github&label_filter=%2A' | jq -r '.entities[].profiles[].profileStatus.profileName'
```
returns all the profiles
    
2. results API - list the profiles without labels
```shell
curl  -H "Authorization: Bearer $MINDER_BEARER_TOKEN" 'http://localhost:8080/api/v1/results?context.project=2e7e96d2-6cf0-4af0-8f02-c84df2c2dddf&context.provider==github' | jq -r '.entities[].profiles[].profileStatus.profileName'
```
only lists profiles without labels

3. listProfiles API - list all the profiles
```shell
curl -H "Authorization: Bearer $MINDER_BEARER_TOKEN" 'http://localhost:8080/api/v1/profiles?context.project=2e7e96d2-6cf0-4af0-8f02-c84df2c2dddf&context.provider=github&filter_labels=%2A' | jq '.profiles[].name'
```
5. listProfiles API - list profiles without labels
```
curl -H "Authorization: Bearer $MINDER_BEARER_TOKEN" 'http://localhost:8080/api/v1/profiles?context.project=2e7e96d2-6cf0-4af0-8f02-c84df2c2dddf&context.provider=github' | jq '.profiles[].name'
```
6. listProfiles API - list all profiles but those labeles with `stacklok:health`
```
curl -H "Authorization: Bearer $MINDER_BEARER_TOKEN" 'http://localhost:8080/api/v1/profiles?context.project=2e7e96d2-6cf0-4af0-8f02-c84df2c2dddf&context.provider=github&label_filter=%2A%2C%21stacklok%3Ahealth' | jq '.profiles[].name'
```
***Outline how the changes were tested, including steps to reproduce and any relevant configurations. 
Attach screenshots if helpful.***

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [x] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [x] Included tests that validate the fix or feature.
- [ ] Checked that related changes are merged.
