### PR TITLE
Ignore description and defaults when validing ruletype updates

### DIFF
--- a/internal/util/schemaupdate/schemaupdate_test.go
+++ b/internal/util/schemaupdate/schemaupdate_test.go
@@ -194,6 +194,122 @@ func TestValidateSchemaUpdate(t *testing.T) {
 			},
 			wantErr: true,
 		},
+		{
+			name: "changing the description is allowed",
+			args: args{
+				oldRuleSchemaDef: `{
+					"type": "object",
+					"properties": {
+						"foo": {
+							"type": "string",
+							"description": "foo desc original"
+						},
+						"bar": {
+							"type": "string"
+						}
+					}
+				}`,
+				newRuleSchemaDef: `{
+					"type": "object",
+					"properties": {
+						"foo": {
+							"type": "string",
+							"description": "foo desc modified"
+						},
+						"bar": {
+							"type": "string"
+						}
+					}
+				}`,
+			},
+			wantErr: false,
+		},
+		{
+			name: "changing a property named description is not allowed",
+			args: args{
+				oldRuleSchemaDef: `{
+					"type": "object",
+					"properties": {
+						"description": {
+							"type": "string"
+						},
+						"bar": {
+							"type": "string"
+						}
+					}
+				}`,
+				newRuleSchemaDef: `{
+					"type": "object",
+					"properties": {
+						"description": {
+							"type": "int"
+						},
+						"bar": {
+							"type": "string"
+						}
+					}
+				}`,
+			},
+			wantErr: true,
+		},
+		{
+			name: "changing the default is allowed",
+			args: args{
+				oldRuleSchemaDef: `{
+					"type": "object",
+					"properties": {
+						"foo": {
+							"type": "string",
+							"default": "f-o-o"
+						},
+						"bar": {
+							"type": "string"
+						}
+					}
+				}`,
+				newRuleSchemaDef: `{
+					"type": "object",
+					"properties": {
+						"foo": {
+							"type": "string",
+							"default": "o-o-f"
+						},
+						"bar": {
+							"type": "string"
+						}
+					}
+				}`,
+			},
+			wantErr: false,
+		},
+		{
+			name: "changing a property named default is not allowed",
+			args: args{
+				oldRuleSchemaDef: `{
+					"type": "object",
+					"properties": {
+						"default": {
+							"type": "string"
+						},
+						"bar": {
+							"type": "string"
+						}
+					}
+				}`,
+				newRuleSchemaDef: `{
+					"type": "object",
+					"properties": {
+						"default": {
+							"type": "int"
+						},
+						"bar": {
+							"type": "string"
+						}
+					}
+				}`,
+			},
+			wantErr: true,
+		},
 	}
 	for _, tt := range tests {
 		tt := tt


### PR DESCRIPTION
# Summary

We've been doing a bunch of changes to the defaults and descriptions to
make UI render better, but those are being flagged by minder ruletype
apply as incompatible because we require that the new ruletype is a
strict superset of the old one.

Let's ignore the description field as long as it's a scalar with a string
value and let's ignore the default field as long as it has a 'type'
sibling. These additional checks make sure that we don't accidentally
allow updating parameters that are named default or description.

Fixes: https://github.com/stacklok/minder/issues/3079

## Change Type

***Mark the type of change your PR introduces:***

- [x] Bug fix (resolves an issue without affecting existing features)
- [x] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [ ] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

ruletype apply -f with ruletypes that change either only defaults or description (those should pass)
or change something else (those should fail)

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [x] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [x] Included tests that validate the fix or feature.
- [ ] Checked that related changes are merged.
