### PR TITLE
Create Getting Started > Overview page

### DIFF
--- a/docs/docs/getting_started/overview
+++ b/docs/docs/getting_started/overview
@@ -1,0 +1,2 @@
+## Outlines the different ways to get started with Minder, like: Minder UI, Minder CLI, Minder GitHub App, Minder REST API, Minder self-hosted instance
+## Inspiration: https://docs.socket.dev/docs/getting-started


### PR DESCRIPTION
Adds a new page to Minder documentation called Overview, in the Getting Started section, where we list the different options for using Minder. 
