### PR TITLE
Don't use SELECT * when joining profile tables

### DIFF
--- a/database/query/profiles.sql
+++ b/database/query/profiles.sql
@@ -40,7 +40,7 @@ DELETE FROM entity_profiles WHERE profile_id = $1 AND entity = $2;
 SELECT * FROM entity_profiles WHERE profile_id = $1 AND entity = $2;
 
 -- name: GetProfileByProjectAndID :many
-SELECT * FROM profiles JOIN profiles_with_entity_profiles ON profiles.id = profiles_with_entity_profiles.profid
+SELECT sqlc.embed(profiles), sqlc.embed(profiles_with_entity_profiles) FROM profiles JOIN profiles_with_entity_profiles ON profiles.id = profiles_with_entity_profiles.profid
 WHERE profiles.project_id = $1 AND profiles.id = $2;
 
 -- name: GetProfileByID :one

--- a/internal/db/profiles.sql.go
+++ b/internal/db/profiles.sql.go
@@ -7,13 +7,11 @@ package db
 
 import (
 	"context"
-	"database/sql"
 	"encoding/json"
 	"time"
 
 	"github.com/google/uuid"
 	"github.com/lib/pq"
-	"github.com/sqlc-dev/pqtype"
 )
 
 const countProfilesByEntityType = `-- name: CountProfilesByEntityType :many
@@ -270,7 +268,7 @@ func (q *Queries) GetProfileByNameAndLock(ctx context.Context, arg GetProfileByN
 }
 
 const getProfileByProjectAndID = `-- name: GetProfileByProjectAndID :many
