### PR TITLE
Refactor repo deletion to move db/provider logic behind interface

### DIFF
--- a/database/mock/store.go
+++ b/database/mock/store.go
@@ -987,6 +987,21 @@ func (mr *MockStoreMockRecorder) GetProviderByName(arg0, arg1 any) *gomock.Call 
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetProviderByName", reflect.TypeOf((*MockStore)(nil).GetProviderByName), arg0, arg1)
 }
 
+// GetProviderWebhooks mocks base method.
+func (m *MockStore) GetProviderWebhooks(arg0 context.Context, arg1 uuid.UUID) ([]db.GetProviderWebhooksRow, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetProviderWebhooks", arg0, arg1)
+	ret0, _ := ret[0].([]db.GetProviderWebhooksRow)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetProviderWebhooks indicates an expected call of GetProviderWebhooks.
+func (mr *MockStoreMockRecorder) GetProviderWebhooks(arg0, arg1 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetProviderWebhooks", reflect.TypeOf((*MockStore)(nil).GetProviderWebhooks), arg0, arg1)
+}
+
 // GetPullRequest mocks base method.
 func (m *MockStore) GetPullRequest(arg0 context.Context, arg1 db.GetPullRequestParams) (db.PullRequest, error) {
 	m.ctrl.T.Helper()

--- a/database/query/repositories.sql
+++ b/database/query/repositories.sql
@@ -51,3 +51,9 @@ WHERE id = $1;
 
 -- name: CountRepositories :one
 SELECT COUNT(*) FROM repositories;
+
+-- get a list of repos with webhooks belonging to a provider
+-- is used for webhook cleanup during provider deletion
+-- name: GetProviderWebhooks :many
+SELECT repo_owner, repo_name, webhook_id FROM repositories
+WHERE webhook_id IS NOT NULL AND provider_id = $1;

--- a/internal/controlplane/handlers_providers_test.go
+++ b/internal/controlplane/handlers_providers_test.go
@@ -40,7 +40,6 @@ import (
 	mockprovsvc "github.com/stacklok/minder/internal/providers/github/service/mock"
 	"github.com/stacklok/minder/internal/providers/manager"
 	"github.com/stacklok/minder/internal/providers/ratecache"
-	mockghrepo "github.com/stacklok/minder/internal/repositories/github/mock"
 	mockwebhooks "github.com/stacklok/minder/internal/repositories/github/webhooks/mock"
 	minder "github.com/stacklok/minder/pkg/api/protobuf/go/minder/v1"
 	provinfv1 "github.com/stacklok/minder/pkg/providers/v1"
@@ -103,7 +102,6 @@ func TestDeleteProvider(t *testing.T) {
 				WebhookID: sql.NullInt64{Valid: true, Int64: 12345},
 			}}, nil)
 
-	mockRepoSvc := mockghrepo.NewMockRepositoryService(ctrl)
 	whManager := mockwebhooks.NewMockWebhookManager(ctrl)
 	whManager.EXPECT().DeleteWebhook(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any())
 
@@ -135,7 +133,6 @@ func TestDeleteProvider(t *testing.T) {
 		cryptoEngine:    mockCryptoEngine,
 		store:           mockStore,
 		ghProviders:     mockProvidersSvc,
-		repos:           mockRepoSvc,
 		authzClient:     authzClient,
 		providerStore:   providerStore,
 		providerManager: providerManager,
@@ -221,7 +218,6 @@ func TestDeleteProviderByID(t *testing.T) {
 				WebhookID: sql.NullInt64{Valid: true, Int64: 12345},
 			}}, nil)
 
-	mockRepoSvc := mockghrepo.NewMockRepositoryService(ctrl)
 	whManager := mockwebhooks.NewMockWebhookManager(ctrl)
 	whManager.EXPECT().DeleteWebhook(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any())
 
