### PR TITLE
Use output.formats.format in golangci.yaml

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -97,7 +97,8 @@ issues:
         - lll
 
 output:
-  format: colored-line-number
+  formats:
+    - format: colored-line-number
   print-issued-lines: true
   print-linter-name: true
   sort-results: true


### PR DESCRIPTION
# Summary

I recently upgraded golangci-lint and started seeing:
```
WARN [config_reader] The configuration option `output.format` is
deprecated, please use `output.formats`
```

According to their example config:
https://github.com/golangci/golangci-lint/blob/master/.golangci.reference.yml#L75

We might even get away with not using any formats configuration as what
we're using is already the default, but let's fix the config name now to
get rid of the warning.

## Change Type

***Mark the type of change your PR introduces:***

- [ ] Bug fix (resolves an issue without affecting existing features)
- [ ] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [x] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

run `make lint`

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [ ] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [ ] Included tests that validate the fix or feature.
- [ ] Checked that related changes are merged.
