### PR TITLE
Return verified attestation in verification results

### DIFF
--- a/internal/engine/ingester/artifact/artifact.go
+++ b/internal/engine/ingester/artifact/artifact.go
@@ -53,13 +53,19 @@ type Ingest struct {
 }
 
 type verification struct {
-	IsSigned          bool   `json:"is_signed"`
-	IsVerified        bool   `json:"is_verified"`
-	Repository        string `json:"repository"`
-	Branch            string `json:"branch"`
-	SignerIdentity    string `json:"signer_identity"`
-	RunnerEnvironment string `json:"runner_environment"`
-	CertIssuer        string `json:"cert_issuer"`
+	IsSigned          bool                 `json:"is_signed"`
+	IsVerified        bool                 `json:"is_verified"`
+	Repository        string               `json:"repository"`
+	Branch            string               `json:"branch"`
+	SignerIdentity    string               `json:"signer_identity"`
+	RunnerEnvironment string               `json:"runner_environment"`
+	CertIssuer        string               `json:"cert_issuer"`
+	Attestation       *verifiedAttestation `json:"attestation,omitempty"`
+}
+
+type verifiedAttestation struct {
+	PredicateType string `json:"predicate_type,omitempty"`
+	Predicate     any    `json:"predicate,omitempty"`
 }
 
 // NewArtifactDataIngest creates a new artifact rule data ingest engine
@@ -207,6 +213,13 @@ func (i *Ingest) getVerificationResult(
 				verResult.SignerIdentity = signerIdentityFromSignature(res.Signature)
 				verResult.RunnerEnvironment = res.Signature.Certificate.RunnerEnvironment
 				verResult.CertIssuer = res.Signature.Certificate.Issuer
+			}
+
+			if res.Statement != nil {
+				verResult.Attestation = &verifiedAttestation{
+					PredicateType: res.Statement.PredicateType,
+					Predicate:     res.Statement.Predicate,
+				}
 			}
 			// Append the verification result to the list
 			versionResults = append(versionResults, *verResult)


### PR DESCRIPTION
# Summary

This PR modifies the artifact ingester to return the attestation after verifying ingested sigstore bundles.

Fixes #https://github.com/stacklok/minder/issues/3210

## Change Type

- [x] Bug fix (resolves an issue without affecting existing features)
- [ ] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [ ] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

***Outline how the changes were tested, including steps to reproduce and any relevant configurations. 
Attach screenshots if helpful.***

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [ ] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [ ] Included tests that validate the fix or feature.
- [ ] Checked that related changes are merged.
