### PR TITLE
Bump docusaurus packages to 3.2.1

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -14,9 +14,9 @@
     "write-heading-ids": "docusaurus write-heading-ids"
   },
   "dependencies": {
-    "@docusaurus/core": "^3.2.0",
-    "@docusaurus/preset-classic": "^3.2.0",
-    "@docusaurus/theme-mermaid": "^3.2.0",
+    "@docusaurus/core": "3.2.1",
+    "@docusaurus/preset-classic": "3.2.1",
+    "@docusaurus/theme-mermaid": "3.2.1",
     "@mdx-js/react": "^3.0.1",
     "clsx": "^2.1.0",
     "docusaurus-protobuffet": "^0.3.3",

--- a/docs/yarn.lock
+++ b/docs/yarn.lock
@@ -1215,10 +1215,10 @@
     "@docsearch/css" "3.5.2"
     algoliasearch "^4.19.1"
 
-"@docusaurus/core@3.2.0", "@docusaurus/core@^3.2.0":
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/@docusaurus/core/-/core-3.2.0.tgz#10acb993fb76960890d1aa43025245aaa8dcdbbb"
-  integrity sha512-WTO6vW4404nhTmK9NL+95nd13I1JveFwZ8iOBYxb4xt+N2S3KzY+mm+1YtWw2vV37FbYfH+w+KrlrRaWuy5Hzw==
+"@docusaurus/core@3.2.1":
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/@docusaurus/core/-/core-3.2.1.tgz#e9216f9f642b2139541e21f9eebbdb11e12f66da"
+  integrity sha512-ZeMAqNvy0eBv2dThEeMuNzzuu+4thqMQakhxsgT5s02A8LqRcdkg+rbcnuNqUIpekQ4GRx3+M5nj0ODJhBXo9w==
   dependencies:
     "@babel/core" "^7.23.3"
     "@babel/generator" "^7.23.3"
@@ -1230,13 +1230,13 @@
     "@babel/runtime" "^7.22.6"
     "@babel/runtime-corejs3" "^7.22.6"
     "@babel/traverse" "^7.22.8"
-    "@docusaurus/cssnano-preset" "3.2.0"
-    "@docusaurus/logger" "3.2.0"
-    "@docusaurus/mdx-loader" "3.2.0"
+    "@docusaurus/cssnano-preset" "3.2.1"
+    "@docusaurus/logger" "3.2.1"
+    "@docusaurus/mdx-loader" "3.2.1"
     "@docusaurus/react-loadable" "5.5.2"
-    "@docusaurus/utils" "3.2.0"
-    "@docusaurus/utils-common" "3.2.0"
-    "@docusaurus/utils-validation" "3.2.0"
+    "@docusaurus/utils" "3.2.1"
+    "@docusaurus/utils-common" "3.2.1"
+    "@docusaurus/utils-validation" "3.2.1"
     "@svgr/webpack" "^6.5.1"
     autoprefixer "^10.4.14"
     babel-loader "^9.1.3"
@@ -1291,10 +1291,10 @@
     webpack-merge "^5.9.0"
     webpackbar "^5.0.2"
 
-"@docusaurus/cssnano-preset@3.2.0":
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/@docusaurus/cssnano-preset/-/cssnano-preset-3.2.0.tgz#0e0fbf19873a726f92e670b9d511e9f2828d6097"
-  integrity sha512-H88RXGUia7r/VF3XfyoA4kbwgpUZcKsObF6VvwBOP91EdArTf6lnHbJ/x8Ca79KS/zf98qaWyBGzW+5ez58Iyw==
+"@docusaurus/cssnano-preset@3.2.1":
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/@docusaurus/cssnano-preset/-/cssnano-preset-3.2.1.tgz#b36041004e837574d0147fcc4932210cdb1efbc1"
+  integrity sha512-wTL9KuSSbMJjKrfu385HZEzAoamUsbKqwscAQByZw4k6Ja/RWpqgVvt/CbAC+aYEH6inLzOt+MjuRwMOrD3VBA==
   dependencies:
     cssnano-preset-advanced "^5.3.10"
     postcss "^8.4.26"
@@ -1309,22 +1309,22 @@
     chalk "^4.1.2"
     tslib "^2.4.0"
 
-"@docusaurus/logger@3.2.0":
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/@docusaurus/logger/-/logger-3.2.0.tgz#99d2b09478bcba69c964ec0c8600d855fb8e9e0f"
-  integrity sha512-Z1R1NcOGXZ8CkIJSvjvyxnuDDSlx/+1xlh20iVTw1DZRjonFmI3T3tTgk40YpXyWUYQpIgAoqqPMpuseMMdgRQ==
+"@docusaurus/logger@3.2.1":
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/@docusaurus/logger/-/logger-3.2.1.tgz#6032e421b0b40a2379a3973dcd230d1be49afaa1"
+  integrity sha512-0voOKJCn9RaM3np6soqEfo7SsVvf2C+CDTWhW+H/1AyBhybASpExtDEz+7ECck9TwPzFQ5tt+I3zVugUJbJWDg==
   dependencies:
     chalk "^4.1.2"
     tslib "^2.6.0"
 
-"@docusaurus/mdx-loader@3.2.0":
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/@docusaurus/mdx-loader/-/mdx-loader-3.2.0.tgz#d17f17ae1bb38255643c82705dda719b23c27831"
-  integrity sha512-JtkI5o6R/rJSr1Y23cHKz085aBJCvJw3AYHihJ7r+mBX+O8EuQIynG0e6/XpbSCpr7Ino0U50UtxaXcEbFwg9Q==
+"@docusaurus/mdx-loader@3.2.1":
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/@docusaurus/mdx-loader/-/mdx-loader-3.2.1.tgz#bea07d47300a158537bc81553769acf72c91c6c3"
+  integrity sha512-Fs8tXhXKZjNkdGaOy1xSLXSwfjCMT73J3Zfrju2U16uGedRFRjgK0ojpK5tiC7TnunsL3tOFgp1BSMBRflX9gw==
   dependencies:
-    "@docusaurus/logger" "3.2.0"
-    "@docusaurus/utils" "3.2.0"
-    "@docusaurus/utils-validation" "3.2.0"
+    "@docusaurus/logger" "3.2.1"
+    "@docusaurus/utils" "3.2.1"
+    "@docusaurus/utils-validation" "3.2.1"
     "@mdx-js/mdx" "^3.0.0"
     "@slorber/remark-comment" "^1.0.0"
     escape-html "^1.0.3"
@@ -1347,21 +1347,7 @@
     vfile "^6.0.1"
     webpack "^5.88.1"
 
-"@docusaurus/module-type-aliases@3.2.0":
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/@docusaurus/module-type-aliases/-/module-type-aliases-3.2.0.tgz#ef883d8418f37e551eca72adc409014e720786d4"
-  integrity sha512-jRSp9YkvBwwNz6Xgy0RJPsnie+Ebb//gy7GdbkJ2pW2gvvlYKGib2+jSF0pfIzvyZLulfCynS1KQdvDKdSl8zQ==
-  dependencies:
-    "@docusaurus/react-loadable" "5.5.2"
-    "@docusaurus/types" "3.2.0"
-    "@types/history" "^4.7.11"
-    "@types/react" "*"
-    "@types/react-router-config" "*"
-    "@types/react-router-dom" "*"
-    react-helmet-async "*"
-    react-loadable "npm:@docusaurus/react-loadable@5.5.2"
-
-"@docusaurus/module-type-aliases@^3.2.1":
+"@docusaurus/module-type-aliases@3.2.1", "@docusaurus/module-type-aliases@^3.2.1":
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/@docusaurus/module-type-aliases/-/module-type-aliases-3.2.1.tgz#fa8fd746890825b4301db2ddbe29d7cfbeee0380"
   integrity sha512-FyViV5TqhL1vsM7eh29nJ5NtbRE6Ra6LP1PDcPvhwPSlA7eiWGRKAn3jWwMUcmjkos5SYY+sr0/feCdbM3eQHQ==
@@ -1375,18 +1361,18 @@
     react-helmet-async "*"
     react-loadable "npm:@docusaurus/react-loadable@5.5.2"
 
-"@docusaurus/plugin-content-blog@3.2.0":
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/@docusaurus/plugin-content-blog/-/plugin-content-blog-3.2.0.tgz#b7b43e71634272a80a9532dc166731332391cb4b"
-  integrity sha512-MABqwjSicyHmYEfQueMthPCz18JkVxhK3EGhXTSRWwReAZ0UTuw9pG6+Wo+uXAugDaIcJH28rVZSwTDINPm2bw==
+"@docusaurus/plugin-content-blog@3.2.1":
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/@docusaurus/plugin-content-blog/-/plugin-content-blog-3.2.1.tgz#1b28c45102abc4be1a57caba76672c5ccdacce63"
+  integrity sha512-lOx0JfhlGZoZu6pEJfeEpSISZR5dQbJGGvb42IP13G5YThNHhG9R9uoWuo4IOimPqBC7sHThdLA3VLevk61Fsw==
   dependencies:
-    "@docusaurus/core" "3.2.0"
-    "@docusaurus/logger" "3.2.0"
-    "@docusaurus/mdx-loader" "3.2.0"
-    "@docusaurus/types" "3.2.0"
-    "@docusaurus/utils" "3.2.0"
-    "@docusaurus/utils-common" "3.2.0"
-    "@docusaurus/utils-validation" "3.2.0"
+    "@docusaurus/core" "3.2.1"
+    "@docusaurus/logger" "3.2.1"
+    "@docusaurus/mdx-loader" "3.2.1"
+    "@docusaurus/types" "3.2.1"
+    "@docusaurus/utils" "3.2.1"
+    "@docusaurus/utils-common" "3.2.1"
+    "@docusaurus/utils-validation" "3.2.1"
     cheerio "^1.0.0-rc.12"
     feed "^4.2.2"
     fs-extra "^11.1.1"
@@ -1398,19 +1384,19 @@
     utility-types "^3.10.0"
     webpack "^5.88.1"
 
-"@docusaurus/plugin-content-docs@3.2.0":
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/@docusaurus/plugin-content-docs/-/plugin-content-docs-3.2.0.tgz#6e4f727a0cce301b9d9361bf41ca6a978fe79475"
-  integrity sha512-uuqhahmsBnirxOz+SXksnWt7+wc+iN4ntxNRH48BUgo7QRNLATWjHCgI8t6zrMJxK4o+QL9DhLaPDlFHs91B3Q==
+"@docusaurus/plugin-content-docs@3.2.1":
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/@docusaurus/plugin-content-docs/-/plugin-content-docs-3.2.1.tgz#d3a36239aa11392b0fbed2eaea105c17f64f50ef"
+  integrity sha512-GHe5b/lCskAR8QVbfWAfPAApvRZgqk7FN3sOHgjCtjzQACZxkHmq6QqyqZ8Jp45V7lVck4wt2Xw2IzBJ7Cz3bA==
   dependencies:
-    "@docusaurus/core" "3.2.0"
-    "@docusaurus/logger" "3.2.0"
-    "@docusaurus/mdx-loader" "3.2.0"
-    "@docusaurus/module-type-aliases" "3.2.0"
-    "@docusaurus/types" "3.2.0"
-    "@docusaurus/utils" "3.2.0"
-    "@docusaurus/utils-common" "3.2.0"
-    "@docusaurus/utils-validation" "3.2.0"
+    "@docusaurus/core" "3.2.1"
+    "@docusaurus/logger" "3.2.1"
+    "@docusaurus/mdx-loader" "3.2.1"
+    "@docusaurus/module-type-aliases" "3.2.1"
+    "@docusaurus/types" "3.2.1"
+    "@docusaurus/utils" "3.2.1"
+    "@docusaurus/utils-common" "3.2.1"
+    "@docusaurus/utils-validation" "3.2.1"
     "@types/react-router-config" "^5.0.7"
     combine-promises "^1.1.0"
     fs-extra "^11.1.1"
@@ -1420,96 +1406,96 @@
     utility-types "^3.10.0"
     webpack "^5.88.1"
 
-"@docusaurus/plugin-content-pages@3.2.0":
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/@docusaurus/plugin-content-pages/-/plugin-content-pages-3.2.0.tgz#df28a6ee6b52c4b292a726f29f39b119756caf44"
-  integrity sha512-4ofAN7JDsdb4tODO9OIrizWY5DmEJXr0eu+UDIkLqGP+gXXTahJZv8h2mlxO+lPXGXRCVBOfA14OG1hOYJVPwA==
+"@docusaurus/plugin-content-pages@3.2.1":
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/@docusaurus/plugin-content-pages/-/plugin-content-pages-3.2.1.tgz#7e04c470958147ec8bf72c05d3608f1bb8307aab"
+  integrity sha512-TOqVfMVTAHqWNEGM94Drz+PUpHDbwFy6ucHFgyTx9zJY7wPNSG5EN+rd/mU7OvAi26qpOn2o9xTdUmb28QLjEQ==
   dependencies:
-    "@docusaurus/core" "3.2.0"
-    "@docusaurus/mdx-loader" "3.2.0"
-    "@docusaurus/types" "3.2.0"
-    "@docusaurus/utils" "3.2.0"
-    "@docusaurus/utils-validation" "3.2.0"
+    "@docusaurus/core" "3.2.1"
+    "@docusaurus/mdx-loader" "3.2.1"
+    "@docusaurus/types" "3.2.1"
+    "@docusaurus/utils" "3.2.1"
+    "@docusaurus/utils-validation" "3.2.1"
     fs-extra "^11.1.1"
     tslib "^2.6.0"
     webpack "^5.88.1"
 
-"@docusaurus/plugin-debug@3.2.0":
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/@docusaurus/plugin-debug/-/plugin-debug-3.2.0.tgz#643d13d403685c2b9bdb3b65bec8050847b920a3"
-  integrity sha512-p6WxtO5XZGz66y6QNQtCJwBefq4S6/w75XaXVvH1/2P9uaijvF7R+Cm2EWQZ5WsvA5wl//DFWblyDHRyVC207Q==
+"@docusaurus/plugin-debug@3.2.1":
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/@docusaurus/plugin-debug/-/plugin-debug-3.2.1.tgz#59918ac654cbf0f7cf48d43fb9d944296d440784"
+  integrity sha512-AMKq8NuUKf2sRpN1m/sIbqbRbnmk+rSA+8mNU1LNxEl9BW9F/Gng8m9HKlzeyMPrf5XidzS1jqkuTLDJ6KIrFw==
   dependencies:
-    "@docusaurus/core" "3.2.0"
-    "@docusaurus/types" "3.2.0"
-    "@docusaurus/utils" "3.2.0"
+    "@docusaurus/core" "3.2.1"
+    "@docusaurus/types" "3.2.1"
+    "@docusaurus/utils" "3.2.1"
     fs-extra "^11.1.1"
     react-json-view-lite "^1.2.0"
     tslib "^2.6.0"
 
-"@docusaurus/plugin-google-analytics@3.2.0":
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/@docusaurus/plugin-google-analytics/-/plugin-google-analytics-3.2.0.tgz#770151947c0ee49500586e9200631852ab97e23a"
-  integrity sha512-//TepJTEyAZSvBwHKEbXHu9xT/VkK3wUil2ZakKvQZYfUC01uWn6A1E3toa8R7WhCy1xPUeIukqmJy1Clg8njQ==
+"@docusaurus/plugin-google-analytics@3.2.1":
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/@docusaurus/plugin-google-analytics/-/plugin-google-analytics-3.2.1.tgz#6cab8df9218b016ce508ff96dd39cf9c87cdc9e5"
+  integrity sha512-/rJ+9u+Px0eTCiF4TNcNtj3kHf8cp6K1HCwOTdbsSlz6Xn21syZYcy+f1VM9wF6HrvUkXUcbM5TDCvg2IRL6bQ==
   dependencies:
-    "@docusaurus/core" "3.2.0"
-    "@docusaurus/types" "3.2.0"
-    "@docusaurus/utils-validation" "3.2.0"
+    "@docusaurus/core" "3.2.1"
+    "@docusaurus/types" "3.2.1"
+    "@docusaurus/utils-validation" "3.2.1"
     tslib "^2.6.0"
 
-"@docusaurus/plugin-google-gtag@3.2.0":
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/@docusaurus/plugin-google-gtag/-/plugin-google-gtag-3.2.0.tgz#65fc7ddc242185c3a10e60308471564075229406"
-  integrity sha512-3s6zxlaMMb87MW2Rxy6EnSRDs0WDEQPuHilZZH402C8kOrUnIwlhlfjWZ4ZyLDziGl/Eec/DvD0PVqj0qHRomA==
+"@docusaurus/plugin-google-gtag@3.2.1":
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/@docusaurus/plugin-google-gtag/-/plugin-google-gtag-3.2.1.tgz#b54e6bfa0ca2efac5ed02fea39cbf069d2893a2c"
+  integrity sha512-XtuJnlMvYfppeVdUyKiDIJAa/gTJKCQU92z8CLZZ9ibJdgVjFOLS10s0hIC0eL5z0U2u2loJz2rZ63HOkNHbBA==
   dependencies:
-    "@docusaurus/core" "3.2.0"
-    "@docusaurus/types" "3.2.0"
-    "@docusaurus/utils-validation" "3.2.0"
+    "@docusaurus/core" "3.2.1"
+    "@docusaurus/types" "3.2.1"
+    "@docusaurus/utils-validation" "3.2.1"
     "@types/gtag.js" "^0.0.12"
     tslib "^2.6.0"
 
-"@docusaurus/plugin-google-tag-manager@3.2.0":
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/@docusaurus/plugin-google-tag-manager/-/plugin-google-tag-manager-3.2.0.tgz#730c28a43ff5073f595509c6cb77ce4311a2e369"
-  integrity sha512-rAKtsJ11vPHA7dTAqWCgyIy7AyFRF/lpI77Zd/4HKgqcIvIayVBvL3QtelhUazfYTLTH6ls6kQ9wjMcIFxRiGg==
+"@docusaurus/plugin-google-tag-manager@3.2.1":
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/@docusaurus/plugin-google-tag-manager/-/plugin-google-tag-manager-3.2.1.tgz#8b38237c154a377f6e199b77ecc871c6c6bb41a4"
+  integrity sha512-wiS/kE0Ny5pnjTxVCs8ljRnkL1RVMj59t6jmSsgEX7piDOoaXSMIUaoIt9ogS/v132uO0xEsxHstkRUZHQyPcQ==
   dependencies:
-    "@docusaurus/core" "3.2.0"
-    "@docusaurus/types" "3.2.0"
-    "@docusaurus/utils-validation" "3.2.0"
+    "@docusaurus/core" "3.2.1"
+    "@docusaurus/types" "3.2.1"
+    "@docusaurus/utils-validation" "3.2.1"
     tslib "^2.6.0"
 
-"@docusaurus/plugin-sitemap@3.2.0":
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/@docusaurus/plugin-sitemap/-/plugin-sitemap-3.2.0.tgz#cae7c92a8631072fff39dd5caf5ea7608c795540"
-  integrity sha512-gnWDFt6MStjLkdtt63Lzc+14EPSd8B6mzJGJp9GQMvWDUoMAUijUqpVIHYQq+DPMcI4PJZ5I2nsl5XFf1vOldA==
+"@docusaurus/plugin-sitemap@3.2.1":
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/@docusaurus/plugin-sitemap/-/plugin-sitemap-3.2.1.tgz#306b3e34cfbe38582ccbbd85d83ce0bdd0ae4cf7"
+  integrity sha512-uWZ7AxzdeaQSTCwD2yZtOiEm9zyKU+wqCmi/Sf25kQQqqFSBZUStXfaQ8OHP9cecnw893ZpZ811rPhB/wfujJw==
   dependencies:
-    "@docusaurus/core" "3.2.0"
-    "@docusaurus/logger" "3.2.0"
-    "@docusaurus/types" "3.2.0"
-    "@docusaurus/utils" "3.2.0"
-    "@docusaurus/utils-common" "3.2.0"
-    "@docusaurus/utils-validation" "3.2.0"
+    "@docusaurus/core" "3.2.1"
+    "@docusaurus/logger" "3.2.1"
+    "@docusaurus/types" "3.2.1"
+    "@docusaurus/utils" "3.2.1"
+    "@docusaurus/utils-common" "3.2.1"
+    "@docusaurus/utils-validation" "3.2.1"
     fs-extra "^11.1.1"
     sitemap "^7.1.1"
     tslib "^2.6.0"
 
-"@docusaurus/preset-classic@^3.2.0":
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/@docusaurus/preset-classic/-/preset-classic-3.2.0.tgz#f64d970eace76c61e4f1b4b7d85d9f69d4a2dd0e"
-  integrity sha512-t7tXyk8kUgT7hUqEOgSJnPs+Foem9ucuan/a9QVYaVFCDjp92Sb2FpCY8bVasAokYCjodYe2LfpAoSCj5YDYWg==
+"@docusaurus/preset-classic@3.2.1":
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/@docusaurus/preset-classic/-/preset-classic-3.2.1.tgz#25a18ebaf271ec91ab7430a76a9054f101593de1"
+  integrity sha512-E3OHSmttpEBcSMhfPBq3EJMBxZBM01W1rnaCUTXy9EHvkmB5AwgTfW1PwGAybPAX579ntE03R+2zmXdizWfKnQ==
   dependencies:
-    "@docusaurus/core" "3.2.0"
-    "@docusaurus/plugin-content-blog" "3.2.0"
-    "@docusaurus/plugin-content-docs" "3.2.0"
-    "@docusaurus/plugin-content-pages" "3.2.0"
-    "@docusaurus/plugin-debug" "3.2.0"
-    "@docusaurus/plugin-google-analytics" "3.2.0"
-    "@docusaurus/plugin-google-gtag" "3.2.0"
-    "@docusaurus/plugin-google-tag-manager" "3.2.0"
-    "@docusaurus/plugin-sitemap" "3.2.0"
-    "@docusaurus/theme-classic" "3.2.0"
-    "@docusaurus/theme-common" "3.2.0"
-    "@docusaurus/theme-search-algolia" "3.2.0"
-    "@docusaurus/types" "3.2.0"
+    "@docusaurus/core" "3.2.1"
+    "@docusaurus/plugin-content-blog" "3.2.1"
+    "@docusaurus/plugin-content-docs" "3.2.1"
+    "@docusaurus/plugin-content-pages" "3.2.1"
+    "@docusaurus/plugin-debug" "3.2.1"
+    "@docusaurus/plugin-google-analytics" "3.2.1"
+    "@docusaurus/plugin-google-gtag" "3.2.1"
+    "@docusaurus/plugin-google-tag-manager" "3.2.1"
+    "@docusaurus/plugin-sitemap" "3.2.1"
+    "@docusaurus/theme-classic" "3.2.1"
+    "@docusaurus/theme-common" "3.2.1"
+    "@docusaurus/theme-search-algolia" "3.2.1"
+    "@docusaurus/types" "3.2.1"
 
 "@docusaurus/react-loadable@5.5.2", "react-loadable@npm:@docusaurus/react-loadable@5.5.2":
   version "5.5.2"
@@ -1519,23 +1505,23 @@
     "@types/react" "*"
     prop-types "^15.6.2"
 
-"@docusaurus/theme-classic@3.2.0":
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/@docusaurus/theme-classic/-/theme-classic-3.2.0.tgz#4aa229f1a4b1b4c138a5c80089f1d8146f56252c"
-  integrity sha512-4oSO5BQOJ5ja7WYdL6jK1n4J96tp+VJHamdwao6Ea252sA3W3vvR0otTflG4p4XVjNZH6hlPQoi5lKW0HeRgfQ==
+"@docusaurus/theme-classic@3.2.1":
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/@docusaurus/theme-classic/-/theme-classic-3.2.1.tgz#0aea144bbbfa77b699f6eff7ffaeb36a1adc6c02"
+  integrity sha512-+vSbnQyoWjc6vRZi4vJO2dBU02wqzynsai15KK+FANZudrYaBHtkbLZAQhgmxzBGVpxzi87gRohlMm+5D8f4tA==
   dependencies:
-    "@docusaurus/core" "3.2.0"
-    "@docusaurus/mdx-loader" "3.2.0"
-    "@docusaurus/module-type-aliases" "3.2.0"
-    "@docusaurus/plugin-content-blog" "3.2.0"
-    "@docusaurus/plugin-content-docs" "3.2.0"
-    "@docusaurus/plugin-content-pages" "3.2.0"
-    "@docusaurus/theme-common" "3.2.0"
-    "@docusaurus/theme-translations" "3.2.0"
-    "@docusaurus/types" "3.2.0"
-    "@docusaurus/utils" "3.2.0"
-    "@docusaurus/utils-common" "3.2.0"
-    "@docusaurus/utils-validation" "3.2.0"
+    "@docusaurus/core" "3.2.1"
+    "@docusaurus/mdx-loader" "3.2.1"
+    "@docusaurus/module-type-aliases" "3.2.1"
+    "@docusaurus/plugin-content-blog" "3.2.1"
+    "@docusaurus/plugin-content-docs" "3.2.1"
+    "@docusaurus/plugin-content-pages" "3.2.1"
+    "@docusaurus/theme-common" "3.2.1"
+    "@docusaurus/theme-translations" "3.2.1"
+    "@docusaurus/types" "3.2.1"
+    "@docusaurus/utils" "3.2.1"
+    "@docusaurus/utils-common" "3.2.1"
+    "@docusaurus/utils-validation" "3.2.1"
     "@mdx-js/react" "^3.0.0"
     clsx "^2.0.0"
     copy-text-to-clipboard "^3.2.0"
@@ -1550,18 +1536,18 @@
     tslib "^2.6.0"
     utility-types "^3.10.0"
 
-"@docusaurus/theme-common@3.2.0":
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/@docusaurus/theme-common/-/theme-common-3.2.0.tgz#67f5f1a1e265e1f1a5b9fa7bfb4bf7b98dfcf981"
-  integrity sha512-sFbw9XviNJJ+760kAcZCQMQ3jkNIznGqa6MQ70E5BnbP+ja36kGgPOfjcsvAcNey1H1Rkhh3p2Mhf4HVLdKVVw==
+"@docusaurus/theme-common@3.2.1":
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/@docusaurus/theme-common/-/theme-common-3.2.1.tgz#017b0cf05de2a4fa7b117ee44f25a3e8541c8bb9"
+  integrity sha512-d+adiD7L9xv6EvfaAwUqdKf4orsM3jqgeqAM+HAjgL/Ux0GkVVnfKr+tsoe+4ow4rHe6NUt+nkkW8/K8dKdilA==
   dependencies:
-    "@docusaurus/mdx-loader" "3.2.0"
-    "@docusaurus/module-type-aliases" "3.2.0"
-    "@docusaurus/plugin-content-blog" "3.2.0"
-    "@docusaurus/plugin-content-docs" "3.2.0"
-    "@docusaurus/plugin-content-pages" "3.2.0"
-    "@docusaurus/utils" "3.2.0"
-    "@docusaurus/utils-common" "3.2.0"
+    "@docusaurus/mdx-loader" "3.2.1"
+    "@docusaurus/module-type-aliases" "3.2.1"
+    "@docusaurus/plugin-content-blog" "3.2.1"
+    "@docusaurus/plugin-content-docs" "3.2.1"
+    "@docusaurus/plugin-content-pages" "3.2.1"
+    "@docusaurus/utils" "3.2.1"
+    "@docusaurus/utils-common" "3.2.1"
     "@types/history" "^4.7.11"
     "@types/react" "*"
     "@types/react-router-config" "*"
@@ -1571,32 +1557,32 @@
     tslib "^2.6.0"
     utility-types "^3.10.0"
 
-"@docusaurus/theme-mermaid@^3.2.0":
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/@docusaurus/theme-mermaid/-/theme-mermaid-3.2.0.tgz#b6d43b853ccc562a9c0be28e1100dad6324b8a8f"
-  integrity sha512-PvN6K6m3JaM9cr9oSPyba6OlwAiSfBzqQtNqdgPFDjakKuT4kj6JODfExi+HKtWuxayOVRQlRl7zTnWxM4sTVw==
+"@docusaurus/theme-mermaid@3.2.1":
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/@docusaurus/theme-mermaid/-/theme-mermaid-3.2.1.tgz#ee17d8d2115f0c4a046427ade3c7a77fe4dfbf6f"
+  integrity sha512-l1FzUPgDUor/25XeJDeO22dttmzB0QnmAbF2qKjDz3ENa9vlD5rd5r0NrItZIe8y7qoa+OOxkl5lLBKBxBVbLg==
   dependencies:
-    "@docusaurus/core" "3.2.0"
-    "@docusaurus/module-type-aliases" "3.2.0"
-    "@docusaurus/theme-common" "3.2.0"
-    "@docusaurus/types" "3.2.0"
-    "@docusaurus/utils-validation" "3.2.0"
+    "@docusaurus/core" "3.2.1"
+    "@docusaurus/module-type-aliases" "3.2.1"
+    "@docusaurus/theme-common" "3.2.1"
+    "@docusaurus/types" "3.2.1"
+    "@docusaurus/utils-validation" "3.2.1"
     mermaid "^10.4.0"
     tslib "^2.6.0"
 
-"@docusaurus/theme-search-algolia@3.2.0":
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/@docusaurus/theme-search-algolia/-/theme-search-algolia-3.2.0.tgz#05338b37753dd13899fb0296f2c57130e9893dbf"
-  integrity sha512-PgvF4qHoqJp8+GfqClUbTF/zYNOsz4De251IuzXon7+7FAXwvb2qmYtA2nEwyMbB7faKOz33Pxzv+y+153KS/g==
+"@docusaurus/theme-search-algolia@3.2.1":
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/@docusaurus/theme-search-algolia/-/theme-search-algolia-3.2.1.tgz#6617d43ab0726b744bf8e32eb8533417c0d66b7d"
+  integrity sha512-bzhCrpyXBXzeydNUH83II2akvFEGfhsNTPPWsk5N7e+odgQCQwoHhcF+2qILbQXjaoZ6B3c48hrvkyCpeyqGHw==
   dependencies:
     "@docsearch/react" "^3.5.2"
-    "@docusaurus/core" "3.2.0"
-    "@docusaurus/logger" "3.2.0"
-    "@docusaurus/plugin-content-docs" "3.2.0"
-    "@docusaurus/theme-common" "3.2.0"
-    "@docusaurus/theme-translations" "3.2.0"
-    "@docusaurus/utils" "3.2.0"
-    "@docusaurus/utils-validation" "3.2.0"
+    "@docusaurus/core" "3.2.1"
+    "@docusaurus/logger" "3.2.1"
+    "@docusaurus/plugin-content-docs" "3.2.1"
+    "@docusaurus/theme-common" "3.2.1"
+    "@docusaurus/theme-translations" "3.2.1"
+    "@docusaurus/utils" "3.2.1"
+    "@docusaurus/utils-validation" "3.2.1"
     algoliasearch "^4.18.0"
     algoliasearch-helper "^3.13.3"
     clsx "^2.0.0"
@@ -1606,28 +1592,13 @@
     tslib "^2.6.0"
     utility-types "^3.10.0"
 
-"@docusaurus/theme-translations@3.2.0":
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/@docusaurus/theme-translations/-/theme-translations-3.2.0.tgz#02a0e9bd0ed8cebc21a2f1e5b6d252b0e5ee39a9"
-  integrity sha512-VXzZJBuyVEmwUYyud+7IgJQEBRM6R2u/s10Rp3DOP19CBQxeKgHYTKkKhFtDeKMHDassb665kjgOi0YlJfUT6w==
+"@docusaurus/theme-translations@3.2.1":
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/@docusaurus/theme-translations/-/theme-translations-3.2.1.tgz#894f6cb5bb121aa45a4a5f1383b70a8e3ae6a5d9"
+  integrity sha512-jAUMkIkFfY+OAhJhv6mV8zlwY6J4AQxJPTgLdR2l+Otof9+QdJjHNh/ifVEu9q0lp3oSPlJj9l05AaP7Ref+cg==
   dependencies:
     fs-extra "^11.1.1"
     tslib "^2.6.0"
-
-"@docusaurus/types@3.2.0":
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/@docusaurus/types/-/types-3.2.0.tgz#c5bfd000ad4f72e9a7e6beff79905f9ea165fcd3"
-  integrity sha512-uG3FfTkkkbZIPPNYx6xRfZHKeGyRd/inIT1cqvYt1FobFLd+7WhRXrSBqwJ9JajJjEAjNioRMVFgGofGf/Wdww==
-  dependencies:
-    "@mdx-js/mdx" "^3.0.0"
-    "@types/history" "^4.7.11"
-    "@types/react" "*"
-    commander "^5.1.0"
-    joi "^17.9.2"
-    react-helmet-async "^1.3.0"
-    utility-types "^3.10.0"
-    webpack "^5.88.1"
-    webpack-merge "^5.9.0"
 
 "@docusaurus/types@3.2.1":
   version "3.2.1"
@@ -1644,32 +1615,32 @@
     webpack "^5.88.1"
     webpack-merge "^5.9.0"
 
-"@docusaurus/utils-common@3.2.0":
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/@docusaurus/utils-common/-/utils-common-3.2.0.tgz#6163a2c415d150d6df73a8aceec6004f0ba3bb06"
-  integrity sha512-WEQT5L2lT/tBQgDRgeZQAIi9YJBrwEILb1BuObQn1St3T/4K1gx5fWwOT8qdLOov296XLd1FQg9Ywu27aE9svw==
+"@docusaurus/utils-common@3.2.1":
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/@docusaurus/utils-common/-/utils-common-3.2.1.tgz#c275fd9984951244cc4f595ce6dfd0522e40c68d"
+  integrity sha512-N5vadULnRLiqX2QfTjVEU3u5vo6RG2EZTdyXvJdzDOdrLCGIZAfnf/VkssinFZ922sVfaFfQ4FnStdhn5TWdVg==
   dependencies:
     tslib "^2.6.0"
 
-"@docusaurus/utils-validation@3.2.0":
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/@docusaurus/utils-validation/-/utils-validation-3.2.0.tgz#b53463d9dc6eb335a2ad93ed4b3c397162533e6d"
-  integrity sha512-rCzMTqwNrBrEOyU8EaD1fYWdig4TDhfj+YLqB8DY68VUAqSIgbY+yshpqFKB0bznFYNBJbn0bGpvVuImQOa/vA==
+"@docusaurus/utils-validation@3.2.1":
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/@docusaurus/utils-validation/-/utils-validation-3.2.1.tgz#42ff0d2ae11c81d199ea485f27b86b40779673ed"
+  integrity sha512-+x7IR9hNMXi62L1YAglwd0s95fR7+EtirjTxSN4kahYRWGqOi3jlQl1EV0az/yTEvKbxVvOPcdYicGu9dk4LJw==
   dependencies:
-    "@docusaurus/logger" "3.2.0"
-    "@docusaurus/utils" "3.2.0"
-    "@docusaurus/utils-common" "3.2.0"
+    "@docusaurus/logger" "3.2.1"
+    "@docusaurus/utils" "3.2.1"
+    "@docusaurus/utils-common" "3.2.1"
     joi "^17.9.2"
     js-yaml "^4.1.0"
     tslib "^2.6.0"
 
-"@docusaurus/utils@3.2.0":
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/@docusaurus/utils/-/utils-3.2.0.tgz#1312221d224eb2cbaaaf53d24efca3e1e976db3e"
-  integrity sha512-3rgrE7iL60yV2JQivlcoxUNNTK2APmn+OHLUmTvX2pueIM8DEOCEFHpJO4MiWjFO7V/Wq3iA/W1M03JnjdugVw==
+"@docusaurus/utils@3.2.1":
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/@docusaurus/utils/-/utils-3.2.1.tgz#25247d071618bc7ece9bbc3d59f3ee1ac3ded727"
+  integrity sha512-DPkIS/EPc+pGAV798PUXgNzJFM3HJouoQXgr0KDZuJVz1EkWbDLOcQwLIz8Qx7liI9ddfkN/TXTRQdsTPZNakw==
   dependencies:
-    "@docusaurus/logger" "3.2.0"
-    "@docusaurus/utils-common" "3.2.0"
+    "@docusaurus/logger" "3.2.1"
+    "@docusaurus/utils-common" "3.2.1"
     "@svgr/webpack" "^6.5.1"
     escape-string-regexp "^4.0.0"
     file-loader "^6.2.0"


### PR DESCRIPTION
# Summary

Seems like dependabot has trouble updating the docusaurus packages
one-by-one.

I ran this instead:
```
yarn add @docusaurus/core@3.2.1 @docusaurus/preset-classic@3.2.1
@docusaurus/theme-mermaid@3.2.1 @docusaurus/core@3.2.1
```

And checked that `yarn build` and `yarn serve` still works and I can
browse the documentation.

## Change Type

***Mark the type of change your PR introduces:***

- [x] Bug fix (resolves an issue without affecting existing features)
- [ ] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [ ] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

see above

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [ ] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [ ] Included tests that validate the fix or feature.
- [ ] Checked that related changes are merged.
