### PR TITLE
Use a separate webhook secret for the GH App

### DIFF
--- a/internal/config/server/github_app.go
+++ b/internal/config/server/github_app.go
@@ -34,6 +34,8 @@ type GitHubAppConfig struct {
 	UserID int64 `mapstructure:"user_id" default:"0"`
 	// PrivateKey is the GitHub App's private key
 	PrivateKey string `mapstructure:"private_key"`
+	// WebhookSecret is the GitHub App's webhook secret
+	WebhookSecret string `mapstructure:"webhook_secret"`
 }
 
 // GetPrivateKey returns the GitHub App's private key

--- a/internal/controlplane/handlers_githubwebhooks.go
+++ b/internal/controlplane/handlers_githubwebhooks.go
@@ -125,7 +125,7 @@ func (s *Server) HandleGitHubAppWebhook() http.HandlerFunc {
 			s.mt.AddWebhookEventTypeCount(r.Context(), wes)
 		}()
 
-		rawWBPayload, err := validatePayloadSignature(r, &s.cfg.WebhookConfig)
+		rawWBPayload, err := s.providers.ValidateGitHubAppWebhookPayload(r)
 		if err != nil {
 			log.Printf("Error validating webhook payload: %v", err)
 			w.WriteHeader(http.StatusBadRequest)

--- a/internal/providers/mock/service.go
+++ b/internal/providers/mock/service.go
@@ -11,6 +11,7 @@ package mockprofsvc
 
 import (
 	context "context"
+	http "net/http"
 	reflect "reflect"
 
 	db "github.com/stacklok/minder/internal/db"
@@ -98,6 +99,21 @@ func (m *MockProviderService) DeleteGitHubAppInstallation(arg0 context.Context, 
 func (mr *MockProviderServiceMockRecorder) DeleteGitHubAppInstallation(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteGitHubAppInstallation", reflect.TypeOf((*MockProviderService)(nil).DeleteGitHubAppInstallation), arg0, arg1)
+}
+
+// ValidateGitHubAppWebhookPayload mocks base method.
+func (m *MockProviderService) ValidateGitHubAppWebhookPayload(arg0 *http.Request) ([]byte, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ValidateGitHubAppWebhookPayload", arg0)
+	ret0, _ := ret[0].([]byte)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ValidateGitHubAppWebhookPayload indicates an expected call of ValidateGitHubAppWebhookPayload.
+func (mr *MockProviderServiceMockRecorder) ValidateGitHubAppWebhookPayload(arg0 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ValidateGitHubAppWebhookPayload", reflect.TypeOf((*MockProviderService)(nil).ValidateGitHubAppWebhookPayload), arg0)
 }
 
 // ValidateGitHubInstallationId mocks base method.


### PR DESCRIPTION
# Summary

instead of reusing the same one we already use for repos

## Change Type

***Mark the type of change your PR introduces:***

- [ ] Bug fix (resolves an issue without affecting existing features)
- [x] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [ ] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

manually by setting the webhook secret in the config file and making sure that I can validate incoming messages with the right secret and can't with the wrong secret
```
provider:
  github-app:
    app_name: jakub-s-local-minder-test
    app_id: 864067
    user_id: 165174215
    private_key: ".secrets/github-app.pem"
    webhook_secret: "test5"
```

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [x] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [x] Included tests that validate the fix or feature.
- [ ] Checked that related changes are merged.
