### PR TITLE
CLI: Print applicable entity when getting rule type info

### DIFF
--- a/cmd/cli/app/ruletype/common.go
+++ b/cmd/cli/app/ruletype/common.go
@@ -123,6 +123,7 @@ func oneRuleTypeToRows(t table.Table, rt *minderv1.RuleType) {
 	t.AddRow("ID", *rt.Id)
 	t.AddRow("Name", rt.Name)
 	t.AddRow("Description", rt.Description)
+	t.AddRow("Applicable Entity", rt.GetDef().InEntity)
 	t.AddRow("Project", *rt.Context.Project)
 	t.AddRow("Ingest type", rt.Def.Ingest.Type)
 	t.AddRow("Eval type", rt.Def.Eval.Type)


### PR DESCRIPTION
# Summary

This prints the applicable entity as part of the table output
for rule types. A sample looks as follows:

```bash
$ minder ruletype get -n stacklok/trivy_action_enabled
+-------------------+---------------------------------------------------------------------------------------+
|     RULE TYPE     |                                        DETAILS                                        |
+-------------------+---------------------------------------------------------------------------------------+
| ID                | 2244c88f-0c07-4c52-be45-9191a77d085d                                                  |
+-------------------+---------------------------------------------------------------------------------------+
| Name              | stacklok/trivy_action_enabled                                                         |
+-------------------+---------------------------------------------------------------------------------------+
| Description       | Verifies that the Trivy action is enabled for the repository and scanning             |
+-------------------+---------------------------------------------------------------------------------------+
...
```

## Change Type

***Mark the type of change your PR introduces:***

- [ ] Bug fix (resolves an issue without affecting existing features)
- [x] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [ ] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [ ] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [ ] Included tests that validate the fix or feature.
- [ ] Checked that related changes are merged.
