### PR TITLE
Uninstall GitHub Apps when a user account is deleted

### DIFF
--- a/cmd/server/app/serve.go
+++ b/cmd/server/app/serve.go
@@ -103,11 +103,6 @@ var serveCmd = &cobra.Command{
 			return fmt.Errorf("unable to prepare authz client for run: %w", err)
 		}
 
-		err = controlplane.SubscribeToIdentityEvents(ctx, store, authzc, cfg)
-		if err != nil {
-			return fmt.Errorf("unable to subscribe to identity server events: %w", err)
-		}
-
 		providerMetrics := provtelemetry.NewProviderMetrics()
 		restClientCache := ratecache.NewRestClientCache(ctx)
 		defer restClientCache.Close()

--- a/internal/controlplane/handlers_projects.go
+++ b/internal/controlplane/handlers_projects.go
@@ -194,7 +194,7 @@ func (s *Server) DeleteProject(
 		Str("operation", "delete").
 		Str("project", projectID.String()).
 		Logger()
-	if err := projects.DeleteProject(ctx, projectID, qtx, s.authzClient, l); err != nil {
+	if err := projects.DeleteProject(ctx, projectID, qtx, s.authzClient, s.providers, l); err != nil {
 		return nil, status.Errorf(codes.Internal, "error deleting project: %v", err)
 	}
 

--- a/internal/controlplane/handlers_user.go
+++ b/internal/controlplane/handlers_user.go
@@ -166,7 +166,7 @@ func (s *Server) DeleteUser(ctx context.Context,
 
 	subject := token.Subject()
 
-	err = DeleteUser(ctx, s.store, s.authzClient, subject)
+	err = DeleteUser(ctx, s.store, s.authzClient, s.providers, subject)
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "failed to delete user from database: %v", err)
 	}

--- a/internal/controlplane/identity_events_test.go
+++ b/internal/controlplane/identity_events_test.go
@@ -35,6 +35,7 @@ import (
 	serverconfig "github.com/stacklok/minder/internal/config/server"
 	"github.com/stacklok/minder/internal/db"
 	"github.com/stacklok/minder/internal/db/embedded"
+	mockprofsvc "github.com/stacklok/minder/internal/providers/mock"
 	minderv1 "github.com/stacklok/minder/pkg/api/protobuf/go/minder/v1"
 )
 
@@ -87,7 +88,7 @@ func TestHandleEvents(t *testing.T) {
 			},
 		},
 	}
-	HandleEvents(context.Background(), mockStore, &mock.NoopClient{Authorized: true}, &c)
+	HandleEvents(context.Background(), mockStore, &mock.NoopClient{Authorized: true}, &c, mockprofsvc.NewMockProviderService(ctrl))
 }
 
 func TestDeleteUserOneProject(t *testing.T) {
@@ -126,8 +127,11 @@ func TestDeleteUserOneProject(t *testing.T) {
 		},
 	}
 
+	ctrl := gomock.NewController(t)
+	providerService := mockprofsvc.NewMockProviderService(ctrl)
+
 	t.Log("Deleting user")
-	err = DeleteUser(ctx, store, &authzClient, u1.IdentitySubject)
+	err = DeleteUser(ctx, store, &authzClient, providerService, u1.IdentitySubject)
 	assert.NoError(t, err, "DeleteUser failed")
 
 	t.Log("Checking if user is removed from project")

--- a/internal/controlplane/server.go
+++ b/internal/controlplane/server.go
@@ -205,6 +205,11 @@ func (s *Server) GetProviderService() providers.ProviderService {
 	return s.providers
 }
 
+// GetAuthzClient returns the authz client
+func (s *Server) GetAuthzClient() authz.Client {
+	return s.authzClient
+}
+
 func (s *Server) initTracer() (*sdktrace.TracerProvider, error) {
 	// create a stdout exporter to show collected spans out to stdout.
 	exporter, err := stdout.New(stdout.WithPrettyPrint())

--- a/internal/providers/service.go
+++ b/internal/providers/service.go
@@ -386,6 +386,13 @@ type GitHubAppInstallationDeletedPayload struct {
 func (p *providerService) DeleteGitHubAppInstallation(ctx context.Context, installationID int64) error {
 	installation, err := p.store.GetInstallationIDByAppID(ctx, installationID)
 	if err != nil {
+		// This installation has already been deleted
+		if errors.Is(err, sql.ErrNoRows) {
+			zerolog.Ctx(ctx).Info().
+				Int64("installationID", installationID).
+				Msg("Installation already deleted")
+			return nil
+		}
 		return fmt.Errorf("error getting installation: %w", err)
 	}
 

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -60,6 +60,12 @@ func AllInOneServerService(
 		return fmt.Errorf("unable to create server: %w", err)
 	}
 
+	// Subscribe to events from the identity server
+	err = controlplane.SubscribeToIdentityEvents(ctx, store, s.GetAuthzClient(), cfg, s.GetProviderService())
+	if err != nil {
+		return fmt.Errorf("unable to subscribe to identity server events: %w", err)
+	}
+
 	aggr := eea.NewEEA(store, evt, &cfg.Events.Aggregator)
 
 	// consume flush-all events


### PR DESCRIPTION

# Summary

This cleans up the providers when the user account is deleted.
It also instantiates the identity server event subscription in the `AllInOneService` so that it has access to the `ProviderService`.

Fixes #2958

## Change Type

***Mark the type of change your PR introduces:***

- [x] Bug fix (resolves an issue without affecting existing features)
- [ ] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [ ] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

***Outline how the changes were tested, including steps to reproduce and any relevant configurations. 
Attach screenshots if helpful.***

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [x] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [x] Included tests that validate the fix or feature.
- [x] Checked that related changes are merged.
