### PR TITLE
Distinguish between score 0 and missing score in Trusty

### DIFF
--- a/internal/engine/eval/trusty/actions.go
+++ b/internal/engine/eval/trusty/actions.go
@@ -121,7 +121,7 @@ func (sph *summaryPrHandler) generateSummary() (string, error) {
 
 		higherScoringAlternatives := make([]Alternative, 0)
 		for _, alt := range alternative.trustyReply.Alternatives.Packages {
-			if alt.Score > alternative.trustyReply.Summary.Score {
+			if alternative.trustyReply.Summary.Score != nil && alt.Score > *alternative.trustyReply.Summary.Score {
 				alt.PackageNameURL = url.PathEscape(alt.PackageName)
 				higherScoringAlternatives = append(higherScoringAlternatives, alt)
 			}
@@ -145,7 +145,7 @@ func (sph *summaryPrHandler) generateSummary() (string, error) {
 			Ecosystem:    strings.ToLower(alternative.Dependency.Ecosystem.AsString()),
 			Name:         alternative.Dependency.Name,
 			NameURL:      url.PathEscape(alternative.Dependency.Name),
-			Score:        alternative.trustyReply.Summary.Score,
+			Score:        *alternative.trustyReply.Summary.Score,
 			Alternatives: higherScoringAlternatives,
 			BaseUrl:      constants.TrustyHttpURL,
 		}); err != nil {

--- a/internal/engine/eval/trusty/config.go
+++ b/internal/engine/eval/trusty/config.go
@@ -119,8 +119,8 @@ func (ec *ecosystemConfig) getScoreSource() string {
 }
 
 func (ec *ecosystemConfig) getScore(inSummary ScoreSummary) (float64, error) {
-	if ec.EvaluateScore == DefaultScore || ec.EvaluateScore == SummaryScore {
-		return inSummary.Score, nil
+	if inSummary.Score != nil && (ec.EvaluateScore == DefaultScore || ec.EvaluateScore == SummaryScore) {
+		return *inSummary.Score, nil
 	}
 
 	// If the score is not the summary score, then it must be in the details

--- a/internal/engine/eval/trusty/trusty.go
+++ b/internal/engine/eval/trusty/trusty.go
@@ -134,7 +134,7 @@ func (e *Evaluator) Eval(ctx context.Context, pol map[string]any, res *engif.Res
 			continue
 		}
 
-		if resp.Summary.Score == 0 {
+		if resp.Summary.Score == nil {
 			logger.Info().
 				Str("dependency", dep.Dep.Name).
 				Msgf("the dependency has no score, skipping")

--- a/internal/engine/eval/trusty/trusty_rest_handler.go
+++ b/internal/engine/eval/trusty/trusty_rest_handler.go
@@ -61,7 +61,7 @@ type Alternative struct {
 
 // ScoreSummary is the summary score returned from the package intelligence API
 type ScoreSummary struct {
-	Score       float64        `json:"score"`
+	Score       *float64       `json:"score"`
 	Description map[string]any `json:"description"`
 }
 


### PR DESCRIPTION
# Summary

This was a leftover from when trusty didn't have scores for some
packages at all, but it was not handled well. We tried to handle score 0
as missing.

Instead, let's use a `*float64` instead to distinguish between missing
score and score that is set but is zero.

## Change Type

- [x] Bug fix (resolves an issue without affecting existing features)
- [ ] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [ ] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

See e.g. https://github.com/jakubtestorg/bad-python/pull/192 - there are two comments,
one from the buggy version where minder just skipped the dep with score 0 and
one where minder adds the comment.

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [ ] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [ ] Included tests that validate the fix or feature.
- [ ] Checked that related changes are merged.