-SELECT profiles.id, name, provider, project_id, remediate, alert, profiles.created_at, profiles.updated_at, provider_id, subscription_id, display_name, labels, profiles_with_entity_profiles.id, entity, profile_id, contextual_rules, profiles_with_entity_profiles.created_at, profiles_with_entity_profiles.updated_at, profid FROM profiles JOIN profiles_with_entity_profiles ON profiles.id = profiles_with_entity_profiles.profid
+SELECT profiles.id, profiles.name, profiles.provider, profiles.project_id, profiles.remediate, profiles.alert, profiles.created_at, profiles.updated_at, profiles.provider_id, profiles.subscription_id, profiles.display_name, profiles.labels, profiles_with_entity_profiles.id, profiles_with_entity_profiles.entity, profiles_with_entity_profiles.profile_id, profiles_with_entity_profiles.contextual_rules, profiles_with_entity_profiles.created_at, profiles_with_entity_profiles.updated_at, profiles_with_entity_profiles.profid FROM profiles JOIN profiles_with_entity_profiles ON profiles.id = profiles_with_entity_profiles.profid
 WHERE profiles.project_id = $1 AND profiles.id = $2
 `
 
@@ -280,25 +278,8 @@ type GetProfileByProjectAndIDParams struct {
 }
 
 type GetProfileByProjectAndIDRow struct {
-	ID              uuid.UUID             `json:"id"`
-	Name            string                `json:"name"`
-	Provider        sql.NullString        `json:"provider"`
-	ProjectID       uuid.UUID             `json:"project_id"`
-	Remediate       NullActionType        `json:"remediate"`
-	Alert           NullActionType        `json:"alert"`
-	CreatedAt       time.Time             `json:"created_at"`
-	UpdatedAt       time.Time             `json:"updated_at"`
-	ProviderID      uuid.NullUUID         `json:"provider_id"`
-	SubscriptionID  uuid.NullUUID         `json:"subscription_id"`
-	DisplayName     string                `json:"display_name"`
-	Labels          []string              `json:"labels"`
-	ID_2            uuid.NullUUID         `json:"id_2"`
-	Entity          NullEntities          `json:"entity"`
-	ProfileID       uuid.NullUUID         `json:"profile_id"`
-	ContextualRules pqtype.NullRawMessage `json:"contextual_rules"`
-	CreatedAt_2     sql.NullTime          `json:"created_at_2"`
-	UpdatedAt_2     sql.NullTime          `json:"updated_at_2"`
-	Profid          uuid.UUID             `json:"profid"`
+	Profile                   Profile                   `json:"profile"`
+	ProfilesWithEntityProfile ProfilesWithEntityProfile `json:"profiles_with_entity_profile"`
 }
 
 func (q *Queries) GetProfileByProjectAndID(ctx context.Context, arg GetProfileByProjectAndIDParams) ([]GetProfileByProjectAndIDRow, error) {
@@ -311,25 +292,25 @@ func (q *Queries) GetProfileByProjectAndID(ctx context.Context, arg GetProfileBy
 	for rows.Next() {
 		var i GetProfileByProjectAndIDRow
 		if err := rows.Scan(
-			&i.ID,
-			&i.Name,
-			&i.Provider,
-			&i.ProjectID,
-			&i.Remediate,
-			&i.Alert,
-			&i.CreatedAt,
-			&i.UpdatedAt,
-			&i.ProviderID,
-			&i.SubscriptionID,
-			&i.DisplayName,
-			pq.Array(&i.Labels),
-			&i.ID_2,
-			&i.Entity,
-			&i.ProfileID,
-			&i.ContextualRules,
-			&i.CreatedAt_2,
-			&i.UpdatedAt_2,
-			&i.Profid,
+			&i.Profile.ID,
+			&i.Profile.Name,
+			&i.Profile.Provider,
+			&i.Profile.ProjectID,
+			&i.Profile.Remediate,
+			&i.Profile.Alert,
+			&i.Profile.CreatedAt,
+			&i.Profile.UpdatedAt,
+			&i.Profile.ProviderID,
+			&i.Profile.SubscriptionID,
+			&i.Profile.DisplayName,
+			pq.Array(&i.Profile.Labels),
+			&i.ProfilesWithEntityProfile.ID,
+			&i.ProfilesWithEntityProfile.Entity,
+			&i.ProfilesWithEntityProfile.ProfileID,
+			&i.ProfilesWithEntityProfile.ContextualRules,
+			&i.ProfilesWithEntityProfile.CreatedAt,
+			&i.ProfilesWithEntityProfile.UpdatedAt,
+			&i.ProfilesWithEntityProfile.Profid,
 		); err != nil {
 			return nil, err
 		}

--- a/internal/engine/profile.go
+++ b/internal/engine/profile.go
@@ -238,38 +238,42 @@ func MergeDatabaseGetIntoProfiles(ppl []db.GetProfileByProjectAndIDRow) map[stri
 		// so we don't need to worry about collisions.
 
 		// first we check if profile already exists, if not we create a new one
-		if _, ok := profiles[p.Name]; !ok {
-			profileID := p.ID.String()
-			project := p.ProjectID.String()
+		if _, ok := profiles[p.Profile.Name]; !ok {
+			profileID := p.Profile.ID.String()
+			project := p.Profile.ProjectID.String()
 
-			displayName := p.DisplayName
+			displayName := p.Profile.DisplayName
 			if displayName == "" {
-				displayName = p.Name
+				displayName = p.Profile.Name
 			}
 
-			profiles[p.Name] = &pb.Profile{
+			profiles[p.Profile.Name] = &pb.Profile{
 				Id:          &profileID,
-				Name:        p.Name,
+				Name:        p.Profile.Name,
 				DisplayName: displayName,
 				Context: &pb.Context{
 					Project: &project,
 				},
 			}
 
-			if p.Remediate.Valid {
-				profiles[p.Name].Remediate = proto.String(string(p.Remediate.ActionType))
+			if p.Profile.Remediate.Valid {
+				profiles[p.Profile.Name].Remediate = proto.String(string(p.Profile.Remediate.ActionType))
 			} else {
-				profiles[p.Name].Remediate = proto.String(string(db.ActionTypeOff))
+				profiles[p.Profile.Name].Remediate = proto.String(string(db.ActionTypeOff))
 			}
 
-			if p.Alert.Valid {
-				profiles[p.Name].Alert = proto.String(string(p.Alert.ActionType))
+			if p.Profile.Alert.Valid {
+				profiles[p.Profile.Name].Alert = proto.String(string(p.Profile.Alert.ActionType))
 			} else {
-				profiles[p.Name].Alert = proto.String(string(db.ActionTypeOn))
+				profiles[p.Profile.Name].Alert = proto.String(string(db.ActionTypeOn))
 			}
 		}
-		if pm := rowInfoToProfileMap(profiles[p.Name], p.Entity, p.ContextualRules); pm != nil {
-			profiles[p.Name] = pm
+		if pm := rowInfoToProfileMap(
+			profiles[p.Profile.Name],
+			p.ProfilesWithEntityProfile.Entity,
+			p.ProfilesWithEntityProfile.ContextualRules,
+		); pm != nil {
+			profiles[p.Profile.Name] = pm
 		}
 	}
 


### PR DESCRIPTION
# Summary

This patch has no functional changes, it is just a cleanup in our Go
database models that I didn't want to send before the recent release.

If sqlc generates a model for a query that joins over two tables, it
autogenerates column names that are represented as structure members, so
you end up with a single structure with members such as `ID` and `ID_2`.

This can be confusing and invite bugs. It's much cleaner to use
`sqlc.embed` to make sure that each table is represented by a separate
attribute in the models.

## Change Type

***Mark the type of change your PR introduces:***

- [ ] Bug fix (resolves an issue without affecting existing features)
- [ ] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [x] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

There is no tests for this functionality /right now in main/ but there are tests added in PR #2990, so maybe that one should go first.

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [ ] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [ ] Included tests that validate the fix or feature.
- [ ] Checked that related changes are merged.
