### PR TITLE
zerolog: Don't reuse event in `Eval` call

### DIFF
--- a/internal/engine/rule_type_engine.go
+++ b/internal/engine/rule_type_engine.go
@@ -148,11 +148,11 @@ func (r *RuleTypeEngine) GetRuleInstanceValidator() *RuleValidator {
 
 // Eval runs the rule type engine against the given entity
 func (r *RuleTypeEngine) Eval(ctx context.Context, inf *entities.EntityInfoWrapper, params engif.EvalParamsReadWriter) error {
-	logger := zerolog.Ctx(ctx).Info().
+	logger := zerolog.Ctx(ctx).With().
 		Str("entity_type", inf.Type.ToString()).
-		Str("execution_id", inf.ExecutionID.String())
+		Str("execution_id", inf.ExecutionID.String()).Logger()
 
-	logger.Msg("entity evaluation - ingest started")
+	logger.Info().Msg("entity evaluation - ingest started")
 	// Try looking at the ingesting cache first
 	result, ok := r.ingestCache.Get(r.rdi, inf.Entity, params.GetRule().Params)
 	if !ok {
@@ -166,15 +166,15 @@ func (r *RuleTypeEngine) Eval(ctx context.Context, inf *entities.EntityInfoWrapp
 		}
 		r.ingestCache.Set(r.rdi, inf.Entity, params.GetRule().Params, result)
 	} else {
-		logger.Str("id", r.GetID()).Msg("entity evaluation - ingest using cache")
+		logger.Info().Str("id", r.GetID()).Msg("entity evaluation - ingest using cache")
 	}
-	logger.Msg("entity evaluation - ingest completed")
+	logger.Info().Msg("entity evaluation - ingest completed")
 	params.SetIngestResult(result)
 
 	// Process evaluation
-	logger.Msg("entity evaluation - evaluation started")
+	logger.Info().Msg("entity evaluation - evaluation started")
 	err := r.reval.Eval(ctx, params.GetRule().Def.AsMap(), result)
-	logger.Msg("entity evaluation - evaluation completed")
+	logger.Info().Msg("entity evaluation - evaluation completed")
 	return err
 }
 


### PR DESCRIPTION
# Summary

We were seeing a panic, and it's because we're reusing events in
zerolog [1]... this stops doing that for that function.

[1] https://github.com/rs/zerolog/issues/443

## Change Type

***Mark the type of change your PR introduces:***

- [x] Bug fix (resolves an issue without affecting existing features)
- [ ] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [ ] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

***Outline how the changes were tested, including steps to reproduce and any relevant configurations. 
Attach screenshots if helpful.***

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [ ] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [ ] Included tests that validate the fix or feature.
- [ ] Checked that related changes are merged.
