### PR TITLE
Handle entity delete events, i.e. when a repo is deleted

### DIFF
--- a/internal/controlplane/handlers_githubwebhooks_test.go
+++ b/internal/controlplane/handlers_githubwebhooks_test.go
@@ -97,7 +97,7 @@ func (s *UnitTestSuite) TestHandleWebHookPing() {
 	pq := testqueue.NewPassthroughQueue(t)
 	queued := pq.GetQueue()
 
-	evt.Register(events.ExecuteEntityEventTopic, pq.Pass)
+	evt.Register(events.TopicQueueEntityEvaluate, pq.Pass)
 
 	go func() {
 		err := evt.Run(context.Background())
@@ -152,7 +152,7 @@ func (s *UnitTestSuite) TestHandleWebHookUnexistentRepository() {
 	pq := testqueue.NewPassthroughQueue(t)
 	queued := pq.GetQueue()
 
-	evt.Register(events.ExecuteEntityEventTopic, pq.Pass)
+	evt.Register(events.TopicQueueEntityEvaluate, pq.Pass)
 
 	go func() {
 		err := evt.Run(context.Background())
@@ -226,7 +226,7 @@ func (s *UnitTestSuite) TestHandleWebHookRepository() {
 	pq := testqueue.NewPassthroughQueue(t)
 	queued := pq.GetQueue()
 
-	evt.Register(events.ExecuteEntityEventTopic, pq.Pass)
+	evt.Register(events.TopicQueueEntityEvaluate, pq.Pass)
 
 	go func() {
 		err := evt.Run(context.Background())
@@ -353,7 +353,7 @@ func (s *UnitTestSuite) TestHandleWebHookUnexistentRepoPackage() {
 	pq := testqueue.NewPassthroughQueue(t)
 	queued := pq.GetQueue()
 
-	evt.Register(events.ExecuteEntityEventTopic, pq.Pass)
+	evt.Register(events.TopicQueueEntityEvaluate, pq.Pass)
 
 	go func() {
 		err := evt.Run(context.Background())

--- a/internal/controlplane/handlers_profile.go
+++ b/internal/controlplane/handlers_profile.go
@@ -31,6 +31,7 @@ import (
 	"github.com/stacklok/minder/internal/db"
 	"github.com/stacklok/minder/internal/engine"
 	"github.com/stacklok/minder/internal/engine/entities"
+	"github.com/stacklok/minder/internal/events"
 	"github.com/stacklok/minder/internal/logger"
 	prof "github.com/stacklok/minder/internal/profiles"
 	"github.com/stacklok/minder/internal/reconcilers"
@@ -603,7 +604,7 @@ func (s *Server) PatchProfile(ctx context.Context, ppr *minderv1.PatchProfileReq
 		zerolog.Ctx(ctx).Err(err).Msg("error creating reconciler event message")
 	} else {
 		// This is a non-fatal error, so we'll just log it and continue with the next ones
-		if err := s.evt.Publish(reconcilers.InternalProfileInitEventTopic, msg); err != nil {
+		if err := s.evt.Publish(events.TopicQueueReconcileProfileInit, msg); err != nil {
 			zerolog.Ctx(ctx).Err(err).Msg("error publishing reconciler event message")
 		}
 	}

--- a/internal/controlplane/handlers_reconciliationtasks.go
+++ b/internal/controlplane/handlers_reconciliationtasks.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/stacklok/minder/internal/db"
 	"github.com/stacklok/minder/internal/engine"
+	"github.com/stacklok/minder/internal/events"
 	"github.com/stacklok/minder/internal/logger"
 	"github.com/stacklok/minder/internal/reconcilers"
 	pb "github.com/stacklok/minder/pkg/api/protobuf/go/minder/v1"
@@ -59,7 +60,7 @@ func (s *Server) CreateEntityReconciliationTask(ctx context.Context,
 		if err != nil {
 			return nil, err
 		}
-		topic = reconcilers.InternalReconcilerEventTopic
+		topic = events.TopicQueueReconcileRepoInit
 	} else {
 		return nil, status.Errorf(codes.InvalidArgument, "entity type %s is not supported", entity.GetType())
 	}

--- a/internal/eea/eea.go
+++ b/internal/eea/eea.go
@@ -54,7 +54,7 @@ func NewEEA(querier db.Store, evt events.Publisher, cfg *serverconfig.Aggregator
 
 // Register implements the Consumer interface.
 func (e *EEA) Register(r events.Registrar) {
-	r.Register(events.FlushEntityEventTopic, e.FlushMessageHandler)
+	r.Register(events.TopicQueueEntityFlush, e.FlushMessageHandler)
 }
 
 // AggregateMiddleware will pass on the event to the executor engine

--- a/internal/eea/eea_test.go
+++ b/internal/eea/eea_test.go
@@ -87,7 +87,7 @@ func TestAggregator(t *testing.T) {
 	aggr.Register(evt)
 
 	// This tests that flushing sends messages to the executor engine
-	evt.Register(events.ExecuteEntityEventTopic, flushedMessages.Add, aggr.AggregateMiddleware)
+	evt.Register(events.TopicQueueEntityEvaluate, flushedMessages.Add, aggr.AggregateMiddleware)
 
 	go func() {
 		t.Log("Running eventer")
@@ -134,7 +134,7 @@ func TestAggregator(t *testing.T) {
 			msg, err := inf.BuildMessage()
 			require.NoError(t, err, "expected no error when building message")
 
-			err = evt.Publish(events.FlushEntityEventTopic, msg.Copy())
+			err = evt.Publish(events.TopicQueueEntityFlush, msg.Copy())
 			require.NoError(t, err, "expected no error when publishing message")
 		}()
 	}
@@ -338,7 +338,7 @@ func TestFlushAll(t *testing.T) {
 			require.NoError(t, err)
 
 			flushedMessages := newTestPubSub()
-			evt.Register(events.ExecuteEntityEventTopic, flushedMessages.Add)
+			evt.Register(events.TopicQueueEntityEvaluate, flushedMessages.Add)
 
 			go func() {
 				t.Log("Running eventer")
@@ -395,7 +395,7 @@ func TestFlushAllListFlushIsEmpty(t *testing.T) {
 	flushedMessages := newTestPubSub()
 
 	// This tests that flushing sends messages to the executor engine
-	evt.Register(events.ExecuteEntityEventTopic, flushedMessages.Add, aggr.AggregateMiddleware)
+	evt.Register(events.TopicQueueEntityEvaluate, flushedMessages.Add, aggr.AggregateMiddleware)
 
 	t.Log("Flushing all")
 	require.NoError(t, aggr.FlushAll(ctx), "expected no error")
@@ -423,7 +423,7 @@ func TestFlushAllListFlushFails(t *testing.T) {
 	require.NoError(t, err)
 
 	// This tests that flushing sends messages to the executor engine
-	evt.Register(events.ExecuteEntityEventTopic, flushedMessages.Add)
+	evt.Register(events.TopicQueueEntityEvaluate, flushedMessages.Add)
 
 	go func() {
 		t.Log("Running eventer")
@@ -469,7 +469,7 @@ func TestFlushAllListFlushListsARepoThatGetsDeletedLater(t *testing.T) {
 	require.NoError(t, err)
 
 	// This tests that flushing sends messages to the executor engine
-	evt.Register(events.ExecuteEntityEventTopic, flushedMessages.Add)
+	evt.Register(events.TopicQueueEntityEvaluate, flushedMessages.Add)
 
 	go func() {
 		t.Log("Running eventer")

--- a/internal/engine/entities/entity_event.go
+++ b/internal/engine/entities/entity_event.go
@@ -208,7 +208,7 @@ func (eiw *EntityInfoWrapper) Publish(evt events.Publisher) error {
 		return err
 	}
 
-	if err := evt.Publish(events.ExecuteEntityEventTopic, msg); err != nil {
+	if err := evt.Publish(events.TopicQueueEntityEvaluate, msg); err != nil {
 		return fmt.Errorf("error publishing entity event: %w", err)
 	}
 

--- a/internal/engine/entities/entity_event.go
+++ b/internal/engine/entities/entity_event.go
@@ -298,11 +298,9 @@ func (eiw *EntityInfoWrapper) withProviderFromMessage(msg *message.Message) erro
 	return nil
 }
 
-//nolint:unparam
-func (eiw *EntityInfoWrapper) withActionEventFromMessage(msg *message.Message) error {
+func (eiw *EntityInfoWrapper) withActionEventFromMessage(msg *message.Message) {
 	action := msg.Metadata.Get(ActionEventKey)
 	eiw.ActionEvent = action
-	return nil
 }
 
 func (eiw *EntityInfoWrapper) withRepositoryIDFromMessage(msg *message.Message) error {
@@ -396,9 +394,7 @@ func ParseEntityEvent(msg *message.Message) (*EntityInfoWrapper, error) {
 		return nil, err
 	}
 
-	if err := out.withActionEventFromMessage(msg); err != nil {
-		return nil, err
-	}
+	out.withActionEventFromMessage(msg)
 
 	typ := msg.Metadata.Get(EntityTypeEventKey)
 	switch typ {

--- a/internal/engine/executor_test.go
+++ b/internal/engine/executor_test.go
@@ -291,7 +291,7 @@ default allow = true`,
 
 	go func() {
 		t.Log("Running eventer")
-		evt.Register(events.FlushEntityEventTopic, pq.Pass)
+		evt.Register(events.TopicQueueEntityFlush, pq.Pass)
 		err := evt.Run(context.Background())
 		require.NoError(t, err, "failed to run eventer")
 	}()

--- a/internal/events/constants.go
+++ b/internal/events/constants.go
@@ -35,8 +35,14 @@ const (
 )
 
 const (
-	// ExecuteEntityEventTopic is the topic for internal webhook events
-	ExecuteEntityEventTopic = "execute.entity.event"
-	// FlushEntityEventTopic is the topic for flushing internal webhook events
-	FlushEntityEventTopic = "flush.entity.event"
+	// TopicQueueEntityEvaluate is the topic for entity evaluation events from webhooks
+	TopicQueueEntityEvaluate = "execute.entity.event"
+	// TopicQueueEntityFlush is the topic for flushing internal webhook events
+	TopicQueueEntityFlush = "flush.entity.event"
+	// TopicQueueReconcileRepoInit is the topic for reconciling repository events, i.e. when a new repository is registered
+	TopicQueueReconcileRepoInit = "internal.repo.reconciler.event"
+	// TopicQueueReconcileProfileInit is the topic for reconciling when a profile is created or updated
+	TopicQueueReconcileProfileInit = "internal.profile.init.event"
+	// TopicQueueReconcileEntityDelete is the topic for reconciling when an entity is deleted
+	TopicQueueReconcileEntityDelete = "internal.entity.delete.event"
 )

--- a/internal/profiles/service.go
+++ b/internal/profiles/service.go
@@ -337,7 +337,7 @@ func (p *profileService) sendNewProfileEvent(
 	}
 
 	// This is a non-fatal error, so we'll just log it and continue with the next ones
-	if err := p.publisher.Publish(reconcilers.InternalProfileInitEventTopic, msg); err != nil {
+	if err := p.publisher.Publish(events.TopicQueueReconcileProfileInit, msg); err != nil {
 		log.Printf("error publishing reconciler event: %v", err)
 	}
 }

--- a/internal/reconcilers/entity_delete.go
+++ b/internal/reconcilers/entity_delete.go
@@ -1,0 +1,64 @@
+// Copyright 2023 Stacklok, Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package reconcilers
+
+import (
+	"fmt"
+
+	"github.com/ThreeDotsLabs/watermill/message"
+	"github.com/rs/zerolog"
+
+	"github.com/stacklok/minder/internal/engine/entities"
+	minderlogger "github.com/stacklok/minder/internal/logger"
+	pb "github.com/stacklok/minder/pkg/api/protobuf/go/minder/v1"
+)
+
+//nolint:exhaustive
+func (r *Reconciler) handleEntityDeleteEvent(msg *message.Message) error {
+	ctx := msg.Context()
+
+	inf, err := entities.ParseEntityEvent(msg)
+	if err != nil {
+		return fmt.Errorf("error unmarshalling payload: %w", err)
+	}
+
+	l := zerolog.Ctx(ctx).With().
+		Str("provider", inf.Provider).
+		Str("project_id", inf.ProjectID.String()).
+		Str("entity_type", inf.Type.ToString()).
+		Str("action", inf.ActionEvent).
+		Logger()
+
+	repoID, _, _ := inf.GetEntityDBIDs()
+
+	// Telemetry logging
+	minderlogger.BusinessRecord(ctx).Provider = inf.Provider
+	minderlogger.BusinessRecord(ctx).Project = inf.ProjectID
+	switch inf.Type {
+	case pb.Entity_ENTITY_REPOSITORIES:
+		l.Info().Str("repo_id", repoID.String()).Msg("handling entity delete event")
+		// Remove the entry in the DB. There's no need to clean any webhook we created for this repository, as GitHub
+		// will automatically remove them when the repository is deleted.
+		if err := r.store.DeleteRepository(ctx, repoID); err != nil {
+			return fmt.Errorf("error deleting repository from DB: %w", err)
+		}
+		minderlogger.BusinessRecord(ctx).Repository = repoID
+		return nil
+	default:
+		err := fmt.Errorf("unsupported entity delete event for: %s", inf.Type)
+		l.Err(err).Msg("error handling entity delete event")
+		return err
+	}
+}

--- a/internal/reconcilers/entity_delete.go
+++ b/internal/reconcilers/entity_delete.go
@@ -59,6 +59,7 @@ func (r *Reconciler) handleEntityDeleteEvent(msg *message.Message) error {
 	default:
 		err := fmt.Errorf("unsupported entity delete event for: %s", inf.Type)
 		l.Err(err).Msg("error handling entity delete event")
-		return err
+		// Do not return the error, as we don't want to nack the message and retry
+		return nil
 	}
 }

--- a/internal/reconcilers/reconcilers.go
+++ b/internal/reconcilers/reconcilers.go
@@ -28,13 +28,6 @@ import (
 	providertelemetry "github.com/stacklok/minder/internal/providers/telemetry"
 )
 
-const (
-	// InternalReconcilerEventTopic is the topic for internal reconciler events
-	InternalReconcilerEventTopic = "internal.repo.reconciler.event"
-	// InternalProfileInitEventTopic is the topic for internal init events
-	InternalProfileInitEventTopic = "internal.profile.init.event"
-)
-
 // Reconciler is a helper that reconciles entities
 type Reconciler struct {
 	store               db.Store
@@ -96,6 +89,7 @@ func NewReconciler(
 
 // Register implements the Consumer interface.
 func (r *Reconciler) Register(reg events.Registrar) {
-	reg.Register(InternalReconcilerEventTopic, r.handleRepoReconcilerEvent)
-	reg.Register(InternalProfileInitEventTopic, r.handleProfileInitEvent)
+	reg.Register(events.TopicQueueReconcileRepoInit, r.handleRepoReconcilerEvent)
+	reg.Register(events.TopicQueueReconcileProfileInit, r.handleProfileInitEvent)
+	reg.Register(events.TopicQueueReconcileEntityDelete, r.handleEntityDeleteEvent)
 }

--- a/internal/reconcilers/repository.go
+++ b/internal/reconcilers/repository.go
@@ -20,7 +20,6 @@ import (
 	"errors"
 	"fmt"
 	"strings"
-	"time"
 
 	"github.com/ThreeDotsLabs/watermill/message"
 	"github.com/go-playground/validator/v10"
@@ -35,11 +34,6 @@ import (
 	"github.com/stacklok/minder/internal/util"
 	"github.com/stacklok/minder/internal/verifier/verifyif"
 	pb "github.com/stacklok/minder/pkg/api/protobuf/go/minder/v1"
-)
-
-var (
-	// ArtifactTypeContainerRetentionPeriod represents the retention period for container artifacts
-	ArtifactTypeContainerRetentionPeriod = time.Now().AddDate(0, -6, 0)
 )
 
 // RepoReconcilerEvent is an event that is sent to the reconciler topic

--- a/internal/repositories/github/service.go
+++ b/internal/repositories/github/service.go
@@ -254,7 +254,7 @@ func (r *repositoryService) pushReconcilerEvent(pbRepo *pb.Repository, projectID
 	}
 
 	// This is a non-fatal error, so we'll just log it and continue with the next ones
-	if err = r.eventProducer.Publish(reconcilers.InternalReconcilerEventTopic, msg); err != nil {
+	if err = r.eventProducer.Publish(events.TopicQueueReconcileRepoInit, msg); err != nil {
 		log.Printf("error publishing reconciler event: %v", err)
 	}
 


### PR DESCRIPTION
# Summary

The following PR:
* Attaches the webhook action event to the watermill message we publish
* Adds a new reconciler for processing entity `delete` events. Currently it has meaning only for artifact entities, but I've left it as a switch so if we decide to handle other events which mean a similar action for other entities we can easily extend it., i.e. closed for pull requests.
* Renamed and put all watermill event constants to be part of `./internal/events/constants.go`
* Added constants for webhook action events, i.e. "deleted", "opened", etc.
* Added handling for the use case when a webhook is deleted for a registered repo. 

Fixes https://github.com/stacklok/minder/issues/2927

## Change Type

***Mark the type of change your PR introduces:***

- [x] Bug fix (resolves an issue without affecting existing features)
- [ ] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [ ] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

- [x] I'd like to add a smoke test for this so we merge them in parallel - https://github.com/stacklok/minder-smoke-tests/pull/93

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [ ] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [ ] Included tests that validate the fix or feature.
- [ ] Checked that related changes are merged.