@@ -251,7 +247,6 @@ func TestDeleteProviderByID(t *testing.T) {
 		cryptoEngine:    mockCryptoEngine,
 		store:           mockStore,
 		ghProviders:     mockProvidersSvc,
-		repos:           mockRepoSvc,
 		authzClient:     authzClient,
 		providerStore:   providerStore,
 		providerManager: providerManager,

--- a/internal/controlplane/handlers_repositories.go
+++ b/internal/controlplane/handlers_repositories.go
@@ -272,11 +272,11 @@ func (s *Server) DeleteRepositoryById(
 
 	projectID := getProjectID(ctx)
 
-	err = s.deleteRepository(ctx, func() (db.Repository, error) {
-		return s.repos.GetRepositoryById(ctx, parsedRepositoryID, projectID)
-	})
-	if err != nil {
-		return nil, err
+	err = s.repos.DeleteByID(ctx, parsedRepositoryID, projectID)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, status.Errorf(codes.NotFound, "repository not found")
+	} else if err != nil {
+		return nil, status.Errorf(codes.Internal, "unexpected error deleting repo: %v", err)
 	}
 
 	// return the response with the id of the deleted repository
@@ -299,11 +299,11 @@ func (s *Server) DeleteRepositoryByName(
 	projectID := getProjectID(ctx)
 	providerName := getProviderName(ctx)
 
-	err := s.deleteRepository(ctx, func() (db.Repository, error) {
-		return s.repos.GetRepositoryByName(ctx, fragments[0], fragments[1], projectID, providerName)
-	})
-	if err != nil {
-		return nil, err
+	err := s.repos.DeleteByName(ctx, fragments[0], fragments[1], projectID, providerName)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, status.Errorf(codes.NotFound, "repository not found")
+	} else if err != nil {
+		return nil, status.Errorf(codes.Internal, "unexpected error deleting repo: %v", err)
 	}
 
 	// return the response with the name of the deleted repository
@@ -430,7 +430,7 @@ func (s *Server) listRemoteRepositoriesForProvider(
 }
 
 // covers the common logic for the two varieties of repo deletion
-func (s *Server) deleteRepository(
+/*func (s *Server) deleteRepository(
 	ctx context.Context,
 	repoQueryMethod func() (db.Repository, error),
 ) error {
@@ -456,7 +456,7 @@ func (s *Server) deleteRepository(
 		return status.Errorf(codes.Internal, "unexpected error deleting repo: %v", err)
 	}
 	return nil
-}
+}*/
 
 // TODO: move out of controlplane
 // inferProviderByOwner returns the provider to use for a given repo owner

--- a/internal/controlplane/handlers_repositories.go
+++ b/internal/controlplane/handlers_repositories.go
@@ -429,35 +429,6 @@ func (s *Server) listRemoteRepositoriesForProvider(
 	return results, nil
 }
 
-// covers the common logic for the two varieties of repo deletion
-/*func (s *Server) deleteRepository(
-	ctx context.Context,
-	repoQueryMethod func() (db.Repository, error),
-) error {
-	repo, err := repoQueryMethod()
-	if errors.Is(err, sql.ErrNoRows) {
-		return status.Errorf(codes.NotFound, "repository not found")
-	} else if err != nil {
-		return status.Errorf(codes.Internal, "unexpected error fetching repo: %v", err)
-	}
-
-	provider, err := s.providerStore.GetByID(ctx, repo.ProviderID)
-	if err != nil {
-		return status.Errorf(codes.Internal, "cannot get provider: %v", err)
-	}
-
-	client, err := s.getClientForProvider(ctx, *provider)
-	if err != nil {
-		return status.Errorf(codes.Internal, "cannot get client for provider: %v", err)
-	}
-
-	err = s.repos.DeleteRepository(ctx, client, &repo)
-	if err != nil {
-		return status.Errorf(codes.Internal, "unexpected error deleting repo: %v", err)
-	}
-	return nil
-}*/
-
 // TODO: move out of controlplane
 // inferProviderByOwner returns the provider to use for a given repo owner
 func (s *Server) inferProviderByOwner(ctx context.Context, owner string, projectID uuid.UUID, providerName string,

--- a/internal/controlplane/server.go
+++ b/internal/controlplane/server.go
@@ -181,7 +181,6 @@ func NewServer(
 		return nil, fmt.Errorf("failed to create marketplace: %w", err)
 	}
 	fallbackTokenClient := ghprov.NewFallbackTokenClient(cfg.Provider)
-	repoSvc := github.NewRepositoryService(whManager, store, evt)
 
 	s := &Server{
 		store:               store,
@@ -194,7 +193,6 @@ func NewServer(
 		provMt:              provMt,
 		profiles:            profileSvc,
 		ruleTypes:           ruleSvc,
-		repos:               repoSvc,
 		marketplace:         marketplace,
 		providerStore:       providerStore,
 		featureFlags:        openfeature.NewClient(cfg.Flags.AppName),
@@ -223,7 +221,7 @@ func NewServer(
 		&cfg.Provider,
 		fallbackTokenClient,
 		eng,
-		repoSvc,
+		whManager,
 		store,
 		s.ghProviders,
 	)
@@ -232,6 +230,7 @@ func NewServer(
 		return nil, fmt.Errorf("failed to create provider manager: %w", err)
 	}
 	s.providerManager = providerManager
+	s.repos = github.NewRepositoryService(whManager, store, evt, providerManager)
 
 	return s, nil
 }

--- a/internal/db/querier.go
+++ b/internal/db/querier.go
@@ -86,6 +86,9 @@ type Querier interface {
 	// if it exists in the project or any of its ancestors. It'll return the first
 	// provider that matches the name.
 	GetProviderByName(ctx context.Context, arg GetProviderByNameParams) (Provider, error)
+	// get a list of repos with webhooks belonging to a provider
+	// is used for webhook cleanup during provider deletion
+	GetProviderWebhooks(ctx context.Context, providerID uuid.UUID) ([]GetProviderWebhooksRow, error)
 	GetPullRequest(ctx context.Context, arg GetPullRequestParams) (PullRequest, error)
 	GetPullRequestByID(ctx context.Context, id uuid.UUID) (PullRequest, error)
 	// avoid using this, where possible use GetRepositoryByIDAndProject instead

--- a/internal/providers/manager/mock/fixtures/manager.go
+++ b/internal/providers/manager/mock/fixtures/manager.go
@@ -1,0 +1,59 @@
+// Copyright 2024 Stacklok, Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance cf.With the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package fixtures contains code for creating ProfileService fixtures and is used in
+// various parts of the code. For testing use only.
+//
+//nolint:all
+package fixtures
+
+import (
+	"errors"
+	mockmanager "github.com/stacklok/minder/internal/providers/manager/mock"
+	provinfv1 "github.com/stacklok/minder/pkg/providers/v1"
+	"go.uber.org/mock/gomock"
+)
+
+type (
+	ProviderManagerMock        = *mockmanager.MockProviderManager
+	ProviderManagerMockBuilder = func(*gomock.Controller) ProviderManagerMock
+)
+
+func NewProviderManagerMock(opts ...func(mock ProviderManagerMock)) ProviderManagerMockBuilder {
+	return func(ctrl *gomock.Controller) ProviderManagerMock {
+		mock := mockmanager.NewMockProviderManager(ctrl)
+		for _, opt := range opts {
+			opt(mock)
+		}
+		return mock
+	}
+}
+
+var (
+	errDefault = errors.New("error during provider manager operation")
+)
+
+func WithSuccessfulInstantiateFromID(provider provinfv1.Provider) func(mock ProviderManagerMock) {
+	return func(mock ProviderManagerMock) {
+		mock.EXPECT().
+			InstantiateFromID(gomock.Any(), gomock.Any()).
+			Return(provider, nil)
+	}
+}
+
+func WithFailedInstantiateFromID(mock ProviderManagerMock) {
+	mock.EXPECT().
+		InstantiateFromID(gomock.Any(), gomock.Any()).
+		Return(nil, errDefault)
+}

--- a/internal/repositories/github/mock/service.go
+++ b/internal/repositories/github/mock/service.go
@@ -58,32 +58,32 @@ func (mr *MockRepositoryServiceMockRecorder) CreateRepository(ctx, client, provi
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateRepository", reflect.TypeOf((*MockRepositoryService)(nil).CreateRepository), ctx, client, provider, projectID, repoName, repoOwner)
 }
 
-// DeleteRepositoriesByProvider mocks base method.
-func (m *MockRepositoryService) DeleteRepositoriesByProvider(ctx context.Context, client clients.GitHubRepoClient, providerName string, projectID uuid.UUID) error {
+// DeleteByID mocks base method.
+func (m *MockRepositoryService) DeleteByID(ctx context.Context, repoID, projectID uuid.UUID) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DeleteRepositoriesByProvider", ctx, client, providerName, projectID)
+	ret := m.ctrl.Call(m, "DeleteByID", ctx, repoID, projectID)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-// DeleteRepositoriesByProvider indicates an expected call of DeleteRepositoriesByProvider.
-func (mr *MockRepositoryServiceMockRecorder) DeleteRepositoriesByProvider(ctx, client, providerName, projectID any) *gomock.Call {
+// DeleteByID indicates an expected call of DeleteByID.
+func (mr *MockRepositoryServiceMockRecorder) DeleteByID(ctx, repoID, projectID any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteRepositoriesByProvider", reflect.TypeOf((*MockRepositoryService)(nil).DeleteRepositoriesByProvider), ctx, client, providerName, projectID)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteByID", reflect.TypeOf((*MockRepositoryService)(nil).DeleteByID), ctx, repoID, projectID)
 }
 
-// DeleteRepository mocks base method.
-func (m *MockRepositoryService) DeleteRepository(ctx context.Context, client clients.GitHubRepoClient, repo *db.Repository) error {
+// DeleteByName mocks base method.
+func (m *MockRepositoryService) DeleteByName(ctx context.Context, repoOwner, repoName string, projectID uuid.UUID, providerName string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DeleteRepository", ctx, client, repo)
+	ret := m.ctrl.Call(m, "DeleteByName", ctx, repoOwner, repoName, projectID, providerName)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-// DeleteRepository indicates an expected call of DeleteRepository.
-func (mr *MockRepositoryServiceMockRecorder) DeleteRepository(ctx, client, repo any) *gomock.Call {
+// DeleteByName indicates an expected call of DeleteByName.
+func (mr *MockRepositoryServiceMockRecorder) DeleteByName(ctx, repoOwner, repoName, projectID, providerName any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteRepository", reflect.TypeOf((*MockRepositoryService)(nil).DeleteRepository), ctx, client, repo)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteByName", reflect.TypeOf((*MockRepositoryService)(nil).DeleteByName), ctx, repoOwner, repoName, projectID, providerName)
 }
 
 // GetRepositoryById mocks base method.

--- a/internal/repositories/github/service_test.go
+++ b/internal/repositories/github/service_test.go
@@ -29,6 +29,9 @@ import (
 	mockdb "github.com/stacklok/minder/database/mock"
 	"github.com/stacklok/minder/internal/db"
 	mockevents "github.com/stacklok/minder/internal/events/mock"
+	mock_github "github.com/stacklok/minder/internal/providers/github/mock"
+	"github.com/stacklok/minder/internal/providers/manager"
+	pf "github.com/stacklok/minder/internal/providers/manager/mock/fixtures"
 	"github.com/stacklok/minder/internal/repositories/github"
 	"github.com/stacklok/minder/internal/repositories/github/clients"
 	cf "github.com/stacklok/minder/internal/repositories/github/fixtures"
@@ -115,7 +118,7 @@ func TestRepositoryService_CreateRepository(t *testing.T) {
 				ghClient = scenario.ClientSetup(ctrl)
 			}
 
-			svc := createService(ctrl, scenario.WebhookSetup, scenario.DBSetup, scenario.EventSendFails)
+			svc := createService(ctrl, scenario.WebhookSetup, scenario.DBSetup, nil, scenario.EventSendFails)
 			res, err := svc.CreateRepository(ctx, ghClient, &provider, projectID, repoOwner, repoName)
 			if scenario.ExpectedError == "" {
 				require.NoError(t, err)
@@ -130,30 +133,89 @@ func TestRepositoryService_CreateRepository(t *testing.T) {
 	}
 }
 
+// bundling delete by ID and name together due to the similarities of the tests
 func TestRepositoryService_DeleteRepository(t *testing.T) {
 	t.Parallel()
 
 	scenarios := []struct {
 		Name          string
 		DBSetup       dbMockBuilder
+		ProviderSetup pf.ProviderManagerMockBuilder
 		WebhookSetup  whMockBuilder
 		DeleteType    DeleteCallType
-		ShouldSucceed bool
+		ExpectedError string
 	}{
 		{
-			Name:         "Delete fails when webhook cannot be deleted",
-			WebhookSetup: newWebhookMock(withFailedWebhookDelete),
+			Name:          "DeleteByName fails when repo cannot be retrieved",
+			DeleteType:    ByName,
+			DBSetup:       newDBMock(withFailedGetByName),
+			ExpectedError: "error retrieving repository",
 		},
 		{
-			Name:         "Delete by ID fails when repo cannot be deleted from DB",
-			DBSetup:      newDBMock(withFailedDelete),
-			WebhookSetup: newWebhookMock(withSuccessfulWebhookDelete),
+			Name:          "DeleteByName fails when provider cannot be instantiated",
+			DeleteType:    ByName,
+			DBSetup:       newDBMock(withSuccessfulGetByName),
+			ProviderSetup: pf.NewProviderManagerMock(pf.WithFailedInstantiateFromID),
+			ExpectedError: "error while instantiating provider",
 		},
 		{
-			Name:          "Delete succeeds",
-			DBSetup:       newDBMock(withSuccessfulDelete),
+			Name:          "DeleteByName fails when webhook cannot be deleted",
+			DeleteType:    ByName,
+			DBSetup:       newDBMock(withSuccessfulGetByName),
+			WebhookSetup:  newWebhookMock(withFailedWebhookDelete),
+			ProviderSetup: pf.NewProviderManagerMock(pf.WithSuccessfulInstantiateFromID(ghProvider)),
+			ExpectedError: "error deleting webhook",
+		},
+		{
+			Name:          "DeleteByName by ID fails when repo cannot be deleted from DB",
+			DeleteType:    ByName,
+			DBSetup:       newDBMock(withSuccessfulGetByName, withFailedDelete),
 			WebhookSetup:  newWebhookMock(withSuccessfulWebhookDelete),
-			ShouldSucceed: true,
+			ProviderSetup: pf.NewProviderManagerMock(pf.WithSuccessfulInstantiateFromID(ghProvider)),
+			ExpectedError: "error deleting repository from DB",
+		},
+		{
+			Name:          "DeleteByName succeeds",
+			DeleteType:    ByName,
+			DBSetup:       newDBMock(withSuccessfulGetByName, withSuccessfulDelete),
+			WebhookSetup:  newWebhookMock(withSuccessfulWebhookDelete),
+			ProviderSetup: pf.NewProviderManagerMock(pf.WithSuccessfulInstantiateFromID(ghProvider)),
+		},
+		{
+			Name:          "DeleteByID fails when repo cannot be retrieved",
+			DeleteType:    ByID,
+			DBSetup:       newDBMock(withFailedGetById),
+			ExpectedError: "error retrieving repository",
+		},
+		{
+			Name:          "DeleteByID fails when provider cannot be instantiated",
+			DeleteType:    ByID,
+			DBSetup:       newDBMock(withSuccessfulGetById),
+			ProviderSetup: pf.NewProviderManagerMock(pf.WithFailedInstantiateFromID),
+			ExpectedError: "error while instantiating provider",
+		},
+		{
+			Name:          "DeleteByID fails when webhook cannot be deleted",
+			DeleteType:    ByID,
+			DBSetup:       newDBMock(withSuccessfulGetById),
+			WebhookSetup:  newWebhookMock(withFailedWebhookDelete),
+			ProviderSetup: pf.NewProviderManagerMock(pf.WithSuccessfulInstantiateFromID(ghProvider)),
+			ExpectedError: "error deleting webhook",
+		},
+		{
+			Name:          "DeleteByID by ID fails when repo cannot be deleted from DB",
+			DeleteType:    ByID,
+			DBSetup:       newDBMock(withSuccessfulGetById, withFailedDelete),
+			WebhookSetup:  newWebhookMock(withSuccessfulWebhookDelete),
+			ProviderSetup: pf.NewProviderManagerMock(pf.WithSuccessfulInstantiateFromID(ghProvider)),
+			ExpectedError: "error deleting repository from DB",
+		},
+		{
+			Name:          "DeleteByID succeeds",
+			DeleteType:    ByID,
+			DBSetup:       newDBMock(withSuccessfulGetById, withSuccessfulDelete),
+			WebhookSetup:  newWebhookMock(withSuccessfulWebhookDelete),
+			ProviderSetup: pf.NewProviderManagerMock(pf.WithSuccessfulInstantiateFromID(ghProvider)),
 		},
 	}
 
@@ -164,68 +226,18 @@ func TestRepositoryService_DeleteRepository(t *testing.T) {
 			defer ctrl.Finish()
 			ctx := context.Background()
 
-			// For the purposes of this test, we do not need to attach any
-			// mock behaviour to the client. We can leave it as a nil pointer.
-			var ghClient clients.GitHubRepoClient
-
-			svc := createService(ctrl, scenario.WebhookSetup, scenario.DBSetup, false)
-			err := svc.DeleteRepository(ctx, ghClient, &dbRepo)
-
-			if scenario.ShouldSucceed {
-				require.NoError(t, err)
+			svc := createService(ctrl, scenario.WebhookSetup, scenario.DBSetup, scenario.ProviderSetup, false)
+			var err error
+			if scenario.DeleteType == ByName {
+				err = svc.DeleteByName(ctx, dbRepo.RepoOwner, dbRepo.RepoName, projectID, providerName)
 			} else {
-				require.Error(t, err)
+				err = svc.DeleteByID(ctx, dbRepo.ID, projectID)
 			}
-		})
-	}
-}
 
-func TestRepositoryService_DeleteRepositoriesByProvider(t *testing.T) {
-	t.Parallel()
-
-	scenarios := []struct {
-		Name          string
-		DBSetup       dbMockBuilder
-		WebhookSetup  whMockBuilder
-		DeleteType    DeleteCallType
-		ShouldSucceed bool
-	}{
-		{
-			Name:         "Delete fails when a webhook cannot be deleted",
-			DBSetup:      newDBMock(withSuccessfulListRepos),
-			WebhookSetup: newWebhookMock(withFailedWebhookDelete),
-		},
-		{
-			Name:         "Delete by ID fails when a repo cannot be deleted from DB",
-			DBSetup:      newDBMock(withSuccessfulListRepos, withFailedDelete),
-			WebhookSetup: newWebhookMock(withSuccessfulWebhookDelete),
-		},
-		{
-			Name:          "Delete succeeds",
-			DBSetup:       newDBMock(withSuccessfulListRepos, withTwoSuccessfulDeletes),
-			WebhookSetup:  newWebhookMock(withTwoSuccessfulWebhookDeletes),
-			ShouldSucceed: true,
-		},
-	}
-
-	for _, scenario := range scenarios {
-		t.Run(scenario.Name, func(t *testing.T) {
-			t.Parallel()
-			ctrl := gomock.NewController(t)
-			defer ctrl.Finish()
-			ctx := context.Background()
-
-			// For the purposes of this test, we do not need to attach any
-			// mock behaviour to the client. We can leave it as a nil pointer.
-			var ghClient clients.GitHubRepoClient
-
-			svc := createService(ctrl, scenario.WebhookSetup, scenario.DBSetup, false)
-			err := svc.DeleteRepositoriesByProvider(ctx, ghClient, providerName, projectID)
-
-			if scenario.ShouldSucceed {
+			if scenario.ExpectedError == "" {
 				require.NoError(t, err)
 			} else {
-				require.Error(t, err)
+				require.ErrorContains(t, err, scenario.ExpectedError)
 			}
 		})
 	}
@@ -261,7 +273,7 @@ func TestRepositoryService_GetRepositoryById(t *testing.T) {
 			// For the purposes of this test, we do not need to attach any
 			// mock behaviour to the client. We can leave it as a nil pointer.
 
-			svc := createService(ctrl, newWebhookMock(), scenario.DBSetup, false)
+			svc := createService(ctrl, newWebhookMock(), scenario.DBSetup, nil, false)
 			_, err := svc.GetRepositoryById(ctx, repoID, projectID)
 
 			if scenario.ShouldSucceed {
@@ -303,7 +315,7 @@ func TestRepositoryService_GetRepositoryByName(t *testing.T) {
 			// For the purposes of this test, we do not need to attach any
 			// mock behaviour to the client. We can leave it as a nil pointer.
 
-			svc := createService(ctrl, newWebhookMock(), scenario.DBSetup, false)
+			svc := createService(ctrl, newWebhookMock(), scenario.DBSetup, nil, false)
 			_, err := svc.GetRepositoryByName(ctx, repoOwner, repoName, projectID, providerName)
 
 			if scenario.ShouldSucceed {
@@ -319,6 +331,7 @@ func createService(
 	ctrl *gomock.Controller,
 	whSetup whMockBuilder,
 	dbSetup dbMockBuilder,
+	providerSetup pf.ProviderManagerMockBuilder,
 	eventsFail bool,
 ) github.RepositoryService {
 	var store db.Store
@@ -328,6 +341,10 @@ func createService(
 	var whManager webhooks.WebhookManager
 	if whSetup != nil {
 		whManager = whSetup(ctrl)
+	}
+	var providerManager manager.ProviderManager
+	if providerSetup != nil {
+		providerManager = providerSetup(ctrl)
 	}
 
 	var eventErr error
@@ -340,7 +357,7 @@ func createService(
 		Return(eventErr).
 		AnyTimes()
 
-	return github.NewRepositoryService(whManager, store, events)
+	return github.NewRepositoryService(whManager, store, events, providerManager)
 }
 
 const (
@@ -383,6 +400,7 @@ var (
 		Implements: []db.ProviderType{db.ProviderTypeGithub},
 		Version:    provinfv1.V1,
 	}
+	ghProvider = mock_github.NewMockGitHub(nil)
 )
 
 type (
@@ -432,13 +450,6 @@ func withSuccessfulWebhookDelete(mock whMock) {
 		Return(nil)
 }
 
-func withTwoSuccessfulWebhookDeletes(mock whMock) {
-	mock.EXPECT().
-		DeleteWebhook(gomock.Any(), gomock.Any(), repoOwner, gomock.Any(), gomock.Any()).
-		Return(nil).
-		Times(2)
-}
-
 func withFailedWebhookDelete(mock whMock) {
 	mock.EXPECT().
 		DeleteWebhook(gomock.Any(), gomock.Any(), repoOwner, repoName, cf.HookID).
@@ -455,13 +466,6 @@ func withSuccessfulDelete(mock dbMock) {
 	mock.EXPECT().
 		DeleteRepository(gomock.Any(), gomock.Eq(repoID)).
 		Return(nil)
-}
-
-func withTwoSuccessfulDeletes(mock dbMock) {
-	mock.EXPECT().
-		DeleteRepository(gomock.Any(), gomock.Any()).
-		Return(nil).
-		Times(2)
 }
 
 func withFailedGetById(mock dbMock) {
@@ -510,22 +514,6 @@ func withPrivateReposDisabled(mock dbMock) {
 	mock.EXPECT().
 		GetFeatureInProject(gomock.Any(), gomock.Any()).
 		Return(json.RawMessage{}, sql.ErrNoRows)
-}
-
-func withSuccessfulListRepos(mock dbMock) {
-	dbRepo2 := db.Repository{
-		ID:        uuid.New(),
-		ProjectID: projectID,
-		RepoOwner: repoOwner,
-		RepoName:  "other-repo",
-		WebhookID: sql.NullInt64{
-			Valid: true,
-			Int64: int64(9876),
-		},
-	}
-	mock.EXPECT().
-		ListRegisteredRepositoriesByProjectIDAndProvider(gomock.Any(), gomock.Any()).
-		Return([]db.Repository{dbRepo, dbRepo2}, nil)
 }
 
 func newGithubRepo(isPrivate bool) *gh.Repository {


### PR DESCRIPTION
Relates to #2845

Change the interface of the repo service so that it takes care of DB queries and provider instantiation. This moves various details about repo cleanup out of the controlplane.

As part of this, change the provider cleanup process to delete webhooks directly instead of deleting repos. This avoided a circular dependency, and more closely aligns with the idea that webhook management is a provider-specific detail.

Tested locally.

# Summary

***Provide a brief overview of the changes and the issue being addressed. 
Explain the rationale and any background necessary for understanding the changes. 
List dependencies required by this change, if any.***

Fixes #(related issue)

## Change Type

***Mark the type of change your PR introduces:***

- [ ] Bug fix (resolves an issue without affecting existing features)
- [ ] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [x] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

***Outline how the changes were tested, including steps to reproduce and any relevant configurations. 
Attach screenshots if helpful.***

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [x] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [x] Included tests that validate the fix or feature.
- [ ] Checked that related changes are merged.
