### PR TITLE
Handle when the user declines T&C in minder auth login

### DIFF
--- a/cmd/cli/app/auth/html/access_denied.html
+++ b/cmd/cli/app/auth/html/access_denied.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<!--
+ Copyright 2024 Stacklok, Inc
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Authentication Failed</title>
+  <style>
+    .main {
+      font-family: Arial, sans-serif;
+      text-align: center;
+      margin-top: 20vh;
+    }
+
+    h1 {
+      margin-bottom: 20px;
+    }
+  </style>
+</head>
+<body>
+<div class="main">
+  <h1>Access Denied</h1>
+  <p>You need to access the terms of service before continuing</p>
+</div>
+</body>
+</html>

--- a/cmd/cli/app/auth/html/generic_failure.html
+++ b/cmd/cli/app/auth/html/generic_failure.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<!--
+ Copyright 2024 Stacklok, Inc
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Authentication Failed</title>
+  <style>
+    .main {
+      font-family: Arial, sans-serif;
+      text-align: center;
+      margin-top: 20vh;
+    }
+
+    h1 {
+      margin-bottom: 20px;
+    }
+  </style>
+</head>
+<body>
+<div class="main">
+  <h1>Access Denied</h1>
+</div>
+</body>
+</html>


### PR DESCRIPTION
# Summary

When the user doesn't accept keycloak T&C, then KC redirects back to the
callback handler. Unfortunately the details are a bit sparse and the
only thing we get is the parameter `errorType` set to `access_denied`

This PR extends the Relaying Party with an error handler that aborts the
login process by sending the error parameter as an error-like type
upwards and displays an HTML rendered page in the login browser

Fixes: https://github.com/stacklok/epics/issues/297

## Change Type

***Mark the type of change your PR introduces:***

- [ ] Bug fix (resolves an issue without affecting existing features)
- [x] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [ ] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

1) enable ToC in your keycloak instance. In the left panel, select the right realm, then from the left menu select Authentication.
You'll see 'Terms and Conditions' in the list. Click both "Enabled" and "Set as default action".
2) `minder auth login`.
3) make sure you need to accept the terms and conditions before logging in

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [ ] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [ ] Included tests that validate the fix or feature.
- [ ] Checked that related changes are merged.
