### PR TITLE
Issue a bespoke profile update message on patching a profile

### DIFF
--- a/internal/controlplane/handlers_profile.go
+++ b/internal/controlplane/handlers_profile.go
@@ -34,6 +34,7 @@ import (
 	"github.com/stacklok/minder/internal/engine/entities"
 	"github.com/stacklok/minder/internal/logger"
 	prof "github.com/stacklok/minder/internal/profiles"
+	"github.com/stacklok/minder/internal/reconcilers"
 	"github.com/stacklok/minder/internal/util"
 	minderv1 "github.com/stacklok/minder/pkg/api/protobuf/go/minder/v1"
 )
@@ -605,6 +606,18 @@ func (s *Server) PatchProfile(ctx context.Context, ppr *minderv1.PatchProfileReq
 	updatedProfile, err := getProfilePBFromDB(ctx, profileID, entityCtx, s.store)
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "failed to get profile: %s", err)
+	}
+
+	// This is temporary technical debt until we merge PR #2990
+	// re-trigger profile evaluation
+	msg, err := reconcilers.NewProfileInitMessage(entityCtx.Project.ID)
+	if err != nil {
+		zerolog.Ctx(ctx).Err(err).Msg("error creating reconciler event message")
+	} else {
+		// This is a non-fatal error, so we'll just log it and continue with the next ones
+		if err := s.evt.Publish(reconcilers.InternalProfileInitEventTopic, msg); err != nil {
+			zerolog.Ctx(ctx).Err(err).Msg("error publishing reconciler event message")
+		}
 	}
 
 	resp := &minderv1.PatchProfileResponse{


### PR DESCRIPTION
# Summary

I forgot to issue a profile update message on patching a profile. Since
the profile update message is currently nicely encapsulated in
`sendNewProfileEvent` which is a private method of the Profile service
and we already have PR #2990 that would move all of the Patch
functionality to that service and remove the current Patch handler
implementation, I decided to create a bespoke message for now.

This code will be removed once we merge PR #2990.

## Change Type

***Mark the type of change your PR introduces:***

- [x] Bug fix (resolves an issue without affecting existing features)
- [ ] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [ ] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

1) create a profile with remediate: off
2) patch the profile to have remediate: on
3) with this PR, the profile should re-evaluate

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [ ] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [ ] Included tests that validate the fix or feature.
- [ ] Checked that related changes are merged.
