### PR TITLE
Log the token type while creating the installation token and during the ping received event

### DIFF
--- a/internal/providers/providers.go
+++ b/internal/providers/providers.go
@@ -436,5 +436,12 @@ func createProviderWithInstallationToken(
 	credential := credentials.NewGitHubInstallationTokenCredential(ctx, provCfg.GitHubApp.AppID, privateKey, cfg.Endpoint,
 		installation.AppInstallationID)
 
+	zerolog.Ctx(ctx).
+		Debug().
+		Str("github-app-name", provCfg.GitHubApp.AppName).
+		Int64("github-app-id", provCfg.GitHubApp.AppID).
+		Int64("github-app-installation-id", installation.AppInstallationID).
+		Msg("created provider with installation token")
+
 	return NewProviderBuilder(&prov, ownerFilter, installation.IsOrg, credential, provCfg, fallbackTokenClient, opts...), nil
 }


### PR DESCRIPTION
# Summary

The following PR logs the token type:
* While creating the installation token
* During the ping received event. Since this is done only for the ping event, it is assumed that the sender is the app that installed the webhook on the repository. This way we can create a link between the repo ID and the webhook token type.

## Change Type

***Mark the type of change your PR introduces:***

- [ ] Bug fix (resolves an issue without affecting existing features)
- [ ] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [x] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

***Outline how the changes were tested, including steps to reproduce and any relevant configurations. 
Attach screenshots if helpful.***

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [ ] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [ ] Included tests that validate the fix or feature.
- [ ] Checked that related changes are merged.
