### PR TITLE
Do not skip action processing decision if evaluation did not changed

### DIFF
--- a/internal/engine/actions/actions.go
+++ b/internal/engine/actions/actions.go
@@ -150,12 +150,6 @@ func shouldRemediate(prevEvalFromDb *db.ListRuleEvaluationsByProfileIdRow, evalE
 	// Get current evaluation status
 	newEval := enginerr.ErrorAsEvalStatus(evalErr)
 
-	// Get previous evaluation status
-	prevEval := db.EvalStatusTypesPending
-	if prevEvalFromDb.EvalStatus.Valid {
-		prevEval = prevEvalFromDb.EvalStatus.EvalStatusTypes
-	}
-
 	// Get previous Remediation status
 	prevRemediation := db.RemediationStatusTypesSkipped
 	if prevEvalFromDb.RemStatus.Valid {
@@ -164,10 +158,7 @@ func shouldRemediate(prevEvalFromDb *db.ListRuleEvaluationsByProfileIdRow, evalE
 
 	// Start evaluation scenarios
 
-	// Case 1 - Do nothing if the evaluation status has not changed and remediation did not errored-out
-	if newEval == prevEval && prevRemediation != db.RemediationStatusTypesError {
-		return engif.ActionCmdDoNothing
-	}
+	// Case 1 - Do not try to be smart about it by doing nothing if the evaluation status has not changed
 
 	// Proceed with use cases where the evaluation changed
 	switch newEval {
@@ -208,12 +199,6 @@ func shouldAlert(
 	// Get current evaluation status
 	newEval := enginerr.ErrorAsEvalStatus(evalErr)
 
-	// Get previous evaluation status
-	prevEval := db.EvalStatusTypesPending
-	if prevEvalFromDb.EvalStatus.Valid {
-		prevEval = prevEvalFromDb.EvalStatus.EvalStatusTypes
-	}
-
 	// Get previous Alert status
 	prevAlert := db.AlertStatusTypesSkipped
 	if prevEvalFromDb.AlertStatus.Valid {
@@ -231,10 +216,7 @@ func shouldAlert(
 		return engif.ActionCmdDoNothing
 	}
 
-	// Case 2 - Do nothing if the evaluation status has not changed
-	if newEval == prevEval && prevAlert != db.AlertStatusTypesError {
-		return engif.ActionCmdDoNothing
-	}
+	// Case 2 - Do not try to be smart about it by doing nothing if the evaluation status has not changed
 
 	// Proceed with use cases where the evaluation changed
 	switch newEval {


### PR DESCRIPTION
# Summary

This fixes another issue caught by the smoke tests - that if we update the action setting, i.e. alert or remediation afterwards in a profile this does not cause alerts or remediations to happen.

This was not easily happening so far with alerts because they were enabled by default.

## Change Type

***Mark the type of change your PR introduces:***

- [x] Bug fix (resolves an issue without affecting existing features)
- [ ] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [ ] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

Locally

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [ ] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [ ] Included tests that validate the fix or feature.
- [ ] Checked that related changes are merged.
