### PR TITLE
Create ProviderStore interface, migrate controlplane to use it

### DIFF
--- a/internal/controlplane/common.go
+++ b/internal/controlplane/common.go
@@ -16,17 +16,12 @@
 package controlplane
 
 import (
-	"context"
 	"database/sql"
 	"errors"
 	"fmt"
-	"strings"
 
-	"github.com/google/uuid"
 	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
 
-	"github.com/stacklok/minder/internal/db"
 	"github.com/stacklok/minder/internal/util"
 	pb "github.com/stacklok/minder/pkg/api/protobuf/go/minder/v1"
 )
@@ -42,102 +37,4 @@ func providerError(err error) error {
 		return util.UserVisibleError(codes.NotFound, "provider not found")
 	}
 	return fmt.Errorf("provider error: %w", err)
-}
-
-// builds an error message based on the given filters.
-func filteredResultNotFoundError(name sql.NullString, trait db.NullProviderType) error {
-	msgs := []string{}
-	if name.Valid {
-		msgs = append(msgs, fmt.Sprintf("name: %s", name.String))
-	}
-	if trait.Valid {
-		msgs = append(msgs, fmt.Sprintf("trait: %s", trait.ProviderType))
-	}
-
-	return util.UserVisibleError(codes.NotFound, "provider not found with filters: %s", strings.Join(msgs, ", "))
-}
-
-func getProviderFromRequestOrDefault(
-	ctx context.Context,
-	store db.Store,
-	in HasProtoContext,
-	projectId uuid.UUID,
-) (db.Provider, error) {
-	name := getNameFilterParam(in.GetContext())
-	providers, err := findProvider(ctx, name, db.NullProviderType{}, projectId, store)
-	if err != nil {
-		return db.Provider{}, err
-	}
-
-	return inferProvider(providers, name)
-}
-
-func getProvidersByTrait(
-	ctx context.Context,
-	store db.Store,
-	in HasProtoContext,
-	projectId uuid.UUID,
-	trait db.ProviderType,
-) ([]db.Provider, error) {
-	name := getNameFilterParam(in.GetContext())
-	t := db.NullProviderType{ProviderType: trait, Valid: true}
-	providers, err := findProvider(ctx, name, t, projectId, store)
-	if err != nil {
-		return nil, err
-	}
-
-	return providers, nil
-}
-
-// findProvider is a helper function to find a provider by name and trait
-func findProvider(
-	ctx context.Context,
-	name sql.NullString,
-	trait db.NullProviderType,
-	projectId uuid.UUID,
-	store db.Store,
-) ([]db.Provider, error) {
-	// Allows us to take into account the hierarchy to find the provider
-	parents, err := store.GetParentProjects(ctx, projectId)
-	if err != nil {
-		return nil, status.Errorf(codes.InvalidArgument, "cannot retrieve parent projects: %s", err)
-	}
-
-	provs, err := store.FindProviders(ctx, db.FindProvidersParams{
-		Projects: parents,
-		Name:     name,
-		Trait:    trait,
-	})
-	if err != nil {
-		return nil, fmt.Errorf("cannot retrieve providers: %w", err)
-	}
-
-	if len(provs) == 0 {
-		return nil, filteredResultNotFoundError(name, trait)
-	}
-
-	return provs, nil
-}
-
-// getNameFilterParam allows us to build a name filter for our provider queries
-func getNameFilterParam(in *pb.Context) sql.NullString {
-	return sql.NullString{
-		String: in.GetProvider(),
-		Valid:  in.GetProvider() != "",
-	}
-}
-
-// given a list of providers, inferProvider will validate the filter and
-// return the provider if it can be inferred. Note that this assumes that validation
-// has already been made and that the list of providers is not empty.
-func inferProvider(providers []db.Provider, nameFilter sql.NullString) (db.Provider, error) {
-	if !nameFilter.Valid {
-		if len(providers) == 1 {
-			return providers[0], nil
-		}
-		return db.Provider{}, util.UserVisibleError(codes.InvalidArgument, "cannot infer provider, there are %d providers available",
-			len(providers))
-	}
-
-	return providers[0], nil
 }

--- a/internal/controlplane/handlers_artifacts.go
+++ b/internal/controlplane/handlers_artifacts.go
@@ -40,7 +40,7 @@ func (s *Server) ListArtifacts(ctx context.Context, in *pb.ListArtifactsRequest)
 	entityCtx := engine.EntityFromContext(ctx)
 	projectID := entityCtx.Project.ID
 
