### PR TITLE
Expose and actually fix skip browser

### DIFF
--- a/cmd/cli/app/auth/auth_login.go
+++ b/cmd/cli/app/auth/auth_login.go
@@ -50,7 +50,7 @@ func LoginCommand(cmd *cobra.Command, _ []string) error {
 		return cli.MessageAndError("Unable to read config", err)
 	}
 
-	skipBrowser := viper.GetBool("skip-browser")
+	skipBrowser := viper.GetBool("login.skip-browser")
 
 	// No longer print usage on returned error, since we've parsed our inputs
 	// See https://github.com/spf13/cobra/issues/340#issuecomment-374617413
@@ -118,9 +118,8 @@ func init() {
 
 	// hidden flags
 	loginCmd.Flags().BoolP("skip-browser", "", false, "Skip opening the browser for OAuth flow")
-	// mark hidden
-	if err := loginCmd.Flags().MarkHidden("skip-browser"); err != nil {
-		loginCmd.Printf("Error marking flag hidden: %s", err)
+	// Bind flags
+	if err := viper.BindPFlag("login.skip-browser", loginCmd.Flags().Lookup("skip-browser")); err != nil {
 		panic(err)
 	}
 }

--- a/cmd/cli/app/auth/common.go
+++ b/cmd/cli/app/auth/common.go
@@ -216,16 +216,19 @@ func login(
 	// get the OAuth authorization URL
 	loginUrl := fmt.Sprintf("http://localhost:%v/login", port)
 
-	// Redirect user to provider to log in
-	cmd.Printf("Your browser will now be opened to: %s\n", loginUrl)
-	cmd.Println("Please follow the instructions on the page to log in.")
-
-	// open user's browser to login page
 	if !skipBroswer {
+		// Redirect user to provider to log in
+		cmd.Printf("Your browser will now be opened to: %s\n", loginUrl)
+
+		// open user's browser to login page
 		if err := browser.OpenURL(loginUrl); err != nil {
 			cmd.Printf("You may login by pasting this URL into your browser: %s\n", loginUrl)
 		}
+	} else {
+		cmd.Printf("Skipping browser login. You may login by pasting this URL into your browser: %s\n", loginUrl)
 	}
+
+	cmd.Println("Please follow the instructions on the page to log in.")
 
 	cmd.Println("Waiting for token...")
 

--- a/cmd/cli/app/auth/offline_get.go
+++ b/cmd/cli/app/auth/offline_get.go
@@ -48,7 +48,7 @@ that need to authenticate to the control plane.`,
 		}
 
 		f := viper.GetString("file")
-		skipBrowser := viper.GetBool("skip-browser")
+		skipBrowser := viper.GetBool("offline.get.skip-browser")
 
 		// No longer print usage on returned error, since we've parsed our inputs
 		// See https://github.com/spf13/cobra/issues/340#issuecomment-374617413
@@ -80,11 +80,8 @@ func init() {
 		panic(err)
 	}
 
-	// hidden flags
 	offlineTokenGetCmd.Flags().BoolP("skip-browser", "", false, "Skip opening the browser for OAuth flow")
-	// mark hidden
-	if err := offlineTokenGetCmd.Flags().MarkHidden("skip-browser"); err != nil {
-		offlineTokenGetCmd.Printf("Error marking flag hidden: %s", err)
+	if err := viper.BindPFlag("offline.get.skip-browser", offlineTokenGetCmd.Flag("skip-browser")); err != nil {
 		panic(err)
 	}
 }

--- a/cmd/cli/app/provider/provider_enroll.go
+++ b/cmd/cli/app/provider/provider_enroll.go
@@ -240,9 +240,4 @@ func init() {
 
 	// hidden flags
 	enrollCmd.Flags().BoolP("skip-browser", "", false, "Skip opening the browser for OAuth flow")
-	// mark hidden
-	if err := enrollCmd.Flags().MarkHidden("skip-browser"); err != nil {
-		enrollCmd.Printf("Error marking flag hidden: %s", err)
-		os.Exit(1)
-	}
 }


### PR DESCRIPTION
# Summary

Turns out the viper keys were conflicting and I was not fetching what I
thought I was. This resulted in `skip-browser` always being false.

By using a unique flag name, I'm now able to pass `--skip-browser` to either `offline get`
or `login`.

This also removes the `hidden` flag from this parameter, as it's handy enough to expose it.

## Change Type

***Mark the type of change your PR introduces:***

- [x] Bug fix (resolves an issue without affecting existing features)
- [x] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [ ] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

***Outline how the changes were tested, including steps to reproduce and any relevant configurations. 
Attach screenshots if helpful.***

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [ ] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [ ] Included tests that validate the fix or feature.
- [ ] Checked that related changes are merged.
