### PR TITLE
Provide a default configuration for the Trusty evaluator

### DIFF
--- a/internal/engine/eval/trusty/config.go
+++ b/internal/engine/eval/trusty/config.go
@@ -16,7 +16,6 @@
 package trusty
 
 import (
-	"errors"
 	"fmt"
 	"strings"
 
@@ -56,9 +55,29 @@ type config struct {
 	EcosystemConfig []ecosystemConfig `json:"ecosystem_config" mapstructure:"ecosystem_config" validate:"required"`
 }
 
+func defaultConfig() *config {
+	return &config{
+		Action: pr_actions.ActionSummary,
+		EcosystemConfig: []ecosystemConfig{
+			{
+				Name:  "npm",
+				Score: 5.0,
+			},
+			{
+				Name:  "pypi",
+				Score: 5.0,
+			},
+			{
+				Name:  "go",
+				Score: 5.0,
+			},
+		},
+	}
+}
+
 func parseConfig(ruleCfg map[string]any) (*config, error) {
-	if ruleCfg == nil {
-		return nil, errors.New("config was missing")
+	if len(ruleCfg) == 0 {
+		return defaultConfig(), nil
 	}
 
 	var conf config


### PR DESCRIPTION
# Summary

This is similar to 9187f9644e775cec9f6fe63a4919d8db15808440 just for
trusty. The point is again to not require any configuration to get the
Trusty evaluator up in the default configuration because configuring the
evaluator is currently quite painful from the UI.

## Change Type

***Mark the type of change your PR introduces:***

- [ ] Bug fix (resolves an issue without affecting existing features)
- [x] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [ ] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

```
version: v1
type: profile
name: pr-trusty-check
context:
  provider: github
  pull_request:
    - type: pr_trusty_check
        def: {}

```

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [ ] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [ ] Included tests that validate the fix or feature.
- [ ] Checked that related changes are merged.
