### PR TITLE
Handle GitHub App installation deleted event

### DIFF
--- a/database/mock/store.go
+++ b/database/mock/store.go
@@ -398,7 +398,7 @@ func (mr *MockStoreMockRecorder) DeleteProject(arg0, arg1 any) *gomock.Call {
 }
 
 // DeleteProvider mocks base method.
-func (m *MockStore) DeleteProvider(arg0 context.Context, arg1 db.DeleteProviderParams) error {
+func (m *MockStore) DeleteProvider(arg0 context.Context, arg1 uuid.UUID) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteProvider", arg0, arg1)
 	ret0, _ := ret[0].(error)

--- a/database/mock/store.go
+++ b/database/mock/store.go
@@ -354,6 +354,20 @@ func (mr *MockStoreMockRecorder) DeleteExpiredSessionStates(arg0 any) *gomock.Ca
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteExpiredSessionStates", reflect.TypeOf((*MockStore)(nil).DeleteExpiredSessionStates), arg0)
 }
 
+// DeleteInstallationIDByAppID mocks base method.
+func (m *MockStore) DeleteInstallationIDByAppID(arg0 context.Context, arg1 string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteInstallationIDByAppID", arg0, arg1)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DeleteInstallationIDByAppID indicates an expected call of DeleteInstallationIDByAppID.
+func (mr *MockStoreMockRecorder) DeleteInstallationIDByAppID(arg0, arg1 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteInstallationIDByAppID", reflect.TypeOf((*MockStore)(nil).DeleteInstallationIDByAppID), arg0, arg1)
+}
+
 // DeleteProfile mocks base method.
 func (m *MockStore) DeleteProfile(arg0 context.Context, arg1 db.DeleteProfileParams) error {
 	m.ctrl.T.Helper()
@@ -716,6 +730,21 @@ func (m *MockStore) GetFeatureInProject(arg0 context.Context, arg1 db.GetFeature
 func (mr *MockStoreMockRecorder) GetFeatureInProject(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetFeatureInProject", reflect.TypeOf((*MockStore)(nil).GetFeatureInProject), arg0, arg1)
+}
+
+// GetInstallationIDByAppID mocks base method.
+func (m *MockStore) GetInstallationIDByAppID(arg0 context.Context, arg1 string) (db.ProviderGithubAppInstallation, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetInstallationIDByAppID", arg0, arg1)
+	ret0, _ := ret[0].(db.ProviderGithubAppInstallation)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetInstallationIDByAppID indicates an expected call of GetInstallationIDByAppID.
+func (mr *MockStoreMockRecorder) GetInstallationIDByAppID(arg0, arg1 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetInstallationIDByAppID", reflect.TypeOf((*MockStore)(nil).GetInstallationIDByAppID), arg0, arg1)
 }
 
 // GetInstallationIDByEnrollmentNonce mocks base method.

--- a/database/query/provider_github_app_installations.sql
+++ b/database/query/provider_github_app_installations.sql
@@ -1,6 +1,9 @@
 -- name: GetInstallationIDByProviderID :one
 SELECT * FROM provider_github_app_installations WHERE provider_id = $1;
 
+-- name: GetInstallationIDByAppID :one
+SELECT * FROM provider_github_app_installations WHERE app_installation_id = $1;
+
 -- name: UpsertInstallationID :one
 INSERT INTO provider_github_app_installations
     (provider_id, app_installation_id, organization_id, enrolling_user_id, enrollment_nonce, project_id)
@@ -18,3 +21,6 @@ WHERE provider_github_app_installations.provider_id = $1
 
 -- name: GetInstallationIDByEnrollmentNonce :one
 SELECT * FROM provider_github_app_installations WHERE project_id = $1 AND enrollment_nonce = $2;
+
+-- name: DeleteInstallationIDByAppID :exec
+DELETE FROM provider_github_app_installations WHERE app_installation_id = $1;

--- a/database/query/providers.sql
+++ b/database/query/providers.sql
@@ -58,4 +58,4 @@ UPDATE providers
     WHERE id = sqlc.arg('id') AND project_id = sqlc.arg('project_id');
 
 -- name: DeleteProvider :exec
-DELETE FROM providers WHERE id = $1 AND project_id = $2;
+DELETE FROM providers WHERE id = $1;

--- a/internal/controlplane/server.go
+++ b/internal/controlplane/server.go
@@ -189,6 +189,11 @@ func NewServer(
 	return s, nil
 }
 
+// GetProviderService returns the provider service
+func (s *Server) GetProviderService() providers.ProviderService {
+	return s.providers
+}
+
 func (s *Server) initTracer() (*sdktrace.TracerProvider, error) {
 	// create a stdout exporter to show collected spans out to stdout.
 	exporter, err := stdout.New(stdout.WithPrettyPrint())

--- a/internal/controlplane/server.go
+++ b/internal/controlplane/server.go
@@ -359,6 +359,7 @@ func (s *Server) StartHTTPServer(ctx context.Context) error {
 
 	mux.Handle("/", s.handlerWithHTTPMiddleware(gwmux))
 	mux.Handle("/api/v1/webhook/", mw(s.HandleGitHubWebHook()))
+	mux.Handle("/api/v1/ghapp/", mw(s.HandleGitHubAppWebhook()))
 	mux.Handle("/static/", fs)
 
 	errch := make(chan error)

--- a/internal/db/provider_github_app_installations.sql.go
+++ b/internal/db/provider_github_app_installations.sql.go
@@ -12,6 +12,35 @@ import (
 	"github.com/google/uuid"
 )
 
+const deleteInstallationIDByAppID = `-- name: DeleteInstallationIDByAppID :exec
+DELETE FROM provider_github_app_installations WHERE app_installation_id = $1
+`
+
+func (q *Queries) DeleteInstallationIDByAppID(ctx context.Context, appInstallationID string) error {
+	_, err := q.db.ExecContext(ctx, deleteInstallationIDByAppID, appInstallationID)
+	return err
+}
+
+const getInstallationIDByAppID = `-- name: GetInstallationIDByAppID :one
+SELECT app_installation_id, provider_id, organization_id, enrolling_user_id, created_at, updated_at, enrollment_nonce, project_id FROM provider_github_app_installations WHERE app_installation_id = $1
+`
+
+func (q *Queries) GetInstallationIDByAppID(ctx context.Context, appInstallationID string) (ProviderGithubAppInstallation, error) {
+	row := q.db.QueryRowContext(ctx, getInstallationIDByAppID, appInstallationID)
+	var i ProviderGithubAppInstallation
+	err := row.Scan(
+		&i.AppInstallationID,
+		&i.ProviderID,
+		&i.OrganizationID,
+		&i.EnrollingUserID,
+		&i.CreatedAt,
+		&i.UpdatedAt,
+		&i.EnrollmentNonce,
+		&i.ProjectID,
+	)
+	return i, err
+}
+
 const getInstallationIDByEnrollmentNonce = `-- name: GetInstallationIDByEnrollmentNonce :one
 SELECT app_installation_id, provider_id, organization_id, enrolling_user_id, created_at, updated_at, enrollment_nonce, project_id FROM provider_github_app_installations WHERE project_id = $1 AND enrollment_nonce = $2
 `

--- a/internal/db/providers.sql.go
+++ b/internal/db/providers.sql.go
@@ -60,16 +60,11 @@ func (q *Queries) CreateProvider(ctx context.Context, arg CreateProviderParams) 
 }
 
 const deleteProvider = `-- name: DeleteProvider :exec
-DELETE FROM providers WHERE id = $1 AND project_id = $2
+DELETE FROM providers WHERE id = $1
 `
 
-type DeleteProviderParams struct {
-	ID        uuid.UUID `json:"id"`
-	ProjectID uuid.UUID `json:"project_id"`
-}
-
-func (q *Queries) DeleteProvider(ctx context.Context, arg DeleteProviderParams) error {
-	_, err := q.db.ExecContext(ctx, deleteProvider, arg.ID, arg.ProjectID)
+func (q *Queries) DeleteProvider(ctx context.Context, id uuid.UUID) error {
+	_, err := q.db.ExecContext(ctx, deleteProvider, id)
 	return err
 }
 

--- a/internal/db/providers_test.go
+++ b/internal/db/providers_test.go
@@ -17,6 +17,7 @@ package db
 
 import (
 	"context"
+	"database/sql"
 	"encoding/json"
 	"testing"
 	"time"
@@ -44,4 +45,20 @@ func createRandomProvider(t *testing.T, projectID uuid.UUID) Provider {
 	require.NotEmpty(t, prov, "Empty provider returned")
 
 	return prov
+}
+
+func TestCreateAndDeleteProvider(t *testing.T) {
+	org := createRandomOrganization(t)
+	proj := createRandomProject(t, org.ID)
+	prov := createRandomProvider(t, proj.ID)
+
+	getProv, err := testQueries.GetProviderByID(context.Background(), prov.ID)
+	require.NoError(t, err, "Error getting provider")
+	require.NotEmpty(t, getProv, "Empty provider returned")
+
+	err = testQueries.DeleteProvider(context.Background(), prov.ID)
+	require.NoError(t, err, "Error deleting provider")
+
+	_, err = testQueries.GetProviderByID(context.Background(), prov.ID)
+	require.ErrorIs(t, err, sql.ErrNoRows, "Retrieved provider after deletion")
 }

--- a/internal/db/providers_test.go
+++ b/internal/db/providers_test.go
@@ -48,6 +48,8 @@ func createRandomProvider(t *testing.T, projectID uuid.UUID) Provider {
 }
 
 func TestCreateAndDeleteProvider(t *testing.T) {
+	t.Parallel()
+
 	org := createRandomOrganization(t)
 	proj := createRandomProject(t, org.ID)
 	prov := createRandomProvider(t, proj.ID)

--- a/internal/db/querier.go
+++ b/internal/db/querier.go
@@ -31,6 +31,7 @@ type Querier interface {
 	CreateUser(ctx context.Context, identitySubject string) (User, error)
 	DeleteArtifact(ctx context.Context, id uuid.UUID) error
 	DeleteExpiredSessionStates(ctx context.Context) error
+	DeleteInstallationIDByAppID(ctx context.Context, appInstallationID string) error
 	DeleteProfile(ctx context.Context, arg DeleteProfileParams) error
 	DeleteProfileForEntity(ctx context.Context, arg DeleteProfileForEntityParams) error
 	DeleteProject(ctx context.Context, id uuid.UUID) ([]DeleteProjectRow, error)
@@ -63,6 +64,7 @@ type Querier interface {
 	// GetFeatureInProject verifies if a feature is available for a specific project.
 	// It returns the settings for the feature if it is available.
 	GetFeatureInProject(ctx context.Context, arg GetFeatureInProjectParams) (json.RawMessage, error)
+	GetInstallationIDByAppID(ctx context.Context, appInstallationID string) (ProviderGithubAppInstallation, error)
 	GetInstallationIDByEnrollmentNonce(ctx context.Context, arg GetInstallationIDByEnrollmentNonceParams) (ProviderGithubAppInstallation, error)
 	GetInstallationIDByProviderID(ctx context.Context, providerID uuid.NullUUID) (ProviderGithubAppInstallation, error)
 	GetParentProjects(ctx context.Context, id uuid.UUID) ([]uuid.UUID, error)

--- a/internal/db/querier.go
+++ b/internal/db/querier.go
@@ -34,7 +34,7 @@ type Querier interface {
 	DeleteProfile(ctx context.Context, arg DeleteProfileParams) error
 	DeleteProfileForEntity(ctx context.Context, arg DeleteProfileForEntityParams) error
 	DeleteProject(ctx context.Context, id uuid.UUID) ([]DeleteProjectRow, error)
-	DeleteProvider(ctx context.Context, arg DeleteProviderParams) error
+	DeleteProvider(ctx context.Context, id uuid.UUID) error
 	DeletePullRequest(ctx context.Context, arg DeletePullRequestParams) error
 	DeleteRepository(ctx context.Context, id uuid.UUID) error
 	DeleteRuleInstantiation(ctx context.Context, arg DeleteRuleInstantiationParams) error

--- a/internal/providers/installations.go
+++ b/internal/providers/installations.go
@@ -1,0 +1,113 @@
+//
+// Copyright 2024 Stacklok, Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package providers
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/ThreeDotsLabs/watermill/message"
+	"github.com/rs/zerolog"
+
+	"github.com/stacklok/minder/internal/db"
+	"github.com/stacklok/minder/internal/events"
+)
+
+const (
+	// ProviderInstallationTopic is the topic for when a provider installation is removed
+	ProviderInstallationTopic = "internal.provider.installation.removed.event"
+)
+
+// ProviderInstallationEvent is an event that occurs when a provider installation changes
+type ProviderInstallationEvent string
+
+const (
+	// ProviderInstanceRemovedEvent is an event that occurs when a provider instance is removed
+	ProviderInstanceRemovedEvent ProviderInstallationEvent = "provider_instance_removed"
+)
+
+const (
+	// InstallationEventKey is the key for the event in the message metadata (e.g. removed)
+	InstallationEventKey = "event"
+	// ClassKey is the key for the provider class in the message metadata
+	ClassKey = "class"
+)
+
+// InstallationManager is a struct representing the installation manager
+type InstallationManager struct {
+	evt     events.Publisher
+	svc     ProviderService
+	querier db.Querier
+}
+
+// NewInstallationManager creates a new installation manager
+func NewInstallationManager(
+	evt events.Publisher,
+	querier db.Querier,
+	svc ProviderService,
+) (*InstallationManager, error) {
+	return &InstallationManager{
+		evt:     evt,
+		svc:     svc,
+		querier: querier,
+	}, nil
+}
+
+// Register implements the Consumer interface.
+func (im *InstallationManager) Register(reg events.Registrar) {
+	reg.Register(ProviderInstallationTopic, im.handleProviderInstallationEvent)
+}
+
+func (im *InstallationManager) handleProviderInstallationEvent(msg *message.Message) error {
+	ctx := msg.Context()
+	zerolog.Ctx(ctx).Info().Msg("Handling provider installation event")
+
+	event := ProviderInstallationEvent(msg.Metadata.Get(InstallationEventKey))
+	if event == ProviderInstanceRemovedEvent {
+		return im.handleProviderInstanceRemovedEvent(ctx, msg)
+	}
+	return nil
+}
+
+func (im *InstallationManager) handleProviderInstanceRemovedEvent(ctx context.Context, msg *message.Message) error {
+	class := msg.Metadata.Get(ClassKey)
+
+	if db.ProviderClass(class) != db.ProviderClassGithubApp {
+		zerolog.Ctx(ctx).Error().Str("class", class).Msg("Provider class is not supported")
+		return nil
+	}
+
+	var payload GitHubAppInstallationDeletedPayload
+
+	err := json.Unmarshal(msg.Payload, &payload)
+	if err != nil {
+		return fmt.Errorf("failed to unmarshal payload: %w", err)
+	}
+
+	return im.svc.DeleteGitHubAppInstallation(ctx, payload.InstallationID)
+}
+
+// ProviderInstanceRemovedMessage returns the provider installation event from the message
+func ProviderInstanceRemovedMessage(
+	msg *message.Message,
+	providerClass db.ProviderClass,
+	payload []byte,
+) {
+	msg.Metadata.Set(InstallationEventKey, string(ProviderInstanceRemovedEvent))
+	msg.Metadata.Set(ClassKey, string(providerClass))
+	msg.Payload = payload
+}

--- a/internal/providers/installations_test.go
+++ b/internal/providers/installations_test.go
@@ -1,0 +1,84 @@
+//
+// Copyright 2024 Stacklok, Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package providers
+
+import (
+	"testing"
+
+	"github.com/ThreeDotsLabs/watermill/message"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+
+	"github.com/stacklok/minder/internal/db"
+	mockprofsvc "github.com/stacklok/minder/internal/providers/mock"
+)
+
+func TestProviderInstanceRemovedMessage(t *testing.T) {
+	t.Parallel()
+
+	payload := []byte(`{"installation_id": 123}`)
+	msg := message.NewMessage(uuid.New().String(), nil)
+	ProviderInstanceRemovedMessage(msg, db.ProviderClassGithubApp, payload)
+
+	require.Equal(t, string(db.ProviderClassGithubApp), msg.Metadata.Get(ClassKey))
+	require.Equal(t, string(ProviderInstanceRemovedEvent), msg.Metadata.Get(InstallationEventKey))
+}
+
+func testNewInstallationManager(t *testing.T, mockSvc *mockprofsvc.MockProviderService) *InstallationManager {
+	t.Helper()
+
+	return NewInstallationManager(mockSvc)
+}
+
+func TestHandleProviderInstanceRemovedMessage(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockSvc := mockprofsvc.NewMockProviderService(ctrl)
+	im := testNewInstallationManager(t, mockSvc)
+
+	installationID := 123
+	payload := []byte(`{"installation_id": 123}`)
+	msg := message.NewMessage(uuid.New().String(), nil)
+	ProviderInstanceRemovedMessage(msg, db.ProviderClassGithubApp, payload)
+
+	mockSvc.EXPECT().
+		DeleteGitHubAppInstallation(gomock.Any(), int64(installationID)).
+		Return(nil)
+
+	err := im.handleProviderInstallationEvent(msg)
+	require.NoError(t, err)
+}
+
+func TestHandleUnknownEvent(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockSvc := mockprofsvc.NewMockProviderService(ctrl)
+	im := testNewInstallationManager(t, mockSvc)
+
+	msg := message.NewMessage(uuid.New().String(), nil)
+	msg.Metadata.Set(InstallationEventKey, "unknown")
+
+	// no error but note that we don't have to EXPECT any mock
+	// which means the handler just ignores the unknown event
+
+	err := im.handleProviderInstallationEvent(msg)
+	require.NoError(t, err)
+}

--- a/internal/providers/mock/service.go
+++ b/internal/providers/mock/service.go
@@ -86,6 +86,20 @@ func (mr *MockProviderServiceMockRecorder) CreateUnclaimedGitHubAppInstallation(
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateUnclaimedGitHubAppInstallation", reflect.TypeOf((*MockProviderService)(nil).CreateUnclaimedGitHubAppInstallation), arg0, arg1, arg2)
 }
 
+// DeleteGitHubAppInstallation mocks base method.
+func (m *MockProviderService) DeleteGitHubAppInstallation(arg0 context.Context, arg1 int64) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteGitHubAppInstallation", arg0, arg1)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DeleteGitHubAppInstallation indicates an expected call of DeleteGitHubAppInstallation.
+func (mr *MockProviderServiceMockRecorder) DeleteGitHubAppInstallation(arg0, arg1 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteGitHubAppInstallation", reflect.TypeOf((*MockProviderService)(nil).DeleteGitHubAppInstallation), arg0, arg1)
+}
+
 // ValidateGitHubInstallationId mocks base method.
 func (m *MockProviderService) ValidateGitHubInstallationId(arg0 context.Context, arg1 *oauth2.Token, arg2 int64) error {
 	m.ctrl.T.Helper()

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -29,6 +29,7 @@ import (
 	"github.com/stacklok/minder/internal/eea"
 	"github.com/stacklok/minder/internal/engine"
 	"github.com/stacklok/minder/internal/events"
+	"github.com/stacklok/minder/internal/providers"
 	"github.com/stacklok/minder/internal/reconcilers"
 )
 
@@ -81,6 +82,12 @@ func AllInOneServerService(
 	}
 
 	evt.ConsumeEvents(rec)
+
+	im, err := providers.NewInstallationManager(evt, store, s.GetProviderService())
+	if err != nil {
+		return fmt.Errorf("unable to create installation manager: %w", err)
+	}
+	evt.ConsumeEvents(im)
 
 	// Start the gRPC and HTTP server in separate goroutines
 	errg.Go(func() error {

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -83,10 +83,7 @@ func AllInOneServerService(
 
 	evt.ConsumeEvents(rec)
 
-	im, err := providers.NewInstallationManager(evt, store, s.GetProviderService())
-	if err != nil {
-		return fmt.Errorf("unable to create installation manager: %w", err)
-	}
+	im := providers.NewInstallationManager(s.GetProviderService())
 	evt.ConsumeEvents(im)
 
 	// Start the gRPC and HTTP server in separate goroutines


### PR DESCRIPTION
# Summary

Adds a new HTTP handler for handling the github app. The handler fires an event
to a newly added provider installation handler which in turns talks to the
provider service that handles the deletion.

There's some additional refactoring as well as questions about provider and installation
relationships that I'll point out inline in the PR.

Fixes: #2727

## Change Type

***Mark the type of change your PR introduces:***

- [ ] Bug fix (resolves an issue without affecting existing features)
- [x] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [ ] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

I tested two scenarios:
1) "claimed" installation that I created with `minder provider enroll --provider=github-app --owner=jakubtestorg`
and then deleted from the org page. This hits the codepath that deletes both the installation and the provider.
2) "unclaimed" installation that I created by navigating to `https://github.com/apps/jakub-s-local-minder-test/installations/new` where `jakub-s-local-minder-test` is my gh app name and then deleting the app from the org page. This only hits the codepath that deletes the installation.

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [ ] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [ ] Included tests that validate the fix or feature.
- [ ] Checked that related changes are merged.
