### PR TITLE
Use fallback token for listing artifacts with GH App

### DIFF
--- a/cmd/dev/app/container/cmd_verify.go
+++ b/cmd/dev/app/container/cmd_verify.go
@@ -128,6 +128,7 @@ func buildGitHubClient(token string) (provifv1.GitHub, error) {
 		false,
 		credentials.NewGitHubTokenCredential(token),
 		&serverconfig.ProviderConfig{},
+		nil, // this is unused here
 	)
 
 	return pbuild.GetGitHub()

--- a/cmd/dev/app/rule_type/rttst.go
+++ b/cmd/dev/app/rule_type/rttst.go
@@ -176,6 +176,7 @@ func testCmdRun(cmd *cobra.Command, _ []string) error {
 				AppName: "test",
 			},
 		},
+		nil, // this is unused here
 	))
 	inf := &entities.EntityInfoWrapper{
 		Entity:      ent,

--- a/cmd/server/app/serve.go
+++ b/cmd/server/app/serve.go
@@ -131,8 +131,7 @@ var serveCmd = &cobra.Command{
 			reconcilers.WithRestClientCache(restClientCache),
 		}
 
-		return service.AllInOneServerService(ctx, cfg, store, vldtr,
-			serverOpts, executorOpts, reconcilerOpts)
+		return service.AllInOneServerService(ctx, cfg, store, vldtr, serverOpts, executorOpts, reconcilerOpts)
 	},
 }
 

--- a/cmd/server/app/webhook_update.go
+++ b/cmd/server/app/webhook_update.go
@@ -96,9 +96,11 @@ func runCmdWebhookUpdate(cmd *cobra.Command, _ []string) error {
 		return fmt.Errorf("unable to parse webhook url: %w", err)
 	}
 
