### PR TITLE
Use provider ID instead of name when sending events

### DIFF
--- a/internal/artifacts/db.go
+++ b/internal/artifacts/db.go
@@ -1,0 +1,81 @@
+// Copyright 2024 Stacklok, Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package artifacts stores logic relating to the artifact entity type
+package artifacts
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+
+	"github.com/google/uuid"
+	"google.golang.org/protobuf/types/known/timestamppb"
+
+	"github.com/stacklok/minder/internal/db"
+	"github.com/stacklok/minder/internal/util/ptr"
+	minderv1 "github.com/stacklok/minder/pkg/api/protobuf/go/minder/v1"
+)
+
+// GetArtifact retrieves an artifact and its versions from the database
+// Returns provider ID alongside the artifact
+func GetArtifact(
+	ctx context.Context,
+	store db.Querier,
+	projectID uuid.UUID,
+	artifactID uuid.UUID,
+) (uuid.UUID, *minderv1.Artifact, error) {
+	// Retrieve artifact details
+	artifact, err := store.GetArtifactByID(ctx, db.GetArtifactByIDParams{
+		ID:        artifactID,
+		ProjectID: projectID,
+	})
+	if errors.Is(err, sql.ErrNoRows) {
+		return uuid.Nil, nil, fmt.Errorf("artifact not found")
+	} else if err != nil {
+		return uuid.Nil, nil, fmt.Errorf("failed to get artifact: %v", err)
+	}
+
+	var repoOwner, repoName string
+	if artifact.RepositoryID.Valid {
+		dbrepo, err := store.GetRepositoryByIDAndProject(ctx, db.GetRepositoryByIDAndProjectParams{
+			ID:        artifact.RepositoryID.UUID,
+			ProjectID: projectID,
+		})
+		if errors.Is(err, sql.ErrNoRows) {
+			return uuid.Nil, nil, fmt.Errorf("repository not found")
+		} else if err != nil {
+			return uuid.Nil, nil, fmt.Errorf("cannot read repository: %v", err)
+		}
+
+		repoOwner = dbrepo.RepoOwner
+		repoName = dbrepo.RepoName
+	}
+
+	// Build the artifact protobuf
+	return artifact.ProviderID, &minderv1.Artifact{
+		ArtifactPk: artifact.ID.String(),
+		Context: &minderv1.Context{
+			Project:  ptr.Ptr(projectID.String()),
+			Provider: ptr.Ptr(artifact.ProviderName),
+		},
+		Owner:      repoOwner,
+		Name:       artifact.ArtifactName,
+		Type:       artifact.ArtifactType,
+		Visibility: artifact.ArtifactVisibility,
+		Repository: repoName,
+		CreatedAt:  timestamppb.New(artifact.CreatedAt),
+	}, nil
+}

--- a/internal/controlplane/handlers_reconciliationtasks.go
+++ b/internal/controlplane/handlers_reconciliationtasks.go
@@ -99,7 +99,7 @@ func getRepositoryReconciliationMessage(ctx context.Context, store db.Store,
 		return nil, status.Errorf(codes.NotFound, "repository not found")
 	}
 
-	msg, err := reconcilers.NewRepoReconcilerMessage(repo.Provider, repo.RepoID, repo.ProjectID)
+	msg, err := reconcilers.NewRepoReconcilerMessage(repo.ProviderID, repo.RepoID, repo.ProjectID)
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "error getting reconciler message: %v", err)
 	}

--- a/internal/controlplane/handlers_repositories.go
+++ b/internal/controlplane/handlers_repositories.go
@@ -443,7 +443,7 @@ func (s *Server) deleteRepository(
 		return status.Errorf(codes.Internal, "unexpected error fetching repo: %v", err)
 	}
 
-	provider, err := s.providerStore.GetByName(ctx, projectID, repo.Provider)
+	provider, err := s.providerStore.GetByID(ctx, repo.ID)
 	if err != nil {
 		return status.Errorf(codes.Internal, "cannot get provider: %v", err)
 	}

