### PR TITLE
Tx changes for marketplace

### DIFF
--- a/internal/controlplane/handlers_profile_test.go
+++ b/internal/controlplane/handlers_profile_test.go
@@ -354,7 +354,7 @@ func TestCreateProfile(t *testing.T) {
 			s := &Server{
 				store: dbStore,
 				// Do not replace this with a mock - these tests are used to test ProfileService as well
-				profiles: profiles.NewProfileService(dbStore, evts),
+				profiles: profiles.NewProfileService(evts),
 				evt:      evts,
 			}
 

--- a/internal/controlplane/server.go
+++ b/internal/controlplane/server.go
@@ -149,7 +149,7 @@ func NewServer(
 		return nil, fmt.Errorf("failed to create crypto engine: %w", err)
 	}
 	whManager := webhooks.NewWebhookManager(cfg.WebhookConfig)
-	profileSvc := profiles.NewProfileService(store, evt)
+	profileSvc := profiles.NewProfileService(evt)
 	mt := metrics.NewNoopMetrics()
 	provMt := provtelemetry.NewNoopMetrics()
 	s := &Server{

--- a/internal/marketplaces/service.go
+++ b/internal/marketplaces/service.go
@@ -35,14 +35,14 @@ type Marketplace interface {
 		ctx context.Context,
 		project types.ProjectContext,
 		bundleID mindpak.BundleID,
-		qtx db.ExtendQuerier,
+		qtx db.Querier,
 	) error
 	AddProfile(
 		ctx context.Context,
 		project types.ProjectContext,
 		bundleID mindpak.BundleID,
 		profileName string,
-		qtx db.ExtendQuerier,
+		qtx db.Querier,
 	) error
 }
 
@@ -64,7 +64,7 @@ func (s *singleSourceMarketplace) Subscribe(
 	ctx context.Context,
 	project types.ProjectContext,
 	bundleID mindpak.BundleID,
-	qtx db.ExtendQuerier,
+	qtx db.Querier,
 ) error {
 	bundle, err := s.source.GetBundle(bundleID)
 	if err != nil {
@@ -82,7 +82,7 @@ func (s *singleSourceMarketplace) AddProfile(
 	project types.ProjectContext,
 	bundleID mindpak.BundleID,
 	profileName string,
-	qtx db.ExtendQuerier,
+	qtx db.Querier,
 ) error {
 	bundle, err := s.source.GetBundle(bundleID)
 	if err != nil {

--- a/internal/marketplaces/subscriptions/mock/subscription.go
+++ b/internal/marketplaces/subscriptions/mock/subscription.go
@@ -43,7 +43,7 @@ func (m *MockSubscriptionService) EXPECT() *MockSubscriptionServiceMockRecorder 
 }
 
 // CreateProfile mocks base method.
-func (m *MockSubscriptionService) CreateProfile(arg0 context.Context, arg1 types.ProjectContext, arg2 reader.BundleReader, arg3 string, arg4 db.ExtendQuerier) error {
+func (m *MockSubscriptionService) CreateProfile(arg0 context.Context, arg1 types.ProjectContext, arg2 reader.BundleReader, arg3 string, arg4 db.Querier) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateProfile", arg0, arg1, arg2, arg3, arg4)
 	ret0, _ := ret[0].(error)
@@ -57,7 +57,7 @@ func (mr *MockSubscriptionServiceMockRecorder) CreateProfile(arg0, arg1, arg2, a
 }
 
 // Subscribe mocks base method.
-func (m *MockSubscriptionService) Subscribe(arg0 context.Context, arg1 types.ProjectContext, arg2 reader.BundleReader, arg3 db.ExtendQuerier) error {
+func (m *MockSubscriptionService) Subscribe(arg0 context.Context, arg1 types.ProjectContext, arg2 reader.BundleReader, arg3 db.Querier) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Subscribe", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(error)

--- a/internal/marketplaces/subscriptions/service.go
+++ b/internal/marketplaces/subscriptions/service.go
@@ -45,7 +45,7 @@ type SubscriptionService interface {
 		ctx context.Context,
 		project types.ProjectContext,
 		bundle reader.BundleReader,
-		qtx db.ExtendQuerier,
+		qtx db.Querier,
 	) error
 	// CreateProfile creates the specified profile from the bundle in the project.
 	CreateProfile(
@@ -53,7 +53,7 @@ type SubscriptionService interface {
 		project types.ProjectContext,
 		bundle reader.BundleReader,
 		profileName string,
-		qtx db.ExtendQuerier,
+		qtx db.Querier,
 	) error
 }
 
@@ -77,7 +77,7 @@ func (s *subscriptionService) Subscribe(
 	ctx context.Context,
 	project types.ProjectContext,
 	bundle reader.BundleReader,
-	qtx db.ExtendQuerier,
+	qtx db.Querier,
 ) error {
 	metadata := bundle.GetMetadata()
 	_, err := qtx.GetSubscriptionByProjectBundle(ctx, db.GetSubscriptionByProjectBundleParams{
@@ -123,7 +123,7 @@ func (s *subscriptionService) CreateProfile(
 	project types.ProjectContext,
 	bundle reader.BundleReader,
 	profileName string,
-	qtx db.ExtendQuerier,
+	qtx db.Querier,
 ) error {
 	// ensure project is subscribed to this bundle
 	subscription, err := s.findSubscription(ctx, qtx, project.ID, bundle.GetMetadata())
@@ -145,7 +145,7 @@ func (s *subscriptionService) CreateProfile(
 
 func (_ *subscriptionService) findSubscription(
 	ctx context.Context,
-	qtx db.ExtendQuerier,
+	qtx db.Querier,
 	projectID uuid.UUID,
 	metadata *mindpak.Metadata,
 ) (result db.Subscription, err error) {
@@ -168,7 +168,7 @@ func (_ *subscriptionService) findSubscription(
 
 func ensureBundleExists(
 	ctx context.Context,
-	qtx db.ExtendQuerier,
+	qtx db.Querier,
 	namespace, bundleName string,
 ) (uuid.UUID, error) {
 	// This is a no-op if this namespace/name pair already exists
@@ -185,7 +185,7 @@ func ensureBundleExists(
 
 func (s *subscriptionService) upsertBundleRules(
 	ctx context.Context,
-	qtx db.ExtendQuerier,
+	qtx db.Querier,
 	projectID uuid.UUID,
 	provider *db.Provider,
 	bundle reader.BundleReader,

--- a/internal/profiles/mock/service.go
+++ b/internal/profiles/mock/service.go
@@ -43,7 +43,7 @@ func (m *MockProfileService) EXPECT() *MockProfileServiceMockRecorder {
 }
 
 // CreateProfile mocks base method.
-func (m *MockProfileService) CreateProfile(arg0 context.Context, arg1 uuid.UUID, arg2 *db.Provider, arg3 uuid.UUID, arg4 *v1.Profile, arg5 db.ExtendQuerier) (*v1.Profile, error) {
+func (m *MockProfileService) CreateProfile(arg0 context.Context, arg1 uuid.UUID, arg2 *db.Provider, arg3 uuid.UUID, arg4 *v1.Profile, arg5 db.Querier) (*v1.Profile, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateProfile", arg0, arg1, arg2, arg3, arg4, arg5)
 	ret0, _ := ret[0].(*v1.Profile)
@@ -58,7 +58,7 @@ func (mr *MockProfileServiceMockRecorder) CreateProfile(arg0, arg1, arg2, arg3, 
 }
 
 // UpdateProfile mocks base method.
-func (m *MockProfileService) UpdateProfile(arg0 context.Context, arg1 uuid.UUID, arg2 *db.Provider, arg3 uuid.UUID, arg4 *v1.Profile, arg5 db.ExtendQuerier) (*v1.Profile, error) {
+func (m *MockProfileService) UpdateProfile(arg0 context.Context, arg1 uuid.UUID, arg2 *db.Provider, arg3 uuid.UUID, arg4 *v1.Profile, arg5 db.Querier) (*v1.Profile, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpdateProfile", arg0, arg1, arg2, arg3, arg4, arg5)
 	ret0, _ := ret[0].(*v1.Profile)

--- a/internal/profiles/validator_test.go
+++ b/internal/profiles/validator_test.go
@@ -141,8 +141,8 @@ func TestValidatorScenarios(t *testing.T) {
 				testScenario.DBSetup(store)
 			}
 
-			result, err := profiles.NewValidator(store).
-				ValidateAndExtractRules(context.Background(), projectID, testScenario.Profile)
+			v := &profiles.Validator{}
+			result, err := v.ValidateAndExtractRules(context.Background(), store, projectID, testScenario.Profile)
 
 			if testScenario.ExpectedError != "" && testScenario.ExpectedResult == nil {
 				require.Nil(t, result)

--- a/internal/ruletypes/mock/service.go
+++ b/internal/ruletypes/mock/service.go
@@ -43,7 +43,7 @@ func (m *MockRuleTypeService) EXPECT() *MockRuleTypeServiceMockRecorder {
 }
 
 // CreateRuleType mocks base method.
-func (m *MockRuleTypeService) CreateRuleType(arg0 context.Context, arg1 uuid.UUID, arg2 *db.Provider, arg3 uuid.UUID, arg4 *v1.RuleType, arg5 db.ExtendQuerier) (*v1.RuleType, error) {
+func (m *MockRuleTypeService) CreateRuleType(arg0 context.Context, arg1 uuid.UUID, arg2 *db.Provider, arg3 uuid.UUID, arg4 *v1.RuleType, arg5 db.Querier) (*v1.RuleType, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateRuleType", arg0, arg1, arg2, arg3, arg4, arg5)
 	ret0, _ := ret[0].(*v1.RuleType)
@@ -58,7 +58,7 @@ func (mr *MockRuleTypeServiceMockRecorder) CreateRuleType(arg0, arg1, arg2, arg3
 }
 
 // UpdateRuleType mocks base method.
-func (m *MockRuleTypeService) UpdateRuleType(arg0 context.Context, arg1 uuid.UUID, arg2 *db.Provider, arg3 uuid.UUID, arg4 *v1.RuleType, arg5 db.ExtendQuerier) (*v1.RuleType, error) {
+func (m *MockRuleTypeService) UpdateRuleType(arg0 context.Context, arg1 uuid.UUID, arg2 *db.Provider, arg3 uuid.UUID, arg4 *v1.RuleType, arg5 db.Querier) (*v1.RuleType, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpdateRuleType", arg0, arg1, arg2, arg3, arg4, arg5)
 	ret0, _ := ret[0].(*v1.RuleType)
@@ -73,7 +73,7 @@ func (mr *MockRuleTypeServiceMockRecorder) UpdateRuleType(arg0, arg1, arg2, arg3
 }
 
 // UpsertRuleType mocks base method.
-func (m *MockRuleTypeService) UpsertRuleType(arg0 context.Context, arg1 uuid.UUID, arg2 *db.Provider, arg3 uuid.UUID, arg4 *v1.RuleType, arg5 db.ExtendQuerier) error {
+func (m *MockRuleTypeService) UpsertRuleType(arg0 context.Context, arg1 uuid.UUID, arg2 *db.Provider, arg3 uuid.UUID, arg4 *v1.RuleType, arg5 db.Querier) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpsertRuleType", arg0, arg1, arg2, arg3, arg4, arg5)
 	ret0, _ := ret[0].(error)

--- a/internal/ruletypes/service.go
+++ b/internal/ruletypes/service.go
@@ -46,7 +46,7 @@ type RuleTypeService interface {
 		provider *db.Provider,
 		subscriptionID uuid.UUID,
 		ruleType *pb.RuleType,
-		qtx db.ExtendQuerier,
+		qtx db.Querier,
 	) (*pb.RuleType, error)
 
 	// UpdateRuleType updates rule types in the database
@@ -59,7 +59,7 @@ type RuleTypeService interface {
 		provider *db.Provider,
 		subscriptionID uuid.UUID,
 		ruleType *pb.RuleType,
-		qtx db.ExtendQuerier,
+		qtx db.Querier,
 	) (*pb.RuleType, error)
 
 	// UpsertRuleType creates the rule type if it does not exist
@@ -71,7 +71,7 @@ type RuleTypeService interface {
 		provider *db.Provider,
 		subscriptionID uuid.UUID,
 		ruleType *pb.RuleType,
-		qtx db.ExtendQuerier,
+		qtx db.Querier,
 	) error
 }
 
@@ -100,7 +100,7 @@ func (_ *ruleTypeService) CreateRuleType(
 	provider *db.Provider,
 	subscriptionID uuid.UUID,
 	ruleType *pb.RuleType,
-	qtx db.ExtendQuerier,
+	qtx db.Querier,
 ) (*pb.RuleType, error) {
 	// Telemetry logging
 	logger.BusinessRecord(ctx).Provider = provider.Name
@@ -169,7 +169,7 @@ func (_ *ruleTypeService) UpdateRuleType(
 	provider *db.Provider,
 	subscriptionID uuid.UUID,
 	ruleType *pb.RuleType,
-	qtx db.ExtendQuerier,
+	qtx db.Querier,
 ) (*pb.RuleType, error) {
 	// Telemetry logging
 	logger.BusinessRecord(ctx).Provider = provider.Name
@@ -240,7 +240,7 @@ func (s *ruleTypeService) UpsertRuleType(
 	provider *db.Provider,
 	subscriptionID uuid.UUID,
 	ruleType *pb.RuleType,
-	qtx db.ExtendQuerier,
+	qtx db.Querier,
 ) error {
 	// In future, we may want to refactor the code so that we use upserts
 	// instead of separate create and update methods. For now, simulate upsert


### PR DESCRIPTION
Relates to #2541

1) Use `db.Querier` instead of `db.ExtendQuerier` - we do not need the
   extra methods of ExtendQuerier
2) Modify Validator to accept a qtx. This is needed for the project
   creation flow where the rules used by the profile get created in the
   same transaction that the profile gets created in.

# Summary

***Provide a brief overview of the changes and the issue being addressed. 
Explain the rationale and any background necessary for understanding the changes. 
List dependencies required by this change, if any.***

Fixes #(related issue)

## Change Type

***Mark the type of change your PR introduces:***

- [x] Bug fix (resolves an issue without affecting existing features)
- [ ] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [ ] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

***Outline how the changes were tested, including steps to reproduce and any relevant configurations. 
Attach screenshots if helpful.***

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [ ] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [x] Included tests that validate the fix or feature.
- [ ] Checked that related changes are merged.