+	fallbackTokenClient := ghprovider.NewFallbackTokenClient(cfg.Provider)
+
 	for _, provider := range allProviders {
 		zerolog.Ctx(ctx).Info().Str("name", provider.Name).Str("uuid", provider.ID.String()).Msg("provider")
-		pb, err := providers.GetProviderBuilder(ctx, provider, store, cryptoEng, &cfg.Provider)
+		pb, err := providers.GetProviderBuilder(ctx, provider, store, cryptoEng, &cfg.Provider, fallbackTokenClient)
 		if err != nil {
 			return fmt.Errorf("unable to get provider builder: %w", err)
 		}

--- a/deployment/helm/templates/deployment.yaml
+++ b/deployment/helm/templates/deployment.yaml
@@ -79,6 +79,8 @@ spec:
             value: "/secrets/github-app/github_app_private_key"
           - name: "MINDER_PROVIDER_GITHUB_APP_WEBHOOK_SECRET"
             value: "/secrets/github-app/github_app_webhook_secret"
+          - name: "MINDER_PROVIDER_GITHUB_APP_FALLBACK_TOKEN"
+            value: "/secrets/github-app/github_app_fallback_token"
           {{- if .Values.deploymentSettings.extraEnv }}
           {{- toYaml .Values.deploymentSettings.extraEnv | nindent 10 }}
           {{- end }}

--- a/internal/config/server/github_app.go
+++ b/internal/config/server/github_app.go
@@ -36,6 +36,8 @@ type GitHubAppConfig struct {
 	PrivateKey string `mapstructure:"private_key"`
 	// WebhookSecret is the GitHub App's webhook secret
 	WebhookSecret string `mapstructure:"webhook_secret"`
+	// FallbackToken is the fallback token to use when listing packages
+	FallbackToken string `mapstructure:"fallback_token"`
 }
 
 // GetPrivateKey returns the GitHub App's private key

--- a/internal/controlplane/handlers_githubwebhooks.go
+++ b/internal/controlplane/handlers_githubwebhooks.go
@@ -422,7 +422,8 @@ func (s *Server) parseGithubEventForProcessing(
 		providers.WithProviderMetrics(s.provMt),
 		providers.WithRestClientCache(s.restClientCache),
 	}
-	provBuilder, err := providers.GetProviderBuilder(ctx, *prov, s.store, s.cryptoEngine, &s.cfg.Provider, pbOpts...)
+	provBuilder, err := providers.GetProviderBuilder(ctx, *prov, s.store, s.cryptoEngine, &s.cfg.Provider,
+		s.fallbackTokenClient, pbOpts...)
 	if err != nil {
 		return fmt.Errorf("error building client: %w", err)
 	}

--- a/internal/controlplane/handlers_providers.go
+++ b/internal/controlplane/handlers_providers.go
@@ -226,7 +226,8 @@ func (s *Server) deleteProvider(ctx context.Context, provider *db.Provider, proj
 		providers.WithRestClientCache(s.restClientCache),
 	}
 
-	p, err := providers.GetProviderBuilder(ctx, *provider, s.store, s.cryptoEngine, &s.cfg.Provider, pbOpts...)
+	p, err := providers.GetProviderBuilder(ctx, *provider, s.store, s.cryptoEngine, &s.cfg.Provider,
+		s.fallbackTokenClient, pbOpts...)
 	if err != nil {
 		return status.Errorf(codes.Internal, "cannot get provider builder: %v", err)
 	}

--- a/internal/controlplane/handlers_repositories.go
+++ b/internal/controlplane/handlers_repositories.go
@@ -343,7 +343,8 @@ func (s *Server) ListRemoteRepositoriesFromProvider(
 			providers.WithProviderMetrics(s.provMt),
 			providers.WithRestClientCache(s.restClientCache),
 		}
-		p, err := providers.GetProviderBuilder(ctx, provider, s.store, s.cryptoEngine, &s.cfg.Provider, pbOpts...)
+		p, err := providers.GetProviderBuilder(ctx, provider, s.store, s.cryptoEngine, &s.cfg.Provider,
+			s.fallbackTokenClient, pbOpts...)
 		if err != nil {
 			zerolog.Ctx(ctx).Error().Err(err).Msg("cannot get provider builder")
 			erroringProviders = append(erroringProviders, provider.Name)
@@ -494,7 +495,7 @@ func (s *Server) getClientForProvider(
 		providers.WithRestClientCache(s.restClientCache),
 	}
 
-	p, err := providers.GetProviderBuilder(ctx, provider, s.store, s.cryptoEngine, &s.cfg.Provider, pbOpts...)
+	p, err := providers.GetProviderBuilder(ctx, provider, s.store, s.cryptoEngine, &s.cfg.Provider, s.fallbackTokenClient, pbOpts...)
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "cannot get provider builder: %v", err)
 	}

