### PR TITLE
Explicitly coalesce labels on create and update to {}

### DIFF
--- a/database/migrations/000038_coalesce_nil_labels.down.sql
+++ b/database/migrations/000038_coalesce_nil_labels.down.sql
@@ -1,0 +1,15 @@
+-- Copyright 2024 Stacklok, Inc
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--      http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+-- no down migration, the up migration fixes a bug where we could end up with nil label columns in profiles

--- a/database/migrations/000038_coalesce_nil_labels.up.sql
+++ b/database/migrations/000038_coalesce_nil_labels.up.sql
@@ -1,0 +1,22 @@
+-- Copyright 2024 Stacklok, Inc
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--      http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+BEGIN;
+
+-- Update profiles with NULL labels to empty array
+UPDATE profiles
+SET labels = '{}'
+WHERE labels IS NULL;
+
+COMMIT;

--- a/database/query/profiles.sql
+++ b/database/query/profiles.sql
@@ -9,7 +9,7 @@ INSERT INTO profiles (
     subscription_id,
     display_name,
     labels
-) VALUES ($1, $2, $3, $4, $5, sqlc.arg(provider_id), sqlc.narg(subscription_id), sqlc.arg(display_name), sqlc.arg(labels)::text[]) RETURNING *;
+) VALUES ($1, $2, $3, $4, $5, sqlc.arg(provider_id), sqlc.narg(subscription_id), sqlc.arg(display_name), COALESCE(sqlc.arg(labels)::text[], '{}'::text[])) RETURNING *;
 
 -- name: UpdateProfile :one
 UPDATE profiles SET
@@ -17,7 +17,7 @@ UPDATE profiles SET
     alert = $4,
     updated_at = NOW(),
     display_name = sqlc.arg(display_name),
-    labels = sqlc.arg(labels)::TEXT[]
+    labels = COALESCE(sqlc.arg(labels)::TEXT[], '{}'::TEXT[])
 WHERE id = $1 AND project_id = $2 RETURNING *;
 
 -- name: CreateProfileForEntity :one

--- a/internal/db/profiles.sql.go
+++ b/internal/db/profiles.sql.go
@@ -71,7 +71,7 @@ INSERT INTO profiles (
     subscription_id,
     display_name,
     labels
-) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9::text[]) RETURNING id, name, provider, project_id, remediate, alert, created_at, updated_at, provider_id, subscription_id, display_name, labels
+) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, COALESCE($9::text[], '{}'::text[])) RETURNING id, name, provider, project_id, remediate, alert, created_at, updated_at, provider_id, subscription_id, display_name, labels
 `
 
 type CreateProfileParams struct {
@@ -556,7 +556,7 @@ UPDATE profiles SET
     alert = $4,
     updated_at = NOW(),
     display_name = $5,
-    labels = $6::TEXT[]
+    labels = COALESCE($6::TEXT[], '{}'::TEXT[])
 WHERE id = $1 AND project_id = $2 RETURNING id, name, provider, project_id, remediate, alert, created_at, updated_at, provider_id, subscription_id, display_name, labels
 `
 


### PR DESCRIPTION
# Summary

I was stupid and thought that setting the default on the column in
migration would ensure that we default to '{}' as well as the
grpc-generated getter returning an empty slice by default. Turns out
that one defaults to returning nil.

To fix that, we explicitly rewrite nil labels to an empty array.

## Change Type

***Mark the type of change your PR introduces:***

- [x] Bug fix (resolves an issue without affecting existing features)
- [ ] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [ ] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

***Outline how the changes were tested, including steps to reproduce and any relevant configurations. 
Attach screenshots if helpful.***

# Review Checklist:

- [ ] Reviewed my own code for quality and clarity.
- [ ] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [ ] Included tests that validate the fix or feature.
- [ ] Checked that related changes are merged.
