### PR TITLE
Remove OpenFGA CVE ignore from `.trivyignore` file

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -1,6 +1,3 @@
 # Ignoring this CVE since we've got mitigations for it and we need to use this
 # version because of a regression
 CVE-2023-47108
-
-# Our model is not vulnerable to this OpenFGA CVE
-CVE-2024-31452


### PR DESCRIPTION
We've upgraded the CLI utility and we should no longer get a warning.

Signed-off-by: Juan Antonio Osorio <ozz@stacklok.com>
