### PR TITLE
Add Helm configuration for feature flags

### DIFF
--- a/deployment/helm/templates/deployment.yaml
+++ b/deployment/helm/templates/deployment.yaml
@@ -81,6 +81,8 @@ spec:
             value: "/secrets/github-app/github_app_webhook_secret"
           - name: "MINDER_PROVIDER_GITHUB_APP_FALLBACK_TOKEN_FILE"
             value: "/secrets/github-app/github_app_fallback_token"
+          - name: "MINDER_FLAGS_GO_FEATURE_FILE_PATH"
+            value: "/flags/flags-config.yaml"
           {{- if .Values.deploymentSettings.extraEnv }}
           {{- toYaml .Values.deploymentSettings.extraEnv | nindent 10 }}
           {{- end }}
@@ -111,6 +113,8 @@ spec:
           volumeMounts:
           - name: config
             mountPath: /config
+          - name: flags
+            mountPath: /flags
           - name: auth-secrets
             mountPath: /secrets/auth
           - name: app-secrets
@@ -136,6 +140,13 @@ spec:
             path: server-config.yaml
           - key: overrides.yaml
             path: overrides.yaml
+      - name: flags
+        configMap:
+          name: minder-flags
+          optional: true  # We expect the outside environment to create this ConfigMap
+          items:
+          - key: flags-config.yaml
+            path: flags-config.yaml
       - name: auth-secrets
         secret:
           secretName: {{ .Values.deploymentSettings.secrets.authSecretName }}


### PR DESCRIPTION
# Summary

Adds the ability to control configured Minder flags by creating a ConfigMap named `minder-flags` containing a key `flags-config.yaml` using [a GoFeatureFlag config file](https://gofeatureflag.org/docs/configure_flag/flag_format).

See https://gofeatureflag.org/editor for a UI editor for the same.

Fixes #3187

## Change Type

***Mark the type of change your PR introduces:***

- [ ] Bug fix (resolves an issue without affecting existing features)
- [x] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [ ] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

I used my brain, sorry!

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [x] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [ ] Included tests that validate the fix or feature.
- [x] Checked that related changes are merged.
