### PR TITLE
Frizbee: Cache GitHub action entries

### DIFF
--- a/internal/engine/actions/remediate/pull_request/types_actions_replace_tags.go
+++ b/internal/engine/actions/remediate/pull_request/types_actions_replace_tags.go
@@ -67,9 +67,10 @@ func newFrizbeeTagResolveModification(
 
 func (ftr *frizbeeTagResolveModification) createFsModEntries(ctx context.Context, _ interfaces.ActionsParams) error {
 	entries := []*fsEntry{}
+	cache := utils.NewRefCacher()
 
 	err := ghactions.TraverseGitHubActionWorkflows(ftr.fs, ".github/workflows", func(path string, wflow *yaml.Node) error {
-		m, err := ghactions.ModifyReferencesInYAML(ctx, ftr.ghCli, wflow, ftr.fzcfg)
+		m, err := ghactions.ModifyReferencesInYAMLWithCache(ctx, ftr.ghCli, wflow, ftr.fzcfg, cache)
 		if err != nil {
 			return fmt.Errorf("failed to process YAML file %s: %w", path, err)
 		}


### PR DESCRIPTION
# Summary

This uses frizbee's builtin cache to store the found github actions
in-between file modifications.

We always had cache support but simply were not using it. This should
reduce the number of calls we do to GitHub.

## Change Type

***Mark the type of change your PR introduces:***

- [x] Bug fix (resolves an issue without affecting existing features)
- [x] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [ ] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [ ] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [ ] Included tests that validate the fix or feature.
- [ ] Checked that related changes are merged.
