### PR TITLE
Disabling linter rules for pre-Go 1.22 loop var issue

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,5 +1,5 @@
 run:
-  go: "1.20"
+  go: "1.22"
   issues-exit-code: 1
   timeout: 5m
 
@@ -36,8 +36,7 @@ linters-settings:
       - name: indent-error-flow
       - name: import-shadowing
       - name: package-comments
-      - name: range-val-in-closure
-      - name: range-val-address
+      # NOTE: range-val-address and range-val-in-closure are irrelevant in Go 1.22 and later
       - name: redefines-builtin-id
       - name: struct-tag
       - name: unconditional-recursion
@@ -52,6 +51,8 @@ linters-settings:
       - G114 # for the moment we need to use listenandserve that has no support for timeouts
       - G404 # use unsafe random generator until logic change is discussed
       - G307 # Deferring unsafe method "Close" on type "io.ReadCloser"
+      - G601 # Irrelevant for Go 1.22 and later, see: https://github.com/securego/gosec/issues/1099
+
   depguard:
     rules:
       prevent_unmaintained_packages:
@@ -95,6 +96,7 @@ issues:
       linters:
         - lll
 
+severity:
 output:
   format: colored-line-number
   print-issued-lines: true

--- a/internal/auth/jwauth_test.go
+++ b/internal/auth/jwauth_test.go
@@ -124,8 +124,7 @@ func TestParseAndValidate(t *testing.T) {
 		},
 	}
 
