### PR TITLE
Nicer error message when creating profile with non-unique rule types missing names

### DIFF
--- a/internal/profiles/validator.go
+++ b/internal/profiles/validator.go
@@ -51,7 +51,12 @@ func (v *Validator) ValidateAndExtractRules(
 
 	// ensure that the rule names follow all naming constraints
 	if err := validateRuleNames(profile); err != nil {
-		return nil, err
+		var violation *engine.RuleValidationError
+		if errors.As(err, &violation) {
+			return nil, util.UserVisibleError(codes.InvalidArgument,
+				"profile failed rule name validation: %s", violation)
+		}
+		return nil, status.Errorf(codes.Internal, "error validating rule names in profile")
 	}
 
 	// validate that the rule invocations match what the rule types expect


### PR DESCRIPTION
# Summary

better than unknown error

## Change Type

***Mark the type of change your PR introduces:***

- [x] Bug fix (resolves an issue without affecting existing features)
- [ ] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [ ] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

```
$ cat ~/devel/playground/dependabot.yaml
---
# sample profile for validating repositories
version: v1
type: profile
name: dependabot-enabled-profile
remediate: on
alerts: on
context:
  provider: github
repository:
  - type: dependabot_configured
    #name: dep_go
    def:
      package_ecosystem: gomod
      schedule_interval: weekly
      apply_if_file: go.mod
  - type: dependabot_configured
    #name: dep_py
    def:
      package_ecosystem: pypi
      schedule_interval: weekly
      apply_if_file: requirements.txt
$ ./bin/minder profile create -f ~/devel/playground/dependabot.yaml
WARNING: Running against a test environment (127.0.0.1) and may not be stable
Message: error creating profile from /Users/jakub/devel/playground/dependabot.yaml
Details: profile failed rule name validation: error in rule "dependabot_configured": multiple rules with empty name and same type in entity 'repository', add unique names to rules
```

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [ ] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [ ] Included tests that validate the fix or feature.
- [ ] Checked that related changes are merged.
