### PR TITLE
Fix deleting project with artifacts

### DIFF
--- a/database/migrations/000051_artifact_projects_cascade_delete.down.sql
+++ b/database/migrations/000051_artifact_projects_cascade_delete.down.sql
@@ -1,0 +1,31 @@
+-- Copyright 2024 Stacklok, Inc
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--      http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+-- Artifact changes
+
+BEGIN;
+
+-- delete artifacts that are associated with a project that gets deleted
+-- otherwise removing a project would cause:
+-- "update or delete on table "projects" violates foreign key constraint "fk_artifacts_project_id" on table "artifacts""
+ALTER TABLE artifacts DROP CONSTRAINT fk_artifacts_project_id;
+ALTER TABLE artifacts ADD CONSTRAINT fk_artifacts_project_id FOREIGN KEY (project_id) REFERENCES projects (id);
+
+-- delete artifacts that are associated with a provider that gets deleted
+-- same reason as above. This is mostly a noop now because we also have a on delete cascade on the repository_id column
+-- which while technically nullable is always set to a value, but would bite us in the future
+ALTER TABLE artifacts DROP CONSTRAINT fk_artifacts_provider_id_and_name;
+ALTER TABLE artifacts ADD CONSTRAINT fk_artifacts_provider_id_and_name FOREIGN KEY (provider_id, provider_name) REFERENCES providers (id, name);
+
+COMMIT;

--- a/database/migrations/000051_artifact_projects_cascade_delete.up.sql
+++ b/database/migrations/000051_artifact_projects_cascade_delete.up.sql
@@ -1,0 +1,31 @@
+-- Copyright 2024 Stacklok, Inc
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--      http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+-- Artifact changes
+
+BEGIN;
+
+-- delete artifacts that are associated with a project that gets deleted
+-- otherwise removing a project would cause:
+-- "update or delete on table "projects" violates foreign key constraint "fk_artifacts_project_id" on table "artifacts""
+ALTER TABLE artifacts DROP CONSTRAINT fk_artifacts_project_id;
+ALTER TABLE artifacts ADD CONSTRAINT fk_artifacts_project_id FOREIGN KEY (project_id) REFERENCES projects (id) ON DELETE CASCADE;
+
+-- delete artifacts that are associated with a provider that gets deleted
+-- same reason as above. This is mostly a noop now because we also have a on delete cascade on the repository_id column
+-- which while technically nullable is always set to a value, but would bite us in the future
+ALTER TABLE artifacts DROP CONSTRAINT fk_artifacts_provider_id_and_name;
+ALTER TABLE artifacts ADD CONSTRAINT fk_artifacts_provider_id_and_name FOREIGN KEY (provider_id, provider_name) REFERENCES providers (id, name) ON DELETE CASCADE;
+
+COMMIT;


### PR DESCRIPTION
# Summary

In case a project with an artifact was being deleted, the foreign key
would have prevented the deletion of the project.

As a user-facing effect, this meant that `auth login delete` no longer
worked if a user had any artifacts stored.

## Change Type

***Mark the type of change your PR introduces:***

- [x] Bug fix (resolves an issue without affecting existing features)
- [ ] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [ ] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

1. enroll a project, register a repo and make sure that an artifact is registered through a webhook or initial reconcile
2. minder auth delete

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [x] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [ ] Included tests that validate the fix or feature.
- [ ] Checked that related changes are merged.