-	for i := range testCases {
-		tc := testCases[i]
+	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/internal/controlplane/handlers_artifacts.go
+++ b/internal/controlplane/handlers_artifacts.go
@@ -283,7 +283,6 @@ func artifactListRepoFilter(
 
 	var filterRepositories []*db.Repository
 	for _, repo := range repositories {
-		repo := repo
 		if repoInSlubList(&repo, repoSlubList) {
 			filterRepositories = append(filterRepositories, &repo)
 		}

--- a/internal/controlplane/handlers_authz_test.go
+++ b/internal/controlplane/handlers_authz_test.go
@@ -156,8 +156,7 @@ func TestEntityContextProjectInterceptor(t *testing.T) {
 		},
 	}
 
-	for i := range testCases {
-		tc := testCases[i]
+	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -250,8 +249,7 @@ func TestProjectAuthorizationInterceptor(t *testing.T) {
 		},
 	}
 
-	for i := range testCases {
-		tc := testCases[i]
+	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/internal/controlplane/handlers_oauth_test.go
+++ b/internal/controlplane/handlers_oauth_test.go
@@ -273,8 +273,7 @@ func TestGetAuthorizationURL(t *testing.T) {
 		},
 	})
 
-	for i := range testCases {
-		tc := testCases[i]
+	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/internal/controlplane/handlers_repositories.go
+++ b/internal/controlplane/handlers_repositories.go
@@ -144,8 +144,6 @@ func (s *Server) ListRepositories(ctx context.Context,
 	var results []*pb.Repository
 
 	for _, repo := range repos {
-		repo := repo
-
 		projID := repo.ProjectID.String()
 		r := util.PBRepositoryFromDB(repo)
 		r.Context = &pb.Context{

--- a/internal/controlplane/handlers_repositories_test.go
+++ b/internal/controlplane/handlers_repositories_test.go
@@ -95,8 +95,7 @@ func TestServer_RegisterRepository(t *testing.T) {
 		},
 	}
 
-	for i := range scenarios {
-		scenario := scenarios[i]
+	for _, scenario := range scenarios {
 		t.Run(scenario.Name, func(t *testing.T) {
 			t.Parallel()
 			ctrl := gomock.NewController(t)
@@ -156,8 +155,7 @@ func TestServer_ListRemoteRepositoriesFromProvider(t *testing.T) {
 		},
 	}
 
-	for i := range scenarios {
-		scenario := scenarios[i]
+	for _, scenario := range scenarios {
 		t.Run(scenario.Name, func(t *testing.T) {
 			t.Parallel()
 			ctrl := gomock.NewController(t)
@@ -259,8 +257,7 @@ func TestServer_DeleteRepository(t *testing.T) {
 		},
 	}
 
-	for i := range scenarios {
-		scenario := scenarios[i]
+	for _, scenario := range scenarios {
 		t.Run(scenario.Name, func(t *testing.T) {
 			t.Parallel()
 			ctrl := gomock.NewController(t)

--- a/internal/controlplane/handlers_user_test.go
+++ b/internal/controlplane/handlers_user_test.go
@@ -245,8 +245,7 @@ func TestCreateUser_gRPC(t *testing.T) {
 	// Create a new context with added header metadata
 	ctx := metadata.NewIncomingContext(context.Background(), md)
 
-	for i := range testCases {
-		tc := testCases[i]
+	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -408,8 +407,7 @@ func TestDeleteUser_gRPC(t *testing.T) {
 	// Create a new context with added header metadata
 	ctx := metadata.NewIncomingContext(context.Background(), md)
 
-	for i := range testCases {
-		tc := testCases[i]
+	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/internal/engine/actions/remediate/pull_request/types_content.go
+++ b/internal/engine/actions/remediate/pull_request/types_content.go
@@ -79,9 +79,7 @@ func newContentModification(
 
 func prConfigToEntries(prCfg *pb.RuleType_Definition_Remediate_PullRequestRemediation) ([]*fsEntry, error) {
 	entries := make([]*fsEntry, len(prCfg.Contents))
-	for i := range prCfg.Contents {
-		cnt := prCfg.Contents[i]
-
+	for i, cnt := range prCfg.Contents {
 		contentTemplate, err := util.ParseNewTextTemplate(&cnt.Content, fmt.Sprintf("Content[%d]", i))
 		if err != nil {
 			return nil, fmt.Errorf("cannot parse content template (index %d): %w", i, err)

--- a/internal/engine/eval/trusty/actions.go
+++ b/internal/engine/eval/trusty/actions.go
@@ -116,12 +116,12 @@ func (sph *summaryPrHandler) generateSummary() (string, error) {
 	}
 	summary.WriteString(headerBuf.String())
 
-	for i := range sph.trackedAlternatives {
+	for _, alternative := range sph.trackedAlternatives {
 		var rowBuf bytes.Buffer
 
 		higherScoringAlternatives := make([]Alternative, 0)
-		for _, alt := range sph.trackedAlternatives[i].trustyReply.Alternatives.Packages {
-			if alt.Score > sph.trackedAlternatives[i].trustyReply.Summary.Score {
+		for _, alt := range alternative.trustyReply.Alternatives.Packages {
+			if alt.Score > alternative.trustyReply.Summary.Score {
 				alt.PackageNameURL = url.PathEscape(alt.PackageName)
 				higherScoringAlternatives = append(higherScoringAlternatives, alt)
 			}
@@ -142,10 +142,10 @@ func (sph *summaryPrHandler) generateSummary() (string, error) {
 			Alternatives []Alternative
 			BaseUrl      string
 		}{
-			Ecosystem:    strings.ToLower(sph.trackedAlternatives[i].Dependency.Ecosystem.AsString()),
-			Name:         sph.trackedAlternatives[i].Dependency.Name,
-			NameURL:      url.PathEscape(sph.trackedAlternatives[i].Dependency.Name),
-			Score:        sph.trackedAlternatives[i].trustyReply.Summary.Score,
+			Ecosystem:    strings.ToLower(alternative.Dependency.Ecosystem.AsString()),
+			Name:         alternative.Dependency.Name,
+			NameURL:      url.PathEscape(alternative.Dependency.Name),
+			Score:        alternative.trustyReply.Summary.Score,
 			Alternatives: higherScoringAlternatives,
 			BaseUrl:      constants.TrustyHttpURL,
 		}); err != nil {

--- a/internal/engine/eval/vulncheck/report.go
+++ b/internal/engine/eval/vulncheck/report.go
@@ -136,7 +136,7 @@ func (r *vulnSummaryReport) render() (string, error) {
 	}
 	summary.WriteString(headerBuf.String())
 
-	for i := range r.TrackedDependencies {
+	for _, dep := range r.TrackedDependencies {
 		var rowBuf bytes.Buffer
 
 		if err := rowsTmpl.Execute(&rowBuf, struct {
@@ -145,10 +145,10 @@ func (r *vulnSummaryReport) render() (string, error) {
 			DependencyVersion   string
 			Vulnerabilities     []Vulnerability
 		}{
-			DependencyEcosystem: r.TrackedDependencies[i].Dependency.Ecosystem.AsString(),
-			DependencyName:      r.TrackedDependencies[i].Dependency.Name,
-			DependencyVersion:   r.TrackedDependencies[i].Dependency.Version,
-			Vulnerabilities:     r.TrackedDependencies[i].Vulnerabilities,
+			DependencyEcosystem: dep.Dependency.Ecosystem.AsString(),
+			DependencyName:      dep.Dependency.Name,
+			DependencyVersion:   dep.Dependency.Version,
+			Vulnerabilities:     dep.Vulnerabilities,
 		}); err != nil {
 			return "", fmt.Errorf("could not execute template: %w", err)
 		}

--- a/internal/marketplaces/service_test.go
+++ b/internal/marketplaces/service_test.go
@@ -86,8 +86,7 @@ func TestMarketplace_AddProfile(t *testing.T) {
 
 func testHarness(t *testing.T, method testMethod, scenarios []testScenario) {
 	t.Helper()
-	for i := range scenarios {
-		scenario := scenarios[i]
+	for _, scenario := range scenarios {
 		t.Run(scenario.Name, func(t *testing.T) {
 			t.Parallel()
 			ctrl := gomock.NewController(t)

--- a/internal/marketplaces/subscriptions/service_test.go
+++ b/internal/marketplaces/subscriptions/service_test.go
@@ -88,8 +88,7 @@ func TestSubscriptionService_Subscribe(t *testing.T) {
 		},
 	}
 
-	for i := range scenarios {
-		scenario := scenarios[i]
+	for _, scenario := range scenarios {
 		t.Run(scenario.Name, func(t *testing.T) {
 			t.Parallel()
 
@@ -157,8 +156,7 @@ func TestSubscriptionService_CreateProfile(t *testing.T) {
 		},
 	}
 
-	for i := range scenarios {
-		scenario := scenarios[i]
+	for _, scenario := range scenarios {
 		t.Run(scenario.Name, func(t *testing.T) {
 			t.Parallel()
 

--- a/internal/profiles/validator_test.go
+++ b/internal/profiles/validator_test.go
@@ -124,8 +124,7 @@ func TestValidatorScenarios(t *testing.T) {
 	}
 
 	// some of this boilerplate can probably be shared across multiple tests
-	for i := range validatorTestScenarios {
-		testScenario := validatorTestScenarios[i]
+	for _, testScenario := range validatorTestScenarios {
 		t.Run(testScenario.Name, func(t *testing.T) {
 			t.Parallel()
 			ctrl := gomock.NewController(t)

--- a/internal/repositories/github/service.go
+++ b/internal/repositories/github/service.go
@@ -236,8 +236,8 @@ func (r *repositoryService) DeleteRepositoriesByProvider(
 		return fmt.Errorf("error listing repositories for provider: %w", err)
 	}
 
-	for i := range repos {
-		err := r.DeleteRepository(ctx, client, &repos[i]) // use index to avoid memory aliasing
+	for _, repo := range repos {
+		err := r.DeleteRepository(ctx, client, &repo)
 		if err != nil {
 			return fmt.Errorf("error deleting repository: %w", err)
 		}

--- a/internal/repositories/github/service_test.go
+++ b/internal/repositories/github/service_test.go
@@ -103,8 +103,7 @@ func TestRepositoryService_CreateRepository(t *testing.T) {
 		},
 	}
 
-	for i := range scenarios {
-		scenario := scenarios[i]
+	for _, scenario := range scenarios {
 		t.Run(scenario.Name, func(t *testing.T) {
 			t.Parallel()
 			ctrl := gomock.NewController(t)
@@ -158,8 +157,7 @@ func TestRepositoryService_DeleteRepository(t *testing.T) {
 		},
 	}
 
-	for i := range scenarios {
-		scenario := scenarios[i]
+	for _, scenario := range scenarios {
 		t.Run(scenario.Name, func(t *testing.T) {
 			t.Parallel()
 			ctrl := gomock.NewController(t)
@@ -210,8 +208,7 @@ func TestRepositoryService_DeleteRepositoriesByProvider(t *testing.T) {
 		},
 	}
 
-	for i := range scenarios {
-		scenario := scenarios[i]
+	for _, scenario := range scenarios {
 		t.Run(scenario.Name, func(t *testing.T) {
 			t.Parallel()
 			ctrl := gomock.NewController(t)
@@ -254,8 +251,7 @@ func TestRepositoryService_GetRepositoryById(t *testing.T) {
 		},
 	}
 
-	for i := range scenarios {
-		scenario := scenarios[i]
+	for _, scenario := range scenarios {
 		t.Run(scenario.Name, func(t *testing.T) {
 			t.Parallel()
 			ctrl := gomock.NewController(t)
@@ -297,8 +293,7 @@ func TestRepositoryService_GetRepositoryByName(t *testing.T) {
 		},
 	}
 
-	for i := range scenarios {
-		scenario := scenarios[i]
+	for _, scenario := range scenarios {
 		t.Run(scenario.Name, func(t *testing.T) {
 			t.Parallel()
 			ctrl := gomock.NewController(t)

--- a/internal/repositories/github/webhooks/manager_test.go
+++ b/internal/repositories/github/webhooks/manager_test.go
@@ -54,8 +54,7 @@ func TestWebhookManager_DeleteWebhook(t *testing.T) {
 		},
 	}
 
-	for i := range deletionScenarios {
-		scenario := deletionScenarios[i]
+	for _, scenario := range deletionScenarios {
 		t.Run(scenario.Name, func(t *testing.T) {
 			t.Parallel()
 			ctrl := gomock.NewController(t)
@@ -125,8 +124,7 @@ func TestWebhookManager_CreateWebhook(t *testing.T) {
 		},
 	}
 
-	for i := range creationScenarios {
-		scenario := creationScenarios[i]
+	for _, scenario := range creationScenarios {
 		t.Run(scenario.Name, func(t *testing.T) {
 			t.Parallel()
 			ctrl := gomock.NewController(t)

--- a/internal/ruletypes/service_test.go
+++ b/internal/ruletypes/service_test.go
@@ -218,8 +218,7 @@ func TestRuleTypeService(t *testing.T) {
 		},
 	}
 
-	for i := range scenarios {
-		scenario := scenarios[i]
+	for _, scenario := range scenarios {
 		t.Run(scenario.Name, func(t *testing.T) {
 			t.Parallel()
 			ctrl := gomock.NewController(t)

--- a/internal/verifier/sigstore/container/container.go
+++ b/internal/verifier/sigstore/container/container.go
@@ -194,8 +194,7 @@ func bundleFromGHAttestationEndpoint(
 
 	var bundles []sigstoreBundle
 	// Loop through all available attestations and extract the bundle and the certificate identity information
-	for i := range attestationReply.Attestations {
-		att := attestationReply.Attestations[i]
+	for _, att := range attestationReply.Attestations {
 		protobufBundle, err := unmarhsalAttestationReply(&att)
 		if err != nil {
 			logger.Err(err).Msg("error unmarshalling attestation reply")


### PR DESCRIPTION
Since Go 1.22 fixed the long-standing for loop variable scope problem, there are a bunch of linter checks which are not relevant any more. This PR changes the following:

1) Tells the linter to assume go 1.22
2) Explicitly disables some of the linter rules
3) I did a quick find-replace to clean up a bunch of places in the code
   where it worked around the old loop variable behaviour.

See this article for more details: https://go.dev/blog/loopvar-preview

# Summary

***Provide a brief overview of the changes and the issue being addressed. 
Explain the rationale and any background necessary for understanding the changes. 
List dependencies required by this change, if any.***

Fixes #(related issue)

## Change Type

***Mark the type of change your PR introduces:***

- [ ] Bug fix (resolves an issue without affecting existing features)
- [ ] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [ ] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

***Outline how the changes were tested, including steps to reproduce and any relevant configurations. 
Attach screenshots if helpful.***

# Review Checklist:

- [ ] Reviewed my own code for quality and clarity.
- [ ] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [ ] Included tests that validate the fix or feature.
- [ ] Checked that related changes are merged.
