### PR TITLE
Allow creating empty profiles

### DIFF
--- a/internal/controlplane/handlers_profile_test.go
+++ b/internal/controlplane/handlers_profile_test.go
@@ -262,10 +262,17 @@ func TestCreateProfile(t *testing.T) {
 		name: "Create profile with no rules",
 		profile: &minderv1.CreateProfileRequest{
 			Profile: &minderv1.Profile{
-				Name: "test",
+				Name: "test_norules",
 			},
 		},
-		wantErr: `Couldn't create profile: validation failed: profile must have at least one rule`,
+		result: &minderv1.CreateProfileResponse{
+			Profile: &minderv1.Profile{
+				Name:        "test_norules",
+				DisplayName: "test_norules",
+				Alert:       proto.String("on"),
+				Remediate:   proto.String("off"),
+			},
+		},
 	},
 		{
 			name: "Create profile with valid name and rules",
@@ -280,9 +287,36 @@ func TestCreateProfile(t *testing.T) {
 			},
 			result: &minderv1.CreateProfileResponse{
 				Profile: &minderv1.Profile{
-					Name:      "test",
-					Alert:     proto.String("on"),
-					Remediate: proto.String("off"),
+					Name:        "test",
+					DisplayName: "test",
+					Alert:       proto.String("on"),
+					Remediate:   proto.String("off"),
+					Repository: []*minderv1.Profile_Rule{{
+						Type: "rule_type_1",
+						Name: "rule_type_1",
+						Def:  &structpb.Struct{},
+					}},
+				},
+			},
+		},
+		{
+			name: "Create profile with explicit display name",
+			profile: &minderv1.CreateProfileRequest{
+				Profile: &minderv1.Profile{
+					Name:        "test_display",
+					DisplayName: "test_display_name_value",
+					Repository: []*minderv1.Profile_Rule{{
+						Type: "rule_type_1",
+						Def:  &structpb.Struct{},
+					}},
+				},
+			},
+			result: &minderv1.CreateProfileResponse{
+				Profile: &minderv1.Profile{
+					Name:        "test_display",
+					DisplayName: "test_display_name_value",
+					Alert:       proto.String("on"),
+					Remediate:   proto.String("off"),
 					Repository: []*minderv1.Profile_Rule{{
 						Type: "rule_type_1",
 						Name: "rule_type_1",
@@ -306,9 +340,10 @@ func TestCreateProfile(t *testing.T) {
 			},
 			result: &minderv1.CreateProfileResponse{
 				Profile: &minderv1.Profile{
-					Name:      "test_explicit",
-					Alert:     proto.String("off"),
-					Remediate: proto.String("on"),
+					Name:        "test_explicit",
+					DisplayName: "test_explicit",
+					Alert:       proto.String("off"),
+					Remediate:   proto.String("on"),
 					Repository: []*minderv1.Profile_Rule{{
 						Type: "rule_type_1",
 						Name: "rule_type_1",

--- a/internal/profiles/service.go
+++ b/internal/profiles/service.go
@@ -252,6 +252,16 @@ func (p *profileService) UpdateProfile(
 		return nil, status.Errorf(codes.Internal, "error updating profile: %v", err)
 	}
 
+	// special-case for updating to empty profile - insert a dummy repo rule
+	if profile.IsEmpty() {
+		if err := createProfileRulesForEntity(
+			ctx, minderv1.Entity_ENTITY_REPOSITORIES,
+			&updatedProfile, qtx, profile.GetRepository(),
+			make(RuleMapping)); err != nil {
+			return nil, status.Errorf(codes.Internal, "error creating dummy profile entity: %v", err)
+		}
+	}
+
 	logger.BusinessRecord(ctx).Profile = logger.Profile{Name: updatedProfile.Name, ID: updatedProfile.ID}
 
 	profile.Id = ptr.Ptr(updatedProfile.ID.String())

--- a/internal/profiles/service.go
+++ b/internal/profiles/service.go
@@ -110,16 +110,12 @@ func (p *profileService) CreateProfile(
 	// Adds default rule names, if not present
 	PopulateRuleNames(profile)
 
-	displayName := profile.GetDisplayName()
-	// if empty use the name
-	if displayName == "" {
-		displayName = profile.GetName()
-	}
+	profile.ApplyDefaults()
 
 	params := db.CreateProfileParams{
 		ProjectID:      projectID,
 		Name:           profile.GetName(),
-		DisplayName:    displayName,
+		DisplayName:    profile.GetDisplayName(),
 		Labels:         profile.GetLabels(),
 		Remediate:      db.ValidateRemediateType(profile.GetRemediate()),
 		Alert:          db.ValidateAlertType(profile.GetAlert()),
@@ -218,17 +214,13 @@ func (p *profileService) UpdateProfile(
 		return nil, status.Errorf(codes.Internal, "error fetching profile to be updated: %v", err)
 	}
 
-	displayName := profile.GetDisplayName()
-	// if empty use the name
-	if displayName == "" {
-		displayName = profile.GetName()
-	}
+	profile.ApplyDefaults()
 
 	// Update top-level profile db object
 	updatedProfile, err := qtx.UpdateProfile(ctx, db.UpdateProfileParams{
 		ProjectID:   projectID,
 		ID:          oldDBProfile.ID,
-		DisplayName: displayName,
+		DisplayName: profile.GetDisplayName(),
 		Labels:      profile.GetLabels(),
 		Remediate:   db.ValidateRemediateType(profile.GetRemediate()),
 		Alert:       db.ValidateAlertType(profile.GetAlert()),

--- a/internal/profiles/validator_test.go
+++ b/internal/profiles/validator_test.go
@@ -56,11 +56,6 @@ func TestValidatorScenarios(t *testing.T) {
 			ExpectedError: "invalid profile",
 		},
 		{
-			Name:          "Validator rejects profile with no rules defined",
-			Profile:       makeProfile(withBasicProfileData),
-			ExpectedError: "profile must have at least one rule",
-		},
-		{
 			Name:          "Validator rejects profile with multiple unnamed rules of same type",
 			Profile:       makeProfile(withBasicProfileData, withRules(makeRule(withEmptyRuleName), makeRule(withEmptyRuleName))),
 			ExpectedError: "multiple rules with empty name and same type in entity",

--- a/pkg/api/protobuf/go/minder/v1/profile.go
+++ b/pkg/api/protobuf/go/minder/v1/profile.go
@@ -37,12 +37,17 @@ func (r *UpdateProfileRequest) GetContext() *Context {
 	return nil
 }
 
+// ApplyDefaults applies default values to the Profile.
 func (p *Profile) ApplyDefaults() {
 	if p == nil {
 		return
 	}
 
 	p.defaultDisplayName()
+
+	if p.IsEmpty() {
+		p.addEmptyProfileRule()
+	}
 }
 
 func (p *Profile) defaultDisplayName() {
@@ -51,4 +56,27 @@ func (p *Profile) defaultDisplayName() {
 	if displayName == "" {
 		p.DisplayName = p.GetName()
 	}
+}
+
+func (p *Profile) addEmptyProfileRule() {
+	// this is a bit of a hack. When we store profiles, we store just the profile metadata
+	// in the profiles table and then separately the rules per entity in the entity_profiles table.
+	// Most of our SQL queries are written to expect that there is at least one rule per profile
+	// by JOIN-ing the tables. A LEFT JOIN would be impractical because then all results would have
+	// to handle a NULL type for the case where there are no rules and the callers would have to handle
+	// the NULL values as well. So we add an empty rule here that does nothing, is not retrieved in the
+	// profile get commands and because this rule is never evaluated, the profile status is pending
+	// until an actual rule is added and evaluated.
+	p.Repository = []*Profile_Rule{}
+}
+
+// IsEmpty returns true if the Profile has no rules.
+func (p *Profile) IsEmpty() bool {
+	repoRuleCount := len(p.GetRepository())
+	buildEnvRuleCount := len(p.GetBuildEnvironment())
+	artifactRuleCount := len(p.GetArtifact())
+	pullRequestRuleCount := len(p.GetPullRequest())
+	totalRuleCount := repoRuleCount + buildEnvRuleCount + artifactRuleCount + pullRequestRuleCount
+
+	return totalRuleCount == 0
 }

--- a/pkg/api/protobuf/go/minder/v1/profile.go
+++ b/pkg/api/protobuf/go/minder/v1/profile.go
@@ -36,3 +36,19 @@ func (r *UpdateProfileRequest) GetContext() *Context {
 	}
 	return nil
 }
+
+func (p *Profile) ApplyDefaults() {
+	if p == nil {
+		return
+	}
+
+	p.defaultDisplayName()
+}
+
+func (p *Profile) defaultDisplayName() {
+	displayName := p.GetDisplayName()
+	// if empty use the name
+	if displayName == "" {
+		p.DisplayName = p.GetName()
+	}
+}

--- a/pkg/api/protobuf/go/minder/v1/validators.go
+++ b/pkg/api/protobuf/go/minder/v1/validators.go
@@ -208,16 +208,6 @@ func (p *Profile) Validate() error {
 		return fmt.Errorf("%w: %w", ErrValidationFailed, err)
 	}
 
-	repoRuleCount := len(p.GetRepository())
-	buildEnvRuleCount := len(p.GetBuildEnvironment())
-	artifactRuleCount := len(p.GetArtifact())
-	pullRequestRuleCount := len(p.GetPullRequest())
-	totalRuleCount := repoRuleCount + buildEnvRuleCount + artifactRuleCount + pullRequestRuleCount
-
-	if totalRuleCount == 0 {
-		return fmt.Errorf("%w: profile must have at least one rule", ErrValidationFailed)
-	}
-
 	// If the profile is nil or empty, we don't need to validate it
 	for i, r := range p.GetRepository() {
 		if err := validateRule(r); err != nil {


### PR DESCRIPTION
# Summary

UI would benefit from being able to create an empty profile and then update it.

This proved to be tricky because a profile is stored in the database in three places
 - the `profiles` table which stores the data about profiles except the rules themselves
 - `entity_profiles` which stores the payload of the rules such as `def` and `params`
 - `entity_profile_rules` which ties the `entity_profiles` table with `rule_type` instances

In many database operations that operate on profiles such as GetProfile or ListProfiles
we actually don't query the `profiles` table, but a `JOIN` of the `profiles`
and the `entity_profiles` tables. This means that a profile that doesn't instantiate
a rule wouldn't be returned by those queries as the `JOIN` doesn't have anything to
JOIN on if there are no rules.

I experimented a bit with a `LEFT JOIN` but that proved to be tricky as well because
a `LEFT JOIN` needs to return nullable values from the table it joins on (in this case
`entity_profiles`) which would make us redo our models a bit. Not to mention that a `LEFT JOIN` is not exactly fast.

The other approach I considered was to just special case empty profiles in the handlers, but this seems brittle.

Yet another approach I considered was to add a special entity type that would only be used in this specific case and signal an empty profile, but I don't see much value over this hack and we'd need to handle that special entity type all over the codebase as well.

This PR implements a bit of a hack where an empty profile is not actually empty but
stored as a profile that contains an empty rule which doesn't use any rule_type and
has an empty definition. This satisfies all the JOINs we have on `entity_profiles`
making the profile usable in handlers, but is empty from the point of view of the engine.

This PR is missing tests for the affected handlers, but I didn't want to spend that
time until I get a green light on the approach.

Co-authored-by: Radoslav Dimitrov <radoslav@stacklok.com>

Fixes: #2925 

## Change Type

***Mark the type of change your PR introduces:***

- [ ] Bug fix (resolves an issue without affecting existing features)
- [x] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [ ] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

I tested:
 - creating an empty profile
 - making it non-empty with rules for different entities
 - making it empty again
 - retrieving an empty profile to make sure the dummy entity_profile record is not displayed
 - listing and deleting the empty profile

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [x] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [ ] Included tests that validate the fix or feature.
- [ ] Checked that related changes are merged.
