### PR TITLE
Move more provider access methods to store

### DIFF
--- a/internal/controlplane/handlers_githubwebhooks.go
+++ b/internal/controlplane/handlers_githubwebhooks.go
@@ -412,16 +412,8 @@ func (s *Server) parseGithubEventForProcessing(
 		return fmt.Errorf("error getting repo information from payload: %w", err)
 	}
 
-	ph, err := s.store.GetParentProjects(ctx, dbRepo.ProjectID)
-	if err != nil {
-		return fmt.Errorf("error getting project hierarchy: %w", err)
-	}
-
 	// get the provider for the repository
-	prov, err := s.store.GetProviderByName(ctx, db.GetProviderByNameParams{
-		Name:     dbRepo.Provider,
-		Projects: ph,
-	})
+	prov, err := s.providerStore.GetByName(ctx, dbRepo.ProjectID, dbRepo.Provider)
 	if err != nil {
 		return fmt.Errorf("error getting provider: %w", err)
 	}
@@ -430,7 +422,7 @@ func (s *Server) parseGithubEventForProcessing(
 		providers.WithProviderMetrics(s.provMt),
 		providers.WithRestClientCache(s.restClientCache),
 	}
-	provBuilder, err := providers.GetProviderBuilder(ctx, prov, s.store, s.cryptoEngine, &s.cfg.Provider, pbOpts...)
+	provBuilder, err := providers.GetProviderBuilder(ctx, *prov, s.store, s.cryptoEngine, &s.cfg.Provider, pbOpts...)
 	if err != nil {
 		return fmt.Errorf("error building client: %w", err)
 	}

--- a/internal/controlplane/handlers_githubwebhooks_test.go
+++ b/internal/controlplane/handlers_githubwebhooks_test.go
@@ -276,16 +276,17 @@ func (s *UnitTestSuite) TestHandleWebHookRepository() {
 		}, nil)
 
 	mockStore.EXPECT().
