### PR TITLE
Add ProviderID field to EntityInfoWrapper

### DIFF
--- a/internal/engine/entities/entity_event.go
+++ b/internal/engine/entities/entity_event.go
@@ -313,12 +313,15 @@ func (eiw *EntityInfoWrapper) withProviderFromMessage(msg *message.Message) erro
 		return fmt.Errorf("%s not found in metadata", ProviderEventKey)
 	}
 
-	// TODO: Make provider ID mandatory. Right now, default to a nil UUID
 	rawProviderID := msg.Metadata.Get(ProviderIDEventKey)
-	providerID, err := uuid.Parse(rawProviderID)
-	if err != nil {
-		// TODO: this should return an error once ProviderID is mandatory
-		providerID = uuid.Nil
+	// TODO: Make provider ID mandatory. Right now, default to a nil UUID
+	providerID := uuid.Nil
+	if rawProviderID != "" {
+		var err error
+		providerID, err = uuid.Parse(rawProviderID)
+		if err != nil {
+			return fmt.Errorf("malformed provider id %s", rawProviderID)
+		}
 	}
 
 	eiw.Provider = provider

--- a/internal/engine/entities/entity_event.go
+++ b/internal/engine/entities/entity_event.go
@@ -47,7 +47,9 @@ import (
 // - RepositoryEventEntityType - repository
 // - VersionedArtifactEventEntityType - versioned_artifact
 type EntityInfoWrapper struct {
+	// TODO: remove this field
 	Provider      string
+	ProviderID    uuid.UUID
 	ProjectID     uuid.UUID
 	Entity        protoreflect.ProtoMessage
 	Type          minderv1.Entity
@@ -68,6 +70,8 @@ const (
 const (
 	// EntityTypeEventKey is the key for the entity type
 	EntityTypeEventKey = "entity_type"
+	// ProviderIDEventKey is the key for the provider
+	ProviderIDEventKey = "provider_id"
 	// ProviderEventKey is the key for the provider
 	ProviderEventKey = "provider"
 	// ProjectIDEventKey is the key for the project ID
@@ -94,6 +98,13 @@ func NewEntityInfoWrapper() *EntityInfoWrapper {
 // WithProvider sets the provider
 func (eiw *EntityInfoWrapper) WithProvider(provider string) *EntityInfoWrapper {
 	eiw.Provider = provider
+
+	return eiw
+}
+
+// WithProviderID sets the provider
+func (eiw *EntityInfoWrapper) WithProviderID(providerID uuid.UUID) *EntityInfoWrapper {
+	eiw.ProviderID = providerID
 
 	return eiw
 }
@@ -226,6 +237,7 @@ func (eiw *EntityInfoWrapper) ToMessage(msg *message.Message) error {
 		return fmt.Errorf("project ID is required")
 	}
 
+	// TODO: make provider ID mandatory instead
 	if eiw.Provider == "" {
 		return fmt.Errorf("provider is required")
 	}
@@ -235,6 +247,7 @@ func (eiw *EntityInfoWrapper) ToMessage(msg *message.Message) error {
 	}
 
 	msg.Metadata.Set(ProviderEventKey, eiw.Provider)
+	msg.Metadata.Set(ProviderIDEventKey, eiw.ProviderID.String())
 	msg.Metadata.Set(EntityTypeEventKey, typ)
 	msg.Metadata.Set(ProjectIDEventKey, eiw.ProjectID.String())
 	msg.Metadata.Set(ActionEventKey, eiw.ActionEvent)
@@ -300,7 +313,16 @@ func (eiw *EntityInfoWrapper) withProviderFromMessage(msg *message.Message) erro
 		return fmt.Errorf("%s not found in metadata", ProviderEventKey)
 	}
 
+	// TODO: Make provider ID mandatory. Right now, default to a nil UUID
+	rawProviderID := msg.Metadata.Get(ProviderIDEventKey)
+	providerID, err := uuid.Parse(rawProviderID)
+	if err != nil {
+		// TODO: this should return an error once ProviderID is mandatory
+		providerID = uuid.Nil
+	}
+
 	eiw.Provider = provider
+	eiw.ProviderID = providerID
 	return nil
 }
 

--- a/internal/engine/entities/entity_event_test.go
+++ b/internal/engine/entities/entity_event_test.go
@@ -178,6 +178,7 @@ func Test_parseEntityEvent(t *testing.T) {
 			assert.Equal(t, tt.want.Type, got.Type, "entity type mismatch")
 			assert.Equal(t, tt.want.OwnershipData, got.OwnershipData, "ownership data mismatch")
 			assert.Equal(t, tt.want.Provider, got.Provider, "provider mismatch")
+			assert.Equal(t, tt.want.ProviderID, got.ProviderID, "provider ID mismatch")
 		})
 	}
 }
@@ -187,8 +188,10 @@ func TestEntityInfoWrapper_RepositoryToMessage(t *testing.T) {
 
 	projectID := uuid.New()
 	repoID := uuid.New()
+	providerID := uuid.New()
 	eiw := NewEntityInfoWrapper().
 		WithProvider("github").
+		WithProviderID(providerID).
 		WithProjectID(projectID).
 		WithRepository(&pb.Repository{
 			Owner:  "test",
@@ -199,6 +202,7 @@ func TestEntityInfoWrapper_RepositoryToMessage(t *testing.T) {
 	require.NoError(t, err, "unexpected error")
 
 	assert.Equal(t, "github", msg.Metadata.Get(ProviderEventKey), "provider mismatch")
+	assert.Equal(t, providerID.String(), msg.Metadata.Get(ProviderIDEventKey), "provider ID mismatch")
 	assert.Equal(t, RepositoryEventEntityType, msg.Metadata.Get(EntityTypeEventKey), "entity type mismatch")
 	assert.Equal(t, projectID.String(), msg.Metadata.Get(ProjectIDEventKey), "project id mismatch")
 	assert.Equal(t, repoID.String(), msg.Metadata.Get(RepositoryIDEventKey), "repository id mismatch")
@@ -210,9 +214,11 @@ func TestEntityInfoWrapper_VersionedArtifact(t *testing.T) {
 	projectID := uuid.New()
 	artifactID := uuid.New()
 	repoID := uuid.New()
+	providerID := uuid.New()
 
 	eiw := NewEntityInfoWrapper().
 		WithProvider("github").
+		WithProviderID(providerID).
 		WithProjectID(projectID).
 		WithArtifact(&pb.Artifact{
 			ArtifactPk: artifactID.String(),
@@ -230,6 +236,7 @@ func TestEntityInfoWrapper_VersionedArtifact(t *testing.T) {
 	assert.Equal(t, "github", msg.Metadata.Get(ProviderEventKey), "provider mismatch")
 	assert.Equal(t, VersionedArtifactEventEntityType, msg.Metadata.Get(EntityTypeEventKey), "entity type mismatch")
 	assert.Equal(t, projectID.String(), msg.Metadata.Get(ProjectIDEventKey), "project id mismatch")
+	assert.Equal(t, providerID.String(), msg.Metadata.Get(ProviderIDEventKey), "provider id mismatch")
 	assert.Equal(t, repoID.String(), msg.Metadata.Get(RepositoryIDEventKey), "repository id mismatch")
 	assert.Equal(t, artifactID.String(), msg.Metadata.Get(ArtifactIDEventKey), "artifact id mismatch")
 }

--- a/internal/engine/executor.go
+++ b/internal/engine/executor.go
@@ -190,6 +190,7 @@ func (e *Executor) HandleEntityEvent(msg *message.Message) error {
 			zerolog.Ctx(ctx).Info().
 				Str("project", inf.ProjectID.String()).
 				Str("provider", inf.Provider).
+				Str("provider_id", inf.ProviderID.String()).
 				Str("entity", inf.Type.String()).
 				Err(err).Msg("got error while evaluating entity event")
 		}
@@ -198,7 +199,14 @@ func (e *Executor) HandleEntityEvent(msg *message.Message) error {
 	return nil
 }
 func (e *Executor) prepAndEvalEntityEvent(ctx context.Context, inf *entities.EntityInfoWrapper) error {
-	provider, err := e.providerStore.GetByName(ctx, inf.ProjectID, inf.Provider)
+	// TODO: clean this up once we get rid of provider name
+	var provider *db.Provider
+	var err error
+	if inf.ProviderID == uuid.Nil {
+		provider, err = e.providerStore.GetByName(ctx, inf.ProjectID, inf.Provider)
+	} else {
+		provider, err = e.providerStore.GetByID(ctx, inf.ProviderID)
+	}
 	if err != nil {
 		return fmt.Errorf("error getting provider: %w", err)
 	}
@@ -217,7 +225,7 @@ func (e *Executor) prepAndEvalEntityEvent(ctx context.Context, inf *entities.Ent
 			ID: inf.ProjectID,
 		},
 		Provider: Provider{
-			Name: inf.Provider,
+			Name: provider.Name,
 		},
 	}
 
@@ -234,6 +242,7 @@ func (e *Executor) evalEntityEvent(
 		Str("entity_type", inf.Type.ToString()).
 		Str("execution_id", inf.ExecutionID.String()).
 		Str("provider", inf.Provider).
+		Str("provider_id", inf.ProviderID.String()).
 		Str("project_id", inf.ProjectID.String())
 	logger.Msg("entity evaluation - started")
 	// This is a cache, so we can avoid querying the ingester upstream

--- a/internal/logger/telemetry_store_watermill.go
+++ b/internal/logger/telemetry_store_watermill.go
@@ -83,8 +83,8 @@ func newTelemetryStoreFromEntity(inf *entities.EntityInfoWrapper) (*TelemetrySto
 	}
 
 	// Set the provider name and project ID
-	// TODO: Change to ProviderID
 	ts.Provider = inf.Provider
+	ts.ProviderID = inf.ProviderID
 	ts.Project = inf.ProjectID
 
 	// Set the entity telemetry field based on the entity type

--- a/internal/reconcilers/entity_delete.go
+++ b/internal/reconcilers/entity_delete.go
@@ -36,6 +36,7 @@ func (r *Reconciler) handleEntityDeleteEvent(msg *message.Message) error {
 
 	l := zerolog.Ctx(ctx).With().
 		Str("provider", inf.Provider).
+		Str("provider_id", inf.ProviderID.String()).
 		Str("project_id", inf.ProjectID.String()).
 		Str("entity_type", inf.Type.ToString()).
 		Str("action", inf.ActionEvent).
@@ -44,8 +45,8 @@ func (r *Reconciler) handleEntityDeleteEvent(msg *message.Message) error {
 	repoID, _, _ := inf.GetEntityDBIDs()
 
 	// Telemetry logging
-	// TODO: Change to ProviderID
 	minderlogger.BusinessRecord(ctx).Provider = inf.Provider
+	minderlogger.BusinessRecord(ctx).ProviderID = inf.ProviderID
 	minderlogger.BusinessRecord(ctx).Project = inf.ProjectID
 	switch inf.Type {
 	case pb.Entity_ENTITY_REPOSITORIES:


### PR DESCRIPTION
Relates to #3071

This PR adds the ProviderID field to the event structure, and changes the executor to use the ProviderID if present. Note that the ProviderID is not actually set anywhere at this point: I am doing this changeover in phases to avoid backwards compatibility issues as we change the event structure.

# Summary

***Provide a brief overview of the changes and the issue being addressed. 
Explain the rationale and any background necessary for understanding the changes. 
List dependencies required by this change, if any.***

Fixes #(related issue)

## Change Type

***Mark the type of change your PR introduces:***

- [ ] Bug fix (resolves an issue without affecting existing features)
- [x] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [ ] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

***Outline how the changes were tested, including steps to reproduce and any relevant configurations. 
Attach screenshots if helpful.***

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [x] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [x] Included tests that validate the fix or feature.
- [ ] Checked that related changes are merged.
