### PR TITLE
Set security_invoker=true to use permissions on the underlying tables when creating new view

### DIFF
--- a/database/migrations/000047_entity_profiles_views.down.sql
+++ b/database/migrations/000047_entity_profiles_views.down.sql
@@ -1,0 +1,19 @@
+-- Copyright 2024 Stacklok, Inc
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--      http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+BEGIN;
+
+ALTER VIEW profiles_with_entity_profiles SET (security_invoker = false);
+
+COMMIT;

--- a/database/migrations/000047_entity_profiles_views.up.sql
+++ b/database/migrations/000047_entity_profiles_views.up.sql
@@ -1,0 +1,23 @@
+-- Copyright 2024 Stacklok, Inc
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--      http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+BEGIN;
+
+DROP VIEW profiles_with_entity_profiles;
+
+CREATE VIEW profiles_with_entity_profiles WITH (security_invoker = true) AS (
+    SELECT entity_profiles.*, profiles.id as profid FROM profiles LEFT JOIN entity_profiles ON profiles.id = entity_profiles.profile_id
+);
+
+COMMIT;


### PR DESCRIPTION
# Summary

This should avoid the issue we saw in staging where the view didn't inherit the default privileges for tables.  I did this as a drop/create on the "up" to remove the grants we put in place temporarily.

## Change Type

***Mark the type of change your PR introduces:***

- [x] Bug fix (resolves an issue without affecting existing features)
- [ ] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [ ] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

***Outline how the changes were tested, including steps to reproduce and any relevant configurations. 
Attach screenshots if helpful.***

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [x] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [ ] Included tests that validate the fix or feature.
- [x] Checked that related changes are merged.
