### PR TITLE
Implement GitHubClientFactory

### DIFF
--- a/internal/controlplane/server.go
+++ b/internal/controlplane/server.go
@@ -60,6 +60,7 @@ import (
 	"github.com/stacklok/minder/internal/profiles"
 	"github.com/stacklok/minder/internal/providers"
 	ghprov "github.com/stacklok/minder/internal/providers/github"
+	"github.com/stacklok/minder/internal/providers/github/clients"
 	ghmanager "github.com/stacklok/minder/internal/providers/github/manager"
 	"github.com/stacklok/minder/internal/providers/github/service"
 	"github.com/stacklok/minder/internal/providers/manager"
@@ -175,6 +176,7 @@ func NewServer(
 	profileSvc := profiles.NewProfileService(evt)
 	mt := metrics.NewNoopMetrics()
 	provMt := provtelemetry.NewNoopMetrics()
+	ghClientFactory := clients.NewGitHubClientFactory(provMt)
 	ruleSvc := ruletypes.NewRuleTypeService()
 	marketplace, err := marketplaces.NewMarketplaceFromServiceConfig(cfg.Marketplace, profileSvc, ruleSvc)
 	if err != nil {
@@ -217,7 +219,7 @@ func NewServer(
 
 	githubProviderManager := ghmanager.NewGitHubProviderClassManager(
 		s.restClientCache,
-		provMt,
+		ghClientFactory,
 		&cfg.Provider,
 		fallbackTokenClient,
 		eng,

--- a/internal/providers/github/clients/factory.go
+++ b/internal/providers/github/clients/factory.go
@@ -1,0 +1,102 @@
+// Copyright 2024 Stacklok, Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package clients contains the GitHub client factory
+package clients
+
+import (
+	"fmt"
+	"net/http"
+	"net/url"
+	"os"
+
+	gogithub "github.com/google/go-github/v61/github"
+	"github.com/motemen/go-loghttp"
+	"github.com/rs/zerolog"
+	"golang.org/x/oauth2"
+
+	"github.com/stacklok/minder/internal/db"
+	"github.com/stacklok/minder/internal/providers/telemetry"
+	provifv1 "github.com/stacklok/minder/pkg/providers/v1"
+)
+
+// GitHubClientFactory creates instances of the GitHub API client
+type GitHubClientFactory interface {
+	// Build creates an instance of the GitHub Client
+	// `baseURL` should be set to the empty string if there is no need to
+	// override the default GitHub URL
+	Build(baseURL string, credential provifv1.GitHubCredential) (*gogithub.Client, error)
+}
+
+type githubClientFactory struct {
+	metrics telemetry.HttpClientMetrics
+}
+
+// NewGitHubClientFactory creates a new instance of GitHubClientFactory
+func NewGitHubClientFactory(metrics telemetry.HttpClientMetrics) GitHubClientFactory {
+	return &githubClientFactory{metrics: metrics}
+}
+
+func (g *githubClientFactory) Build(baseURL string, credential provifv1.GitHubCredential) (*gogithub.Client, error) {
+	tc := &http.Client{
+		Transport: &oauth2.Transport{
+			Base:   http.DefaultClient.Transport,
+			Source: credential.GetAsOAuth2TokenSource(),
+		},
+	}
+
+	transport, err := g.metrics.NewDurationRoundTripper(tc.Transport, db.ProviderTypeGithub)
+	if err != nil {
+		return nil, fmt.Errorf("error creating duration round tripper: %w", err)
+	}
+
+	// If $MINDER_LOG_GITHUB_REQUESTS is set, wrap the transport in a logger
+	// to record all calls and responses to from GitHub:
+	if os.Getenv("MINDER_LOG_GITHUB_REQUESTS") != "" {
+		transport = &loghttp.Transport{
+			Transport: transport,
+			LogRequest: func(req *http.Request) {
+				zerolog.Ctx(req.Context()).Debug().
+					Str("type", "REQ").
+					Str("method", req.Method).
+					Msg(req.URL.String())
+			},
+			LogResponse: func(resp *http.Response) {
+				zerolog.Ctx(resp.Request.Context()).Debug().
+					Str("type", "RESP").
+					Str("method", resp.Request.Method).
+					Str("status", fmt.Sprintf("%d", resp.StatusCode)).
+					Str("rate-limit", fmt.Sprintf("%s/%s",
+						resp.Request.Header.Get("x-ratelimit-used"),
+						resp.Request.Header.Get("x-ratelimit-remaining"),
+					)).
+					Msg(resp.Request.URL.String())
+
+			},
+		}
+	}
+
+	tc.Transport = transport
+	ghClient := gogithub.NewClient(tc)
+
+	if baseURL != "" {
+		parsedURL, err := url.Parse(baseURL)
+		if err != nil {
+			return nil, err
+		}
+		ghClient.BaseURL = parsedURL
+	}
+
+	return ghClient, nil
+}


### PR DESCRIPTION
Relates to #2845

For a future PR, I want to be able to easily instantiate the GitHub client without going through the provider creation process. Specifically - when creating providers, we end up partially creating a provider, storing it in the database, and then use instantiate it to verify that the user IDs are correct. I want to change this so that we instantiate the client without the provider to make the call we need.

This splits the code for creating the github client out into its own factory. As a bonus - this removes some code which is duplicated between the oauth and app provider instantiation flows.

Validated locally against both app and oauth flows.

# Summary

***Provide a brief overview of the changes and the issue being addressed. 
Explain the rationale and any background necessary for understanding the changes. 
List dependencies required by this change, if any.***

Fixes #(related issue)

## Change Type

***Mark the type of change your PR introduces:***

- [ ] Bug fix (resolves an issue without affecting existing features)
- [ ] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [x] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

***Outline how the changes were tested, including steps to reproduce and any relevant configurations. 
Attach screenshots if helpful.***

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [x] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [x] Included tests that validate the fix or feature.
- [ ] Checked that related changes are merged.
