### PR TITLE
Only run deletion reconciler on repo deleted events

### DIFF
--- a/internal/controlplane/handlers_githubwebhooks.go
+++ b/internal/controlplane/handlers_githubwebhooks.go
@@ -919,5 +919,10 @@ func parseRepoID(repoID any) (int64, error) {
 
 func shouldIssueDeletionEvent(m *message.Message) bool {
 	return m.Metadata.Get(entities.ActionEventKey) == WebhookActionEventDeleted &&
-		m.Metadata.Get(events.GithubWebhookEventTypeKey) == "repository"
+		deletionOfRelevantType(m)
+}
+
+func deletionOfRelevantType(m *message.Message) bool {
+	return m.Metadata.Get(events.GithubWebhookEventTypeKey) == "repository" ||
+		m.Metadata.Get(events.GithubWebhookEventTypeKey) == "meta"
 }

--- a/internal/controlplane/handlers_githubwebhooks.go
+++ b/internal/controlplane/handlers_githubwebhooks.go
@@ -252,12 +252,9 @@ func (s *Server) HandleGitHubWebHook() http.HandlerFunc {
 
 		// Channel the event based on the webhook action
 		var watermillTopic string
-		switch m.Metadata.Get(entities.ActionEventKey) {
-		case WebhookActionEventDeleted:
-			// We got an entity delete event, so we need to reconcile and delete the entity from the DB
+		if shouldIssueDeletionEvent(m) {
 			watermillTopic = events.TopicQueueReconcileEntityDelete
-		default:
-			// Default to evaluating the entity
+		} else {
 			watermillTopic = events.TopicQueueEntityEvaluate
 		}
 
@@ -918,4 +915,9 @@ func parseRepoID(repoID any) (int64, error) {
 	default:
 		return 0, fmt.Errorf("unknown type for repoID: %T", v)
 	}
+}
+
+func shouldIssueDeletionEvent(m *message.Message) bool {
+	return m.Metadata.Get(entities.ActionEventKey) == WebhookActionEventDeleted &&
+		m.Metadata.Get(events.GithubWebhookEventTypeKey) == "repository"
 }


### PR DESCRIPTION
# Summary

The trigger for the reconciler was too greedy and would issue deletion events
on more entities than just repos. e.g. when a branch is deleted. This is not ideal.

Instead, this trims down the triggering of the event to just repo deletion events coming from GitHub.

## Change Type

***Mark the type of change your PR introduces:***

- [x] Bug fix (resolves an issue without affecting existing features)
- [ ] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [ ] Refactoring or test improvements (no bug fixes or new functionality)

# Testing


# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [ ] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [ ] Included tests that validate the fix or feature.
- [ ] Checked that related changes are merged.
