### PR TITLE
Add no-op handler for GitHub Marketplace events

### DIFF
--- a/internal/controlplane/handlers_githubwebhooks.go
+++ b/internal/controlplane/handlers_githubwebhooks.go
@@ -272,6 +272,25 @@ func (s *Server) HandleGitHubWebHook() http.HandlerFunc {
 	}
 }
 
+// NoopWebhookHandler is a no-op handler for webhooks
+func (s *Server) NoopWebhookHandler() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		wes := &metrics.WebhookEventState{
+			Typ:      "unknown",
+			Accepted: false,
+			Error:    true,
+		}
+		defer func() {
+			s.mt.AddWebhookEventTypeCount(r.Context(), wes)
+		}()
+
+		wes.Typ = github.WebHookType(r)
+		wes.Accepted = true
+		wes.Error = false
+		w.WriteHeader(http.StatusOK)
+	}
+}
+
 func validatePayloadSignature(r *http.Request, wc *server.WebhookConfig) (payload []byte, err error) {
 	var br *bytes.Reader
 	br, err = readerFromRequest(r)

--- a/internal/controlplane/server.go
+++ b/internal/controlplane/server.go
@@ -376,6 +376,7 @@ func (s *Server) StartHTTPServer(ctx context.Context) error {
 	mux.Handle("/", s.handlerWithHTTPMiddleware(gwmux))
 	mux.Handle("/api/v1/webhook/", mw(s.HandleGitHubWebHook()))
 	mux.Handle("/api/v1/ghapp/", mw(s.HandleGitHubAppWebhook()))
+	mux.Handle("/api/v1/gh-marketplace/", mw(s.NoopWebhookHandler()))
 	mux.Handle("/static/", fs)
 
 	errch := make(chan error)


### PR DESCRIPTION

# Summary

In order to list our GitHub App on the GitHub Marketplace, we need a webhook handler for Marketplace events.
This is a no-op handler because we don't need to react to marketplace events (e.g. purchases).

Fixes #3063

## Change Type

***Mark the type of change your PR introduces:***

- [ ] Bug fix (resolves an issue without affecting existing features)
- [x] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [ ] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

***Outline how the changes were tested, including steps to reproduce and any relevant configurations. 
Attach screenshots if helpful.***

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [ ] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [x] Included tests that validate the fix or feature.
- [ ] Checked that related changes are merged.
