### PR TITLE
Return 500 if Github AppName is empty when enrolling provider

### DIFF
--- a/internal/controlplane/handlers_oauth.go
+++ b/internal/controlplane/handlers_oauth.go
@@ -52,6 +52,7 @@ import (
 // GetAuthorizationURL returns the URL to redirect the user to for authorization
 // and the state to be used for the callback. It accepts a provider string
 // and a boolean indicating whether the client is a CLI or web client
+// nolint:gocyclo
 func (s *Server) GetAuthorizationURL(ctx context.Context,
 	req *pb.GetAuthorizationURLRequest) (*pb.GetAuthorizationURLResponse, error) {
 	entityCtx := engine.EntityFromContext(ctx)

--- a/internal/controlplane/handlers_oauth.go
+++ b/internal/controlplane/handlers_oauth.go
@@ -143,7 +143,7 @@ func (s *Server) GetAuthorizationURL(ctx context.Context,
 	var authorizationURL string
 	if slices.Contains(providerDef.AuthorizationFlows, db.AuthorizationFlowGithubAppFlow) {
 		gitHubAppConfig := s.cfg.Provider.GitHubApp
-		if gitHubAppConfig == nil {
+		if gitHubAppConfig == nil || gitHubAppConfig.AppName == "" {
 			return nil, status.Errorf(codes.Internal, "error getting GitHub App config: %s", err)
 		}
 		authorizationURL = fmt.Sprintf("%s/apps/%v/installations/new?state=%v", githubURL, gitHubAppConfig.AppName, state)


### PR DESCRIPTION
I did not define this in my local configuration, and it led to some weird errors when enrolling a Github App provider - specificially, it creates a link with an empty app name which will lead to a 404 when the link is acceessed. This will at least return a 500 if the value is omitted, which makes the proble more explicit.

# Summary

***Provide a brief overview of the changes and the issue being addressed. 
Explain the rationale and any background necessary for understanding the changes. 
List dependencies required by this change, if any.***

Fixes #(related issue)

## Change Type

***Mark the type of change your PR introduces:***

- [x] Bug fix (resolves an issue without affecting existing features)
- [ ] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [ ] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

***Outline how the changes were tested, including steps to reproduce and any relevant configurations. 
Attach screenshots if helpful.***

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [ ] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [ ] Included tests that validate the fix or feature.
- [ ] Checked that related changes are merged.
