### PR TITLE
Don't mark a PR remediation as error if no previous result exists

### DIFF
--- a/internal/engine/actions/remediate/pull_request/pull_request.go
+++ b/internal/engine/actions/remediate/pull_request/pull_request.go
@@ -540,7 +540,7 @@ func (_ *Remediator) runDoNothing(ctx context.Context, p *paramsPR) (json.RawMes
 	logger.Debug().Msg("Running do nothing")
 
 	// Return the previous remediation status.
-	err := enginerr.RemediationStatusAsError(p.prevStatus.RemStatus.RemediationStatusTypes)
+	err := enginerr.RemediationStatusAsError(p.prevStatus.RemStatus)
 	// If there is a valid remediation metadata, return it too
 	if p.prevStatus.RemMetadata.Valid {
 		return p.prevStatus.RemMetadata.RawMessage, err

--- a/internal/engine/errors/errors.go
+++ b/internal/engine/errors/errors.go
@@ -157,7 +157,12 @@ func ErrorAsRemediationStatus(err error) db.RemediationStatusTypes {
 }
 
 // RemediationStatusAsError returns the remediation status for a given error
-func RemediationStatusAsError(s db.RemediationStatusTypes) error {
+func RemediationStatusAsError(ns db.NullRemediationStatusTypes) error {
+	if !ns.Valid {
+		return ErrActionSkipped
+	}
+
+	s := ns.RemediationStatusTypes
 	switch s {
 	case db.RemediationStatusTypesSuccess:
 		return nil


### PR DESCRIPTION
# Summary

If there was no previous remediation status the Null DB type would
have had Valid:false and the actual value set to an empty string which
would trigger the default case of returning a generic error in
`RemediationStatusAsError`.

## Change Type

***Mark the type of change your PR introduces:***

- [x] Bug fix (resolves an issue without affecting existing features)
- [ ] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [ ] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

create a profile with remediate: on that uses a pull request remediation but
is already passing. It would end up in error.

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [ ] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [ ] Included tests that validate the fix or feature.
- [ ] Checked that related changes are merged.
