### PR TITLE
Use webhook secrets from files

### DIFF
--- a/deployment/helm/templates/deployment.yaml
+++ b/deployment/helm/templates/deployment.yaml
@@ -83,6 +83,10 @@ spec:
             value: "/secrets/github-app/github_app_fallback_token"
           - name: "MINDER_FLAGS_GO_FEATURE_FILE_PATH"
             value: "/flags/flags-config.yaml"
+          - name: "MINDER_WEBHOOK_CONFIG_WEBHOOK_SECRET_FILE"
+            value: "/secrets/app/repo_webhook_secret"
+          - name: "MINDER_WEBHOOK_CONFIG_PREVIOUS_WEBHOOK_SECRET_FILE"
+            value: "/secrets/app/repo_fallback_webhook_secret"
           {{- if .Values.deploymentSettings.extraEnv }}
           {{- toYaml .Values.deploymentSettings.extraEnv | nindent 10 }}
           {{- end }}


### PR DESCRIPTION

# Summary

Instead of relying on the config to set them.

Relates to: https://github.com/stacklok/infra/issues/954

## Change Type

***Mark the type of change your PR introduces:***

- [ ] Bug fix (resolves an issue without affecting existing features)
- [x] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [ ] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

I just verified that the env names are correct by running:
```
MINDER_WEBHOOK_CONFIG_WEBHOOK_SECRET_FILE=.secrets/webhook_secret MINDER_WEBHOOK_CONFIG_PREVIOUS_WEBHOOK_SECRET_FILE=.secrets/previous_secrets make run-server
```

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [ ] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [ ] Included tests that validate the fix or feature.
- [ ] Checked that related changes are merged.