-		GetProviderByName(gomock.Any(), db.GetProviderByNameParams{
-			Name: providerName,
+		FindProviders(gomock.Any(), db.FindProvidersParams{
+			Name: sql.NullString{String: providerName, Valid: true},
 			Projects: []uuid.UUID{
 				projectID,
 			},
+			Trait: db.NullProviderType{},
 		}).
-		Return(db.Provider{
+		Return([]db.Provider{{
 			ProjectID: projectID,
 			Name:      providerName,
-		}, nil)
+		}}, nil)
 
 	hook := srv.HandleGitHubWebHook()
 	port, err := rand.GetRandomPort()

--- a/internal/controlplane/handlers_oauth.go
+++ b/internal/controlplane/handlers_oauth.go
@@ -392,11 +392,7 @@ func (s *Server) StoreProviderToken(ctx context.Context,
 		return nil, status.Errorf(codes.InvalidArgument, "provider name is required")
 	}
 
-	provider, err := s.store.GetProviderByName(ctx, db.GetProviderByNameParams{
-		// We don't check parent projects here because subprojects should not update the credentials of their parent
-		Projects: []uuid.UUID{projectID},
-		Name:     providerName,
-	})
+	provider, err := s.providerStore.GetByNameInSpecificProject(ctx, projectID, providerName)
 	if err != nil {
 		return nil, providerError(err)
 	}
@@ -500,11 +496,7 @@ func (s *Server) VerifyProviderTokenFrom(ctx context.Context,
 		return &pb.VerifyProviderTokenFromResponse{Status: "KO"}, nil
 	}
 
-	provider, err := s.store.GetProviderByName(ctx, db.GetProviderByNameParams{
-		// We don't check parent projects here because subprojects should not check the credentials of their parent
-		Projects: []uuid.UUID{projectID},
-		Name:     providerName,
-	})
+	provider, err := s.providerStore.GetByNameInSpecificProject(ctx, projectID, providerName)
 	if err != nil {
 		return nil, providerError(err)
 	}
@@ -560,7 +552,7 @@ func (s *Server) VerifyProviderCredential(ctx context.Context,
 	)
 
 	if err == nil {
-		provider, err := s.store.GetProviderByID(ctx, installation.ProviderID.UUID)
+		provider, err := s.providerStore.GetByID(ctx, installation.ProviderID.UUID)
 		if err != nil {
 			return nil, status.Errorf(codes.Internal, "error getting provider: %v", err)
 		}

--- a/internal/controlplane/handlers_oauth_test.go
+++ b/internal/controlplane/handlers_oauth_test.go
@@ -774,6 +774,7 @@ func TestVerifyProviderCredential(t *testing.T) {
 				store:               store,
 				evt:                 evt,
 				providerAuthFactory: providerAuthFactory,
+				providerStore:       providers.NewProviderStore(store),
 				cfg: &serverconfig.Config{
 					Auth: serverconfig.AuthConfig{},
 				},

--- a/internal/controlplane/handlers_repositories_test.go
+++ b/internal/controlplane/handlers_repositories_test.go
@@ -56,7 +56,7 @@ func TestServer_RegisterRepository(t *testing.T) {
 			RepoOwner:     repoOwner,
 			RepoName:      repoName,
 			ProviderFails: true,
-			ExpectedError: "error getting provider",
+			ExpectedError: "cannot retrieve provider",
 		},
 		{
 			Name:          "Repo creation fails when repo name is missing",
@@ -150,7 +150,7 @@ func TestServer_DeleteRepository(t *testing.T) {
 			RepoName:         repoOwnerAndName,
 			RepoServiceSetup: newRepoService(withSuccessfulGetRepoByName),
 			ProviderFails:    true,
-			ExpectedError:    "error getting provider",
+			ExpectedError:    "cannot retrieve provider",
 		},
 		{
 			Name:          "delete by name fails when name is malformed",
@@ -354,12 +354,12 @@ func createServer(ctrl *gomock.Controller, repoServiceSetup repoMockBuilder, pro
 
 	if providerFails {
 		store.EXPECT().
-			GetProviderByName(gomock.Any(), gomock.Any()).
-			Return(db.Provider{}, errDefault)
+			FindProviders(gomock.Any(), gomock.Any()).
+			Return([]db.Provider{}, errDefault)
 	} else {
 		store.EXPECT().
-			GetProviderByName(gomock.Any(), gomock.Any()).
-			Return(provider, nil).AnyTimes()
+			FindProviders(gomock.Any(), gomock.Any()).
+			Return([]db.Provider{provider}, nil).AnyTimes()
 		store.EXPECT().
 			GetAccessTokenByProjectID(gomock.Any(), gomock.Any()).
 			Return(db.ProviderAccessToken{

--- a/internal/providers/store.go
+++ b/internal/providers/store.go
@@ -144,9 +144,10 @@ func (p *providerStore) findProvider(
 	trait db.NullProviderType,
 	projectID uuid.UUID,
 ) ([]db.Provider, error) {
-	projectHierarchy, err := p.getProjectHierarchy(ctx, projectID)
+	// Allows us to take into account the hierarchy to find the provider
+	projectHierarchy, err := p.store.GetParentProjects(ctx, projectID)
 	if err != nil {
-		return nil, err
+		return nil, status.Errorf(codes.InvalidArgument, "cannot retrieve parent projects: %s", err)
 	}
 
 	provs, err := p.store.FindProviders(ctx, db.FindProvidersParams{
@@ -163,15 +164,6 @@ func (p *providerStore) findProvider(
 	}
 
 	return provs, nil
-}
-
-// Allows us to take into account the hierarchy to find the provider
-func (p *providerStore) getProjectHierarchy(ctx context.Context, projectID uuid.UUID) ([]uuid.UUID, error) {
-	parents, err := p.store.GetParentProjects(ctx, projectID)
-	if err != nil {
-		return nil, status.Errorf(codes.InvalidArgument, "cannot retrieve parent projects: %s", err)
-	}
-	return parents, nil
 }
 
 // getNameFilterParam allows us to build a name filter for our provider queries


### PR DESCRIPTION
Relates to #2845

Migrate more queries for providers to ProviderStore. This will make it easier to refactor away direct access to the provider table in subequent PRs.

# Summary

***Provide a brief overview of the changes and the issue being addressed. 
Explain the rationale and any background necessary for understanding the changes. 
List dependencies required by this change, if any.***

Fixes #(related issue)

## Change Type

***Mark the type of change your PR introduces:***

- [ ] Bug fix (resolves an issue without affecting existing features)
- [ ] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [x] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

***Outline how the changes were tested, including steps to reproduce and any relevant configurations. 
Attach screenshots if helpful.***

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [x] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [x] Included tests that validate the fix or feature.
- [ ] Checked that related changes are merged.
