### PR TITLE
Re-enable go CoverageRedesign

### DIFF
--- a/.mk/test.mk
+++ b/.mk/test.mk
@@ -33,11 +33,7 @@ test-silent: clean init-examples ## run tests in a silent mode (errors only outp
 
 .PHONY: cover
 cover: init-examples ## display test coverage
-	# There is a bug in the new coverage logic implemented in go 1.22.
-	# The recommended workaround is to disable the new coverage logic until
-	# this is fixed.
-	# See: https://github.com/golang/go/issues/65653
-	GOEXPERIMENT=nocoverageredesign go test -v -coverpkg=${COVERAGE_PACKAGES} -coverprofile=coverage.out.tmp -race ./...
+	go test -v -coverpkg=${COVERAGE_PACKAGES} -coverprofile=coverage.out.tmp -race ./...
 	cat coverage.out.tmp | grep -v ${COVERAGE_EXCLUSIONS} > coverage.out
 	rm coverage.out.tmp
 	go tool cover -func=coverage.out


### PR DESCRIPTION
# Summary

Remove the workaround that disabled new compiler-based code coverage tooling due to a [bug introduced in go v1.22.0](https://github.com/golang/go/issues/65653) and [fixed in v1.22.2](https://github.com/golang/go/issues/66137), since we bumped go to v1.22.2 in pr #3161.

## Change Type

***Mark the type of change your PR introduces:***

- [x] Bug fix (resolves an issue without affecting existing features)
- [ ] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [ ] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

Local test results attached: [make_cover.log](https://github.com/stacklok/minder/files/15225797/make_cover.log)

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [ ] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [ ] Included tests that validate the fix or feature.
- [ ] Checked that related changes are merged.
