### PR TITLE
Clean up calls to Keycloak behind config

### DIFF
--- a/cmd/server/app/serve.go
+++ b/cmd/server/app/serve.go
@@ -18,7 +18,6 @@ package app
 import (
 	"database/sql"
 	"fmt"
-	"net/url"
 	"os"
 	"os/signal"
 
@@ -86,12 +85,10 @@ var serveCmd = &cobra.Command{
 		}
 
 		// Identity
-		parsedURL, err := url.Parse(cfg.Identity.Server.IssuerUrl)
+		jwksUrl, err := cfg.Identity.Server.Path("realms/stacklok/protocol/openid-connect/certs")
 		if err != nil {
-			return fmt.Errorf("failed to parse issuer URL: %w\n", err)
+			return fmt.Errorf("failed to create JWKS URL: %w\n", err)
 		}
-
-		jwksUrl := parsedURL.JoinPath("realms/stacklok/protocol/openid-connect/certs")
 		vldtr, err := auth.NewJwtValidator(ctx, jwksUrl.String())
 		if err != nil {
 			return fmt.Errorf("failed to fetch and cache identity provider JWKS: %w\n", err)

--- a/internal/util/helpers.go
+++ b/internal/util/helpers.go
@@ -235,14 +235,14 @@ func RefreshCredentials(refreshToken string, issuerUrl string, clientId string) 
 	if err != nil {
 		return OpenIdCredentials{}, fmt.Errorf("error parsing issuer URL: %v", err)
 	}
-	logoutUrl := parsedURL.JoinPath("realms/stacklok/protocol/openid-connect/token")
+	tokenUrl := parsedURL.JoinPath("realms/stacklok/protocol/openid-connect/token")
 
 	data := url.Values{}
 	data.Set("client_id", clientId)
 	data.Set("grant_type", "refresh_token")
 	data.Set("refresh_token", refreshToken)
 
-	req, err := http.NewRequest("POST", logoutUrl.String(), strings.NewReader(data.Encode()))
+	req, err := http.NewRequest("POST", tokenUrl.String(), strings.NewReader(data.Encode()))
 	if err != nil {
 		return OpenIdCredentials{}, fmt.Errorf("error creating: %v", err)
 	}


### PR DESCRIPTION
# Summary

I was getting ready to add some additional user lookups, and I noticed that the current interactions with keycloak were repeated in at least two places.  I unified the existing setup behind interfaces in the configuration, though I expect at some point I'll come back to #2391 and extract things to a proper interface for IDP lookups.

## Change Type

***Mark the type of change your PR introduces:***

- [ ] Bug fix (resolves an issue without affecting existing features)
- [ ] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [x] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

***Outline how the changes were tested, including steps to reproduce and any relevant configurations. 
Attach screenshots if helpful.***

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [x] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [x] Included tests that validate the fix or feature.
- [x] Checked that related changes are merged.