--- a/internal/controlplane/handlers_repositories.go
+++ b/internal/controlplane/handlers_repositories.go
@@ -434,8 +434,6 @@ func (s *Server) deleteRepository(
 	ctx context.Context,
 	repoQueryMethod func() (db.Repository, error),
 ) error {
-	projectID := getProjectID(ctx)
-
 	repo, err := repoQueryMethod()
 	if errors.Is(err, sql.ErrNoRows) {
 		return status.Errorf(codes.NotFound, "repository not found")

--- a/internal/controlplane/handlers_repositories.go
+++ b/internal/controlplane/handlers_repositories.go
@@ -33,6 +33,7 @@ import (
 	"github.com/stacklok/minder/internal/projects/features"
 	"github.com/stacklok/minder/internal/providers"
 	"github.com/stacklok/minder/internal/providers/github"
+	"github.com/stacklok/minder/internal/repositories"
 	ghrepo "github.com/stacklok/minder/internal/repositories/github"
 	"github.com/stacklok/minder/internal/util"
 	cursorutil "github.com/stacklok/minder/internal/util/cursor"
@@ -112,6 +113,9 @@ func (s *Server) ListRepositories(ctx context.Context,
 	projectID := entityCtx.Project.ID
 	providerName := entityCtx.Provider.Name
 
+	logger.BusinessRecord(ctx).Provider = providerName
+	logger.BusinessRecord(ctx).Project = projectID
+
 	providerFilter := getNameFilterParam(providerName)
 
 	reqRepoCursor, err := cursorutil.NewRepoCursor(in.GetCursor())
@@ -149,7 +153,7 @@ func (s *Server) ListRepositories(ctx context.Context,
 
 	for _, repo := range repos {
 		projID := repo.ProjectID.String()
-		r := util.PBRepositoryFromDB(repo)
+		r := repositories.PBRepositoryFromDB(repo)
 		r.Context = &pb.Context{
 			Project:  &projID,
 			Provider: &repo.Provider,
@@ -172,11 +176,6 @@ func (s *Server) ListRepositories(ctx context.Context,
 
 	resp.Results = results
 	resp.Cursor = respRepoCursor.String()
-
-	// Telemetry logging
-	// TODO: Change to ProviderID
-	logger.BusinessRecord(ctx).Provider = providerName
-	logger.BusinessRecord(ctx).Project = projectID
 
 	return &resp, nil
 }
@@ -202,7 +201,7 @@ func (s *Server) GetRepositoryById(ctx context.Context,
 	}
 
 	projID := repo.ProjectID.String()
-	r := util.PBRepositoryFromDB(repo)
+	r := repositories.PBRepositoryFromDB(repo)
 	r.Context = &pb.Context{
 		Project:  &projID,
 		Provider: &repo.Provider,
@@ -247,7 +246,7 @@ func (s *Server) GetRepositoryByName(ctx context.Context,
 	}
 
 	projID := repo.ProjectID.String()
-	r := util.PBRepositoryFromDB(repo)
+	r := repositories.PBRepositoryFromDB(repo)
 	r.Context = &pb.Context{
 		Project:  &projID,
 		Provider: &repo.Provider,

--- a/internal/controlplane/handlers_repositories_test.go
+++ b/internal/controlplane/handlers_repositories_test.go
@@ -58,7 +58,7 @@ func TestServer_RegisterRepository(t *testing.T) {
 			RepoOwner:     repoOwner,
 			RepoName:      repoName,
 			ProviderFails: true,
-			ExpectedError: "cannot retrieve provider",
+			ExpectedError: "cannot get provider",
 		},
 		{
 			Name:          "Repo creation fails when repo name is missing",
@@ -222,7 +222,7 @@ func TestServer_DeleteRepository(t *testing.T) {
 			RepoName:         repoOwnerAndName,
 			RepoServiceSetup: newRepoService(withSuccessfulGetRepoByName),
 			ProviderFails:    true,
-			ExpectedError:    "cannot retrieve provider",
+			ExpectedError:    "cannot get provider",
 		},
 		{
 			Name:          "delete by name fails when name is malformed",
@@ -464,8 +464,11 @@ func createServer(ctrl *gomock.Controller, repoServiceSetup repoMockBuilder, git
 
 	if providerFails {
 		store.EXPECT().
+			GetProviderByID(gomock.Any(), gomock.Any()).
+			Return(db.Provider{}, errDefault).AnyTimes()
+		store.EXPECT().
 			FindProviders(gomock.Any(), gomock.Any()).
-			Return([]db.Provider{}, errDefault)
+			Return([]db.Provider{}, errDefault).AnyTimes()
 	} else {
 		store.EXPECT().
 			FindProviders(gomock.Any(), gomock.Any()).
@@ -475,6 +478,9 @@ func createServer(ctrl *gomock.Controller, repoServiceSetup repoMockBuilder, git
 			Return(db.ProviderAccessToken{
 				EncryptedToken: "encryptedToken",
 			}, nil).AnyTimes()
+		store.EXPECT().
+			GetProviderByID(gomock.Any(), gomock.Any()).
+			Return(provider, nil).AnyTimes()
 	}
 
 	return &Server{

--- a/internal/eea/eea.go
+++ b/internal/eea/eea.go
@@ -29,11 +29,11 @@ import (
 	"github.com/google/uuid"
 	"github.com/rs/zerolog"
 
+	"github.com/stacklok/minder/internal/artifacts"
 	serverconfig "github.com/stacklok/minder/internal/config/server"
 	"github.com/stacklok/minder/internal/db"
 	"github.com/stacklok/minder/internal/engine/entities"
 	"github.com/stacklok/minder/internal/events"
-	"github.com/stacklok/minder/internal/util"
 )
 
 // EEA is the Event Execution Aggregator
@@ -310,7 +310,7 @@ func (e *EEA) buildRepositoryInfoWrapper(
 	repoID uuid.NullUUID,
 	projID uuid.UUID,
 ) (*entities.EntityInfoWrapper, error) {
-	r, err := util.GetRepository(ctx, e.querier, projID, repoID.UUID)
+	providerID, r, err := getRepository(ctx, e.querier, projID, repoID.UUID)
 	if err != nil {
 		return nil, fmt.Errorf("error getting repository: %w", err)
 	}
@@ -319,7 +319,7 @@ func (e *EEA) buildRepositoryInfoWrapper(
 		WithRepository(r).
 		WithRepositoryID(repoID.UUID).
 		WithProjectID(projID).
-		WithProvider(*r.Context.Provider), nil
+		WithProviderID(providerID), nil
 }
 
 func (e *EEA) buildArtifactInfoWrapper(
@@ -328,7 +328,7 @@ func (e *EEA) buildArtifactInfoWrapper(
 	projID uuid.UUID,
 	artID uuid.NullUUID,
 ) (*entities.EntityInfoWrapper, error) {
-	a, err := util.GetArtifact(ctx, e.querier, projID, artID.UUID)
+	providerID, a, err := artifacts.GetArtifact(ctx, e.querier, projID, artID.UUID)
 	if err != nil {
 		return nil, fmt.Errorf("error getting artifact with versions: %w", err)
 	}
@@ -337,7 +337,7 @@ func (e *EEA) buildArtifactInfoWrapper(
 		WithProjectID(projID).
 		WithArtifact(a).
 		WithArtifactID(artID.UUID).
-		WithProvider(*a.Context.Provider)
+		WithProviderID(providerID)
 	if repoID.Valid {
 		eiw.WithRepositoryID(repoID.UUID)
 	}
@@ -350,7 +350,7 @@ func (e *EEA) buildPullRequestInfoWrapper(
 	projID uuid.UUID,
 	prID uuid.NullUUID,
 ) (*entities.EntityInfoWrapper, error) {
-	pr, err := util.GetPullRequest(ctx, e.querier, projID, repoID.UUID, prID.UUID)
+	providerID, pr, err := getPullRequest(ctx, e.querier, projID, repoID.UUID, prID.UUID)
 	if err != nil {
 		return nil, fmt.Errorf("error getting pull request: %w", err)
 	}
@@ -360,5 +360,5 @@ func (e *EEA) buildPullRequestInfoWrapper(
 		WithProjectID(projID).
 		WithPullRequest(pr).
 		WithPullRequestID(prID.UUID).
-		WithProvider(*pr.Context.Provider), nil
+		WithProviderID(providerID), nil
 }

--- a/internal/eea/eea_test.go
+++ b/internal/eea/eea_test.go
@@ -45,6 +45,10 @@ const (
 	providerName = "test-provider"
 )
 
+var (
+	providerID = uuid.New()
+)
+
 func TestAggregator(t *testing.T) {
 	t.Parallel()
 
@@ -100,7 +104,7 @@ func TestAggregator(t *testing.T) {
 		WithRepository(&minderv1.Repository{}).
 		WithRepositoryID(repoID).
 		WithProjectID(projectID).
-		WithProvider(providerName)
+		WithProviderID(providerID)
 
 	<-evt.Running()
 
@@ -208,16 +212,18 @@ func TestFlushAll(t *testing.T) {
 				// base repo info
 				mockStore.EXPECT().GetRepositoryByID(ctx, repoID).
 					Return(db.Repository{
-						ID:        repoID,
-						ProjectID: projectID,
-						Provider:  providerName,
+						ID:         repoID,
+						ProjectID:  projectID,
+						Provider:   providerName,
+						ProviderID: providerID,
 					}, nil)
 				// subsequent repo fetch for protobuf conversion
 				mockStore.EXPECT().GetRepositoryByIDAndProject(ctx, gomock.Any()).
 					Return(db.Repository{
-						ID:        repoID,
-						ProjectID: projectID,
-						Provider:  providerName,
+						ID:         repoID,
+						ProjectID:  projectID,
+						Provider:   providerName,
+						ProviderID: providerID,
 					}, nil)
 
 				// There should be one flush in the end
@@ -252,22 +258,25 @@ func TestFlushAll(t *testing.T) {
 				// base repo info
 				mockStore.EXPECT().GetRepositoryByID(ctx, repoID).
 					Return(db.Repository{
-						ID:        repoID,
-						ProjectID: projectID,
-						Provider:  providerName,
+						ID:         repoID,
+						ProjectID:  projectID,
+						Provider:   providerName,
+						ProviderID: providerID,
 					}, nil)
 				// subsequent artifact fetch for protobuf conversion
 				mockStore.EXPECT().GetRepositoryByIDAndProject(ctx, gomock.Any()).
 					Return(db.Repository{
-						ID:        repoID,
-						ProjectID: projectID,
-						Provider:  providerName,
+						ID:         repoID,
+						ProjectID:  projectID,
+						Provider:   providerName,
+						ProviderID: providerID,
 					}, nil)
 				mockStore.EXPECT().GetArtifactByID(ctx, gomock.Any()).
 					Return(db.Artifact{
 						ID:           artID,
 						ProjectID:    projectID,
 						ProviderName: providerName,
+						ProviderID:   providerID,
 						RepositoryID: uuid.NullUUID{UUID: repoID, Valid: true},
 					}, nil)
 
@@ -306,15 +315,17 @@ func TestFlushAll(t *testing.T) {
 				// subsequent artifact fetch for protobuf conversion
 				mockStore.EXPECT().GetRepositoryByIDAndProject(ctx, gomock.Any()).
 					Return(db.Repository{
-						ID:        repoID,
-						ProjectID: projectID,
-						Provider:  providerName,
+						ID:         repoID,
+						ProjectID:  projectID,
+						Provider:   providerName,
+						ProviderID: providerID,
 					}, nil)
 				mockStore.EXPECT().GetArtifactByID(ctx, gomock.Any()).
 					Return(db.Artifact{
 						ID:           artID,
 						ProjectID:    projectID,
 						ProviderName: providerName,
+						ProviderID:   providerID,
 						RepositoryID: uuid.NullUUID{UUID: repoID, Valid: true},
 					}, nil)
 
@@ -355,6 +366,7 @@ func TestFlushAll(t *testing.T) {
 						ID:           artID,
 						ProjectID:    projectID,
 						ProviderName: providerName,
+						ProviderID:   providerID,
 					}, nil)
 
 				// There should be one flush in the end
@@ -389,16 +401,18 @@ func TestFlushAll(t *testing.T) {
 				// base repo info
 				mockStore.EXPECT().GetRepositoryByID(ctx, repoID).
 					Return(db.Repository{
-						ID:        repoID,
-						ProjectID: projectID,
-						Provider:  providerName,
+						ID:         repoID,
+						ProjectID:  projectID,
+						Provider:   providerName,
+						ProviderID: providerID,
 					}, nil)
 				// subsequent artifact fetch for protobuf conversion
 				mockStore.EXPECT().GetRepositoryByIDAndProject(ctx, gomock.Any()).
 					Return(db.Repository{
-						ID:        repoID,
-						ProjectID: projectID,
-						Provider:  providerName,
+						ID:         repoID,
+						ProjectID:  projectID,
+						Provider:   providerName,
+						ProviderID: providerID,
 					}, nil)
 				mockStore.EXPECT().GetPullRequestByID(ctx, prID).
 					Return(db.PullRequest{

--- a/internal/eea/entities.go
+++ b/internal/eea/entities.go
@@ -1,0 +1,91 @@
+// Copyright 2024 Stacklok, Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package eea
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+
+	"github.com/google/uuid"
+
+	"github.com/stacklok/minder/internal/db"
+	"github.com/stacklok/minder/internal/repositories"
+	"github.com/stacklok/minder/internal/util/ptr"
+	minderv1 "github.com/stacklok/minder/pkg/api/protobuf/go/minder/v1"
+)
+
+// various DB access functions for EEA
+
+// GetRepository retrieves a repository from the database
+// and converts it to a protobuf
+// Returns provider ID alongside the repository
+func getRepository(
+	ctx context.Context,
+	store db.Querier,
+	projectID uuid.UUID,
+	repoID uuid.UUID,
+) (uuid.UUID, *minderv1.Repository, error) {
+	dbrepo, err := store.GetRepositoryByIDAndProject(ctx, db.GetRepositoryByIDAndProjectParams{
+		ID:        repoID,
+		ProjectID: projectID,
+	})
+	if err != nil {
+		return uuid.Nil, nil, fmt.Errorf("error getting repository: %w", err)
+	}
+
+	return dbrepo.ProviderID, repositories.PBRepositoryFromDB(dbrepo), nil
+}
+
+// GetPullRequest retrieves a pull request from the database
+// and converts it to a protobuf
+// Returns provider ID alongside the repository
+func getPullRequest(
+	ctx context.Context,
+	store db.Querier,
+	projectID,
+	repoID,
+	pullRequestID uuid.UUID,
+) (uuid.UUID, *minderv1.PullRequest, error) {
+	// Get repository data - we need the owner and name
+	dbrepo, err := store.GetRepositoryByIDAndProject(ctx, db.GetRepositoryByIDAndProjectParams{
+		ID:        repoID,
+		ProjectID: projectID,
+	})
+	if errors.Is(err, sql.ErrNoRows) {
+		return uuid.Nil, nil, fmt.Errorf("repository not found")
+	} else if err != nil {
+		return uuid.Nil, nil, fmt.Errorf("cannot read repository: %v", err)
+	}
+
+	dbpr, err := store.GetPullRequestByID(ctx, pullRequestID)
+	if errors.Is(err, sql.ErrNoRows) {
+		return uuid.Nil, nil, fmt.Errorf("pull request not found")
+	} else if err != nil {
+		return uuid.Nil, nil, fmt.Errorf("cannot read pull request: %v", err)
+	}
+
+	// TODO: Do we need extra columns in the pull request table?
+	return dbrepo.ProviderID, &minderv1.PullRequest{
+		Context: &minderv1.Context{
+			Project:  ptr.Ptr(dbrepo.ProjectID.String()),
+			Provider: ptr.Ptr(dbrepo.Provider),
+		},
+		Number:    dbpr.PrNumber,
+		RepoOwner: dbrepo.RepoOwner,
+		RepoName:  dbrepo.RepoName,
+	}, nil
+}

--- a/internal/engine/entities/entity_event.go
+++ b/internal/engine/entities/entity_event.go
@@ -70,7 +70,7 @@ const (
 const (
 	// EntityTypeEventKey is the key for the entity type
 	EntityTypeEventKey = "entity_type"
-	// ProviderIDEventKey is the key for the provider
+	// ProviderIDEventKey is the key for the provider ID
 	ProviderIDEventKey = "provider_id"
 	// ProviderEventKey is the key for the provider
 	ProviderEventKey = "provider"
@@ -95,14 +95,7 @@ func NewEntityInfoWrapper() *EntityInfoWrapper {
 	}
 }
 
-// WithProvider sets the provider
-func (eiw *EntityInfoWrapper) WithProvider(provider string) *EntityInfoWrapper {
-	eiw.Provider = provider
-
-	return eiw
-}
-
-// WithProviderID sets the provider
+// WithProviderID sets the provider ID
 func (eiw *EntityInfoWrapper) WithProviderID(providerID uuid.UUID) *EntityInfoWrapper {
 	eiw.ProviderID = providerID
 
@@ -237,9 +230,8 @@ func (eiw *EntityInfoWrapper) ToMessage(msg *message.Message) error {
 		return fmt.Errorf("project ID is required")
 	}
 
-	// TODO: make provider ID mandatory instead
-	if eiw.Provider == "" {
-		return fmt.Errorf("provider is required")
+	if eiw.ProviderID == uuid.Nil {
+		return fmt.Errorf("provider ID is required")
 	}
 
 	if eiw.ExecutionID != nil {
@@ -308,12 +300,13 @@ func (eiw *EntityInfoWrapper) withProjectIDFromMessage(msg *message.Message) err
 }
 
 func (eiw *EntityInfoWrapper) withProviderFromMessage(msg *message.Message) error {
-	provider := msg.Metadata.Get(ProviderEventKey)
-	if provider == "" {
-		return fmt.Errorf("%s not found in metadata", ProviderEventKey)
+	providerName := msg.Metadata.Get(ProviderEventKey)
+	rawProviderID := msg.Metadata.Get(ProviderIDEventKey)
+	// TODO: get rid of Provider name
+	if providerName == "" && rawProviderID == "" {
+		return fmt.Errorf("neither %s nor %s found in metadata", ProviderIDEventKey, ProviderEventKey)
 	}
 
-	rawProviderID := msg.Metadata.Get(ProviderIDEventKey)
 	// TODO: Make provider ID mandatory. Right now, default to a nil UUID
 	providerID := uuid.Nil
 	if rawProviderID != "" {
@@ -324,7 +317,7 @@ func (eiw *EntityInfoWrapper) withProviderFromMessage(msg *message.Message) erro
 		}
 	}
 
-	eiw.Provider = provider
+	eiw.Provider = providerName
 	eiw.ProviderID = providerID
 	return nil
 }

--- a/internal/engine/entities/entity_event.go
+++ b/internal/engine/entities/entity_event.go
@@ -299,7 +299,7 @@ func (eiw *EntityInfoWrapper) withProjectIDFromMessage(msg *message.Message) err
 	return nil
 }
 
-func (eiw *EntityInfoWrapper) withProviderFromMessage(msg *message.Message) error {
+func (eiw *EntityInfoWrapper) withProviderIDFromMessage(msg *message.Message) error {
 	providerName := msg.Metadata.Get(ProviderEventKey)
 	rawProviderID := msg.Metadata.Get(ProviderIDEventKey)
 	// TODO: get rid of Provider name
@@ -409,7 +409,7 @@ func ParseEntityEvent(msg *message.Message) (*EntityInfoWrapper, error) {
 		return nil, err
 	}
 
-	if err := out.withProviderFromMessage(msg); err != nil {
+	if err := out.withProviderIDFromMessage(msg); err != nil {
 		return nil, err
 	}
 

--- a/internal/engine/executor.go
+++ b/internal/engine/executor.go
@@ -202,10 +202,10 @@ func (e *Executor) prepAndEvalEntityEvent(ctx context.Context, inf *entities.Ent
 	// TODO: clean this up once we get rid of provider name
 	var provider *db.Provider
 	var err error
-	if inf.ProviderID == uuid.Nil {
-		provider, err = e.providerStore.GetByName(ctx, inf.ProjectID, inf.Provider)
-	} else {
+	if inf.ProviderID != uuid.Nil {
 		provider, err = e.providerStore.GetByID(ctx, inf.ProviderID)
+	} else {
+		provider, err = e.providerStore.GetByName(ctx, inf.ProjectID, inf.Provider)
 	}
 	if err != nil {
 		return fmt.Errorf("error getting provider: %w", err)

--- a/internal/logger/telemetry_store.go
+++ b/internal/logger/telemetry_store.go
@@ -72,7 +72,7 @@ type TelemetryStore struct {
 	// Provider records the provider name that the request was associated with.
 	Provider string `json:"provider"`
 
-	// ProviderID records the provider name that the request was associated with.
+	// ProviderID records the provider ID that the request was associated with.
 	ProviderID uuid.UUID `json:"provider_id"`
 
 	// Repository is the repository ID that the request was associated with.

--- a/internal/logger/telemetry_store_watermill_test.go
+++ b/internal/logger/telemetry_store_watermill_test.go
@@ -61,12 +61,12 @@ func TestTelemetryStoreWMMiddlewareLogsRepositoryInfo(t *testing.T) {
 
 	<-evt.Running()
 
-	providerName := "test-provider"
+	providerID := uuid.New()
 	projectID := uuid.New()
 	repositoryID := uuid.New()
 
 	eiw := entities.NewEntityInfoWrapper().
-		WithProvider(providerName).
+		WithProviderID(providerID).
 		WithProjectID(projectID).
 		WithRepository(&minderv1.Repository{
 			Name:     "test",
@@ -88,7 +88,7 @@ func TestTelemetryStoreWMMiddlewareLogsRepositoryInfo(t *testing.T) {
 	t.Logf("logged: %v", logged)
 
 	require.Equal(t, projectID.String(), logged["project"], "expected project ID to be logged")
-	require.Equal(t, providerName, logged["provider"], "expected provider to be logged")
+	require.Equal(t, providerID.String(), logged["provider_id"], "expected provider to be logged")
 	require.Equal(t, repositoryID.String(), logged["repository"], "expected repository ID to be logged")
 	require.Equal(t, "true", logged["telemetry"], "expected telemetry to be logged")
 }

--- a/internal/reconcilers/repository.go
+++ b/internal/reconcilers/repository.go
@@ -32,7 +32,7 @@ import (
 	"github.com/stacklok/minder/internal/engine/entities"
 	"github.com/stacklok/minder/internal/providers"
 	"github.com/stacklok/minder/internal/providers/github"
-	"github.com/stacklok/minder/internal/util"
+	"github.com/stacklok/minder/internal/repositories"
 	"github.com/stacklok/minder/internal/verifier/verifyif"
 	pb "github.com/stacklok/minder/pkg/api/protobuf/go/minder/v1"
 )
@@ -108,10 +108,10 @@ func (r *Reconciler) handleArtifactsReconcilerEvent(ctx context.Context, evt *Re
 	}
 
 	// evaluate profile for repo
-	repo := util.PBRepositoryFromDB(repository)
+	repo := repositories.PBRepositoryFromDB(repository)
 
 	err = entities.NewEntityInfoWrapper().
-		WithProvider(prov.Name).
+		WithProviderID(prov.ID).
 		WithRepository(repo).
 		WithProjectID(evt.Project).
 		WithRepositoryID(repository.ID).
@@ -184,7 +184,7 @@ func (r *Reconciler) handleArtifactsReconcilerEvent(ctx context.Context, evt *Re
 			CreatedAt:  timestamppb.New(artifact.GetCreatedAt().Time),
 		}
 		err = entities.NewEntityInfoWrapper().
-			WithProvider(prov.Name).
+			WithProviderID(prov.ID).
 			WithArtifact(pbArtifact).
 			WithProjectID(evt.Project).
 			WithArtifactID(newArtifact.ID).

--- a/internal/reconcilers/repository.go
+++ b/internal/reconcilers/repository.go
@@ -46,7 +46,7 @@ type RepoReconcilerEvent struct {
 }
 
 // NewRepoReconcilerMessage creates a new repos init event
-func NewRepoReconcilerMessage(provider string, repoID int64, projectID uuid.UUID) (*message.Message, error) {
+func NewRepoReconcilerMessage(providerID uuid.UUID, repoID int64, projectID uuid.UUID) (*message.Message, error) {
 	evt := &RepoReconcilerEvent{
 		Repository: repoID,
 		Project:    projectID,
@@ -58,7 +58,7 @@ func NewRepoReconcilerMessage(provider string, repoID int64, projectID uuid.UUID
 	}
 
 	msg := message.NewMessage(uuid.New().String(), evtStr)
-	msg.Metadata.Set("provider", provider)
+	msg.Metadata.Set("provider_id", providerID.String())
 	return msg, nil
 }
 

--- a/internal/reconcilers/run_profile.go
+++ b/internal/reconcilers/run_profile.go
@@ -26,10 +26,11 @@ import (
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
 
+	"github.com/stacklok/minder/internal/artifacts"
 	"github.com/stacklok/minder/internal/db"
 	"github.com/stacklok/minder/internal/engine"
 	"github.com/stacklok/minder/internal/engine/entities"
-	"github.com/stacklok/minder/internal/util"
+	"github.com/stacklok/minder/internal/repositories"
 )
 
 // ProfileInitEvent is an event that is sent to the reconciler topic
@@ -112,9 +113,9 @@ func (r *Reconciler) publishProfileInitEvents(
 
 	for _, dbrepo := range dbrepos {
 		// protobufs are our API, so we always execute on these instead of the DB directly.
-		repo := util.PBRepositoryFromDB(dbrepo)
+		repo := repositories.PBRepositoryFromDB(dbrepo)
 		err := entities.NewEntityInfoWrapper().
-			WithProvider(dbrepo.Provider).
+			WithProviderID(dbrepo.ProviderID).
 			WithProjectID(ectx.Project.ID).
 			WithRepository(repo).
 			WithRepositoryID(dbrepo.ID).
@@ -158,13 +159,13 @@ func (r *Reconciler) publishArtifactProfileInitEvents(
 	}
 	for _, dbA := range dbArtifacts {
 		// Get the artifact with all its versions as a protobuf
-		pbArtifact, err := util.GetArtifact(ctx, r.store, dbrepo.ProjectID, dbA.ID)
+		_, pbArtifact, err := artifacts.GetArtifact(ctx, r.store, dbrepo.ProjectID, dbA.ID)
 		if err != nil {
 			return fmt.Errorf("error getting artifact versions: %w", err)
 		}
 
 		err = entities.NewEntityInfoWrapper().
-			WithProvider(dbrepo.Provider).
+			WithProviderID(dbrepo.ProviderID).
 			WithProjectID(ectx.Project.ID).
 			WithArtifact(pbArtifact).
 			WithRepositoryID(dbrepo.ID).

--- a/internal/repositories/db.go
+++ b/internal/repositories/db.go
@@ -1,0 +1,47 @@
+// Copyright 2024 Stacklok, Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package repositories contains logic relating to the repository entity type
+package repositories
+
+import (
+	"google.golang.org/protobuf/types/known/timestamppb"
+
+	"github.com/stacklok/minder/internal/db"
+	"github.com/stacklok/minder/internal/util/ptr"
+	minderv1 "github.com/stacklok/minder/pkg/api/protobuf/go/minder/v1"
+)
+
+// PBRepositoryFromDB converts a database repository to a protobuf
+func PBRepositoryFromDB(dbrepo db.Repository) *minderv1.Repository {
+	return &minderv1.Repository{
+		Id: ptr.Ptr(dbrepo.ID.String()),
+		Context: &minderv1.Context{
+			Provider: &dbrepo.Provider,
+			Project:  ptr.Ptr(dbrepo.ProjectID.String()),
+		},
+		Owner:         dbrepo.RepoOwner,
+		Name:          dbrepo.RepoName,
+		RepoId:        dbrepo.RepoID,
+		IsPrivate:     dbrepo.IsPrivate,
+		IsFork:        dbrepo.IsFork,
+		HookUrl:       dbrepo.WebhookUrl,
+		DeployUrl:     dbrepo.DeployUrl,
+		CloneUrl:      dbrepo.CloneUrl,
+		DefaultBranch: dbrepo.DefaultBranch.String,
+		License:       dbrepo.License.String,
+		CreatedAt:     timestamppb.New(dbrepo.CreatedAt),
+		UpdatedAt:     timestamppb.New(dbrepo.UpdatedAt),
+	}
+}

--- a/internal/repositories/github/service.go
+++ b/internal/repositories/github/service.go
@@ -156,7 +156,7 @@ func (r *repositoryService) CreateRepository(
 	}
 
 	// publish a reconciling event for the registered repositories
-	if err = r.pushReconcilerEvent(pbRepo, projectID, provider.Name); err != nil {
+	if err = r.pushReconcilerEvent(pbRepo, projectID, provider.ID); err != nil {
 		return nil, err
 	}
 
@@ -253,10 +253,10 @@ func (r *repositoryService) DeleteRepositoriesByProvider(
 	return nil
 }
 
-func (r *repositoryService) pushReconcilerEvent(pbRepo *pb.Repository, projectID uuid.UUID, providerName string) error {
+func (r *repositoryService) pushReconcilerEvent(pbRepo *pb.Repository, projectID uuid.UUID, providerID uuid.UUID) error {
 	log.Printf("publishing register event for repository: %s/%s", pbRepo.Owner, pbRepo.Name)
 
-	msg, err := reconcilers.NewRepoReconcilerMessage(providerName, pbRepo.RepoId, projectID)
+	msg, err := reconcilers.NewRepoReconcilerMessage(providerID, pbRepo.RepoId, projectID)
 	if err != nil {
 		return fmt.Errorf("error creating reconciler event: %v", err)
 	}

--- a/internal/util/helpers.go
+++ b/internal/util/helpers.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"crypto/tls"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"io/fs"


### PR DESCRIPTION
Relates to #3071

This PR changes any code which creates an EntityInfoWrapper to use Provider ID instead of name. The name is still left as a field in the event for backwards compatibility purposes, and the consumer can still use the name to create the provider instance. However, the name is no longer populated.

Some other refactoring was carried out, specifically moving code from the helper package to more appropriate packages.

# Summary

***Provide a brief overview of the changes and the issue being addressed. 
Explain the rationale and any background necessary for understanding the changes. 
List dependencies required by this change, if any.***

Fixes #(related issue)

## Change Type

***Mark the type of change your PR introduces:***

- [ ] Bug fix (resolves an issue without affecting existing features)
- [x] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [ ] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

***Outline how the changes were tested, including steps to reproduce and any relevant configurations. 
Attach screenshots if helpful.***

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [x] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [x] Included tests that validate the fix or feature.
- [ ] Checked that related changes are merged.
