### PR TITLE
Remove provider from ruletypes

### DIFF
--- a/cmd/cli/app/ruletype/common.go
+++ b/cmd/cli/app/ruletype/common.go
@@ -38,7 +38,6 @@ func execOnOneRuleType(
 	f string,
 	dashOpen io.Reader,
 	proj string,
-	provider string,
 	exec func(context.Context, string, *minderv1.RuleType) (*minderv1.RuleType, error),
 ) error {
 	ctx, cancel := cli.GetAppContext(ctx, viper.GetViper())
@@ -64,15 +63,6 @@ func execOnOneRuleType(
 		r.Context.Project = &proj
 	}
 
-	// Override the YAML specified provider with the command line argument
-	if provider != "" {
-		if r.Context == nil {
-			r.Context = &minderv1.Context{}
-		}
-
-		r.Context.Provider = &provider
-	}
-
 	// create a rule
 	rt, err := exec(ctx, f, r)
 	if err != nil {
@@ -81,7 +71,6 @@ func execOnOneRuleType(
 
 	// add the rule type to the table rows
 	t.AddRow(
-		*rt.Context.Provider,
 		*rt.Context.Project,
 		*rt.Id,
 		rt.Name,
@@ -134,7 +123,6 @@ func oneRuleTypeToRows(t table.Table, rt *minderv1.RuleType) {
 	t.AddRow("ID", *rt.Id)
 	t.AddRow("Name", rt.Name)
 	t.AddRow("Description", rt.Description)
-	t.AddRow("Provider", *rt.Context.Provider)
 	t.AddRow("Project", *rt.Context.Project)
 	t.AddRow("Ingest type", rt.Def.Ingest.Type)
 	t.AddRow("Eval type", rt.Def.Eval.Type)

--- a/cmd/cli/app/ruletype/ruletype.go
+++ b/cmd/cli/app/ruletype/ruletype.go
@@ -20,7 +20,6 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/stacklok/minder/cmd/cli/app"
-	ghclient "github.com/stacklok/minder/internal/providers/github/oauth"
 )
 
 // ruleTypeCmd is the root command for the rule subcommands
@@ -36,6 +35,5 @@ var ruleTypeCmd = &cobra.Command{
 func init() {
 	app.RootCmd.AddCommand(ruleTypeCmd)
 	// Flags for all subcommands
-	ruleTypeCmd.PersistentFlags().StringP("provider", "p", ghclient.Github, "Name of the provider, i.e. github")
 	ruleTypeCmd.PersistentFlags().StringP("project", "j", "", "ID of the project")
 }

--- a/cmd/cli/app/ruletype/ruletype_apply.go
+++ b/cmd/cli/app/ruletype/ruletype_apply.go
@@ -42,7 +42,6 @@ var applyCmd = &cobra.Command{
 func applyCommand(_ context.Context, cmd *cobra.Command, conn *grpc.ClientConn) error {
 	client := minderv1.NewProfileServiceClient(conn)
 
-	provider := viper.GetString("provider")
 	project := viper.GetString("project")
 
 	fileFlag, err := cmd.Flags().GetStringArray("file")
@@ -101,7 +100,7 @@ func applyCommand(_ context.Context, cmd *cobra.Command, conn *grpc.ClientConn) 
 		}
 		// cmd.Context() is the root context. We need to create a new context for each file
 		// so we can avoid the timeout.
-		if err = execOnOneRuleType(cmd.Context(), table, f, os.Stdin, project, provider, applyFunc); err != nil {
+		if err = execOnOneRuleType(cmd.Context(), table, f, os.Stdin, project, applyFunc); err != nil {
 			return cli.MessageAndError(fmt.Sprintf("error applying rule type from %s", f), err)
 		}
 	}

--- a/cmd/cli/app/ruletype/ruletype_create.go
+++ b/cmd/cli/app/ruletype/ruletype_create.go
@@ -41,7 +41,6 @@ var createCmd = &cobra.Command{
 func createCommand(_ context.Context, cmd *cobra.Command, conn *grpc.ClientConn) error {
 	client := minderv1.NewProfileServiceClient(conn)
 
-	provider := viper.GetString("provider")
 	project := viper.GetString("project")
 
 	fileFlag, err := cmd.Flags().GetStringArray("file")
@@ -81,7 +80,7 @@ func createCommand(_ context.Context, cmd *cobra.Command, conn *grpc.ClientConn)
 		}
 		// cmd.Context() is the root context. We need to create a new context for each file
 		// so we can avoid the timeout.
-		if err = execOnOneRuleType(cmd.Context(), table, f, os.Stdin, project, provider, createFunc); err != nil {
+		if err = execOnOneRuleType(cmd.Context(), table, f, os.Stdin, project, createFunc); err != nil {
 			return cli.MessageAndError(fmt.Sprintf("Error creating rule type from %s", f), err)
 		}
 	}

--- a/cmd/cli/app/ruletype/ruletype_delete.go
+++ b/cmd/cli/app/ruletype/ruletype_delete.go
@@ -37,7 +37,6 @@ var deleteCmd = &cobra.Command{
 func deleteCommand(ctx context.Context, cmd *cobra.Command, conn *grpc.ClientConn) error {
 	client := minderv1.NewProfileServiceClient(conn)
 
-	provider := viper.GetString("provider")
 	project := viper.GetString("project")
 	id := viper.GetString("id")
 	deleteAll := viper.GetBool("all")
@@ -64,7 +63,7 @@ func deleteCommand(ctx context.Context, cmd *cobra.Command, conn *grpc.ClientCon
 	if !deleteAll {
 		// Fetch the rule type from the DB, so we can get its name
 		rtype, err := client.GetRuleTypeById(ctx, &minderv1.GetRuleTypeByIdRequest{
-			Context: &minderv1.Context{Provider: &provider, Project: &project},
+			Context: &minderv1.Context{Project: &project},
 			Id:      id,
 		})
 		if err != nil {
@@ -75,7 +74,7 @@ func deleteCommand(ctx context.Context, cmd *cobra.Command, conn *grpc.ClientCon
 	} else {
 		// List all rule types
 		resp, err := client.ListRuleTypes(ctx, &minderv1.ListRuleTypesRequest{
-			Context: &minderv1.Context{Provider: &provider, Project: &project},
+			Context: &minderv1.Context{Project: &project},
 		})
 		if err != nil {
 			return cli.MessageAndError("Error listing rule types", err)
@@ -84,7 +83,7 @@ func deleteCommand(ctx context.Context, cmd *cobra.Command, conn *grpc.ClientCon
 	}
 
 	// Delete the rule types set for deletion
-	deletedRuleTypes, remainingRuleTypes := deleteRuleTypes(ctx, client, rulesToDelete, provider, project)
+	deletedRuleTypes, remainingRuleTypes := deleteRuleTypes(ctx, client, rulesToDelete, project)
 
 	// Print the results
 	if len(deletedRuleTypes) == 0 && len(remainingRuleTypes) == 0 {
@@ -111,13 +110,13 @@ func deleteRuleTypes(
 	ctx context.Context,
 	client minderv1.ProfileServiceClient,
 	rulesToDelete []*minderv1.RuleType,
-	provider, project string,
+	project string,
 ) ([]string, []string) {
 	var deletedRuleTypes []string
 	var remainingRuleTypes []string
 	for _, ruleType := range rulesToDelete {
 		_, err := client.DeleteRuleType(ctx, &minderv1.DeleteRuleTypeRequest{
-			Context: &minderv1.Context{Provider: &provider, Project: &project},
+			Context: &minderv1.Context{Project: &project},
 			Id:      ruleType.GetId(),
 		})
 		if err != nil {

--- a/cmd/cli/app/ruletype/ruletype_get.go
+++ b/cmd/cli/app/ruletype/ruletype_get.go
@@ -42,7 +42,6 @@ var getCmd = &cobra.Command{
 func getCommand(ctx context.Context, cmd *cobra.Command, conn *grpc.ClientConn) error {
 	client := minderv1.NewProfileServiceClient(conn)
 
-	provider := viper.GetString("provider")
 	project := viper.GetString("project")
 	format := viper.GetString("output")
 	id := viper.GetString("id")
@@ -57,7 +56,7 @@ func getCommand(ctx context.Context, cmd *cobra.Command, conn *grpc.ClientConn) 
 	cmd.SilenceUsage = true
 
 	rtype, err := client.GetRuleTypeById(ctx, &minderv1.GetRuleTypeByIdRequest{
-		Context: &minderv1.Context{Provider: &provider, Project: &project},
+		Context: &minderv1.Context{Project: &project},
 		Id:      id,
 	})
 	if err != nil {

--- a/cmd/cli/app/ruletype/ruletype_list.go
+++ b/cmd/cli/app/ruletype/ruletype_list.go
@@ -41,7 +41,6 @@ var listCmd = &cobra.Command{
 func listCommand(ctx context.Context, cmd *cobra.Command, conn *grpc.ClientConn) error {
 	client := minderv1.NewProfileServiceClient(conn)
 
-	provider := viper.GetString("provider")
 	project := viper.GetString("project")
 	format := viper.GetString("output")
 
@@ -55,7 +54,7 @@ func listCommand(ctx context.Context, cmd *cobra.Command, conn *grpc.ClientConn)
 	cmd.SilenceUsage = true
 
 	resp, err := client.ListRuleTypes(ctx, &minderv1.ListRuleTypesRequest{
-		Context: &minderv1.Context{Provider: &provider, Project: &project},
+		Context: &minderv1.Context{Project: &project},
 	})
 	if err != nil {
 		return cli.MessageAndError("Error listing rule types", err)
@@ -78,7 +77,6 @@ func listCommand(ctx context.Context, cmd *cobra.Command, conn *grpc.ClientConn)
 		table := initializeTableForList()
 		for _, rt := range resp.RuleTypes {
 			table.AddRow(
-				*rt.Context.Provider,
 				*rt.Context.Project,
 				*rt.Id,
 				rt.Name,

--- a/database/migrations/000040_ruletype_drop_provider.down.sql
+++ b/database/migrations/000040_ruletype_drop_provider.down.sql
@@ -1,0 +1,25 @@
+-- Copyright 2024 Stacklok, Inc
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--      http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+ALTER TABLE rule_type
+    ADD CONSTRAINT rule_type_provider_id_name_fkey
+        FOREIGN KEY (provider_id, provider)
+            REFERENCES providers(id, name)
+            ON DELETE CASCADE;
+
+ALTER TABLE rule_type
+    ALTER COLUMN provider SET NOT NULL;
+
+ALTER TABLE rule_type
+    ALTER COLUMN provider_id SET NOT NULL;

--- a/database/migrations/000040_ruletype_drop_provider.up.sql
+++ b/database/migrations/000040_ruletype_drop_provider.up.sql
@@ -1,0 +1,22 @@
+-- Copyright 2024 Stacklok, Inc
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--      http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+-- Drop the existing foreign key constraint on provider
+ALTER TABLE rule_type DROP CONSTRAINT rule_type_provider_id_name_fkey;
+
+ALTER TABLE rule_type
+    ALTER COLUMN provider DROP NOT NULL;
+
+ALTER TABLE rule_type
+    ALTER COLUMN provider_id DROP NOT NULL;

--- a/database/mock/store.go
+++ b/database/mock/store.go
@@ -1347,19 +1347,19 @@ func (mr *MockStoreMockRecorder) ListRuleEvaluationsByProfileId(arg0, arg1 any) 
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListRuleEvaluationsByProfileId", reflect.TypeOf((*MockStore)(nil).ListRuleEvaluationsByProfileId), arg0, arg1)
 }
 
-// ListRuleTypesByProviderAndProject mocks base method.
-func (m *MockStore) ListRuleTypesByProviderAndProject(arg0 context.Context, arg1 db.ListRuleTypesByProviderAndProjectParams) ([]db.RuleType, error) {
+// ListRuleTypesByProject mocks base method.
+func (m *MockStore) ListRuleTypesByProject(arg0 context.Context, arg1 uuid.UUID) ([]db.RuleType, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListRuleTypesByProviderAndProject", arg0, arg1)
+	ret := m.ctrl.Call(m, "ListRuleTypesByProject", arg0, arg1)
 	ret0, _ := ret[0].([]db.RuleType)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// ListRuleTypesByProviderAndProject indicates an expected call of ListRuleTypesByProviderAndProject.
-func (mr *MockStoreMockRecorder) ListRuleTypesByProviderAndProject(arg0, arg1 any) *gomock.Call {
+// ListRuleTypesByProject indicates an expected call of ListRuleTypesByProject.
+func (mr *MockStoreMockRecorder) ListRuleTypesByProject(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListRuleTypesByProviderAndProject", reflect.TypeOf((*MockStore)(nil).ListRuleTypesByProviderAndProject), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListRuleTypesByProject", reflect.TypeOf((*MockStore)(nil).ListRuleTypesByProject), arg0, arg1)
 }
 
 // ListUsers mocks base method.

--- a/database/query/rule_types.sql
+++ b/database/query/rule_types.sql
@@ -1,13 +1,11 @@
 -- name: CreateRuleType :one
 INSERT INTO rule_type (
     name,
-    provider,
     project_id,
     description,
     guidance,
     definition,
     severity_value,
-    provider_id,
     subscription_id,
     display_name
 ) VALUES (
@@ -15,16 +13,14 @@ INSERT INTO rule_type (
     $2,
     $3,
     $4,
-    $5,
     sqlc.arg(definition)::jsonb,
     sqlc.arg(severity_value),
-    sqlc.arg(provider_id),
     sqlc.narg(subscription_id),
     sqlc.arg(display_name)
 ) RETURNING *;
 
--- name: ListRuleTypesByProviderAndProject :many
-SELECT * FROM rule_type WHERE provider = $1 AND project_id = $2;
+-- name: ListRuleTypesByProject :many
+SELECT * FROM rule_type WHERE project_id = $1;
 
 -- name: GetRuleTypeByID :one
 SELECT * FROM rule_type WHERE id = $1;

--- a/docs/docs/ref/cli/minder_ruletype.md
+++ b/docs/docs/ref/cli/minder_ruletype.md
@@ -16,9 +16,8 @@ minder ruletype [flags]
 ### Options
 
 ```
-  -h, --help              help for ruletype
-  -j, --project string    ID of the project
-  -p, --provider string   Name of the provider, i.e. github (default "github")
+  -h, --help             help for ruletype
+  -j, --project string   ID of the project
 ```
 
 ### Options inherited from parent commands

--- a/docs/docs/ref/cli/minder_ruletype_apply.md
+++ b/docs/docs/ref/cli/minder_ruletype_apply.md
@@ -30,7 +30,6 @@ minder ruletype apply [flags]
       --identity-client string   Identity server client ID (default "minder-cli")
       --identity-url string      Identity server issuer URL (default "https://auth.stacklok.com")
   -j, --project string           ID of the project
-  -p, --provider string          Name of the provider, i.e. github (default "github")
 ```
 
 ### SEE ALSO

--- a/docs/docs/ref/cli/minder_ruletype_create.md
+++ b/docs/docs/ref/cli/minder_ruletype_create.md
@@ -30,7 +30,6 @@ minder ruletype create [flags]
       --identity-client string   Identity server client ID (default "minder-cli")
       --identity-url string      Identity server issuer URL (default "https://auth.stacklok.com")
   -j, --project string           ID of the project
-  -p, --provider string          Name of the provider, i.e. github (default "github")
 ```
 
 ### SEE ALSO

--- a/docs/docs/ref/cli/minder_ruletype_delete.md
+++ b/docs/docs/ref/cli/minder_ruletype_delete.md
@@ -32,7 +32,6 @@ minder ruletype delete [flags]
       --identity-client string   Identity server client ID (default "minder-cli")
       --identity-url string      Identity server issuer URL (default "https://auth.stacklok.com")
   -j, --project string           ID of the project
-  -p, --provider string          Name of the provider, i.e. github (default "github")
 ```
 
 ### SEE ALSO

--- a/docs/docs/ref/cli/minder_ruletype_get.md
+++ b/docs/docs/ref/cli/minder_ruletype_get.md
@@ -31,7 +31,6 @@ minder ruletype get [flags]
       --identity-client string   Identity server client ID (default "minder-cli")
       --identity-url string      Identity server issuer URL (default "https://auth.stacklok.com")
   -j, --project string           ID of the project
-  -p, --provider string          Name of the provider, i.e. github (default "github")
 ```
 
 ### SEE ALSO

--- a/docs/docs/ref/cli/minder_ruletype_list.md
+++ b/docs/docs/ref/cli/minder_ruletype_list.md
@@ -30,7 +30,6 @@ minder ruletype list [flags]
       --identity-client string   Identity server client ID (default "minder-cli")
       --identity-url string      Identity server issuer URL (default "https://auth.stacklok.com")
   -j, --project string           ID of the project
-  -p, --provider string          Name of the provider, i.e. github (default "github")
 ```
 
 ### SEE ALSO

--- a/internal/controlplane/handlers_profile_test.go
+++ b/internal/controlplane/handlers_profile_test.go
@@ -225,7 +225,9 @@ func TestCreateProfile(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Error creating project: %v", err)
 	}
-	provider, err := dbStore.CreateProvider(ctx, db.CreateProviderParams{
+
+	// The provider is used in the profile definition
+	_, err = dbStore.CreateProvider(ctx, db.CreateProviderParams{
 		Name:       "github",
 		ProjectID:  dbproj.ID,
 		Class:      db.NullProviderClass{ProviderClass: db.ProviderClassGithub, Valid: true},
@@ -238,8 +240,6 @@ func TestCreateProfile(t *testing.T) {
 	}
 	_, err = dbStore.CreateRuleType(ctx, db.CreateRuleTypeParams{
 		Name:          "rule_type_1",
-		Provider:      provider.Name,
-		ProviderID:    provider.ID,
 		ProjectID:     dbproj.ID,
 		Definition:    []byte(`{"in_entity": "repository","ruleSchema":{}}`),
 		SeverityValue: db.SeverityLow,

--- a/internal/db/models.go
+++ b/internal/db/models.go
@@ -614,7 +614,7 @@ type RuleEvaluation struct {
 type RuleType struct {
 	ID             uuid.UUID       `json:"id"`
 	Name           string          `json:"name"`
-	Provider       string          `json:"provider"`
+	Provider       sql.NullString  `json:"provider"`
 	ProjectID      uuid.UUID       `json:"project_id"`
 	Description    string          `json:"description"`
 	Guidance       string          `json:"guidance"`
@@ -622,7 +622,7 @@ type RuleType struct {
 	CreatedAt      time.Time       `json:"created_at"`
 	UpdatedAt      time.Time       `json:"updated_at"`
 	SeverityValue  Severity        `json:"severity_value"`
-	ProviderID     uuid.UUID       `json:"provider_id"`
+	ProviderID     uuid.NullUUID   `json:"provider_id"`
 	SubscriptionID uuid.NullUUID   `json:"subscription_id"`
 	DisplayName    string          `json:"display_name"`
 }

--- a/internal/db/profiles_test.go
+++ b/internal/db/profiles_test.go
@@ -47,15 +47,13 @@ func createRandomProfile(t *testing.T, prov Provider, projectID uuid.UUID, label
 	return prof
 }
 
-func createRandomRuleType(t *testing.T, prov Provider, projectID uuid.UUID) RuleType {
+func createRandomRuleType(t *testing.T, projectID uuid.UUID) RuleType {
 	t.Helper()
 
 	seed := time.Now().UnixNano()
 
 	arg := CreateRuleTypeParams{
 		Name:          rand.RandomName(seed),
-		Provider:      prov.Name,
-		ProviderID:    prov.ID,
 		ProjectID:     projectID,
 		Description:   rand.RandomString(64, seed),
 		Guidance:      rand.RandomString(64, seed),
@@ -178,8 +176,8 @@ func createTestRandomEntities(t *testing.T) *testRandomEntities {
 	proj := createRandomProject(t, org.ID)
 	prov := createRandomProvider(t, proj.ID)
 	repo := createRandomRepository(t, proj.ID, prov)
-	ruleType1 := createRandomRuleType(t, prov, proj.ID)
-	ruleType2 := createRandomRuleType(t, prov, proj.ID)
+	ruleType1 := createRandomRuleType(t, proj.ID)
+	ruleType2 := createRandomRuleType(t, proj.ID)
 
 	return &testRandomEntities{
 		prov:      prov,

--- a/internal/db/querier.go
+++ b/internal/db/querier.go
@@ -121,7 +121,7 @@ type Querier interface {
 	ListRegisteredRepositoriesByProjectIDAndProvider(ctx context.Context, arg ListRegisteredRepositoriesByProjectIDAndProviderParams) ([]Repository, error)
 	ListRepositoriesByProjectID(ctx context.Context, arg ListRepositoriesByProjectIDParams) ([]Repository, error)
 	ListRuleEvaluationsByProfileId(ctx context.Context, arg ListRuleEvaluationsByProfileIdParams) ([]ListRuleEvaluationsByProfileIdRow, error)
-	ListRuleTypesByProviderAndProject(ctx context.Context, arg ListRuleTypesByProviderAndProjectParams) ([]RuleType, error)
+	ListRuleTypesByProject(ctx context.Context, projectID uuid.UUID) ([]RuleType, error)
 	ListUsers(ctx context.Context, arg ListUsersParams) ([]User, error)
 	// LockIfThresholdNotExceeded is used to lock an entity for execution. It will
 	// attempt to insert or update the entity_execution_lock table only if the

--- a/internal/engine/context.go
+++ b/internal/engine/context.go
@@ -86,3 +86,13 @@ func (c *EntityContext) Validate(ctx context.Context, q db.Querier) error {
 
 	return nil
 }
+
+// ValidateProject validates that the entity context contains a project that is present in the DB
+func (c *EntityContext) ValidateProject(ctx context.Context, q db.Querier) error {
+	_, err := q.GetProjectByID(ctx, c.Project.ID)
+	if err != nil {
+		return fmt.Errorf("unable to get context: failed getting project: %w", err)
+	}
+
+	return nil
+}

--- a/internal/engine/executor_test.go
+++ b/internal/engine/executor_test.go
@@ -191,7 +191,6 @@ default allow = true`,
 		}).Return(db.RuleType{
 		ID:         ruleTypeID,
 		Name:       passthroughRuleType,
-		Provider:   providerName,
 		ProjectID:  projectID,
 		Definition: json.RawMessage(marshalledRTD),
 	}, nil)

--- a/internal/engine/rule_type_engine.go
+++ b/internal/engine/rule_type_engine.go
@@ -40,8 +40,6 @@ import (
 type RuleMeta struct {
 	// Name is the name of the rule
 	Name string
-	// Provider is the ID of the provider that this rule is for
-	Provider string
 	// Organization is the ID of the organization that this rule is for
 	Organization *string
 	// Project is the ID of the project that this rule is for
@@ -51,9 +49,9 @@ type RuleMeta struct {
 // String returns a string representation of the rule meta
 func (r *RuleMeta) String() string {
 	if r.Project != nil {
-		return fmt.Sprintf("%s/group/%s/%s", r.Provider, *r.Project, r.Name)
+		return fmt.Sprintf("group/%s/%s", *r.Project, r.Name)
 	}
-	return fmt.Sprintf("%s/org/%s/%s", r.Provider, *r.Organization, r.Name)
+	return fmt.Sprintf("org/%s/%s", *r.Organization, r.Name)
 }
 
 // RuleTypeEngine is the engine for a rule type. It builds the multiple
@@ -109,8 +107,7 @@ func NewRuleTypeEngine(
 
 	rte := &RuleTypeEngine{
 		Meta: RuleMeta{
-			Name:     rt.Name,
-			Provider: *rt.Context.Provider,
+			Name: rt.Name,
 		},
 		rval:        rval,
 		rdi:         rdi,
@@ -221,12 +218,14 @@ func RuleTypePBFromDB(rt *db.RuleType) (*minderv1.RuleType, error) {
 		displayName = rt.Name
 	}
 
+	// TODO: (2024/03/28) this is for compatibility with old CLI versions that expect provider, remove this eventually
+	noProvider := ""
 	return &minderv1.RuleType{
 		Id:          &id,
 		Name:        rt.Name,
 		DisplayName: displayName,
 		Context: &minderv1.Context{
-			Provider: &rt.Provider,
+			Provider: &noProvider,
 			Project:  &project,
 		},
 		Description: rt.Description,

--- a/internal/marketplaces/subscriptions/service.go
+++ b/internal/marketplaces/subscriptions/service.go
@@ -111,7 +111,7 @@ func (s *subscriptionService) Subscribe(
 	}
 
 	// populate all rule types from this bundle into the project
-	err = s.upsertBundleRules(ctx, qtx, project.ID, project.Provider, bundle, subscription.ID)
+	err = s.upsertBundleRules(ctx, qtx, project.ID, bundle, subscription.ID)
 	if err != nil {
 		return fmt.Errorf("error while creating rules in project: %w", err)
 	}
@@ -197,11 +197,10 @@ func (s *subscriptionService) upsertBundleRules(
 	ctx context.Context,
 	qtx db.Querier,
 	projectID uuid.UUID,
-	provider *db.Provider,
 	bundle reader.BundleReader,
 	subscriptionID uuid.UUID,
 ) error {
 	return bundle.ForEachRuleType(func(ruleType *minderv1.RuleType) error {
-		return s.rules.UpsertRuleType(ctx, projectID, provider, subscriptionID, ruleType, qtx)
+		return s.rules.UpsertRuleType(ctx, projectID, subscriptionID, ruleType, qtx)
 	})
 }

--- a/internal/ruletypes/mock/fixtures/service.go
+++ b/internal/ruletypes/mock/fixtures/service.go
@@ -45,12 +45,12 @@ var (
 
 func WithSuccessfulUpsertRuleType(mock RuleTypeSvcMock) {
 	mock.EXPECT().
-		UpsertRuleType(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+		UpsertRuleType(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 		Return(nil)
 }
 
 func WithFailedUpsertRuleType(mock RuleTypeSvcMock) {
 	mock.EXPECT().
-		UpsertRuleType(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+		UpsertRuleType(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 		Return(errDefault)
 }

--- a/internal/ruletypes/mock/service.go
+++ b/internal/ruletypes/mock/service.go
@@ -43,45 +43,45 @@ func (m *MockRuleTypeService) EXPECT() *MockRuleTypeServiceMockRecorder {
 }
 
 // CreateRuleType mocks base method.
-func (m *MockRuleTypeService) CreateRuleType(arg0 context.Context, arg1 uuid.UUID, arg2 *db.Provider, arg3 uuid.UUID, arg4 *v1.RuleType, arg5 db.Querier) (*v1.RuleType, error) {
+func (m *MockRuleTypeService) CreateRuleType(arg0 context.Context, arg1, arg2 uuid.UUID, arg3 *v1.RuleType, arg4 db.Querier) (*v1.RuleType, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CreateRuleType", arg0, arg1, arg2, arg3, arg4, arg5)
+	ret := m.ctrl.Call(m, "CreateRuleType", arg0, arg1, arg2, arg3, arg4)
 	ret0, _ := ret[0].(*v1.RuleType)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // CreateRuleType indicates an expected call of CreateRuleType.
-func (mr *MockRuleTypeServiceMockRecorder) CreateRuleType(arg0, arg1, arg2, arg3, arg4, arg5 any) *gomock.Call {
+func (mr *MockRuleTypeServiceMockRecorder) CreateRuleType(arg0, arg1, arg2, arg3, arg4 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateRuleType", reflect.TypeOf((*MockRuleTypeService)(nil).CreateRuleType), arg0, arg1, arg2, arg3, arg4, arg5)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateRuleType", reflect.TypeOf((*MockRuleTypeService)(nil).CreateRuleType), arg0, arg1, arg2, arg3, arg4)
 }
 
 // UpdateRuleType mocks base method.
-func (m *MockRuleTypeService) UpdateRuleType(arg0 context.Context, arg1 uuid.UUID, arg2 *db.Provider, arg3 uuid.UUID, arg4 *v1.RuleType, arg5 db.Querier) (*v1.RuleType, error) {
+func (m *MockRuleTypeService) UpdateRuleType(arg0 context.Context, arg1, arg2 uuid.UUID, arg3 *v1.RuleType, arg4 db.Querier) (*v1.RuleType, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UpdateRuleType", arg0, arg1, arg2, arg3, arg4, arg5)
+	ret := m.ctrl.Call(m, "UpdateRuleType", arg0, arg1, arg2, arg3, arg4)
 	ret0, _ := ret[0].(*v1.RuleType)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // UpdateRuleType indicates an expected call of UpdateRuleType.
-func (mr *MockRuleTypeServiceMockRecorder) UpdateRuleType(arg0, arg1, arg2, arg3, arg4, arg5 any) *gomock.Call {
+func (mr *MockRuleTypeServiceMockRecorder) UpdateRuleType(arg0, arg1, arg2, arg3, arg4 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateRuleType", reflect.TypeOf((*MockRuleTypeService)(nil).UpdateRuleType), arg0, arg1, arg2, arg3, arg4, arg5)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateRuleType", reflect.TypeOf((*MockRuleTypeService)(nil).UpdateRuleType), arg0, arg1, arg2, arg3, arg4)
 }
 
 // UpsertRuleType mocks base method.
-func (m *MockRuleTypeService) UpsertRuleType(arg0 context.Context, arg1 uuid.UUID, arg2 *db.Provider, arg3 uuid.UUID, arg4 *v1.RuleType, arg5 db.Querier) error {
+func (m *MockRuleTypeService) UpsertRuleType(arg0 context.Context, arg1, arg2 uuid.UUID, arg3 *v1.RuleType, arg4 db.Querier) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UpsertRuleType", arg0, arg1, arg2, arg3, arg4, arg5)
+	ret := m.ctrl.Call(m, "UpsertRuleType", arg0, arg1, arg2, arg3, arg4)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // UpsertRuleType indicates an expected call of UpsertRuleType.
-func (mr *MockRuleTypeServiceMockRecorder) UpsertRuleType(arg0, arg1, arg2, arg3, arg4, arg5 any) *gomock.Call {
+func (mr *MockRuleTypeServiceMockRecorder) UpsertRuleType(arg0, arg1, arg2, arg3, arg4 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpsertRuleType", reflect.TypeOf((*MockRuleTypeService)(nil).UpsertRuleType), arg0, arg1, arg2, arg3, arg4, arg5)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpsertRuleType", reflect.TypeOf((*MockRuleTypeService)(nil).UpsertRuleType), arg0, arg1, arg2, arg3, arg4)
 }

--- a/internal/ruletypes/service_test.go
+++ b/internal/ruletypes/service_test.go
@@ -27,7 +27,6 @@ import (
 
 	"github.com/stacklok/minder/internal/db"
 	dbf "github.com/stacklok/minder/internal/db/fixtures"
-	"github.com/stacklok/minder/internal/providers/github/oauth"
 	"github.com/stacklok/minder/internal/ruletypes"
 	"github.com/stacklok/minder/internal/util/ptr"
 	pb "github.com/stacklok/minder/pkg/api/protobuf/go/minder/v1"
@@ -239,7 +238,6 @@ func TestRuleTypeService(t *testing.T) {
 				res, err = svc.CreateRuleType(
 					ctx,
 					projectID,
-					&provider,
 					scenario.SubscriptionID,
 					scenario.RuleType,
 					store,
@@ -248,7 +246,6 @@ func TestRuleTypeService(t *testing.T) {
 				res, err = svc.UpdateRuleType(
 					ctx,
 					projectID,
-					&provider,
 					scenario.SubscriptionID,
 					scenario.RuleType,
 					store,
@@ -257,7 +254,6 @@ func TestRuleTypeService(t *testing.T) {
 				err = svc.UpsertRuleType(
 					ctx,
 					projectID,
-					&provider,
 					scenario.SubscriptionID,
 					scenario.RuleType,
 					store,
@@ -298,13 +294,9 @@ const (
 )
 
 var (
-	ruleTypeID     = uuid.New()
-	projectID      = uuid.New()
-	subscriptionID = uuid.New()
-	provider       = db.Provider{
-		ID:   uuid.New(),
-		Name: oauth.Github,
-	}
+	ruleTypeID            = uuid.New()
+	projectID             = uuid.New()
+	subscriptionID        = uuid.New()
 	errDefault            = errors.New("oh no")
 	oldRuleType           = newDBRuleType("low", uuid.Nil)
 	namespacedOldRuleType = newDBRuleType("low", subscriptionID)

--- a/internal/util/cli/table/simple/simple.go
+++ b/internal/util/cli/table/simple/simple.go
@@ -128,7 +128,7 @@ func repoListLayout(table *tablewriter.Table) {
 
 func ruleTypeListLayout(table *tablewriter.Table) {
 	defaultLayout(table)
-	table.SetHeader([]string{"Provider", "Project", "ID", "Name", "Description"})
+	table.SetHeader([]string{"Project", "ID", "Name", "Description"})
 	table.SetAutoMergeCellsByColumnIndex([]int{0, 1, 2, 3})
 	// This is needed for the rule definition and rule parameters
 	table.SetAutoWrapText(true)


### PR DESCRIPTION
# Summary

This removes the provider from the ruletype, so that ruletypes can be created once and then used by all providers.

Fixes #2831

## Change Type

***Mark the type of change your PR introduces:***

- [ ] Bug fix (resolves an issue without affecting existing features)
- [x] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [ ] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

***Outline how the changes were tested, including steps to reproduce and any relevant configurations. 
Attach screenshots if helpful.***

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [x] Added comments to complex or tricky code sections.
- [x] Updated any affected documentation.
- [ ] Included tests that validate the fix or feature.
- [ ] Checked that related changes are merged.
