### PR TITLE
Add bundle build command to mindev

### DIFF
--- a/cmd/dev/app/bundles/build.go
+++ b/cmd/dev/app/bundles/build.go
@@ -1,0 +1,91 @@
+// Copyright 2024 Stacklok, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package bundles
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/stacklok/minder/internal/util/ptr"
+	"github.com/stacklok/minder/pkg/mindpak"
+	"github.com/stacklok/minder/pkg/mindpak/build"
+)
+
+// CmdBuild is the build command
+func CmdBuild() *cobra.Command {
+	var buildCmd = &cobra.Command{
+		Use:   "build bundle_id input output",
+		Short: "build a mindpak bundle",
+		Args:  cobra.ExactArgs(3),
+		Long: `
+The 'bundle build' subcommand allows you to build a mindpak bundle from the specified path.
+
+Arguments:
+
+build_id: an identifier of the form 'namespace/name@version'
+input: Directory containing bundle profiles and rule types
+output: Path to tar where bundle will be written
+`,
+		RunE:         buildCmdRun,
+		SilenceUsage: true,
+	}
+	return buildCmd
+}
+
+func buildCmdRun(_ *cobra.Command, args []string) error {
+	metadata, err := parseVersion(args[0])
+	if err != nil {
+		return err
+	}
+	packer := build.NewPacker()
+	options := build.InitOptions{
+		Metadata: metadata,
+		Path:     args[1],
+	}
+
+	bundle, err := packer.InitBundle(&options)
+	if err != nil {
+		return err
+	}
+
+	err = packer.WriteToFile(bundle, args[2])
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func parseVersion(id string) (*mindpak.Metadata, error) {
+	firstSplit := strings.Split(id, "/")
+	if len(firstSplit) != 2 {
+		return nil, fmt.Errorf("invalid bundle id: %s", id)
+	}
+	secondSplit := strings.Split(firstSplit[1], "@")
+	if len(secondSplit) != 2 {
+		return nil, fmt.Errorf("invalid bundle id: %s", id)
+	}
+
+	// TODO: validate that names and versions meet requirements
+	return &mindpak.Metadata{
+		Namespace: firstSplit[0],
+		Name:      secondSplit[0],
+		Version:   secondSplit[1],
+		Date:      ptr.Ptr(time.Now()),
+	}, nil
+}

--- a/cmd/dev/app/bundles/build.go
+++ b/cmd/dev/app/bundles/build.go
@@ -17,11 +17,9 @@ package bundles
 import (
 	"fmt"
 	"strings"
-	"time"
 
 	"github.com/spf13/cobra"
 
-	"github.com/stacklok/minder/internal/util/ptr"
 	"github.com/stacklok/minder/pkg/mindpak"
 	"github.com/stacklok/minder/pkg/mindpak/build"
 )
@@ -86,6 +84,7 @@ func parseVersion(id string) (*mindpak.Metadata, error) {
 		Namespace: firstSplit[0],
 		Name:      secondSplit[0],
 		Version:   secondSplit[1],
-		Date:      ptr.Ptr(time.Now()),
+		// leave this as nil for now so that the builds are reproducible
+		Date: nil,
 	}, nil
 }

--- a/cmd/dev/app/bundles/bundle.go
+++ b/cmd/dev/app/bundles/bundle.go
@@ -1,0 +1,30 @@
+// Copyright 2024 Stacklok, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package bundles contains logic relating to mindpak bundles
+package bundles
+
+import "github.com/spf13/cobra"
+
+// CmdBundle is the root command for the container subcommands
+func CmdBundle() *cobra.Command {
+	var rtCmd = &cobra.Command{
+		Use:   "bundle",
+		Short: "container provides utilities to create mindpak bundles",
+	}
+
+	rtCmd.AddCommand(CmdBuild())
+
+	return rtCmd
+}

--- a/cmd/dev/app/root.go
+++ b/cmd/dev/app/root.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/stacklok/minder/cmd/dev/app/bundles"
 	"github.com/stacklok/minder/cmd/dev/app/container"
 	"github.com/stacklok/minder/cmd/dev/app/rule_type"
 	"github.com/stacklok/minder/cmd/dev/app/testserver"
@@ -39,6 +40,7 @@ https://docs.stacklok.com/minder`,
 	cmd.AddCommand(rule_type.CmdRuleType())
 	cmd.AddCommand(container.CmdContainer())
 	cmd.AddCommand(testserver.CmdTestServer())
+	cmd.AddCommand(bundles.CmdBundle())
 
 	return cmd
 }

--- a/pkg/mindpak/build/packer_test.go
+++ b/pkg/mindpak/build/packer_test.go
@@ -136,8 +136,8 @@ func TestPackerInitBundle(t *testing.T) {
 			tc.prepare(t, tc.opts)
 			p := NewPacker()
 
-			// Run the nundle initialization
-			err := p.InitBundle(tc.opts)
+			// Run the bundle initialization
+			_, err := p.InitBundle(tc.opts)
 			if tc.mustErr {
 				require.Error(t, err)
 				return


### PR DESCRIPTION
Relates to #2544

Provide a command for building a bundle from a specific directory.

Made a few small changes to mindpak as part of this PR, including writing the archive to a .tar.gz instead of a .tar

Example usage:

```
mindev bundle build stacklok/healthcheck@1.0.0 ~/data/healthcheck healthcheck-bundle.tar.gz
```

# Summary

***Provide a brief overview of the changes and the issue being addressed. 
Explain the rationale and any background necessary for understanding the changes. 
List dependencies required by this change, if any.***

Fixes #(related issue)

## Change Type

***Mark the type of change your PR introduces:***

- [ ] Bug fix (resolves an issue without affecting existing features)
- [x] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [ ] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

***Outline how the changes were tested, including steps to reproduce and any relevant configurations. 
Attach screenshots if helpful.***

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [ ] Added comments to complex or tricky code sections.
- [x] Updated any affected documentation.
- [ ] Included tests that validate the fix or feature.
- [x] Checked that related changes are merged.
