### PR TITLE
Fix bug handling images with slashes in ref

### DIFF
--- a/internal/engine/ingester/artifact/artifact.go
+++ b/internal/engine/ingester/artifact/artifact.go
@@ -19,6 +19,7 @@ package artifact
 import (
 	"context"
 	"fmt"
+	"net/url"
 	"sort"
 	"strings"
 	"time"
@@ -246,7 +247,10 @@ func getAndFilterArtifactVersions(
 	}
 
 	// Fetch all available versions of the artifact
-	upstreamVersions, err := ghCli.GetPackageVersions(ctx, artifact.Owner, artifact.GetTypeLower(), artifact.GetName())
+	artifactName := url.QueryEscape(artifact.GetName())
+	upstreamVersions, err := ghCli.GetPackageVersions(
+		ctx, artifact.Owner, artifact.GetTypeLower(), artifactName,
+	)
 	if err != nil {
 		return nil, fmt.Errorf("error retrieving artifact versions: %w", err)
 	}


### PR DESCRIPTION
# Summary

This commit fixes a bug when trying to list images with   names in their reference. The github API expects the path segments after the org to be url escaped, for example:

     `ghcr.io/org/name/with/slahes`

needs to be

     `ghcr.io/org/name%2Fwith%2Fslahes`



## Change Type

***Mark the type of change your PR introduces:***

- [x] Bug fix (resolves an issue without affecting existing features)
- [ ] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [ ] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

TBD
# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [ ] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [ ] Included tests that validate the fix or feature.
- [ ] Checked that related changes are merged.
