### PR TITLE
Default to github-app in provider enroll

### DIFF
--- a/cmd/cli/app/provider/provider.go
+++ b/cmd/cli/app/provider/provider.go
@@ -20,7 +20,6 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/stacklok/minder/cmd/cli/app"
-	ghclient "github.com/stacklok/minder/internal/providers/github/oauth"
 	minderv1 "github.com/stacklok/minder/pkg/api/protobuf/go/minder/v1"
 )
 
@@ -37,9 +36,9 @@ var ProviderCmd = &cobra.Command{
 func init() {
 	app.RootCmd.AddCommand(ProviderCmd)
 	// Flags for all subcommands
-	// TODO: remove the provider flag from here and add it only to the subcommands that need it
-	ProviderCmd.PersistentFlags().StringP("provider", "p", ghclient.Github, "Name of the provider, i.e. github")
 	ProviderCmd.PersistentFlags().StringP("project", "j", "", "ID of the project")
+	// TODO: get rid of this
+	ProviderCmd.PersistentFlags().StringP("provider", "p", "", "DEPRECATED - use `class` flag of `enroll` instead")
 }
 
 func getImplementsAsStrings(p *minderv1.Provider) []string {

--- a/cmd/cli/app/provider/provider_enroll.go
+++ b/cmd/cli/app/provider/provider_enroll.go
@@ -45,7 +45,7 @@ const (
 	legacyGitHubProvider = minderv1.ProviderClass_PROVIDER_CLASS_GITHUB
 
 	// githubAppProvider is the name used to identify the new GitHub App provider class
-	githubAppProivder = minderv1.ProviderClass_PROVIDER_CLASS_GITHUB_APP
+	githubAppProvider = minderv1.ProviderClass_PROVIDER_CLASS_GITHUB_APP
 )
 
 var enrollCmd = &cobra.Command{
@@ -290,7 +290,7 @@ func init() {
 	enrollCmd.Flags().StringP("token", "t", "", "Personal Access Token (PAT) to use for enrollment (Legacy GitHub only)")
 	enrollCmd.Flags().StringP("owner", "o", "", "Owner to filter on for provider resources (Legacy GitHub only)")
 	enrollCmd.Flags().BoolP("yes", "y", false, "Bypass any yes/no prompts when enrolling a new provider")
-	enrollCmd.Flags().StringP("class", "c", githubAppProivder.String(), "Provider class, defaults to github-app")
+	enrollCmd.Flags().StringP("class", "c", githubAppProvider.String(), "Provider class, defaults to github-app")
 
 	// Bind flags
 	if err := viper.BindPFlag("token", enrollCmd.Flags().Lookup("token")); err != nil {

--- a/internal/providers/github/oauth/oauth.go
+++ b/internal/providers/github/oauth/oauth.go
@@ -34,8 +34,12 @@ import (
 	provifv1 "github.com/stacklok/minder/pkg/providers/v1"
 )
 
-// Github is the string that represents the GitHubOAuth provider
-const Github = "github"
+const (
+	// Github is the string that represents the GitHubOAuth provider
+	Github = "github"
+	// GithubApp is the string that represents the GitHub App provider
+	GithubApp = "github-app"
+)
 
 // Implements is the list of provider types that the GitHubOAuth provider implements
 var Implements = []db.ProviderType{

--- a/internal/providers/github/oauth/oauth.go
+++ b/internal/providers/github/oauth/oauth.go
@@ -34,12 +34,8 @@ import (
 	provifv1 "github.com/stacklok/minder/pkg/providers/v1"
 )
 
-const (
-	// Github is the string that represents the GitHubOAuth provider
-	Github = "github"
-	// GithubApp is the string that represents the GitHub App provider
-	GithubApp = "github-app"
-)
+// Github is the string that represents the GitHubOAuth provider
+const Github = "github"
 
 // Implements is the list of provider types that the GitHubOAuth provider implements
 var Implements = []db.ProviderType{


### PR DESCRIPTION
Fixes #2898

Some additional changes have been made as well:

1) Make the flag to specify the class of provider specific to the enroll
   command. The existing top-level provider flag is left intact, but
   marked as deprecated.
2) The confirmation box is only shown for the legacy Github app workflow
   as requested in the ticket.
3) The timeout duration is listed in the CLI output when the browser is
   opened.
4) Small changes to message verbiage here and there.

# Summary

***Provide a brief overview of the changes and the issue being addressed. 
Explain the rationale and any background necessary for understanding the changes. 
List dependencies required by this change, if any.***

Fixes #(related issue)

## Change Type

***Mark the type of change your PR introduces:***

- [ ] Bug fix (resolves an issue without affecting existing features)
- [x] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [ ] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

***Outline how the changes were tested, including steps to reproduce and any relevant configurations. 
Attach screenshots if helpful.***

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [x] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [ ] Included tests that validate the fix or feature.
- [ ] Checked that related changes are merged.
