### PR TITLE
Do not delete user from OpenFGA in a DB transaction to avoid issues with minder auth delete

### DIFF
--- a/internal/authz/mock/simple_authz.go
+++ b/internal/authz/mock/simple_authz.go
@@ -66,8 +66,12 @@ func (n *SimpleClient) Delete(_ context.Context, _ string, _ authz.Role, project
 }
 
 // DeleteUser implements authz.Client
-func (n *SimpleClient) DeleteUser(_ context.Context, _ string) error {
-	n.Assignments = nil
+func (n *SimpleClient) DeleteUser(_ context.Context, user string) error {
+	for p, as := range n.Assignments {
+		n.Assignments[p] = slices.DeleteFunc(as, func(a *minderv1.RoleAssignment) bool {
+			return a.Subject == user
+		})
+	}
 	n.Allowed = nil
 	return nil
 }

--- a/internal/controlplane/handlers_user_test.go
+++ b/internal/controlplane/handlers_user_test.go
@@ -333,6 +333,8 @@ func TestDeleteUserDBMock(t *testing.T) {
 		DeleteUser(gomock.Any(), gomock.Any()).
 		Return(nil)
 	mockStore.EXPECT().Commit(gomock.Any())
+	// we expect rollback to be called even if there is no error (through defer), in that case it will be a no-op
+	mockStore.EXPECT().Rollback(gomock.Any())
 
 	crypeng := mockcrypto.NewMockEngine(ctrl)
 
@@ -387,6 +389,8 @@ func TestDeleteUser_gRPC(t *testing.T) {
 					DeleteUser(gomock.Any(), gomock.Any()).
 					Return(nil)
 				store.EXPECT().Commit(gomock.Any())
+				// we expect rollback to be called even if there is no error (through defer), in that case it will be a no-op
+				store.EXPECT().Rollback(gomock.Any())
 			},
 			checkResponse: func(t *testing.T, res *pb.DeleteUserResponse, err error) {
 				t.Helper()

--- a/internal/controlplane/identity_events.go
+++ b/internal/controlplane/identity_events.go
@@ -109,36 +109,17 @@ func HandleEvents(
 }
 
 // DeleteUser deletes a user and all their associated data from the minder database
-func DeleteUser(ctx context.Context, store db.Store, authzClient authz.Client, providerService service.GitHubProviderService,
-	userId string) (retErr error) {
+func DeleteUser(
+	ctx context.Context,
+	store db.Store,
+	authzClient authz.Client,
+	providerService service.GitHubProviderService,
+	userId string,
+) error {
 	l := zerolog.Ctx(ctx).With().
 		Str("operation", "delete").
 		Str("subject", userId).
 		Logger()
-
-	tx, err := store.BeginTransaction()
-	if err != nil {
-		return err
-	}
-	defer func() {
-		if retErr != nil {
-			if err := store.Rollback(tx); err != nil && !errors.Is(err, sql.ErrTxDone) {
-				l.Debug().Msgf("error rolling back transaction: %v", err)
-			}
-		}
-	}()
-	qtx := store.GetQuerierWithTransaction(tx)
-
-	var userDBID *int32
-
-	usr, err := qtx.GetUserBySubject(ctx, userId)
-	// If the user doesn't exist, we still want to clean up any associated data
-	if err != nil && !errors.Is(err, sql.ErrNoRows) {
-		return fmt.Errorf("error retrieving user %v", err)
-	} else if err == nil {
-		userDBID = &usr.ID
-		l = l.With().Int32("user_id", usr.ID).Logger()
-	}
 
 	// Fetching the projects for user before the deletion was made.
 	// This allows us to clean up the project from the database
@@ -147,33 +128,47 @@ func DeleteUser(ctx context.Context, store db.Store, authzClient authz.Client, p
 	if err != nil {
 		return fmt.Errorf("error getting projects for user %v", err)
 	}
+	l.Debug().Int("projects", len(projs)).Msg("projects for user")
+
+	dbUser, err := db.WithTransaction(store, func(qtx db.ExtendQuerier) (db.User, error) {
+		var userDBID *int32
+
+		usr, err := qtx.GetUserBySubject(ctx, userId)
+		// If the user doesn't exist, we still want to clean up any associated data
+		if err != nil && !errors.Is(err, sql.ErrNoRows) {
+			return db.User{}, fmt.Errorf("error retrieving user %v", err)
+		} else if err == nil {
+			userDBID = &usr.ID
+			l = l.With().Int32("user_id", usr.ID).Logger()
+		}
+
+		// We only delete the user if it still exists in the database
+		if userDBID != nil {
+			l.Debug().Msg("deleting user from database")
+			if err := qtx.DeleteUser(ctx, *userDBID); err != nil {
+				return db.User{}, fmt.Errorf("error deleting user %v", err)
+			}
+		}
+
+		for _, proj := range projs {
+			l.Debug().Str("project_id", proj.String()).Msg("cleaning up project")
+			if err := projects.CleanUpUnmanagedProjects(ctx, userId, proj, qtx, authzClient, providerService, l); err != nil {
+				return db.User{}, fmt.Errorf("error deleting project %v", err)
+			}
+		}
+
+		return usr, nil
+	})
+	if err != nil {
+		return err
+	}
 
 	l.Debug().Msg("deleting user from authorization system")
-	// We delete the user from the authorization system first
+	// We delete the user from the authorization system last
 	if err := authzClient.DeleteUser(ctx, userId); err != nil {
 		return fmt.Errorf("error deleting authorization tuple %v", err)
 	}
 
-	// We only delete the user if it still exists in the database
-	if userDBID != nil {
-		l.Debug().Msg("deleting user from database")
-		if err := qtx.DeleteUser(ctx, *userDBID); err != nil {
-			return fmt.Errorf("error deleting user %v", err)
-		}
-	}
-
-	for _, proj := range projs {
-		l.Debug().Str("project_id", proj.String()).Msg("cleaning up project")
-		if err := projects.CleanUpUnmanagedProjects(ctx, proj, qtx, authzClient, providerService, l); err != nil {
-			return fmt.Errorf("error deleting project %v", err)
-		}
-	}
-
-	// organizations will be cleaned up in a migration after this change
-
-	l.Debug().Msg("committing account deletion")
-	if err = store.Commit(tx); err != nil {
-		return fmt.Errorf("error committing account deletion %w", err)
-	}
+	zerolog.Ctx(ctx).Info().Str("subject", dbUser.IdentitySubject).Msg("user account deleted")
 	return nil
 }

--- a/internal/controlplane/identity_events.go
+++ b/internal/controlplane/identity_events.go
@@ -121,9 +121,10 @@ func DeleteUser(
 		Str("subject", userId).
 		Logger()
 
-	// Fetching the projects for user before the deletion was made.
-	// This allows us to clean up the project from the database
-	// if there are no more role assignments for the project.
+	// Get the projects the user is associated with. We'll want to clean up any projects
+	// that the user is the only member of. Because projects are identified by UUIDs, if
+	// we end up deleting the project but for some reason fail to delete the role assignments
+	// in openFGA, we'll just end up with dangling role assignments to UUIDs that don't exist.
 	projs, err := authzClient.ProjectsForUser(ctx, userId)
 	if err != nil {
 		return fmt.Errorf("error getting projects for user %v", err)
@@ -131,29 +132,24 @@ func DeleteUser(
 	l.Debug().Int("projects", len(projs)).Msg("projects for user")
 
 	dbUser, err := db.WithTransaction(store, func(qtx db.ExtendQuerier) (db.User, error) {
-		var userDBID *int32
-
 		usr, err := qtx.GetUserBySubject(ctx, userId)
 		// If the user doesn't exist, we still want to clean up any associated data
 		if err != nil && !errors.Is(err, sql.ErrNoRows) {
 			return db.User{}, fmt.Errorf("error retrieving user %v", err)
-		} else if err == nil {
-			userDBID = &usr.ID
-			l = l.With().Int32("user_id", usr.ID).Logger()
-		}
-
-		// We only delete the user if it still exists in the database
-		if userDBID != nil {
-			l.Debug().Msg("deleting user from database")
-			if err := qtx.DeleteUser(ctx, *userDBID); err != nil {
-				return db.User{}, fmt.Errorf("error deleting user %v", err)
-			}
 		}
 
 		for _, proj := range projs {
 			l.Debug().Str("project_id", proj.String()).Msg("cleaning up project")
 			if err := projects.CleanUpUnmanagedProjects(ctx, userId, proj, qtx, authzClient, providerService, l); err != nil {
 				return db.User{}, fmt.Errorf("error deleting project %v", err)
+			}
+		}
+
+		// We only delete the user if it still exists in the database
+		if usr.IdentitySubject != "" {
+			l = l.With().Int32("user_id", usr.ID).Logger()
+			if err := qtx.DeleteUser(ctx, usr.ID); err != nil {
+				return db.User{}, fmt.Errorf("error deleting user %v", err)
 			}
 		}
 

--- a/internal/projects/delete.go
+++ b/internal/projects/delete.go
@@ -48,7 +48,7 @@ func CleanUpUnmanagedProjects(
 		return fmt.Errorf("error getting role assignments for project %v", err)
 	}
 
-	if !hasOtherRoleAssignmens(as, subject) {
+	if !hasOtherRoleAssignments(as, subject) {
 		l.Info().Msg("deleting project")
 		if err := DeleteProject(ctx, proj, querier, authzClient, providerService, l); err != nil {
 			return fmt.Errorf("error deleting project %v", err)
@@ -59,7 +59,7 @@ func CleanUpUnmanagedProjects(
 	return nil
 }
 
-func hasOtherRoleAssignmens(as []*v1.RoleAssignment, subject string) bool {
+func hasOtherRoleAssignments(as []*v1.RoleAssignment, subject string) bool {
 	return slices.ContainsFunc(as, func(a *v1.RoleAssignment) bool {
 		return a.Subject != subject
 	})


### PR DESCRIPTION
# Summary

NOTE: This patch touches a bit delicate part of minder. Please review carefully - I was not super acquainted with the code earlier and I wouldn't be suprised if I missed something.

We've been occasionally hitting issues where `minder auth delete` would
delete the user entry but leave the project around. Recovering from this
state then requires database write permissions to manually clean up the
projects.

At least in the case that I reproduced by accident the flow went like
this:
- user issues auth delete
- the transaction starts
- the user projects are returned and contain a non-empty list
- the user entry is deleted from OpenFGA
- the user entry is staged for deletion from the DB as part of the
  transaction
- one of the projects are attempted to be deleted, but the deletion
  fails. This error rolls back the transaction and deleting the user.
- the end-user gets an error message, thinks 'a fluke' and runs auth
  delete again
- the new run starts, calls list project for user from OpenFGA which
  returns an empty list
- the user is deleted from the db and the transaction is commited
- the project are left behind because openFGA returned none for the user
  because as far as openFGA knows the user is gone
- the next auth login can't create the project for the user becasue it already exists

This patch reorganizes the `DeleteUser` flow is such a way that if the
all the database operations are wrapped in a transaction, but the
OpenFGA delete user call is kept outside; the list of projects before the
transaction and deleting the user entry after it.

The call to delete unmanaged projects is changed so that only the
projects that have other subjects than the one being deleted are
deleted.


## Change Type

- [x] Bug fix (resolves an issue without affecting existing features)
- [ ] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [ ] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

I reverted the patch that prevents deleting a project in case it still contains
artifacts as a way to easily break project deletion.

Then without the patch, deleting a project caused the projects to be essentially orphaned
and subsequent auth login calls were all failing.

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [ ] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [x] Included tests that validate the fix or feature.
- [ ] Checked that related changes are merged.
