### PR TITLE
Ensure provider name is set during repo delete

### DIFF
--- a/internal/controlplane/handlers_repositories.go
+++ b/internal/controlplane/handlers_repositories.go
@@ -298,6 +298,9 @@ func (s *Server) DeleteRepositoryByName(
 
 	projectID := getProjectID(ctx)
 	providerName := getProviderName(ctx)
+	if providerName == "" {
+		return nil, util.UserVisibleError(codes.InvalidArgument, "provider name missing from request")
+	}
 
 	err := s.repos.DeleteByName(ctx, fragments[0], fragments[1], projectID, providerName)
 	if errors.Is(err, sql.ErrNoRows) {

--- a/internal/controlplane/handlers_repositories_test.go
+++ b/internal/controlplane/handlers_repositories_test.go
@@ -215,6 +215,7 @@ func TestServer_DeleteRepository(t *testing.T) {
 		RepoID           string
 		RepoServiceSetup repoMockBuilder
 		ProviderFails    bool
+		ProviderMissing  bool
 		ExpectedError    string
 	}{
 		{
@@ -226,6 +227,12 @@ func TestServer_DeleteRepository(t *testing.T) {
 			Name:          "delete by ID fails when ID is malformed",
 			RepoID:        "I am not a UUID",
 			ExpectedError: "invalid repository ID",
+		},
+		{
+			Name:            "delete by name fails when provider name is omitted",
+			RepoName:        repoOwnerAndName,
+			ProviderMissing: true,
+			ExpectedError:   "provider name missing from request",
 		},
 		{
 			Name:             "deletion fails when repo service returns error",
@@ -268,8 +275,12 @@ func TestServer_DeleteRepository(t *testing.T) {
 			t.Parallel()
 			ctrl := gomock.NewController(t)
 			defer ctrl.Finish()
+			var providerName string
+			if !scenario.ProviderMissing {
+				providerName = ghprovider.Github
+			}
 			ctx := engine.WithEntityContext(context.Background(), &engine.EntityContext{
-				Provider: engine.Provider{Name: ghprovider.Github},
+				Provider: engine.Provider{Name: providerName},
 				Project:  engine.Project{ID: projectID},
 			})
 

--- a/internal/repositories/github/service.go
+++ b/internal/repositories/github/service.go
@@ -243,7 +243,10 @@ func (r *repositoryService) DeleteByName(
 		ProjectID: projectID,
 		Provider: sql.NullString{
 			String: providerName,
-			Valid:  providerName != "",
+			// This should be validated by the controlplane.
+			// If not, a provider with an empty name will not match any repo
+			// and this will fail closed.
+			Valid: true,
 		},
 	})
 	if err != nil {


### PR DESCRIPTION
When handling a request to delete a repository by name, Minder does not enforce that the request contains a non empty provider name. The SQL query used to find the repository will ignore the provider field if the provider name is empty. This leads to a potential bug which could arise if there is more than one repo with the same name in the same project, but with different providers. In this case, one of the repos will get deleted, but it is not deterministic which one will get deleted from the client's viewpoint.

This introduces a slight API compatibility change, but at least avoids the bug described above.

# Summary

***Provide a brief overview of the changes and the issue being addressed. 
Explain the rationale and any background necessary for understanding the changes. 
List dependencies required by this change, if any.***

Fixes #(related issue)

## Change Type

***Mark the type of change your PR introduces:***

- [x] Bug fix (resolves an issue without affecting existing features)
- [ ] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [ ] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

***Outline how the changes were tested, including steps to reproduce and any relevant configurations. 
Attach screenshots if helpful.***

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [x] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [x] Included tests that validate the fix or feature.
- [ ] Checked that related changes are merged.
