### PR TITLE
Remediation types other than pull_request don't have a turn-off behaviour, so skip instead

### DIFF
--- a/internal/engine/actions/remediate/rest/rest.go
+++ b/internal/engine/actions/remediate/rest/rest.go
@@ -116,12 +116,18 @@ func (_ *Remediator) GetOnOffState(p *pb.Profile) interfaces.ActionOpt {
 // Do perform the remediation
 func (r *Remediator) Do(
 	ctx context.Context,
-	_ interfaces.ActionCmd,
+	cmd interfaces.ActionCmd,
 	setting interfaces.ActionOpt,
 	entity protoreflect.ProtoMessage,
 	params interfaces.ActionsParams,
 	_ *json.RawMessage,
 ) (json.RawMessage, error) {
+	// Remediating through rest doesn't really have a turn-off behavior so
+	// only proceed with the remediation if the command is to turn on the action
+	if cmd != interfaces.ActionCmdOn {
+		return nil, engerrors.ErrActionSkipped
+	}
+
 	retp := &EndpointTemplateParams{
 		Entity:  entity,
 		Profile: params.GetRule().Def.AsMap(),


### PR DESCRIPTION
# Summary

Another fix caused by the change of how we decide which actions should run and which not. This affectsr ruletypes that don't remediate through pull requests.

## Change Type

***Mark the type of change your PR introduces:***

- [x] Bug fix (resolves an issue without affecting existing features)
- [ ] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [ ] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [ ] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [ ] Included tests that validate the fix or feature.
- [ ] Checked that related changes are merged.
