### PR TITLE
A nicer error message when listing remote repos without an enrolled provider

### DIFF
--- a/internal/controlplane/handlers_repositories.go
+++ b/internal/controlplane/handlers_repositories.go
@@ -73,6 +73,10 @@ func (s *Server) RegisterRepository(
 
 	provider, err := s.inferProviderByOwner(ctx, githubRepo.GetOwner(), projectID, providerName)
 	if err != nil {
+		pErr := providers.ErrProviderNotFoundBy{}
+		if errors.As(err, &pErr) {
+			return nil, util.UserVisibleError(codes.NotFound, "no suitable provider found, please enroll a provider")
+		}
 		return nil, status.Errorf(codes.Internal, "cannot get provider: %v", err)
 	}
 
@@ -323,6 +327,10 @@ func (s *Server) ListRemoteRepositoriesFromProvider(
 	providerName := in.GetContext().GetProvider()
 	provs, err := s.providerStore.GetByNameAndTrait(ctx, projectID, providerName, db.ProviderTypeRepoLister)
 	if err != nil {
+		pErr := providers.ErrProviderNotFoundBy{}
+		if errors.As(err, &pErr) {
+			return nil, util.UserVisibleError(codes.NotFound, "no suitable provider found, please enroll a provider")
+		}
 		return nil, providerError(err)
 	}
 


### PR DESCRIPTION
# Summary

Our error message when trying to enroll a repository without a provider was less than ideal.

Before:
```
Message: Error getting list of remote repos
Details: NotFound means some requested entity (e.g., file or directory) was
not found.
```

After:
```
Message: Error getting list of remote repos
Details: no suitable provider found, please enroll a provider
```

## Change Type

***Mark the type of change your PR introduces:***

- [x] Bug fix (resolves an issue without affecting existing features)
- [ ] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [ ] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

minder repo register without a provider

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [ ] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [ ] Included tests that validate the fix or feature.
- [ ] Checked that related changes are merged.
