### PR TITLE
More descriptive error message when validating secrets with any of the fallback webhooks fails

### DIFF
--- a/internal/controlplane/handlers_githubwebhooks.go
+++ b/internal/controlplane/handlers_githubwebhooks.go
@@ -398,6 +398,7 @@ func validatePreviousSecrets(
 		}
 	}
 
+	err = fmt.Errorf("failed to validate payload with any fallback secret")
 	return
 }
 

--- a/internal/controlplane/handlers_githubwebhooks_test.go
+++ b/internal/controlplane/handlers_githubwebhooks_test.go
@@ -327,6 +327,23 @@ func (s *UnitTestSuite) TestHandleWebHookRepository() {
 	assert.Equal(t, repositoryID.String(), received.Metadata["repository_id"])
 
 	// TODO: assert payload is Repository protobuf
+
+	// test that if no secret matches we get back a 400
+	req, err = http.NewRequest("POST", fmt.Sprintf("http://%s", addr), bytes.NewBuffer(packageJson))
+	require.NoError(t, err, "failed to create request")
+	req.Header.Add("X-GitHub-Event", "meta")
+	req.Header.Add("X-GitHub-Delivery", "12345")
+	req.Header.Add("Content-Type", "application/json")
+	req.Header.Add("X-Hub-Signature-256", "sha256=ab22bd9a3712e444e110c8088011fd827143ed63ba8655f07e76ed1a0f05edd1")
+
+	_, err = prevCredsFile.Seek(0, 0)
+	require.NoError(t, err, "failed to seek to beginning of temporary file")
+	_, err = prevCredsFile.WriteString("lets-just-overwrite-what-is-here-with-a-bad-secret")
+	require.NoError(t, err, "failed to write to temporary file")
+
+	resp, err = httpDoWithRetry(client, req)
+	require.NoError(t, err, "failed to make request")
+	require.Equal(t, http.StatusBadRequest, resp.StatusCode, "unexpected status code")
 }
 
 // We should ignore events from packages from repositories that are not registered


### PR DESCRIPTION
# Summary

Previously we would have returned a nil error but also a nil payload on
exhausting all previous secrets in a loop which would later error out when it
couldn't be parsed. That means that this bug has no security implications (we
would just get a 500 instead of a 400), but let's fix it nonetheless.

## Change Type

***Mark the type of change your PR introduces:***

- [x] Bug fix (resolves an issue without affecting existing features)
- [ ] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [ ] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

manually + a unit test

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [ ] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [x] Included tests that validate the fix or feature.
- [ ] Checked that related changes are merged.
