### PR TITLE
Address review comments for labels filtering

### DIFF
--- a/database/query/profiles.sql
+++ b/database/query/profiles.sql
@@ -70,8 +70,8 @@ AND (
 ) AND (
     -- if the exclude_labels arg is empty, we list all profiles
     COALESCE(cardinality(sqlc.arg(exclude_labels)::TEXT[]), 0) = 0 OR
-    -- if the exclude_labels arg is not empty, we list profiles whose labels are not a subset of exclude_labels
-    NOT profiles.labels @> sqlc.arg(exclude_labels)::TEXT[]
+    -- if the exclude_labels arg is not empty, we exclude profiles containing any of the exclude_labels
+    NOT profiles.labels::TEXT[] && sqlc.arg(exclude_labels)::TEXT[]
 );
 
 -- name: DeleteProfile :exec

--- a/internal/db/domain.go
+++ b/internal/db/domain.go
@@ -67,20 +67,27 @@ func (r ListProfilesByProjectIDRow) GetContextualRules() pqtype.NullRawMessage {
 
 // LabelsFromFilter parses the filter string and populates the IncludeLabels and ExcludeLabels fields
 func (lp *ListProfilesByProjectIDAndLabelParams) LabelsFromFilter(filter string) {
-	// otherwise Split would have returned a slice with one empty string
+	// If s does not contain sep and sep is not empty, Split returns a
+	// slice of length 1 whose only element is s. Work around that by
+	// returning early if filter is empty.
 	if filter == "" {
 		return
 	}
 
+	var starMatched bool
 	for _, label := range strings.Split(filter, ",") {
 		switch {
 		case label == "*":
-			lp.IncludeLabels = append(lp.IncludeLabels, label)
+			starMatched = true
 		case strings.HasPrefix(label, "!"):
 			// if the label starts with a "!", it is a negative filter, add it to the negative list
 			lp.ExcludeLabels = append(lp.ExcludeLabels, label[1:])
 		default:
 			lp.IncludeLabels = append(lp.IncludeLabels, label)
 		}
+	}
+
+	if starMatched {
+		lp.IncludeLabels = []string{"*"}
 	}
 }

--- a/internal/db/profiles.sql.go
+++ b/internal/db/profiles.sql.go
@@ -415,8 +415,8 @@ AND (
 ) AND (
     -- if the exclude_labels arg is empty, we list all profiles
     COALESCE(cardinality($3::TEXT[]), 0) = 0 OR
-    -- if the exclude_labels arg is not empty, we list profiles whose labels are not a subset of exclude_labels
-    NOT profiles.labels @> $3::TEXT[]
+    -- if the exclude_labels arg is not empty, we exclude profiles containing any of the exclude_labels
+    NOT profiles.labels::TEXT[] && $3::TEXT[]
 )
 `
 

--- a/internal/db/profiles_test.go
+++ b/internal/db/profiles_test.go
@@ -197,12 +197,14 @@ func TestProfileLabels(t *testing.T) {
 
 	randomEntities := createTestRandomEntities(t)
 
-	health1 := createRandomProfile(t, randomEntities.proj.ID, []string{"stacklok:health"})
+	health1 := createRandomProfile(t, randomEntities.proj.ID, []string{"stacklok:health", "managed"})
 	require.NotEmpty(t, health1)
-	health2 := createRandomProfile(t, randomEntities.proj.ID, []string{"stacklok:health", "obsolete"})
+	health2 := createRandomProfile(t, randomEntities.proj.ID, []string{"stacklok:health", "obsolete", "managed"})
 	require.NotEmpty(t, health2)
 	obsolete := createRandomProfile(t, randomEntities.proj.ID, []string{"obsolete"})
 	require.NotEmpty(t, obsolete)
+	managed := createRandomProfile(t, randomEntities.proj.ID, []string{"managed"})
+	require.NotEmpty(t, managed)
 	p1 := createRandomProfile(t, randomEntities.proj.ID, []string{})
 	require.NotEmpty(t, p1)
 	p2 := createRandomProfile(t, randomEntities.proj.ID, []string{})
@@ -217,7 +219,7 @@ func TestProfileLabels(t *testing.T) {
 		{
 			name:          "list all profiles",
 			includeLabels: []string{"*"},
-			expectedNames: []string{health1.Name, health2.Name, obsolete.Name, p1.Name, p2.Name},
+			expectedNames: []string{health1.Name, health2.Name, obsolete.Name, p1.Name, p2.Name, managed.Name},
 		},
 		{
 			name:          "list profiles with no labels",
@@ -259,7 +261,13 @@ func TestProfileLabels(t *testing.T) {
 			name:          "include all labels but exclude one",
 			includeLabels: []string{"*"},
 			excludeLabels: []string{"obsolete"},
-			expectedNames: []string{health1.Name, p1.Name, p2.Name},
+			expectedNames: []string{health1.Name, p1.Name, p2.Name, managed.Name},
+		},
+		{
+			name:          "excluding filters out any profile with exclude labels",
+			includeLabels: []string{"*"},
+			excludeLabels: []string{"stacklok:health", "managed"},
+			expectedNames: []string{obsolete.Name, p1.Name, p2.Name},
 		},
 	}
 
@@ -281,6 +289,8 @@ func TestProfileLabels(t *testing.T) {
 			for _, row := range rows {
 				names = append(names, row.Profile.Name)
 			}
+			slices.Sort(names)
+			slices.Sort(tt.expectedNames)
 			require.True(t, slices.Equal(names, tt.expectedNames), "expected %v, got %v", tt.expectedNames, names)
 		})
 	}


### PR DESCRIPTION
# Summary

In the interest of time we merged labels filtering with some comments
not being addressed. This patch fixes that:
- exclude_labels now excludes any profiles containing any of the exclude
  labels. Add a test for this new behaviour.
- fix confusing comment in LabelsFromFilter
- special-case wildcard matching to only return the wildcard
- sort the slice in test to avoid issues where the slices contain the
  right elements, but in wrong order

## Change Type

***Mark the type of change your PR introduces:***

- [ ] Bug fix (resolves an issue without affecting existing features)
- [ ] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [x] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

`make test`

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [x] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [x] Included tests that validate the fix or feature.
- [ ] Checked that related changes are merged.
