### PR TITLE
Add sensible defaults to the OSV evaluator to allow running without any configuration

### DIFF
--- a/internal/engine/eval/vulncheck/config.go
+++ b/internal/engine/eval/vulncheck/config.go
@@ -16,7 +16,6 @@
 package vulncheck
 
 import (
-	"errors"
 	"fmt"
 	"strings"
 
@@ -53,9 +52,44 @@ type config struct {
 	EcosystemConfig []ecosystemConfig `json:"ecosystem_config" mapstructure:"ecosystem_config" validate:"required"`
 }
 
+func defaultConfig() *config {
+	return &config{
+		Action: pr_actions.ActionReviewPr,
+		EcosystemConfig: []ecosystemConfig{
+			{
+				Name:       "npm",
+				DbType:     vulnDbTypeOsv,
+				DbEndpoint: "https://api.osv.dev/v1/query",
+				PackageRepository: packageRepository{
+					Url: "https://registry.npmjs.org",
+				},
+			},
+			{
+				Name:       "pypi",
+				DbType:     vulnDbTypeOsv,
+				DbEndpoint: "https://api.osv.dev/v1/query",
+				PackageRepository: packageRepository{
+					Url: "https://pypi.org/pypi",
+				},
+			},
+			{
+				Name:       "go",
+				DbType:     vulnDbTypeOsv,
+				DbEndpoint: "https://api.osv.dev/v1/query",
+				PackageRepository: packageRepository{
+					Url: "https://proxy.golang.org",
+				},
+				SumRepository: packageRepository{
+					Url: "https://sum.golang.org",
+				},
+			},
+		},
+	}
+}
+
 func parseConfig(ruleCfg map[string]any) (*config, error) {
-	if ruleCfg == nil {
-		return nil, errors.New("config was missing")
+	if len(ruleCfg) == 0 {
+		return defaultConfig(), nil
 	}
 
 	var conf config


### PR DESCRIPTION
# Summary

Configuring the OSV evaluator is a bit of a PITA, but at the same time,
the configuration is normally not really needed for public projects as
they would all use the same OSV instance and the same package databases.

Let's just hardcode sensible defaults so that profiles can be leaner and
UIs don't have to ask users to input all this data.

## Change Type

***Mark the type of change your PR introduces:***

- [x] Bug fix (resolves an issue without affecting existing features)
- [x] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [ ] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

Create a very minimal profile:
```
# sample profile for validating artifact signatures
version: v1
type: profile
name: acme-github-profile-pr-vuln-check
context:
  provider: github
  pull_request:
    - type: pr_vulnerability_check
        def: {}
```

# Review Checklist:

- [ ] Reviewed my own code for quality and clarity.
- [ ] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [ ] Included tests that validate the fix or feature.
- [ ] Checked that related changes are merged.
