### PR TITLE
Add `initContainers` option to the deployment settings in Helm

### DIFF
--- a/deployment/helm/README.md
+++ b/deployment/helm/README.md
@@ -62,6 +62,7 @@ installed in the namespace specified by your current Kubernetes context.
 | deploymentSettings.extraVolumes | array, optional | `nil` | Additional volumes to mount |
 | deploymentSettings.image | string | `"ko://github.com/stacklok/minder/cmd/server"` | Image to use for the main deployment |
 | deploymentSettings.imagePullPolicy | string | `"IfNotPresent"` | Image pull policy to use for the main deployment |
+| deploymentSettings.initContainers | array, optional | `nil` | Additional init containers to run |
 | deploymentSettings.resources | object | `{"limits":{"cpu":4,"memory":"1.5Gi"},"requests":{"cpu":1,"memory":"1Gi"}}` | Resources to use for the main deployment |
 | deploymentSettings.secrets.appSecretName | string | `"minder-github-secrets"` | Name of the secret containing the GitHub configuration |
 | deploymentSettings.secrets.authSecretName | string | `"minder-auth-secrets"` | Name of the secret containing the auth configuration |

--- a/deployment/helm/templates/deployment.yaml
+++ b/deployment/helm/templates/deployment.yaml
@@ -31,6 +31,10 @@ spec:
         {{ include "common.annotations.pods" (dict "customAnnotationsPods" .Values.commonAnnotationsPods "context" $ ) | nindent 8 }}
     spec:
       serviceAccountName: {{ .Values.serviceAccounts.server | default "minder" }}
+      initContainers:
+        {{- if .Values.deploymentSettings.initContainers }}
+        {{- toYaml .Values.deploymentSettings.initContainers | nindent 8 }}
+        {{- end }}
       containers:
         - name: minder
           # restricted security context:

--- a/deployment/helm/values.yaml
+++ b/deployment/helm/values.yaml
@@ -124,6 +124,8 @@ deploymentSettings:
     githubAppSecretName: "minder-github-app-secrets"
   # -- (array, optional) Additional configuration for sidecar containers
   sidecarContainers: null
+  # -- (array, optional) Additional init containers to run
+  initContainers: null
 
 
 # -- (string) Additional configuration yaml beyond what's in server-config.yaml.example


### PR DESCRIPTION
# Summary

this allows us to run custom init containers in minder, which is handy
in conjunction with `extraVolumes` and `extraVolumeMounts`.

## Change Type

***Mark the type of change your PR introduces:***

- [ ] Bug fix (resolves an issue without affecting existing features)
- [x] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [ ] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [ ] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [ ] Included tests that validate the fix or feature.
- [ ] Checked that related changes are merged.