--- a/internal/controlplane/server.go
+++ b/internal/controlplane/server.go
@@ -22,6 +22,7 @@ import (
 	"net/http"
 	"time"
 
+	gh "github.com/google/go-github/v60/github"
 	"github.com/gorilla/handlers"
 	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
@@ -89,13 +90,14 @@ type Server struct {
 	// We may want to start breaking up the server struct if we use it to
 	// inject more entity-specific interfaces. For example, we may want to
 	// consider having a struct per grpc service
-	ruleTypes     ruletypes.RuleTypeService
-	repos         github.RepositoryService
-	profiles      profiles.ProfileService
-	providers     providers.ProviderService
-	marketplace   marketplaces.Marketplace
-	providerStore providers.ProviderStore
-	ghClient      ghprov.ClientService
+	ruleTypes           ruletypes.RuleTypeService
+	repos               github.RepositoryService
+	profiles            profiles.ProfileService
+	providers           providers.ProviderService
+	marketplace         marketplaces.Marketplace
+	providerStore       providers.ProviderStore
+	ghClient            ghprov.ClientService
+	fallbackTokenClient *gh.Client
 
 	// Implementations for service registration
 	pb.UnimplementedHealthServiceServer
@@ -164,6 +166,7 @@ func NewServer(
 	if err != nil {
 		return nil, fmt.Errorf("failed to create marketplace: %w", err)
 	}
+	fallbackTokenClient := ghprov.NewFallbackTokenClient(cfg.Provider)
 
 	s := &Server{
 		store:               store,
@@ -180,6 +183,7 @@ func NewServer(
 		marketplace:         marketplace,
 		providerStore:       providerStore,
 		ghClient:            &ghprov.ClientServiceImplementation{},
+		fallbackTokenClient: fallbackTokenClient,
 		// TODO: this currently always returns authorized as a transitionary measure.
 		// When OpenFGA is fully rolled out, we may want to make this a hard error or set to false.
 		authzClient: &mock.NoopClient{Authorized: true},
@@ -191,7 +195,7 @@ func NewServer(
 
 	// Moved here because we have a dependency on s.restClientCache
 	s.providers = providers.NewProviderService(
-		store, eng, mt, provMt, &cfg.Provider, s.makeProjectForGitHubApp, s.restClientCache)
+		store, eng, mt, provMt, &cfg.Provider, s.makeProjectForGitHubApp, s.restClientCache, s.fallbackTokenClient)
 
 	return s, nil
 }

--- a/internal/engine/actions/remediate/gh_branch_protect/gh_branch_protect_test.go
+++ b/internal/engine/actions/remediate/gh_branch_protect/gh_branch_protect_test.go
@@ -71,6 +71,7 @@ func testGithubProviderBuilder(baseURL string) *providers.ProviderBuilder {
 		false,
 		credentials.NewGitHubTokenCredential("token"),
 		&serverconfig.ProviderConfig{},
+		nil, // this is unused here
 	)
 }
 

--- a/internal/engine/actions/remediate/pull_request/pull_request_test.go
+++ b/internal/engine/actions/remediate/pull_request/pull_request_test.go
@@ -109,6 +109,7 @@ func testGithubProviderBuilder() *providers.ProviderBuilder {
 		false,
 		credentials.NewGitHubTokenCredential("token"),
 		&serverconfig.ProviderConfig{},
+		nil, // this is unused here
 	)
 }
 

--- a/internal/engine/actions/remediate/remediate_test.go
+++ b/internal/engine/actions/remediate/remediate_test.go
@@ -55,6 +55,7 @@ var (
 		false,
 		credentials.NewGitHubTokenCredential("token"),
 		&serverconfig.ProviderConfig{},
+		nil, // this is unused here
 	)
 )
 

--- a/internal/engine/actions/remediate/rest/rest_test.go
+++ b/internal/engine/actions/remediate/rest/rest_test.go
@@ -61,6 +61,7 @@ var (
 		false,
 		credentials.NewGitHubTokenCredential("token"),
 		&serverconfig.ProviderConfig{},
+		nil, // this is unused here
 	)
 	invalidProviderBuilder = providers.NewProviderBuilder(
 		&db.Provider{
@@ -78,6 +79,7 @@ var (
 		false,
 		credentials.NewGitHubTokenCredential("token"),
 		&serverconfig.ProviderConfig{},
+		nil, // this is unused here
 	)
 	TestActionTypeValid interfaces.ActionType = "remediate-test"
 )
@@ -104,6 +106,7 @@ func testGithubProviderBuilder(baseURL string) *providers.ProviderBuilder {
 		false,
 		credentials.NewGitHubTokenCredential("token"),
 		&serverconfig.ProviderConfig{},
+		nil, // this is unused here
 	)
 }
 

--- a/internal/engine/executor_test.go
+++ b/internal/engine/executor_test.go
@@ -302,7 +302,7 @@ default allow = true`,
 
 	e, err := engine.NewExecutor(ctx, mockStore, &serverconfig.AuthConfig{
 		TokenKey: tokenKeyPath,
-	}, nil, evt, providers.NewProviderStore(mockStore))
+	}, &serverconfig.ProviderConfig{}, evt, providers.NewProviderStore(mockStore))
 	require.NoError(t, err, "expected no error")
 
 	eiw := entities.NewEntityInfoWrapper().

--- a/internal/engine/ingester/artifact/artifact_test.go
+++ b/internal/engine/ingester/artifact/artifact_test.go
@@ -62,6 +62,7 @@ func testGithubProviderBuilder() *providers.ProviderBuilder {
 		false,
 		credentials.NewGitHubTokenCredential("token"),
 		&serverconfig.ProviderConfig{},
+		nil, // this is unused here
 	)
 }
 

--- a/internal/engine/ingester/git/git_test.go
+++ b/internal/engine/ingester/git/git_test.go
@@ -49,6 +49,7 @@ func TestGitIngestWithCloneURLFromRepo(t *testing.T) {
 		false,
 		credentials.NewEmptyCredential(),
 		&serverconfig.ProviderConfig{},
+		nil, // this is unused here
 	))
 	require.NoError(t, err, "expected no error")
 
@@ -88,6 +89,7 @@ func TestGitIngestWithCloneURLFromParams(t *testing.T) {
 		false,
 		credentials.NewEmptyCredential(),
 		&serverconfig.ProviderConfig{},
+		nil, // this is unused here
 	))
 	require.NoError(t, err, "expected no error")
 
@@ -127,6 +129,7 @@ func TestGitIngestWithCustomBranchFromParams(t *testing.T) {
 		false,
 		credentials.NewEmptyCredential(),
 		&serverconfig.ProviderConfig{},
+		nil, // this is unused here
 	))
 	require.NoError(t, err, "expected no error")
 
@@ -166,6 +169,7 @@ func TestGitIngestWithBranchFromRepoEntity(t *testing.T) {
 			false,
 			credentials.NewEmptyCredential(),
 			&serverconfig.ProviderConfig{},
+			nil, // this is unused here
 		))
 	require.NoError(t, err, "expected no error")
 
@@ -207,6 +211,7 @@ func TestGitIngestWithUnexistentBranchFromParams(t *testing.T) {
 		false,
 		credentials.NewEmptyCredential(),
 		&serverconfig.ProviderConfig{},
+		nil, // this is unused here
 	))
 	require.NoError(t, err, "expected no error")
 
@@ -237,6 +242,7 @@ func TestGitIngestFailsBecauseOfAuthorization(t *testing.T) {
 		false,
 		credentials.NewGitHubTokenCredential("foobar"),
 		&serverconfig.ProviderConfig{},
+		nil, // this is unused here
 	),
 	)
 	require.NoError(t, err, "expected no error")
@@ -265,6 +271,7 @@ func TestGitIngestFailsBecauseOfUnexistentCloneUrl(t *testing.T) {
 		// No authentication is the right thing in this case.
 		credentials.NewEmptyCredential(),
 		&serverconfig.ProviderConfig{},
+		nil, // this is unused here
 	))
 	require.NoError(t, err, "expected no error")
 

--- a/internal/engine/ingester/ingester_test.go
+++ b/internal/engine/ingester/ingester_test.go
@@ -182,6 +182,7 @@ func TestNewRuleDataIngest(t *testing.T) {
 				false,
 				credentials.NewGitHubTokenCredential("token"),
 				&serverconfig.ProviderConfig{},
+				nil, // this is unused here
 			))
 			if tt.wantErr {
 				require.Error(t, err, "Expected error")

--- a/internal/engine/ingester/rest/rest_test.go
+++ b/internal/engine/ingester/rest/rest_test.go
@@ -72,6 +72,7 @@ func TestNewRestRuleDataIngest(t *testing.T) {
 					false,
 					credentials.NewGitHubTokenCredential("token"),
 					&serverconfig.ProviderConfig{},
+					nil, // this is unused here
 				),
 			},
 			wantErr: false,
@@ -99,6 +100,7 @@ func TestNewRestRuleDataIngest(t *testing.T) {
 					false,
 					credentials.NewGitHubTokenCredential("token"),
 					&serverconfig.ProviderConfig{},
+					nil, // this is unused here
 				),
 			},
 			wantErr: true,
@@ -126,6 +128,7 @@ func TestNewRestRuleDataIngest(t *testing.T) {
 					false,
 					credentials.NewGitHubTokenCredential("token"),
 					&serverconfig.ProviderConfig{},
+					nil, // this is unused here
 				),
 			},
 			wantErr: true,
@@ -148,6 +151,7 @@ func TestNewRestRuleDataIngest(t *testing.T) {
 					false,
 					credentials.NewGitHubTokenCredential("token"),
 					&serverconfig.ProviderConfig{},
+					nil, // this is unused here
 				),
 			},
 			wantErr: true,
@@ -175,6 +179,7 @@ func TestNewRestRuleDataIngest(t *testing.T) {
 					false,
 					credentials.NewGitHubTokenCredential("token"),
 					&serverconfig.ProviderConfig{},
+					nil, // this is unused here
 				),
 			},
 			wantErr: true,
@@ -201,6 +206,7 @@ func TestNewRestRuleDataIngest(t *testing.T) {
 					false,
 					credentials.NewGitHubTokenCredential("token"),
 					&serverconfig.ProviderConfig{},
+					nil, // this is unused here
 				),
 			},
 			wantErr: true,
@@ -247,6 +253,7 @@ func testGithubProviderBuilder(baseURL string) *providers.ProviderBuilder {
 		false,
 		credentials.NewGitHubTokenCredential("token"),
 		&serverconfig.ProviderConfig{},
+		nil, // this is unused here
 	)
 }
 

--- a/internal/providers/github/app/app.go
+++ b/internal/providers/github/app/app.go
@@ -70,6 +70,7 @@ func NewGitHubAppProvider(
 	metrics telemetry.HttpClientMetrics,
 	restClientCache ratecache.RestClientCache,
 	credential provifv1.GitHubCredential,
+	packageListingClient *gogithub.Client,
 	isOrg bool,
 ) (*github.GitHub, error) {
 	var err error
@@ -109,6 +110,8 @@ func NewGitHubAppProvider(
 
 	return github.NewGitHub(
 		ghClient,
+		// Use the fallback token for package listing, since fine-grained tokens don't have access
+		packageListingClient,
 		restClientCache,
 		oauthDelegate,
 	), nil

--- a/internal/providers/github/app/app_test.go
+++ b/internal/providers/github/app/app_test.go
@@ -16,8 +16,10 @@ package app
 
 import (
 	"context"
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"strconv"
 	"sync"
 	"testing"
@@ -26,6 +28,7 @@ import (
 	"github.com/google/go-github/v60/github"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
 
 	config "github.com/stacklok/minder/internal/config/server"
 	"github.com/stacklok/minder/internal/db"
@@ -45,6 +48,7 @@ func TestNewGitHubAppProvider(t *testing.T) {
 		&config.GitHubAppConfig{},
 		provtelemetry.NewNoopMetrics(),
 		nil, credentials.NewGitHubTokenCredential("token"),
+		github.NewClient(http.DefaultClient),
 		false,
 	)
 
@@ -70,6 +74,7 @@ func TestUserInfo(t *testing.T) {
 		},
 		provtelemetry.NewNoopMetrics(),
 		nil, credentials.NewGitHubTokenCredential("token"),
+		github.NewClient(http.DefaultClient),
 		false,
 	)
 	assert.NoError(t, err)
@@ -155,12 +160,18 @@ func TestArtifactAPIEscapes(t *testing.T) {
 			testServer := httptest.NewServer(tt.testHandler)
 			defer testServer.Close()
 
+			packageListingClient := github.NewClient(http.DefaultClient)
+			testServerUrl, err := url.Parse(testServer.URL + "/")
+			assert.NoError(t, err)
+			packageListingClient.BaseURL = testServerUrl
+
 			client, err := NewGitHubAppProvider(&minderv1.GitHubAppProviderConfig{
 				Endpoint: testServer.URL + "/",
 			},
 				&config.GitHubAppConfig{},
 				provtelemetry.NewNoopMetrics(),
 				nil, credentials.NewGitHubTokenCredential("token"),
+				packageListingClient,
 				true,
 			)
 			assert.NoError(t, err)
@@ -170,6 +181,101 @@ func TestArtifactAPIEscapes(t *testing.T) {
 		})
 	}
 
+}
+
+func TestListPackagesByRepository(t *testing.T) {
+	t.Parallel()
+
+	accessToken := "token"
+	repositoryId := int64(1234)
+	gitHubPackage := github.Package{
+		Name: github.String("test-package"),
+		Repository: &github.Repository{
+			ID: github.Int64(repositoryId),
+		},
+	}
+
+	tests := []struct {
+		name          string
+		testHandler   http.HandlerFunc
+		ExpectedError string
+	}{
+		{
+			name: "ListPackagesByRepository returns matching package",
+			testHandler: func(w http.ResponseWriter, r *http.Request) {
+				assert.Equal(t, "/orgs/owner/packages?package_type=repo&page=1&per_page=1", r.URL.RequestURI())
+				data := []github.Package{gitHubPackage}
+				w.Header().Add("Content-Type", "application/json")
+				w.WriteHeader(http.StatusOK)
+				err := json.NewEncoder(w).Encode(data)
+				if err != nil {
+					t.Fatal(err)
+				}
+			},
+		},
+		{
+			name: "ListPackagesByRepository filters out non-matching packages",
+			testHandler: func(w http.ResponseWriter, r *http.Request) {
+				assert.Equal(t, "/orgs/owner/packages?package_type=repo&page=1&per_page=1", r.URL.RequestURI())
+				packageOtherRepo := github.Package{
+					Name: github.String("other-package"),
+					Repository: &github.Repository{
+						ID: github.Int64(5678),
+					},
+				}
+				data := []github.Package{gitHubPackage, packageOtherRepo}
+				w.Header().Add("Content-Type", "application/json")
+				w.WriteHeader(http.StatusOK)
+				err := json.NewEncoder(w).Encode(data)
+				if err != nil {
+					t.Fatal(err)
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			testServer := httptest.NewServer(tt.testHandler)
+			defer testServer.Close()
+
+			packageListingClient := github.NewClient(http.DefaultClient)
+			testServerUrl, err := url.Parse(testServer.URL + "/")
+			assert.NoError(t, err)
+			packageListingClient.BaseURL = testServerUrl
+
+			provider, err := NewGitHubAppProvider(
+				&minderv1.GitHubAppProviderConfig{},
+				&config.GitHubAppConfig{
+					FallbackToken: accessToken,
+				},
+				provtelemetry.NewNoopMetrics(),
+				nil,
+				credentials.NewGitHubTokenCredential(accessToken),
+				packageListingClient,
+				true,
+			)
+			assert.NoError(t, err)
+			assert.NotNil(t, provider)
+
+			packages, err := provider.ListPackagesByRepository(context.Background(), "owner", "repo", repositoryId, 1, 1)
+			if tt.ExpectedError == "" {
+				assert.NoError(t, err)
+				assert.Len(t, packages, 1)
+				assert.Equal(t, gitHubPackage.Name, packages[0].Name)
+			} else {
+				assert.Error(t, err)
+			}
+
+		})
+	}
 }
 
 func TestWaitForRateLimitReset(t *testing.T) {
@@ -190,12 +296,18 @@ func TestWaitForRateLimitReset(t *testing.T) {
 	}))
 	defer server.Close()
 
+	packageListingClient := github.NewClient(http.DefaultClient)
+	testServerUrl, err := url.Parse(server.URL + "/")
+	assert.NoError(t, err)
+	packageListingClient.BaseURL = testServerUrl
+
 	client, err := NewGitHubAppProvider(
 		&minderv1.GitHubAppProviderConfig{Endpoint: server.URL + "/"},
 		&config.GitHubAppConfig{},
 		provtelemetry.NewNoopMetrics(),
 		ratecache.NewRestClientCache(context.Background()),
 		credentials.NewGitHubTokenCredential(token),
+		packageListingClient,
 		false,
 	)
 	require.NoError(t, err)
@@ -235,6 +347,11 @@ func TestConcurrentWaitForRateLimitReset(t *testing.T) {
 	}))
 	defer server.Close()
 
+	packageListingClient := github.NewClient(http.DefaultClient)
+	testServerUrl, err := url.Parse(server.URL + "/")
+	assert.NoError(t, err)
+	packageListingClient.BaseURL = testServerUrl
+
 	wg := sync.WaitGroup{}
 
 	wg.Add(1)
@@ -247,6 +364,7 @@ func TestConcurrentWaitForRateLimitReset(t *testing.T) {
 			provtelemetry.NewNoopMetrics(),
 			restClientCache,
 			credentials.NewGitHubTokenCredential(token),
+			packageListingClient,
 			false,
 		)
 		require.NoError(t, err)

--- a/internal/providers/github/oauth/oauth.go
+++ b/internal/providers/github/oauth/oauth.go
@@ -104,6 +104,7 @@ func NewRestClient(
 
 	return github.NewGitHub(
 		ghClient,
+		ghClient, // use the same client for listing packages and all other operations
 		restClientCache,
 		oauthDelegate,
 	), nil

--- a/internal/providers/service.go
+++ b/internal/providers/service.go
@@ -81,29 +81,31 @@ type ProjectFactory func(
 	ctx context.Context, qtx db.Querier, name string, user int64) (*db.Project, error)
 
 type providerService struct {
-	store           db.Store
-	cryptoEngine    crypto.Engine
-	mt              metrics.Metrics
-	provMt          provtelemetry.ProviderMetrics
-	config          *server.ProviderConfig
-	projectFactory  ProjectFactory
-	restClientCache ratecache.RestClientCache
-	ghClientService ghprov.ClientService
+	store               db.Store
+	cryptoEngine        crypto.Engine
+	mt                  metrics.Metrics
+	provMt              provtelemetry.ProviderMetrics
+	config              *server.ProviderConfig
+	projectFactory      ProjectFactory
+	restClientCache     ratecache.RestClientCache
+	ghClientService     ghprov.ClientService
+	fallbackTokenClient *github.Client
 }
 
 // NewProviderService creates an instance of ProviderService
 func NewProviderService(store db.Store, cryptoEngine crypto.Engine, mt metrics.Metrics,
 	provMt provtelemetry.ProviderMetrics, config *server.ProviderConfig,
-	projectFactory ProjectFactory, restClientCache ratecache.RestClientCache) ProviderService {
+	projectFactory ProjectFactory, restClientCache ratecache.RestClientCache, fallbackTokenClient *github.Client) ProviderService {
 	return &providerService{
-		store:           store,
-		cryptoEngine:    cryptoEngine,
-		mt:              mt,
-		provMt:          provMt,
-		config:          config,
-		projectFactory:  projectFactory,
-		restClientCache: restClientCache,
-		ghClientService: ghprov.ClientServiceImplementation{},
+		store:               store,
+		cryptoEngine:        cryptoEngine,
+		mt:                  mt,
+		provMt:              provMt,
+		config:              config,
+		projectFactory:      projectFactory,
+		restClientCache:     restClientCache,
+		ghClientService:     ghprov.ClientServiceImplementation{},
+		fallbackTokenClient: fallbackTokenClient,
 	}
 }
 
@@ -456,7 +458,7 @@ func (p *providerService) verifyProviderTokenIdentity(
 		WithRestClientCache(p.restClientCache),
 	}
 	builder := NewProviderBuilder(&provider, sql.NullString{}, false, credentials.NewGitHubTokenCredential(token),
-		p.config, pbOpts...)
+		p.config, p.fallbackTokenClient, pbOpts...)
 	// NOTE: this is github-specific at the moment.  We probably need to generally
 	// re-think token enrollment when we add more providers.
 	ghClient, err := builder.GetGitHub()

--- a/internal/providers/service_test.go
+++ b/internal/providers/service_test.go
@@ -27,6 +27,8 @@ import (
 	"encoding/pem"
 	"errors"
 	"net/http"
+	"net/http/httptest"
+	"net/url"
 	"os"
 	"strconv"
 	"testing"
@@ -78,6 +80,15 @@ func testNewProviderService(
 	}
 	require.NoError(t, err)
 
+	testServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer testServer.Close()
+	packageListingClient := github.NewClient(http.DefaultClient)
+	testServerUrl, err := url.Parse(testServer.URL + "/")
+	require.NoError(t, err)
+	packageListingClient.BaseURL = testServerUrl
+
 	psi := NewProviderService(
 		mocks.fakeStore,
 		mocks.cryptoMocks,
@@ -86,6 +97,7 @@ func testNewProviderService(
 		config,
 		projectFactory,
 		mockratecache.NewMockRestClientCache(mockCtrl),
+		packageListingClient,
 	)
 
 	ps, ok := psi.(*providerService)

--- a/internal/reconcilers/artifacts.go
+++ b/internal/reconcilers/artifacts.go
@@ -107,7 +107,7 @@ func (r *Reconciler) handleArtifactsReconcilerEvent(ctx context.Context, evt *Re
 		providers.WithProviderMetrics(r.provMt),
 		providers.WithRestClientCache(r.restClientCache),
 	}
-	p, err := providers.GetProviderBuilder(ctx, prov, r.store, r.crypteng, r.provCfg, pbOpts...)
+	p, err := providers.GetProviderBuilder(ctx, prov, r.store, r.crypteng, r.provCfg, r.fallbackTokenClient, pbOpts...)
 	if err != nil {
 		return fmt.Errorf("error building client: %w", err)
 	}

--- a/internal/reconcilers/reconcilers.go
+++ b/internal/reconcilers/reconcilers.go
@@ -17,10 +17,13 @@
 package reconcilers
 
 import (
+	gogithub "github.com/google/go-github/v60/github"
+
 	serverconfig "github.com/stacklok/minder/internal/config/server"
 	"github.com/stacklok/minder/internal/crypto"
 	"github.com/stacklok/minder/internal/db"
 	"github.com/stacklok/minder/internal/events"
+	"github.com/stacklok/minder/internal/providers/github"
 	"github.com/stacklok/minder/internal/providers/ratecache"
 	providertelemetry "github.com/stacklok/minder/internal/providers/telemetry"
 )
@@ -34,12 +37,13 @@ const (
 
 // Reconciler is a helper that reconciles entities
 type Reconciler struct {
-	store           db.Store
-	evt             events.Publisher
-	crypteng        crypto.Engine
-	restClientCache ratecache.RestClientCache
-	provCfg         *serverconfig.ProviderConfig
-	provMt          providertelemetry.ProviderMetrics
+	store               db.Store
+	evt                 events.Publisher
+	crypteng            crypto.Engine
+	restClientCache     ratecache.RestClientCache
+	provCfg             *serverconfig.ProviderConfig
+	provMt              providertelemetry.ProviderMetrics
+	fallbackTokenClient *gogithub.Client
 }
 
 // ReconcilerOption is a function that modifies a reconciler
@@ -72,12 +76,15 @@ func NewReconciler(
 		return nil, err
 	}
 
+	fallbackTokenClient := github.NewFallbackTokenClient(*provCfg)
+
 	r := &Reconciler{
-		store:    store,
-		evt:      evt,
-		crypteng: crypteng,
-		provCfg:  provCfg,
-		provMt:   providertelemetry.NewNoopMetrics(),
+		store:               store,
+		evt:                 evt,
+		crypteng:            crypteng,
+		provCfg:             provCfg,
+		provMt:              providertelemetry.NewNoopMetrics(),
+		fallbackTokenClient: fallbackTokenClient,
 	}
 
 	for _, opt := range opts {


### PR DESCRIPTION
# Summary

Add a fallback token that will be used when listing artifacts from a GitHub app provider, since the installation token cannot access that API.

This also adds rate limit handling to the `ListPackagesByRepository`.

The fallback token, generated from bot accounts, is already added to infra and AWS secrets manager for both staging and prod.

Fixes https://github.com/stacklok/epics/issues/280

## Change Type

***Mark the type of change your PR introduces:***

- [x] Bug fix (resolves an issue without affecting existing features)
- [ ] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [ ] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

***Outline how the changes were tested, including steps to reproduce and any relevant configurations. 
Attach screenshots if helpful.***

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [x] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [x] Included tests that validate the fix or feature.
- [x] Checked that related changes are merged.
