### PR TITLE
Use ProviderID in telemetry data

### DIFF
--- a/internal/controlplane/handlers_artifacts.go
+++ b/internal/controlplane/handlers_artifacts.go
@@ -42,6 +42,10 @@ func (s *Server) ListArtifacts(ctx context.Context, in *pb.ListArtifactsRequest)
 	projectID := entityCtx.Project.ID
 	providerName := entityCtx.Provider.Name
 
+	// Telemetry logging
+	logger.BusinessRecord(ctx).Provider = providerName
+	logger.BusinessRecord(ctx).Project = projectID
+
 	artifactFilter, err := parseArtifactListFrom(s.store, in.From)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse artifact list from: %w", err)
@@ -51,10 +55,6 @@ func (s *Server) ListArtifacts(ctx context.Context, in *pb.ListArtifactsRequest)
 	if err != nil {
 		return nil, fmt.Errorf("failed to list artifacts: %w", err)
 	}
-
-	// Telemetry logging
-	logger.BusinessRecord(ctx).Provider = providerName
-	logger.BusinessRecord(ctx).Project = projectID
 
 	return &pb.ListArtifactsResponse{Results: results}, nil
 }
@@ -70,7 +70,10 @@ func (s *Server) GetArtifactByName(ctx context.Context, in *pb.GetArtifactByName
 
 	entityCtx := engine.EntityFromContext(ctx)
 	projectID := entityCtx.Project.ID
-	providerFilter := getNameFilterParam(entityCtx.Provider.Name)
+	providerName := entityCtx.Provider.Name
+	providerFilter := getNameFilterParam(providerName)
+
+	logger.BusinessRecord(ctx).Provider = providerName
 
 	// the artifact name is the rest of the parts
 	artifactName := strings.Join(nameParts[2:], "/")
@@ -108,7 +111,7 @@ func (s *Server) GetArtifactByName(ctx context.Context, in *pb.GetArtifactByName
 	}
 
 	// Telemetry logging
-	logger.BusinessRecord(ctx).Provider = artifact.ProviderName
+	logger.BusinessRecord(ctx).ProviderID = artifact.ProviderID
 	logger.BusinessRecord(ctx).Project = artifact.ProjectID
 	logger.BusinessRecord(ctx).Artifact = artifact.ID
 
@@ -154,7 +157,7 @@ func (s *Server) GetArtifactById(ctx context.Context, in *pb.GetArtifactByIdRequ
 	}
 
 	// Telemetry logging
-	logger.BusinessRecord(ctx).Provider = artifact.ProviderName
+	logger.BusinessRecord(ctx).ProviderID = artifact.ProviderID
 	logger.BusinessRecord(ctx).Project = artifact.ProjectID
 	logger.BusinessRecord(ctx).Artifact = artifact.ID
 	if artifact.RepositoryID.Valid {

--- a/internal/controlplane/handlers_oauth.go
+++ b/internal/controlplane/handlers_oauth.go
@@ -499,6 +499,7 @@ func (s *Server) VerifyProviderTokenFrom(ctx context.Context,
 	providerName := entityCtx.Provider.Name
 
 	// Telemetry logging
+	logger.BusinessRecord(ctx).Provider = in.GetContext().GetProvider()
 	logger.BusinessRecord(ctx).Project = projectID
 
 	if providerName == "" {

--- a/internal/controlplane/handlers_reconciliationtasks.go
+++ b/internal/controlplane/handlers_reconciliationtasks.go
@@ -100,7 +100,8 @@ func getRepositoryReconciliationMessage(ctx context.Context, store db.Store,
 	}
 
 	// Telemetry logging
-	logger.BusinessRecord(ctx).Provider = repo.Provider
+	// TODO: Change to ProviderID
+	logger.BusinessRecord(ctx).ProviderID = repo.ProviderID
 	logger.BusinessRecord(ctx).Project = repo.ProjectID
 	logger.BusinessRecord(ctx).Repository = repo.ID
 

--- a/internal/controlplane/handlers_reconciliationtasks.go
+++ b/internal/controlplane/handlers_reconciliationtasks.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"database/sql"
 	"errors"
-	"github.com/stacklok/minder/internal/logger"
 
 	"github.com/ThreeDotsLabs/watermill/message"
 	"github.com/google/uuid"
@@ -29,6 +28,7 @@ import (
 	"github.com/stacklok/minder/internal/db"
 	"github.com/stacklok/minder/internal/engine"
 	"github.com/stacklok/minder/internal/events"
+	"github.com/stacklok/minder/internal/logger"
 	"github.com/stacklok/minder/internal/reconcilers"
 	pb "github.com/stacklok/minder/pkg/api/protobuf/go/minder/v1"
 )

--- a/internal/controlplane/handlers_reconciliationtasks.go
+++ b/internal/controlplane/handlers_reconciliationtasks.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"database/sql"
 	"errors"
+	"github.com/stacklok/minder/internal/logger"
 
 	"github.com/ThreeDotsLabs/watermill/message"
 	"github.com/google/uuid"
@@ -28,7 +29,6 @@ import (
 	"github.com/stacklok/minder/internal/db"
 	"github.com/stacklok/minder/internal/engine"
 	"github.com/stacklok/minder/internal/events"
-	"github.com/stacklok/minder/internal/logger"
 	"github.com/stacklok/minder/internal/reconcilers"
 	pb "github.com/stacklok/minder/pkg/api/protobuf/go/minder/v1"
 )
@@ -90,6 +90,11 @@ func getRepositoryReconciliationMessage(ctx context.Context, store db.Store,
 		return nil, status.Errorf(codes.Internal, "cannot read repository: %v", err)
 	}
 
+	// Telemetry logging
+	logger.BusinessRecord(ctx).ProviderID = repo.ProviderID
+	logger.BusinessRecord(ctx).Project = repo.ProjectID
+	logger.BusinessRecord(ctx).Repository = repo.ID
+
 	if repo.Provider != entityCtx.Provider.Name {
 		return nil, status.Errorf(codes.NotFound, "repository not found")
 	}
@@ -98,12 +103,6 @@ func getRepositoryReconciliationMessage(ctx context.Context, store db.Store,
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "error getting reconciler message: %v", err)
 	}
-
-	// Telemetry logging
-	// TODO: Change to ProviderID
-	logger.BusinessRecord(ctx).ProviderID = repo.ProviderID
-	logger.BusinessRecord(ctx).Project = repo.ProjectID
-	logger.BusinessRecord(ctx).Repository = repo.ID
 
 	return msg, nil
 }

--- a/internal/controlplane/handlers_repositories.go
+++ b/internal/controlplane/handlers_repositories.go
@@ -172,6 +172,7 @@ func (s *Server) ListRepositories(ctx context.Context,
 	resp.Cursor = respRepoCursor.String()
 
 	// Telemetry logging
+	// TODO: Change to ProviderID
 	logger.BusinessRecord(ctx).Provider = providerName
 	logger.BusinessRecord(ctx).Project = projectID
 
@@ -206,7 +207,7 @@ func (s *Server) GetRepositoryById(ctx context.Context,
 	}
 
 	// Telemetry logging
-	logger.BusinessRecord(ctx).Provider = repo.Provider
+	logger.BusinessRecord(ctx).ProviderID = repo.ProviderID
 	logger.BusinessRecord(ctx).Project = repo.ProjectID
 	logger.BusinessRecord(ctx).Repository = repo.ID
 
@@ -251,7 +252,7 @@ func (s *Server) GetRepositoryByName(ctx context.Context,
 	}
 
 	// Telemetry logging
-	logger.BusinessRecord(ctx).Provider = repo.Provider
+	logger.BusinessRecord(ctx).ProviderID = repo.ProviderID
 	logger.BusinessRecord(ctx).Project = repo.ProjectID
 	logger.BusinessRecord(ctx).Repository = repo.ID
 

--- a/internal/engine/executor_test.go
+++ b/internal/engine/executor_test.go
@@ -325,7 +325,8 @@ default allow = true`,
 	require.NoError(t, err, "expected no error")
 
 	ts := &logger.TelemetryStore{
-		Project:    projectID,
+		Project: projectID,
+		// TODO: Change to ProviderID
 		Provider:   providerName,
 		Repository: repositoryID,
 	}

--- a/internal/logger/telemetry_store.go
+++ b/internal/logger/telemetry_store.go
@@ -72,6 +72,9 @@ type TelemetryStore struct {
 	// Provider records the provider name that the request was associated with.
 	Provider string `json:"provider"`
 
+	// ProviderID records the provider name that the request was associated with.
+	ProviderID uuid.UUID `json:"provider_id"`
+
 	// Repository is the repository ID that the request was associated with.
 	Repository uuid.UUID `json:"repository"`
 
@@ -175,6 +178,9 @@ func (ts *TelemetryStore) Record(e *zerolog.Event) *zerolog.Event {
 	}
 	if ts.Provider != "" {
 		e.Str("provider", ts.Provider)
+	}
+	if ts.ProviderID != uuid.Nil {
+		e.Str("provider_id", ts.ProviderID.String())
 	}
 	if ts.LoginHash != "" {
 		e.Str("login_sha", ts.LoginHash)

--- a/internal/logger/telemetry_store_watermill.go
+++ b/internal/logger/telemetry_store_watermill.go
@@ -83,6 +83,7 @@ func newTelemetryStoreFromEntity(inf *entities.EntityInfoWrapper) (*TelemetrySto
 	}
 
 	// Set the provider name and project ID
+	// TODO: Change to ProviderID
 	ts.Provider = inf.Provider
 	ts.Project = inf.ProjectID
 

--- a/internal/reconcilers/entity_delete.go
+++ b/internal/reconcilers/entity_delete.go
@@ -44,6 +44,7 @@ func (r *Reconciler) handleEntityDeleteEvent(msg *message.Message) error {
 	repoID, _, _ := inf.GetEntityDBIDs()
 
 	// Telemetry logging
+	// TODO: Change to ProviderID
 	minderlogger.BusinessRecord(ctx).Provider = inf.Provider
 	minderlogger.BusinessRecord(ctx).Project = inf.ProjectID
 	switch inf.Type {

--- a/internal/repositories/github/service.go
+++ b/internal/repositories/github/service.go
@@ -153,7 +153,7 @@ func (r *repositoryService) CreateRepository(
 	}
 
 	// Telemetry logging
-	logger.BusinessRecord(ctx).Provider = provider.Name
+	logger.BusinessRecord(ctx).ProviderID = provider.ID
 	logger.BusinessRecord(ctx).Project = projectID
 	logger.BusinessRecord(ctx).Repository = dbID
 
@@ -211,7 +211,7 @@ func (r *repositoryService) DeleteRepository(ctx context.Context, client ghclien
 	}
 
 	// Telemetry logging
-	logger.BusinessRecord(ctx).Provider = repo.Provider
+	logger.BusinessRecord(ctx).ProviderID = repo.ProviderID
 	logger.BusinessRecord(ctx).Project = repo.ProjectID
 	logger.BusinessRecord(ctx).Repository = repo.ID
 


### PR DESCRIPTION
Relating to my PR for repositories, and Ozz's PRs for artifacts, add ProviderID to the telemetry struct. This is because there will be certain situations where we will not know the name, but know the ID instead.

I have changed some of the code to use ProviderID instead of Provider name where it made sense to do so. In some places, it is not possible yet, so I have left comments. In the controlplane, where the provider name is an input via the request context, I have used both - tracking the provider name input may still be useful for debugging.

# Summary

***Provide a brief overview of the changes and the issue being addressed. 
Explain the rationale and any background necessary for understanding the changes. 
List dependencies required by this change, if any.***

Fixes #(related issue)

## Change Type

***Mark the type of change your PR introduces:***

- [ ] Bug fix (resolves an issue without affecting existing features)
- [ ] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [x] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

***Outline how the changes were tested, including steps to reproduce and any relevant configurations. 
Attach screenshots if helpful.***

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [x] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [ ] Included tests that validate the fix or feature.
- [ ] Checked that related changes are merged.
