### PR TITLE
Revert default config

### DIFF
--- a/internal/config/server/config.go
+++ b/internal/config/server/config.go
@@ -89,14 +89,8 @@ func setViperStructDefaults(v *viper.Viper, prefix string, s any) {
 		}
 		valueName := strings.ToLower(prefix + field.Tag.Get("mapstructure"))
 
-		// Extract a default value the `default` struct tag
-		// we don't support all value types yet, but we can add them as needed
-		value := field.Tag.Get("default")
-
 		if field.Type.Kind() == reflect.Struct {
-			if value != "{}" {
-				setViperStructDefaults(v, valueName+".", reflect.Zero(field.Type).Interface())
-			}
+			setViperStructDefaults(v, valueName+".", reflect.Zero(field.Type).Interface())
 			continue
 		}
 
@@ -105,6 +99,9 @@ func setViperStructDefaults(v *viper.Viper, prefix string, s any) {
 			continue
 		}
 
+		// Extract a default value the `default` struct tag
+		// we don't support all value types yet, but we can add them as needed
+		value := field.Tag.Get("default")
 		defaultValue := reflect.Zero(field.Type).Interface()
 		var err error // We handle errors at the end of the switch
 		fieldType := field.Type.Kind()

--- a/internal/config/server/config.go
+++ b/internal/config/server/config.go
@@ -19,7 +19,10 @@ package server
 
 import (
 	"fmt"
+	"reflect"
+	"strconv"
 	"strings"
+	"unicode"
 
 	"github.com/spf13/viper"
 
@@ -61,6 +64,76 @@ func DefaultConfigForTest() *Config {
 // up by viper
 func SetViperDefaults(v *viper.Viper) {
 	v.SetEnvPrefix("minder")
-	v.SetEnvKeyReplacer(strings.NewReplacer(".", "_"))
-	config.SetViperStructDefaults(v, "", Config{})
+	v.SetEnvKeyReplacer(strings.NewReplacer(".", "_", "-", "_"))
+	setViperStructDefaults(v, "", Config{})
+}
+
+// setViperStructDefaults recursively sets the viper default values for the given struct.
+//
+// Per https://github.com/spf13/viper/issues/188#issuecomment-255519149, and
+// https://github.com/spf13/viper/issues/761, we need to call viper.SetDefault() for each
+// field in the struct to be able to use env var overrides.  This also lets us use the
+// struct as the source of default values, so yay?
+func setViperStructDefaults(v *viper.Viper, prefix string, s any) {
+	structType := reflect.TypeOf(s)
+
+	for i := 0; i < structType.NumField(); i++ {
+		field := structType.Field(i)
+		if unicode.IsLower([]rune(field.Name)[0]) {
+			// Skip private fields
+			continue
+		}
+		if field.Tag.Get("mapstructure") == "" {
+			// Error, need a tag
+			panic(fmt.Sprintf("Untagged config struct field %q", field.Name))
+		}
+		valueName := strings.ToLower(prefix + field.Tag.Get("mapstructure"))
+
+		// Extract a default value the `default` struct tag
+		// we don't support all value types yet, but we can add them as needed
+		value := field.Tag.Get("default")
+
+		if field.Type.Kind() == reflect.Struct {
+			if value != "{}" {
+				setViperStructDefaults(v, valueName+".", reflect.Zero(field.Type).Interface())
+			}
+			continue
+		}
+
+		if field.Type.Kind() == reflect.Ptr {
+			setViperStructDefaults(v, valueName+".", reflect.Zero(field.Type.Elem()).Interface())
+			continue
+		}
+
+		defaultValue := reflect.Zero(field.Type).Interface()
+		var err error // We handle errors at the end of the switch
+		fieldType := field.Type.Kind()
+		//nolint:golint,exhaustive
+		switch fieldType {
+		case reflect.String:
+			defaultValue = value
+		case reflect.Int64, reflect.Int32, reflect.Int16, reflect.Int8, reflect.Int,
+			reflect.Uint64, reflect.Uint32, reflect.Uint16, reflect.Uint8, reflect.Uint:
+			defaultValue, err = strconv.Atoi(value)
+		case reflect.Float64:
+			defaultValue, err = strconv.ParseFloat(value, 64)
+		case reflect.Bool:
+			defaultValue, err = strconv.ParseBool(value)
+		case reflect.Slice:
+			defaultValue = nil
+		case reflect.Ptr:
+			defaultValue = nil
+		default:
+			err = fmt.Errorf("unhandled type %s", fieldType)
+		}
+		if err != nil {
+			// This is effectively a compile-time error, so exit early
+			panic(fmt.Sprintf("Bad value for field %q (%s): %q", valueName, fieldType, err))
+		}
+
+		if err := v.BindEnv(strings.ToUpper(valueName)); err != nil {
+			panic(fmt.Sprintf("Failed to bind %q to env var: %v", valueName, err))
+		}
+		v.SetDefault(valueName, defaultValue)
+	}
 }

--- a/internal/config/server/config_test.go
+++ b/internal/config/server/config_test.go
@@ -137,8 +137,6 @@ func TestReadDefaultConfig(t *testing.T) {
 	cfg := serverconfig.DefaultConfigForTest()
 	require.Equal(t, "debug", cfg.LoggingConfig.Level)
 	require.Equal(t, "minder", cfg.Database.Name)
-	require.Equal(t, int64(0), cfg.Events.Aggregator.LockInterval)
-	require.Equal(t, "", cfg.Events.SQLPubSub.Connection.Name)
 	require.Equal(t, "./.ssh/token_key_passphrase", cfg.Auth.TokenKey)
 }
 

--- a/internal/config/utils.go
+++ b/internal/config/utils.go
@@ -20,10 +20,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"reflect"
-	"strconv"
-	"strings"
-	"unicode"
 
 	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
@@ -190,74 +186,4 @@ func ReadConfigFromViper[CFG any](v *viper.Viper) (*CFG, error) {
 		return nil, err
 	}
 	return &cfg, nil
-}
-
-// SetViperStructDefaults recursively sets the viper default values for the given struct.
-//
-// Per https://github.com/spf13/viper/issues/188#issuecomment-255519149, and
-// https://github.com/spf13/viper/issues/761, we need to call viper.SetDefault() for each
-// field in the struct to be able to use env var overrides.  This also lets us use the
-// struct as the source of default values, so yay?
-func SetViperStructDefaults(v *viper.Viper, prefix string, s any) {
-	structType := reflect.TypeOf(s)
-
-	for i := 0; i < structType.NumField(); i++ {
-		field := structType.Field(i)
-		if unicode.IsLower([]rune(field.Name)[0]) {
-			// Skip private fields
-			continue
-		}
-		if field.Tag.Get("mapstructure") == "" {
-			// Error, need a tag
-			panic(fmt.Sprintf("Untagged config struct field %q", field.Name))
-		}
-		valueName := strings.ToLower(prefix + field.Tag.Get("mapstructure"))
-
-		// Extract a default value the `default` struct tag
-		// we don't support all value types yet, but we can add them as needed
-		value := field.Tag.Get("default")
-
-		if field.Type.Kind() == reflect.Struct {
-			if value != "{}" {
-				SetViperStructDefaults(v, valueName+".", reflect.Zero(field.Type).Interface())
-			}
-			continue
-		}
-
-		if field.Type.Kind() == reflect.Ptr {
-			SetViperStructDefaults(v, valueName+".", reflect.Zero(field.Type.Elem()).Interface())
-			continue
-		}
-
-		defaultValue := reflect.Zero(field.Type).Interface()
-		var err error // We handle errors at the end of the switch
-		fieldType := field.Type.Kind()
-		//nolint:golint,exhaustive
-		switch fieldType {
-		case reflect.String:
-			defaultValue = value
-		case reflect.Int64, reflect.Int32, reflect.Int16, reflect.Int8, reflect.Int,
-			reflect.Uint64, reflect.Uint32, reflect.Uint16, reflect.Uint8, reflect.Uint:
-			defaultValue, err = strconv.Atoi(value)
-		case reflect.Float64:
-			defaultValue, err = strconv.ParseFloat(value, 64)
-		case reflect.Bool:
-			defaultValue, err = strconv.ParseBool(value)
-		case reflect.Slice:
-			defaultValue = nil
-		case reflect.Ptr:
-			defaultValue = nil
-		default:
-			err = fmt.Errorf("unhandled type %s", fieldType)
-		}
-		if err != nil {
-			// This is effectively a compile-time error, so exit early
-			panic(fmt.Sprintf("Bad value for field %q (%s): %q", valueName, fieldType, err))
-		}
-
-		if err := v.BindEnv(strings.ToUpper(valueName)); err != nil {
-			panic(fmt.Sprintf("Failed to bind %q to env var: %v", valueName, err))
-		}
-		v.SetDefault(valueName, defaultValue)
-	}
 }


### PR DESCRIPTION
# Summary

Revert PRs that default the config value.
This is to continue to get the default port for the SQL connection for the events.

## Change Type

***Mark the type of change your PR introduces:***

- [x] Bug fix (resolves an issue without affecting existing features)
- [ ] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [ ] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

***Outline how the changes were tested, including steps to reproduce and any relevant configurations. 
Attach screenshots if helpful.***

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [ ] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [ ] Included tests that validate the fix or feature.
- [ ] Checked that related changes are merged.