-	provider, err := getProviderFromRequestOrDefault(ctx, s.store, in, projectID)
+	provider, err := s.providerStore.GetByName(ctx, projectID, in.GetContext().GetProvider())
 	if err != nil {
 		return nil, providerError(err)
 	}

--- a/internal/controlplane/handlers_oauth.go
+++ b/internal/controlplane/handlers_oauth.go
@@ -383,7 +383,7 @@ func (s *Server) StoreProviderToken(ctx context.Context,
 	entityCtx := engine.EntityFromContext(ctx)
 	projectID := entityCtx.Project.ID
 
-	provider, err := getProviderFromRequestOrDefault(ctx, s.store, in, projectID)
+	provider, err := s.providerStore.GetByName(ctx, projectID, in.GetContext().GetProvider())
 	if err != nil {
 		return nil, providerError(err)
 	}
@@ -448,7 +448,7 @@ func (s *Server) VerifyProviderTokenFrom(ctx context.Context,
 	entityCtx := engine.EntityFromContext(ctx)
 	projectID := entityCtx.Project.ID
 
-	provider, err := getProviderFromRequestOrDefault(ctx, s.store, in, projectID)
+	provider, err := s.providerStore.GetByName(ctx, projectID, in.GetContext().GetProvider())
 	if err != nil {
 		return nil, providerError(err)
 	}

--- a/internal/controlplane/handlers_profile.go
+++ b/internal/controlplane/handlers_profile.go
@@ -58,13 +58,13 @@ func (s *Server) CreateProfile(ctx context.Context,
 	}
 
 	// TODO: This will be removed once we decouple providers from profiles
-	provider, err := getProviderFromRequestOrDefault(ctx, s.store, in, entityCtx.Project.ID)
+	provider, err := s.providerStore.GetByName(ctx, entityCtx.Project.ID, in.GetContext().GetProvider())
 	if err != nil {
 		return nil, providerError(err)
 	}
 
 	newProfile, err := db.WithTransaction(s.store, func(qtx db.ExtendQuerier) (*minderv1.Profile, error) {
-		return s.profiles.CreateProfile(ctx, entityCtx.Project.ID, &provider, uuid.Nil, in, qtx)
+		return s.profiles.CreateProfile(ctx, entityCtx.Project.ID, provider, uuid.Nil, in, qtx)
 	})
 	if err != nil {
 		// assumption: service layer is setting meaningful errors
@@ -634,13 +634,13 @@ func (s *Server) UpdateProfile(ctx context.Context,
 	}
 
 	// TODO: This will be removed once we decouple providers from profiles
-	provider, err := getProviderFromRequestOrDefault(ctx, s.store, in, entityCtx.Project.ID)
+	provider, err := s.providerStore.GetByName(ctx, entityCtx.Project.ID, in.GetContext().GetProvider())
 	if err != nil {
 		return nil, providerError(err)
 	}
 
 	updatedProfile, err := db.WithTransaction(s.store, func(qtx db.ExtendQuerier) (*minderv1.Profile, error) {
-		return s.profiles.UpdateProfile(ctx, entityCtx.Project.ID, &provider, uuid.Nil, in, qtx)
+		return s.profiles.UpdateProfile(ctx, entityCtx.Project.ID, provider, uuid.Nil, in, qtx)
 	})
 
 	if err != nil {

--- a/internal/controlplane/handlers_profile_test.go
+++ b/internal/controlplane/handlers_profile_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/stacklok/minder/internal/engine"
 	stubeventer "github.com/stacklok/minder/internal/events/stubs"
 	"github.com/stacklok/minder/internal/profiles"
+	"github.com/stacklok/minder/internal/providers"
 	"github.com/stacklok/minder/internal/util"
 	minderv1 "github.com/stacklok/minder/pkg/api/protobuf/go/minder/v1"
 )
@@ -354,8 +355,9 @@ func TestCreateProfile(t *testing.T) {
 			s := &Server{
 				store: dbStore,
 				// Do not replace this with a mock - these tests are used to test ProfileService as well
-				profiles: profiles.NewProfileService(evts),
-				evt:      evts,
+				profiles:      profiles.NewProfileService(evts),
+				providerStore: providers.NewProviderStore(dbStore),
+				evt:           evts,
 			}
 
 			res, err := s.CreateProfile(ctx, tc.profile)

--- a/internal/controlplane/handlers_repositories_test.go
+++ b/internal/controlplane/handlers_repositories_test.go
@@ -30,6 +30,7 @@ import (
 	mockcrypto "github.com/stacklok/minder/internal/crypto/mock"
 	"github.com/stacklok/minder/internal/db"
 	"github.com/stacklok/minder/internal/engine"
+	"github.com/stacklok/minder/internal/providers"
 	mockgh "github.com/stacklok/minder/internal/providers/github/mock"
 	ghprovider "github.com/stacklok/minder/internal/providers/github/oauth"
 	"github.com/stacklok/minder/internal/providers/ratecache"
@@ -367,5 +368,6 @@ func createServer(
 		cryptoEngine:    mockCryptoEngine,
 		restClientCache: clientCache,
 		cfg:             &server.Config{},
+		providerStore:   providers.NewProviderStore(store),
 	}
 }

--- a/internal/controlplane/handlers_ruletype.go
+++ b/internal/controlplane/handlers_ruletype.go
@@ -154,7 +154,6 @@ func (s *Server) CreateRuleType(
 	}
 
 	projectID := entityCtx.Project.ID
-
 	newRuleType, err := db.WithTransaction(s.store, func(qtx db.ExtendQuerier) (*minderv1.RuleType, error) {
 		return s.ruleTypes.CreateRuleType(ctx, projectID, uuid.Nil, crt.GetRuleType(), qtx)
 	})
@@ -184,7 +183,6 @@ func (s *Server) UpdateRuleType(
 	}
 
 	projectID := entityCtx.Project.ID
-
 	updatedRuleType, err := db.WithTransaction(s.store, func(qtx db.ExtendQuerier) (*minderv1.RuleType, error) {
 		return s.ruleTypes.UpdateRuleType(ctx, projectID, uuid.Nil, urt.GetRuleType(), qtx)
 	})

--- a/internal/controlplane/server.go
+++ b/internal/controlplane/server.go
@@ -88,11 +88,12 @@ type Server struct {
 	// We may want to start breaking up the server struct if we use it to
 	// inject more entity-specific interfaces. For example, we may want to
 	// consider having a struct per grpc service
-	ruleTypes   ruletypes.RuleTypeService
-	repos       github.RepositoryService
-	profiles    profiles.ProfileService
-	providers   providers.ProviderService
-	marketplace marketplaces.Marketplace
+	ruleTypes     ruletypes.RuleTypeService
+	repos         github.RepositoryService
+	profiles      profiles.ProfileService
+	providers     providers.ProviderService
+	marketplace   marketplaces.Marketplace
+	providerStore providers.ProviderStore
 
 	// Implementations for service registration
 	pb.UnimplementedHealthServiceServer
@@ -174,6 +175,7 @@ func NewServer(
 		ruleTypes:           ruleSvc,
 		repos:               github.NewRepositoryService(whManager, store, evt),
 		marketplace:         marketplace,
+		providerStore:       providers.NewProviderStore(store),
 		// TODO: this currently always returns authorized as a transitionary measure.
 		// When OpenFGA is fully rolled out, we may want to make this a hard error or set to false.
 		authzClient: &mock.NoopClient{Authorized: true},

--- a/internal/providers/store.go
+++ b/internal/providers/store.go
@@ -142,21 +142,3 @@ func getNameFilterParam(name string) sql.NullString {
 		Valid:  name != "",
 	}
 }
-
-// given a list of providers, inferProvider will validate the filter and
-// return the provider if it can be inferred. Note that this assumes that validation
-// has already been made and that the list of providers is not empty.
-func inferProvider(providers []db.Provider, nameFilter sql.NullString) (*db.Provider, error) {
-	if nameFilter.Valid {
-		if len(providers) == 1 {
-			return &providers[0], nil
-		}
-		return nil, util.UserVisibleError(
-			codes.InvalidArgument,
-			"cannot infer provider, there are %d providers available",
-			len(providers),
-		)
-	}
-
-	return &providers[0], nil
-}

--- a/internal/providers/store.go
+++ b/internal/providers/store.go
@@ -1,0 +1,147 @@
+// Copyright 2024 Stacklok, Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package providers
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"strings"
+
+	"github.com/google/uuid"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"github.com/stacklok/minder/internal/db"
+	"github.com/stacklok/minder/internal/util"
+)
+
+// ProviderStore provides methods for retrieving Providers from the database
+type ProviderStore interface {
+	// GetByName returns the provider instance in the database as identified
+	// by its project ID and name.
+	GetByName(ctx context.Context, projectID uuid.UUID, name string) (*db.Provider, error)
+	// GetByNameAndTrait returns the providers in the project which match the
+	// specified trait.
+	GetByNameAndTrait(
+		ctx context.Context,
+		projectID uuid.UUID,
+		name string,
+		trait db.ProviderType,
+	) ([]db.Provider, error)
+}
+
+type providerStore struct {
+	store db.Store
+}
+
+// NewProviderStore returns a new instance of ProviderStore.
+func NewProviderStore(store db.Store) ProviderStore {
+	return &providerStore{store: store}
+}
+
+func (p *providerStore) GetByName(ctx context.Context, projectID uuid.UUID, name string) (*db.Provider, error) {
+	nameFilter := getNameFilterParam(name)
+	providers, err := p.findProvider(ctx, nameFilter, db.NullProviderType{}, projectID)
+	if err != nil {
+		return nil, err
+	}
+
+	return inferProvider(providers, nameFilter)
+}
+
+func (p *providerStore) GetByNameAndTrait(
+	ctx context.Context,
+	projectID uuid.UUID,
+	name string,
+	trait db.ProviderType,
+) ([]db.Provider, error) {
+	nameFilter := getNameFilterParam(name)
+	t := db.NullProviderType{ProviderType: trait, Valid: true}
+	providers, err := p.findProvider(ctx, nameFilter, t, projectID)
+	if err != nil {
+		return nil, err
+	}
+
+	return providers, nil
+}
+
+// builds an error message based on the given filters.
+func filteredResultNotFoundError(name sql.NullString, trait db.NullProviderType) error {
+	msgs := []string{}
+	if name.Valid {
+		msgs = append(msgs, fmt.Sprintf("name: %s", name.String))
+	}
+	if trait.Valid {
+		msgs = append(msgs, fmt.Sprintf("trait: %s", trait.ProviderType))
+	}
+
+	return util.UserVisibleError(codes.NotFound, "provider not found with filters: %s", strings.Join(msgs, ", "))
+}
+
+// findProvider is a helper function to find a provider by name and trait
+func (p *providerStore) findProvider(
+	ctx context.Context,
+	name sql.NullString,
+	trait db.NullProviderType,
+	projectId uuid.UUID,
+) ([]db.Provider, error) {
+	// Allows us to take into account the hierarchy to find the provider
+	parents, err := p.store.GetParentProjects(ctx, projectId)
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "cannot retrieve parent projects: %s", err)
+	}
+
+	provs, err := p.store.FindProviders(ctx, db.FindProvidersParams{
+		Projects: parents,
+		Name:     name,
+		Trait:    trait,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("cannot retrieve providers: %w", err)
+	}
+
+	if len(provs) == 0 {
+		return nil, filteredResultNotFoundError(name, trait)
+	}
+
+	return provs, nil
+}
+
+// getNameFilterParam allows us to build a name filter for our provider queries
+func getNameFilterParam(name string) sql.NullString {
+	return sql.NullString{
+		String: name,
+		Valid:  name != "",
+	}
+}
+
+// given a list of providers, inferProvider will validate the filter and
+// return the provider if it can be inferred. Note that this assumes that validation
+// has already been made and that the list of providers is not empty.
+func inferProvider(providers []db.Provider, nameFilter sql.NullString) (*db.Provider, error) {
+	if nameFilter.Valid {
+		if len(providers) == 1 {
+			return &providers[0], nil
+		}
+		return nil, util.UserVisibleError(
+			codes.InvalidArgument,
+			"cannot infer provider, there are %d providers available",
+			len(providers),
+		)
+	}
+
+	return &providers[0], nil
+}


### PR DESCRIPTION
Relates to #2845

This provides an interface for retrieving Providers out of the database, and encapsulates the logic for doing so. This makes it easier to stub out the provider retrieval logic for testing, and decouples the controlplane from the details of finding the right provider for a request.

There are other places in the codebase where this should be used, but that is an exercise for a future PR.

# Summary

***Provide a brief overview of the changes and the issue being addressed. 
Explain the rationale and any background necessary for understanding the changes. 
List dependencies required by this change, if any.***

Fixes #(related issue)

## Change Type

***Mark the type of change your PR introduces:***

- [ ] Bug fix (resolves an issue without affecting existing features)
- [ ] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [x] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

***Outline how the changes were tested, including steps to reproduce and any relevant configurations. 
Attach screenshots if helpful.***

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [x] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [x] Included tests that validate the fix or feature.
- [x] Checked that related changes are merged.
