### PR TITLE
Make Project Create/Delete a service

### DIFF
--- a/internal/controlplane/handlers_oauth.go
+++ b/internal/controlplane/handlers_oauth.go
@@ -42,7 +42,6 @@ import (
 	"github.com/stacklok/minder/internal/db"
 	"github.com/stacklok/minder/internal/engine"
 	"github.com/stacklok/minder/internal/logger"
-	"github.com/stacklok/minder/internal/projects"
 	"github.com/stacklok/minder/internal/providers"
 	"github.com/stacklok/minder/internal/providers/github/service"
 	"github.com/stacklok/minder/internal/util"
@@ -613,42 +612,6 @@ func (s *Server) VerifyProviderCredential(ctx context.Context,
 	}
 
 	return &pb.VerifyProviderCredentialResponse{Created: false}, nil
-}
-
-// makeProjectForGitHubApp constructs a project for a GitHub App installation which was
-// created by a user through the app installation flow on GitHub.  The flow on GitHub
-// cannot be tied back to a specific project, so we create a new project for the provider.
-//
-// This is a callback because we want to encapsulate components like s.cfg.Identity,
-// s.marketplace, s.authzClient and the like from the providers implementation.
-func (s *Server) makeProjectForGitHubApp(
-	ctx context.Context,
-	qtx db.Querier,
-	name string,
-	ghUser int64,
-) (*db.Project, error) {
-	user, err := auth.GetUserForGitHubId(ctx, s.cfg.Identity, ghUser)
-	if err != nil {
-		return nil, fmt.Errorf("error getting user for GitHub ID: %w", err)
-	}
-	// Ensure the user already exists in the database
-	if _, err := qtx.GetUserBySubject(ctx, user); err != nil {
-		return nil, fmt.Errorf("error getting user %s from database: %w", user, err)
-	}
-
-	topLevelProject, err := projects.ProvisionSelfEnrolledProject(
-		ctx,
-		s.authzClient,
-		qtx,
-		name,
-		user,
-		s.marketplace,
-		s.cfg.DefaultProfiles,
-	)
-	if err != nil {
-		return nil, fmt.Errorf("error creating project: %w", err)
-	}
-	return topLevelProject, nil
 }
 
 type httpResponseError struct {

--- a/internal/controlplane/handlers_projects.go
+++ b/internal/controlplane/handlers_projects.go
@@ -21,7 +21,6 @@ import (
 	"errors"
 
 	"github.com/google/uuid"
-	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -189,12 +188,7 @@ func (s *Server) DeleteProject(
 			"project does not allow project hierarchy operations")
 	}
 
-	l := zerolog.Ctx(ctx).With().
-		Str("component", "controlplane").
-		Str("operation", "delete").
-		Str("project", projectID.String()).
-		Logger()
-	if err := projects.DeleteProject(ctx, projectID, qtx, s.authzClient, s.providerManager, l); err != nil {
+	if err := s.projectDeleter.DeleteProject(ctx, projectID, qtx); err != nil {
 		return nil, status.Errorf(codes.Internal, "error deleting project: %v", err)
 	}
 

--- a/internal/controlplane/handlers_user.go
+++ b/internal/controlplane/handlers_user.go
@@ -77,14 +77,11 @@ func (s *Server) CreateUser(ctx context.Context,
 			baseName = token.PreferredUsername()
 		}
 
-		project, err := projects.ProvisionSelfEnrolledOAuthProject(
+		project, err := s.projectCreator.ProvisionSelfEnrolledOAuthProject(
 			ctx,
-			s.authzClient,
 			qtx,
 			baseName,
 			subject,
-			s.marketplace,
-			s.cfg.DefaultProfiles,
 		)
 		if err != nil {
 			if errors.Is(err, projects.ErrProjectAlreadyExists) {
@@ -166,7 +163,7 @@ func (s *Server) DeleteUser(ctx context.Context,
 
 	subject := token.Subject()
 
-	err = DeleteUser(ctx, s.store, s.authzClient, s.providerManager, subject)
+	err = DeleteUser(ctx, s.store, s.authzClient, s.projectDeleter, subject)
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "failed to delete user from database: %v", err)
 	}

--- a/internal/controlplane/handlers_user_test.go
+++ b/internal/controlplane/handlers_user_test.go
@@ -41,6 +41,7 @@ import (
 	"github.com/stacklok/minder/internal/db"
 	"github.com/stacklok/minder/internal/events"
 	"github.com/stacklok/minder/internal/marketplaces"
+	"github.com/stacklok/minder/internal/projects"
 	"github.com/stacklok/minder/internal/providers"
 	mockprov "github.com/stacklok/minder/internal/providers/github/service/mock"
 	"github.com/stacklok/minder/internal/providers/ratecache"
@@ -259,14 +260,19 @@ func TestCreateUser_gRPC(t *testing.T) {
 			reqCtx := tc.buildStubs(ctx, mockStore, mockJwtValidator, mockProviders)
 			crypeng := mockcrypto.NewMockEngine(ctrl)
 
+			authz := &mock.NoopClient{Authorized: true}
 			server := &Server{
 				store:        mockStore,
 				cfg:          &serverconfig.Config{},
 				cryptoEngine: crypeng,
 				vldtr:        mockJwtValidator,
 				ghProviders:  mockProviders,
-				authzClient:  &mock.NoopClient{Authorized: true},
-				marketplace:  marketplaces.NewNoopMarketplace(),
+				authzClient:  authz,
+				projectCreator: projects.NewProjectCreator(
+					authz,
+					marketplaces.NewNoopMarketplace(),
+					&serverconfig.DefaultProfilesConfig{},
+				),
 			}
 
 			// server, err := NewServer(mockStore, evt, &serverconfig.Config{

--- a/internal/projects/creator_test.go
+++ b/internal/projects/creator_test.go
@@ -51,14 +51,12 @@ func TestProvisionSelfEnrolledProject(t *testing.T) {
 
 	ctx := context.Background()
 
-	_, err := projects.ProvisionSelfEnrolledOAuthProject(
+	creator := projects.NewProjectCreator(authzClient, marketplaces.NewNoopMarketplace(), &server.DefaultProfilesConfig{})
+	_, err := creator.ProvisionSelfEnrolledOAuthProject(
 		ctx,
-		authzClient,
 		mockStore,
 		"test-proj",
 		"test-user",
-		marketplaces.NewNoopMarketplace(),
-		server.DefaultProfilesConfig{},
 	)
 	assert.NoError(t, err)
 
@@ -80,14 +78,12 @@ func TestProvisionSelfEnrolledProjectFailsWritingProjectToDB(t *testing.T) {
 
 	ctx := context.Background()
 
-	_, err := projects.ProvisionSelfEnrolledOAuthProject(
+	creator := projects.NewProjectCreator(authzClient, marketplaces.NewNoopMarketplace(), &server.DefaultProfilesConfig{})
+	_, err := creator.ProvisionSelfEnrolledOAuthProject(
 		ctx,
-		authzClient,
 		mockStore,
 		"test-proj",
 		"test-user",
-		marketplaces.NewNoopMarketplace(),
-		server.DefaultProfilesConfig{},
 	)
 	assert.Error(t, err)
 

--- a/internal/projects/deleter.go
+++ b/internal/projects/deleter.go
@@ -31,14 +31,47 @@ import (
 	v1 "github.com/stacklok/minder/pkg/api/protobuf/go/minder/v1"
 )
 
-// CleanUpUnmanagedProjects deletes a project if it has no role assignments left
-func CleanUpUnmanagedProjects(
+// ProjectDeleter encapsulates operations for deleting projects
+// This is a separate interface/struct to ProjectCreator to avoid a circular
+// dependency issue.
+type ProjectDeleter interface {
+	// CleanUpUnmanagedProjects deletes a project if it has no role assignments left
+	CleanUpUnmanagedProjects(
+		ctx context.Context,
+		subject string,
+		proj uuid.UUID,
+		querier db.Querier,
+	) error
+
+	// DeleteProject deletes a project and authorization relationships
+	DeleteProject(
+		ctx context.Context,
+		proj uuid.UUID,
+		querier db.Querier,
+	) error
+}
+
+type projectDeleter struct {
+	authzClient     authz.Client
+	providerManager manager.ProviderManager
+}
+
+// NewProjectDeleter creates a new instance of the project deleter
+func NewProjectDeleter(
+	authzClient authz.Client,
+	providerManager manager.ProviderManager,
+) ProjectDeleter {
+	return &projectDeleter{
+		authzClient:     authzClient,
+		providerManager: providerManager,
+	}
+}
+
+func (p *projectDeleter) CleanUpUnmanagedProjects(
 	ctx context.Context,
 	subject string,
 	proj uuid.UUID,
 	querier db.Querier,
-	authzClient authz.Client,
-	providerManager manager.ProviderManager,
 ) error {
 	l := zerolog.Ctx(ctx).With().Str("project", proj.String()).Logger()
 	// We know that non-root projects have a parent which has an admin, so
@@ -65,14 +98,14 @@ func CleanUpUnmanagedProjects(
 	// When we add group support, we'll need to check whether admin groups
 	// are empty in this check.  The alternative is to use Expand(), but
 	// that requires expanding the resulting tree ourselves.
-	as, err := authzClient.AssignmentsToProject(ctx, proj)
+	as, err := p.authzClient.AssignmentsToProject(ctx, proj)
 	if err != nil {
 		return fmt.Errorf("error getting role assignments for project: %v", err)
 	}
 
 	if !hasOtherRoleAssignments(as, subject) {
 		l.Info().Msg("deleting project")
-		if err := DeleteProject(ctx, proj, querier, authzClient, providerManager, l); err != nil {
+		if err := p.DeleteProject(ctx, proj, querier); err != nil {
 			return fmt.Errorf("error deleting project %v", err)
 		}
 	}
@@ -80,21 +113,17 @@ func CleanUpUnmanagedProjects(
 	return nil
 }
 
-func hasOtherRoleAssignments(as []*v1.RoleAssignment, subject string) bool {
-	return slices.ContainsFunc(as, func(a *v1.RoleAssignment) bool {
-		return a.GetRole() == authz.AuthzRoleAdmin.String() && a.Subject != subject
-	})
-}
-
 // DeleteProject deletes a project and authorization relationships
-func DeleteProject(
+func (p *projectDeleter) DeleteProject(
 	ctx context.Context,
 	proj uuid.UUID,
 	querier db.Querier,
-	authzClient authz.Client,
-	providerManager manager.ProviderManager,
-	l zerolog.Logger,
 ) error {
+	l := zerolog.Ctx(ctx).With().
+		Str("component", "projects").
+		Str("operation", "delete").
+		Str("project", proj.String()).
+		Logger()
 	_, err := querier.GetProjectByID(ctx, proj)
 	if err != nil {
 		// This project has already been deleted. Skip and go to the next one.
@@ -111,7 +140,7 @@ func DeleteProject(
 		l.Error().Err(err).Msg("error getting providers for project")
 	}
 	for _, provider := range dbProviders {
-		if err := providerManager.DeleteByID(ctx, provider.ID, proj); err != nil {
+		if err := p.providerManager.DeleteByID(ctx, provider.ID, proj); err != nil {
 			l.Error().Err(err).Msg("error deleting provider")
 		}
 	}
@@ -127,11 +156,17 @@ func DeleteProject(
 	for _, d := range deletions {
 		if d.ParentID.Valid {
 			l.Debug().Str("parent_id", d.ParentID.UUID.String()).Msg("orphaning project")
-			if err := authzClient.Orphan(ctx, d.ParentID.UUID, d.ID); err != nil {
+			if err := p.authzClient.Orphan(ctx, d.ParentID.UUID, d.ID); err != nil {
 				return fmt.Errorf("error orphaning project %v", err)
 			}
 		}
 	}
 
 	return nil
+}
+
+func hasOtherRoleAssignments(as []*v1.RoleAssignment, subject string) bool {
+	return slices.ContainsFunc(as, func(a *v1.RoleAssignment) bool {
+		return a.GetRole() == authz.AuthzRoleAdmin.String() && a.Subject != subject
+	})
 }

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -67,7 +67,7 @@ func AllInOneServerService(
 	}
 
 	// Subscribe to events from the identity server
-	err = controlplane.SubscribeToIdentityEvents(ctx, store, s.GetAuthzClient(), cfg, s.GetProviderManager())
+	err = controlplane.SubscribeToIdentityEvents(ctx, store, s.GetAuthzClient(), cfg, s.GetProjectDeleter())
 	if err != nil {
 		return fmt.Errorf("unable to subscribe to identity server events: %w", err)
 	}


### PR DESCRIPTION
Relates to #2845

This is part of a change which allows me to avoid some ugly hackery in my draft PR (#3221). Break Project creation/deletion out into a pair of dedicated structs/interfaces. Change the `ProjectFactory` function used in the GitHubProviderService from a method on the controlplane to a function which returns a function. This is needed for some additional cleanup introduced in a future PR.

Validated locally.

# Summary

***Provide a brief overview of the changes and the issue being addressed. 
Explain the rationale and any background necessary for understanding the changes. 
List dependencies required by this change, if any.***

Fixes #(related issue)

## Change Type

***Mark the type of change your PR introduces:***

- [ ] Bug fix (resolves an issue without affecting existing features)
- [ ] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [x] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

***Outline how the changes were tested, including steps to reproduce and any relevant configurations. 
Attach screenshots if helpful.***

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [x] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [x] Included tests that validate the fix or feature.
- [ ] Checked that related changes are merged.
