### PR TITLE
Add `minder auth token` command

### DIFF
--- a/cmd/cli/app/auth/auth_token.go
+++ b/cmd/cli/app/auth/auth_token.go
@@ -1,5 +1,5 @@
 //
-// Copyright 2023 Stacklok, Inc.
+// Copyright 2024 Stacklok, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/cmd/cli/app/auth/auth_token.go
+++ b/cmd/cli/app/auth/auth_token.go
@@ -1,0 +1,87 @@
+//
+// Copyright 2023 Stacklok, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package auth
+
+import (
+	"context"
+	"errors"
+	"os"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+
+	"github.com/stacklok/minder/internal/config"
+	clientconfig "github.com/stacklok/minder/internal/config/client"
+	"github.com/stacklok/minder/internal/util"
+	"github.com/stacklok/minder/internal/util/cli"
+)
+
+var tokenCmd = &cobra.Command{
+	Use:   "token",
+	Short: "Print your token for Minder",
+	Long: `The token command allows for printing the token for Minder. This is useful
+for using with automation scripts or other tools.`,
+	RunE: TokenCommand,
+}
+
+// TokenCommand is the token subcommand
+func TokenCommand(cmd *cobra.Command, _ []string) error {
+	ctx := context.Background()
+
+	clientConfig, err := config.ReadConfigFromViper[clientconfig.Config](viper.GetViper())
+	if err != nil {
+		return cli.MessageAndError("Unable to read config", err)
+	}
+
+	skipBrowser := viper.GetBool("token.skip-browser")
+
+	// No longer print usage on returned error, since we've parsed our inputs
+	// See https://github.com/spf13/cobra/issues/340#issuecomment-374617413
+	cmd.SilenceUsage = true
+
+	// save credentials
+	issuerUrl := clientConfig.Identity.CLI.IssuerUrl
+	clientId := clientConfig.Identity.CLI.ClientId
+	creds, err := util.GetToken(issuerUrl, clientId)
+	if err != nil {
+		cmd.Printf("Error getting token: %v\n", err)
+		if errors.Is(err, os.ErrNotExist) || errors.Is(err, util.ErrGettingRefreshToken) {
+			// wait for the token to be received
+			token, err := login(ctx, cmd, clientConfig, []string{}, skipBrowser)
+			if err != nil {
+				return err
+			}
+
+			creds = token.AccessToken
+		} else {
+			return cli.MessageAndError("Error getting token", err)
+		}
+	}
+
+	cmd.Print(creds)
+	return nil
+}
+
+func init() {
+	AuthCmd.AddCommand(tokenCmd)
+
+	// hidden flags
+	tokenCmd.Flags().BoolP("skip-browser", "", false, "Skip opening the browser for OAuth flow")
+	// Bind flags
+	if err := viper.BindPFlag("token.skip-browser", tokenCmd.Flags().Lookup("skip-browser")); err != nil {
+		panic(err)
+	}
+}

--- a/internal/util/helpers.go
+++ b/internal/util/helpers.go
@@ -59,6 +59,8 @@ var (
 	// MinderAuthTokenEnvVar is the environment variable for the minder auth token
 	//nolint:gosec // This is not a hardcoded credential
 	MinderAuthTokenEnvVar = "MINDER_AUTH_TOKEN"
+	// ErrGettingRefreshToken is an error for when we can't get a refresh token
+	ErrGettingRefreshToken = errors.New("error refreshing credentials")
 )
 
 // OpenIdCredentials is a struct to hold the access and refresh tokens
@@ -212,7 +214,7 @@ func GetToken(issuerUrl string, clientId string) (string, error) {
 	if needsRefresh {
 		updatedCreds, err := RefreshCredentials(creds.RefreshToken, issuerUrl, clientId)
 		if err != nil {
-			return "", fmt.Errorf("error refreshing credentials: %v", err)
+			return "", fmt.Errorf("%w: %v", ErrGettingRefreshToken, err)
 		}
 		return updatedCreds.AccessToken, nil
 	}


### PR DESCRIPTION
# Summary

This command allows you to retrieve a token from the identity provider
used by the given configuration. This is handy when trying to do work on
a direct API, for debugging, or for working with other tools in the
ecosystem (e.g. trusty).

It'll try to authenticate and print out a token to be used, or simply
read the token that's already in `credentials.json`.

An ideal flow would be `minder auth login` then `minder auth token`.

## Change Type

***Mark the type of change your PR introduces:***

- [ ] Bug fix (resolves an issue without affecting existing features)
- [x] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [ ] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [ ] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [ ] Included tests that validate the fix or feature.
- [ ] Checked that related changes are merged.
