### PR TITLE
Fix CLI doc generation bug

### DIFF
--- a/.mk/gen.mk
+++ b/.mk/gen.mk
@@ -50,10 +50,18 @@ mock: ## generate mocks
 	mockgen -package mockgh -destination internal/providers/github/mock/common.go github.com/stacklok/minder/internal/providers/github ClientService
 
 
+# Ugly hack: cobra uses tabs for code blocks in markdown in some places
+# This leads to some issues with MDX in the docs renderer
+# Use sed to get rid of lines which begin with tabs and swap in backticks.
 .PHONY: cli-docs
 cli-docs: ## generate cli-docs
-	@rm -rf docs/docs/ref/cli
+	$(eval DOC_PATH := docs/docs/ref/cli)
+	@rm -rf ${DOC_PATH}
 	@mkdir -p docs/docs/ref/cli
-	@echo 'label: Minder CLI' > docs/docs/ref/cli/_category_.yml
-	@echo 'position: 20' >> docs/docs/ref/cli/_category_.yml
+	@echo 'label: Minder CLI' > ${DOC_PATH}/_category_.yml
+	@echo 'position: 20' >> ${DOC_PATH}/_category_.yml
 	@go run -tags '$(BUILDTAGS)' cmd/cli/main.go docs
+	@# this sed is much uglier than it should be so that it can run on Mac
+	@sed -i.bak 's/^	\(.*\)$$/```\$\n\1\$\n```/g' ${DOC_PATH}/minder_completion_zsh.md ${DOC_PATH}/minder_completion_bash.md
+	@# clean up temporary files created by sed
+	@rm ${DOC_PATH}/*.bak

--- a/docs/docs/ref/cli/minder_completion_bash.md
+++ b/docs/docs/ref/cli/minder_completion_bash.md
@@ -25,6 +25,7 @@ To load completions for every new session, execute once:
 ```
 minder completion bash > /etc/bash_completion.d/minder
 ```
+
 #### macOS:
 
 ```

--- a/docs/docs/ref/cli/minder_completion_zsh.md
+++ b/docs/docs/ref/cli/minder_completion_zsh.md
@@ -31,6 +31,7 @@ minder completion zsh > "${fpath[1]}/_minder"
 ```
 
 #### macOS:
+
 ```
 minder completion zsh > $(brew --prefix)/share/zsh/site-functions/_minder
 ```


### PR DESCRIPTION
Fixes #2626

Actual cause of this issue is that MDX A) needs some of the characters in the sample shell code to be escaped and B) even if you escape it, it wont render the line as markdown properly.

Do some unholy things with sed to work around this. Forgive me.

# Summary

***Provide a brief overview of the changes and the issue being addressed. 
Explain the rationale and any background necessary for understanding the changes. 
List dependencies required by this change, if any.***

Fixes #(related issue)

## Change Type

***Mark the type of change your PR introduces:***

- [x] Bug fix (resolves an issue without affecting existing features)
- [ ] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [ ] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

***Outline how the changes were tested, including steps to reproduce and any relevant configurations. 
Attach screenshots if helpful.***

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [x] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [ ] Included tests that validate the fix or feature.
- [ ] Checked that related changes are merged.
