### PR TITLE
Allow reading pointer config values from env

### DIFF
--- a/cmd/cli/app/root.go
+++ b/cmd/cli/app/root.go
@@ -114,7 +114,7 @@ func init() {
 
 func initConfig() {
 	viper.SetEnvPrefix("minder")
-	viper.SetEnvKeyReplacer(strings.NewReplacer(".", "_"))
+	viper.SetEnvKeyReplacer(strings.NewReplacer(".", "_", "-", "_"))
 
 	cfgFile := viper.GetString("config")
 	cfgFileData, err := config.GetConfigFileData(cfgFile, filepath.Join(".", "config.yaml"))

--- a/cmd/dev/app/container/cmd_verify.go
+++ b/cmd/dev/app/container/cmd_verify.go
@@ -73,7 +73,7 @@ func CmdVerify() *cobra.Command {
 		os.Exit(1)
 	}
 
-	viper.SetEnvKeyReplacer(strings.NewReplacer(".", "_"))
+	viper.SetEnvKeyReplacer(strings.NewReplacer(".", "_", "-", "_"))
 
 	return verifyCmd
 }

--- a/cmd/dev/app/rule_type/rttst.go
+++ b/cmd/dev/app/rule_type/rttst.go
@@ -72,7 +72,7 @@ func CmdTest() *cobra.Command {
 		os.Exit(1)
 	}
 	// bind environment variable
-	viper.SetEnvKeyReplacer(strings.NewReplacer(".", "_"))
+	viper.SetEnvKeyReplacer(strings.NewReplacer(".", "_", "-", "_"))
 	viper.AutomaticEnv()
 	return testCmd
 }

--- a/cmd/server/app/webhook_update.go
+++ b/cmd/server/app/webhook_update.go
@@ -49,7 +49,7 @@ func cmdWebhookUpdate() *cobra.Command {
 	updateCmd.Flags().StringP("provider",
 		"p", "github",
 		"what provider interface must the provider implement to be updated")
-	viper.SetEnvKeyReplacer(strings.NewReplacer(".", "_"))
+	viper.SetEnvKeyReplacer(strings.NewReplacer(".", "_", "-", "_"))
 
 	if err := updateCmd.MarkFlagRequired("provider"); err != nil {
 		fmt.Fprintf(os.Stderr, "Error marking flag as required: %s\n", err)

--- a/internal/config/server/config.go
+++ b/internal/config/server/config.go
@@ -62,7 +62,7 @@ func DefaultConfigForTest() *Config {
 // up by viper
 func SetViperDefaults(v *viper.Viper) {
 	v.SetEnvPrefix("minder")
-	v.SetEnvKeyReplacer(strings.NewReplacer(".", "_"))
+	v.SetEnvKeyReplacer(strings.NewReplacer(".", "_", "-", "_"))
 	setViperStructDefaults(v, "", Config{})
 }
 
@@ -95,6 +95,11 @@ func setViperStructDefaults(v *viper.Viper, prefix string, s any) {
 			if value != "{}" {
 				setViperStructDefaults(v, valueName+".", reflect.Zero(field.Type).Interface())
 			}
+			continue
+		}
+
+		if field.Type.Kind() == reflect.Ptr {
+			setViperStructDefaults(v, valueName+".", reflect.Zero(field.Type.Elem()).Interface())
 			continue
 		}
 

--- a/internal/config/server/github_app.go
+++ b/internal/config/server/github_app.go
@@ -24,9 +24,9 @@ type GitHubAppConfig struct {
 	// AppName is the name of the GitHub App
 	AppName string `mapstructure:"app_name"`
 	// AppID is the ID of the GitHub App
-	AppID int64 `mapstructure:"app_id"`
+	AppID int64 `mapstructure:"app_id" default:"0"`
 	// UserID is the ID of the GitHub App user
-	UserID int64 `mapstructure:"user_id"`
+	UserID int64 `mapstructure:"user_id" default:"0"`
 	// PrivateKey is the GitHub App's private key
 	PrivateKey string `mapstructure:"private_key"`
 }


### PR DESCRIPTION
# Summary

This ensures that the github app private key can be read from the secret store.

Previously, if a configuration was a pointer type, then we would not bind its fields to environment variables.

## Change Type

***Mark the type of change your PR introduces:***

- [x] Bug fix (resolves an issue without affecting existing features)
- [ ] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [ ] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

***Outline how the changes were tested, including steps to reproduce and any relevant configurations. 
Attach screenshots if helpful.***

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [ ] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [ ] Included tests that validate the fix or feature.
- [ ] Checked that related changes are merged.
