### PR TITLE
Fix auth delete when GitHub App installed

### DIFF
--- a/database/migrations/000044_github_installation_cascade_delete.down.sql
+++ b/database/migrations/000044_github_installation_cascade_delete.down.sql
@@ -1,0 +1,25 @@
+-- Copyright 2024 Stacklok, Inc
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--      http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+BEGIN;
+
+ALTER TABLE provider_github_app_installations
+    DROP CONSTRAINT provider_github_app_installations_project_id_fkey;
+
+ALTER TABLE provider_github_app_installations
+    ADD CONSTRAINT provider_github_app_installations_project_id_fkey
+        FOREIGN KEY (project_id)
+            REFERENCES projects(id);
+
+COMMIT;

--- a/database/migrations/000044_github_installation_cascade_delete.up.sql
+++ b/database/migrations/000044_github_installation_cascade_delete.up.sql
@@ -1,0 +1,28 @@
+-- Copyright 2024 Stacklok, Inc
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--      http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+BEGIN;
+
+-- drop the existing foreign key constraint on project_id
+ALTER TABLE provider_github_app_installations
+    DROP CONSTRAINT provider_github_app_installations_project_id_fkey;
+
+-- create a new foreign key constraint on project_id with ON DELETE CASCADE
+ALTER TABLE provider_github_app_installations
+    ADD CONSTRAINT provider_github_app_installations_project_id_fkey
+        FOREIGN KEY (project_id)
+            REFERENCES projects(id)
+            ON DELETE CASCADE;
+
+COMMIT;


### PR DESCRIPTION

# Summary

In a recent PR I added a foreign key constraint, without adding `ON DELETE CASCADE`. This was preventing the user from being deleted if they had a GitHub App provider.

Fixes #(related issue)

## Change Type

***Mark the type of change your PR introduces:***

- [x] Bug fix (resolves an issue without affecting existing features)
- [ ] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [ ] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

***Outline how the changes were tested, including steps to reproduce and any relevant configurations. 
Attach screenshots if helpful.***

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [ ] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [ ] Included tests that validate the fix or feature.
- [ ] Checked that related changes are merged.
