### PR TITLE
Allow for skipping opening the browser on login

### DIFF
--- a/cmd/cli/app/auth/auth_login.go
+++ b/cmd/cli/app/auth/auth_login.go
@@ -50,12 +50,14 @@ func LoginCommand(cmd *cobra.Command, _ []string) error {
 		return cli.MessageAndError("Unable to read config", err)
 	}
 
+	skipBrowser := viper.GetBool("skip-browser")
+
 	// No longer print usage on returned error, since we've parsed our inputs
 	// See https://github.com/spf13/cobra/issues/340#issuecomment-374617413
 	cmd.SilenceUsage = true
 
 	// wait for the token to be received
-	token, err := login(ctx, cmd, clientConfig, nil)
+	token, err := login(ctx, cmd, clientConfig, nil, skipBrowser)
 	if err != nil {
 		return err
 	}
@@ -113,4 +115,12 @@ func LoginCommand(cmd *cobra.Command, _ []string) error {
 
 func init() {
 	AuthCmd.AddCommand(loginCmd)
+
+	// hidden flags
+	loginCmd.Flags().BoolP("skip-browser", "", false, "Skip opening the browser for OAuth flow")
+	// mark hidden
+	if err := loginCmd.Flags().MarkHidden("skip-browser"); err != nil {
+		loginCmd.Printf("Error marking flag hidden: %s", err)
+		panic(err)
+	}
 }

--- a/cmd/cli/app/auth/common.go
+++ b/cmd/cli/app/auth/common.go
@@ -124,6 +124,7 @@ func login(
 	cmd *cobra.Command,
 	cfg *clientconfig.Config,
 	extraScopes []string,
+	skipBroswer bool,
 ) (*oidc.Tokens[*oidc.IDTokenClaims], error) {
 	issuerUrlStr := cfg.Identity.CLI.IssuerUrl
 	clientID := cfg.Identity.CLI.ClientId
@@ -193,6 +194,7 @@ func login(
 			cmd.Println("Authentication Successful")
 		}
 	}
+
 	http.Handle("/login", rp.AuthURLHandler(stateFn, provider))
 	http.Handle(callbackPath, rp.CodeExchangeHandler(callback, provider))
 
@@ -219,8 +221,10 @@ func login(
 	cmd.Println("Please follow the instructions on the page to log in.")
 
 	// open user's browser to login page
-	if err := browser.OpenURL(loginUrl); err != nil {
-		cmd.Printf("You may login by pasting this URL into your browser: %s\n", loginUrl)
+	if skipBroswer {
+		if err := browser.OpenURL(loginUrl); err != nil {
+			cmd.Printf("You may login by pasting this URL into your browser: %s\n", loginUrl)
+		}
 	}
 
 	cmd.Println("Waiting for token...")

--- a/cmd/cli/app/auth/offline_get.go
+++ b/cmd/cli/app/auth/offline_get.go
@@ -48,13 +48,14 @@ that need to authenticate to the control plane.`,
 		}
 
 		f := viper.GetString("file")
+		skipBrowser := viper.GetBool("skip-browser")
 
 		// No longer print usage on returned error, since we've parsed our inputs
 		// See https://github.com/spf13/cobra/issues/340#issuecomment-374617413
 		cmd.SilenceUsage = true
 
 		// wait for the token to be received
-		token, err := login(ctx, cmd, clientConfig, []string{"offline_access"})
+		token, err := login(ctx, cmd, clientConfig, []string{"offline_access"}, skipBrowser)
 		if err != nil {
 			return err
 		}
@@ -76,6 +77,14 @@ func init() {
 	offlineTokenGetCmd.Flags().StringP("file", "f", "offline.token", "The file to write the offline token to")
 
 	if err := viper.BindPFlag("file", offlineTokenGetCmd.Flag("file")); err != nil {
+		panic(err)
+	}
+
+	// hidden flags
+	offlineTokenGetCmd.Flags().BoolP("skip-browser", "", false, "Skip opening the browser for OAuth flow")
+	// mark hidden
+	if err := offlineTokenGetCmd.Flags().MarkHidden("skip-browser"); err != nil {
+		offlineTokenGetCmd.Printf("Error marking flag hidden: %s", err)
 		panic(err)
 	}
 }


### PR DESCRIPTION
# Summary

For the hipster case of someone running the minder CLI on a toolbox, it is
often the case that the container cannot open a browser. Let's add a hidden flag
to allow for such hipster cases.

## Change Type

***Mark the type of change your PR introduces:***

- [x] Bug fix (resolves an issue without affecting existing features)
- [ ] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [ ] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

***Outline how the changes were tested, including steps to reproduce and any relevant configurations. 
Attach screenshots if helpful.***

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [ ] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [ ] Included tests that validate the fix or feature.
- [ ] Checked that related changes are merged.
