### PR TITLE
Don't trim path from builder URI

### DIFF
--- a/internal/engine/ingester/artifact/artifact.go
+++ b/internal/engine/ingester/artifact/artifact.go
@@ -325,24 +325,16 @@ func branchFromRef(ref string) string {
 
 func signerIdentityFromSignature(s *verify.SignatureVerificationResult) string {
 	if s.Certificate.BuildSignerURI != "" {
-		// Find the index of the start of the ".github/workflows/" part
-		startIndex := strings.Index(s.Certificate.BuildSignerURI, ".github/workflows/")
-		if startIndex == -1 {
-			return ""
-		}
-
-		// Adjust startIndex to get the part right after ".github/workflows/"
-		startIndex += len(".github/workflows/")
-
-		// Extract the part after ".github/workflows/"
-		remainingURL := s.Certificate.BuildSignerURI[startIndex:]
-
+		// TODO(puerco): We should not be trimmin the tag from the signer identity
+		// I'm leavin this part for now as we are capturing the tag and branch
+		// elsewhere but we should improve this.
+		//
 		// Find the index of '@' to isolate the file name
-		atSymbolIndex := strings.Index(remainingURL, "@")
+		atSymbolIndex := strings.Index(s.Certificate.BuildSignerURI, "@")
 		if atSymbolIndex != -1 {
-			return remainingURL[:atSymbolIndex]
+			return s.Certificate.BuildSignerURI[:atSymbolIndex]
 		}
-		return remainingURL
+		return s.Certificate.BuildSignerURI
 	} else if s.Certificate.SubjectAlternativeName.Value != "" {
 		// This is the use case where there is no build signer URI but there is a subject alternative name
 		// Usually this is the case when signing through an OIDC provider. The value is the signer's email identity.


### PR DESCRIPTION
# Summary

This PR modifies the identity extraction function to preserve the full path of the attestation identity recorded in the attestation identity.

Trimming the path opens up a vulnerability as an attestation may be validated by a signature triggered from a workflow with the same filename as the expected one.

The identity extraction function is still timing the branch and tag from the identity which we should probably also not do but we handle it in the rule definition so probably we are ok. Further discussion is needed.

## Change Type

***Mark the type of change your PR introduces:***

- [x] Bug fix (resolves an issue without affecting existing features)
- [ ] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [x] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

Added a unit test to test the treatment of the signer identity

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [x] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [x] Included tests that validate the fix or feature.
- [ ] Checked that related changes are merged.
