### PR TITLE
Warn about empty secret and skip the update in the webhook updater tool

### DIFF
--- a/cmd/server/app/webhook_update.go
+++ b/cmd/server/app/webhook_update.go
@@ -127,6 +127,11 @@ func runCmdWebhookUpdate(cmd *cobra.Command, _ []string) error {
 				zerolog.Ctx(ctx).Err(err).Msg("cannot get webhook secret")
 				continue
 			}
+
+			if whSecret == "" {
+				zerolog.Ctx(ctx).Error().Msg("webhook secret is empty")
+				continue
+			}
 			updateErr = updateGithubWebhooks(ctx, ghCli, store, provider, webhookUrl.Host, whSecret)
 		} else {
 			updateErr = fmt.Errorf("provider type %s not supported", providerName)


### PR DESCRIPTION
# Summary

I was testing the webhook update locally and realized that it's too easy
to let the webhook update proceed with an empty secret. On the server
side we already have a similar check.

## Change Type

- [x] Bug fix (resolves an issue without affecting existing features)
- [ ] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [ ] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

You'd pass the secret file with an env variable:
```
MINDER_WEBHOOK_CONFIG_WEBHOOK_SECRET_FILE=.secrets/webhook_secret ./bin/minder-server webhook update -p github
```

If you omit the secret file, you now get a failure, previously the tool would have proceeded with the update:
```
./bin/minder-server webhook update -p github
```

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [ ] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [ ] Included tests that validate the fix or feature.
- [ ] Checked that related changes are merged.
