### PR TITLE
Remove a link that is overlayed in downstream docs

### DIFF
--- a/docs/docs/understand/remediations.md
+++ b/docs/docs/understand/remediations.md
@@ -9,7 +9,7 @@ Minder can perform _automatic remediation_ for many rules in an attempt to resol
 
 The steps to take during automatic remediation are defined within the rule itself and can perform actions like sending a REST call to an endpoint to change configuration, or creating a pull request with a proposed fix.
 
-For example, if you have a rule in your profile that specifies that [Secret Scanning should be enabled](../ref/rules/secret_scanning), and you have enabled automatic remediation in your profile, then Minder will attempt to turn Secret Scanning on in any repositories where it is not enabled.
+For example, if you have a rule in your profile that specifies that Secret Scanning should be enabled, and you have enabled automatic remediation in your profile, then Minder will attempt to turn Secret Scanning on in any repositories where it is not enabled.
 
 ### Enabling remediations in a profile
 To activate the remediation feature within a profile, you need to adjust the YAML definition.


### PR DESCRIPTION

# Summary

Downstream overlays docs for ruletypes which means that when building
downstream docs the link to the secret_scanning ruletype was broken.

Let's just remove the link instead of creating yet another overlay.

## Change Type

***Mark the type of change your PR introduces:***

- [ ] Bug fix (resolves an issue without affecting existing features)
- [ ] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [x] Documentation (updates or additions to documentation)
- [ ] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

***Outline how the changes were tested, including steps to reproduce and any relevant configurations. 
Attach screenshots if helpful.***

# Review Checklist:

- [ ] Reviewed my own code for quality and clarity.
- [ ] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [ ] Included tests that validate the fix or feature.
- [ ] Checked that related changes are merged.
