### PR TITLE
Refactor engine code to use specific provider traits in more places

### DIFF
--- a/internal/engine/actions/alert/alert.go
+++ b/internal/engine/actions/alert/alert.go
@@ -43,7 +43,11 @@ func NewRuleAlert(rt *pb.RuleType, pbuild *providers.ProviderBuilder) (engif.Act
 		if alertCfg.GetSecurityAdvisory() == nil {
 			return nil, fmt.Errorf("alert engine missing security-advisory configuration")
 		}
-		return security_advisory.NewSecurityAdvisoryAlert(ActionType, rt.GetSeverity(), alertCfg.GetSecurityAdvisory(), pbuild)
+		client, err := pbuild.GetGitHub()
+		if err != nil {
+			return nil, fmt.Errorf("could not instantiate provider: %w", err)
+		}
+		return security_advisory.NewSecurityAdvisoryAlert(ActionType, rt.GetSeverity(), alertCfg.GetSecurityAdvisory(), client)
 	}
 
 	return nil, fmt.Errorf("unknown alert type: %s", alertCfg.GetType())

--- a/internal/engine/actions/alert/security_advisory/security_advisory.go
+++ b/internal/engine/actions/alert/security_advisory/security_advisory.go
@@ -32,7 +32,6 @@ import (
 
 	enginerr "github.com/stacklok/minder/internal/engine/errors"
 	"github.com/stacklok/minder/internal/engine/interfaces"
-	"github.com/stacklok/minder/internal/providers"
 	"github.com/stacklok/minder/internal/util"
 	pb "github.com/stacklok/minder/pkg/api/protobuf/go/minder/v1"
 	provifv1 "github.com/stacklok/minder/pkg/providers/v1"
@@ -135,7 +134,7 @@ func NewSecurityAdvisoryAlert(
 	actionType interfaces.ActionType,
 	sev *pb.Severity,
 	saCfg *pb.RuleType_Definition_Alert_AlertTypeSA,
-	pbuild *providers.ProviderBuilder,
+	cli provifv1.GitHub,
 ) (*Alert, error) {
 	if actionType == "" {
 		return nil, fmt.Errorf("action type cannot be empty")
@@ -155,11 +154,7 @@ func NewSecurityAdvisoryAlert(
 	if err != nil {
 		return nil, fmt.Errorf("cannot parse description template: %w", err)
 	}
-	// Get the GitHub client
-	cli, err := pbuild.GetGitHub()
-	if err != nil {
-		return nil, fmt.Errorf("cannot get http client: %w", err)
-	}
+
 	// Create the alert action
 	return &Alert{
 		actionType:           actionType,

--- a/internal/engine/actions/remediate/gh_branch_protect/gh_branch_protect.go
+++ b/internal/engine/actions/remediate/gh_branch_protect/gh_branch_protect.go
@@ -32,7 +32,6 @@ import (
 
 	engerrors "github.com/stacklok/minder/internal/engine/errors"
 	"github.com/stacklok/minder/internal/engine/interfaces"
-	"github.com/stacklok/minder/internal/providers"
 	mindergh "github.com/stacklok/minder/internal/providers/github"
 	"github.com/stacklok/minder/internal/util"
 	pb "github.com/stacklok/minder/pkg/api/protobuf/go/minder/v1"
@@ -55,7 +54,7 @@ type GhBranchProtectRemediator struct {
 func NewGhBranchProtectRemediator(
 	actionType interfaces.ActionType,
 	ghp *pb.RuleType_Definition_Remediate_GhBranchProtectionType,
-	pbuild *providers.ProviderBuilder,
+	cli provifv1.GitHub,
 ) (*GhBranchProtectRemediator, error) {
 	if actionType == "" {
 		return nil, fmt.Errorf("action type cannot be empty")
@@ -66,10 +65,6 @@ func NewGhBranchProtectRemediator(
 		return nil, fmt.Errorf("cannot parse patch template: %w", err)
 	}
 
-	cli, err := pbuild.GetGitHub()
-	if err != nil {
-		return nil, fmt.Errorf("cannot get http client: %w", err)
-	}
 	return &GhBranchProtectRemediator{
 		actionType:    actionType,
 		cli:           cli,

--- a/internal/engine/actions/remediate/gh_branch_protect/gh_branch_protect_test.go
+++ b/internal/engine/actions/remediate/gh_branch_protect/gh_branch_protect_test.go
@@ -31,7 +31,6 @@ import (
 	"github.com/stacklok/minder/internal/providers/credentials"
 	"github.com/stacklok/minder/internal/providers/github/clients"
 	mock_ghclient "github.com/stacklok/minder/internal/providers/github/mock"
-	"github.com/stacklok/minder/internal/providers/github/oauth"
 	"github.com/stacklok/minder/internal/providers/telemetry"
 	pb "github.com/stacklok/minder/pkg/api/protobuf/go/minder/v1"
 	provifv1 "github.com/stacklok/minder/pkg/providers/v1"
@@ -52,7 +51,7 @@ func testGithubProvider(baseURL string) (provifv1.GitHub, error) {
 		baseURL = baseURL + "/"
 	}
 
-	return oauth.NewRestClient(
+	return clients.NewRestClient(
 		&pb.GitHubProviderConfig{
 			Endpoint: baseURL,
 		},

--- a/internal/engine/actions/remediate/pull_request/pull_request.go
+++ b/internal/engine/actions/remediate/pull_request/pull_request.go
@@ -38,7 +38,6 @@ import (
 	"github.com/stacklok/minder/internal/db"
 	enginerr "github.com/stacklok/minder/internal/engine/errors"
 	"github.com/stacklok/minder/internal/engine/interfaces"
-	"github.com/stacklok/minder/internal/providers"
 	"github.com/stacklok/minder/internal/util"
 	pb "github.com/stacklok/minder/pkg/api/protobuf/go/minder/v1"
 	provifv1 "github.com/stacklok/minder/pkg/providers/v1"
@@ -91,7 +90,7 @@ type paramsPR struct {
 func NewPullRequestRemediate(
 	actionType interfaces.ActionType,
 	prCfg *pb.RuleType_Definition_Remediate_PullRequestRemediation,
-	pbuild *providers.ProviderBuilder,
+	ghCli provifv1.GitHub,
 ) (*Remediator, error) {
 	err := prCfg.Validate()
 	if err != nil {
@@ -106,11 +105,6 @@ func NewPullRequestRemediate(
 	bodyTmpl, err := util.ParseNewHtmlTemplate(&prCfg.Body, "body")
 	if err != nil {
 		return nil, fmt.Errorf("cannot parse body template: %w", err)
-	}
-
-	ghCli, err := pbuild.GetGitHub()
-	if err != nil {
-		return nil, fmt.Errorf("failed to get github client: %w", err)
 	}
 
 	modRegistry := newModificationRegistry()

--- a/internal/engine/actions/remediate/pull_request/pull_request_test.go
+++ b/internal/engine/actions/remediate/pull_request/pull_request_test.go
@@ -42,8 +42,7 @@ import (
 	"github.com/stacklok/minder/internal/engine/interfaces"
 	"github.com/stacklok/minder/internal/providers/credentials"
 	"github.com/stacklok/minder/internal/providers/github/clients"
-	mock_ghclient "github.com/stacklok/minder/internal/providers/github/mock"
-	"github.com/stacklok/minder/internal/providers/github/oauth"
+	mockghclient "github.com/stacklok/minder/internal/providers/github/mock"
 	"github.com/stacklok/minder/internal/providers/telemetry"
 	pb "github.com/stacklok/minder/pkg/api/protobuf/go/minder/v1"
 	provifv1 "github.com/stacklok/minder/pkg/providers/v1"
@@ -89,7 +88,7 @@ jobs:
 var TestActionTypeValid interfaces.ActionType = "remediate-test"
 
 func testGithubProvider() (provifv1.GitHub, error) {
-	return oauth.NewRestClient(
+	return clients.NewRestClient(
 		&pb.GitHubProviderConfig{
 			Endpoint: ghApiUrl + "/",
 		},
@@ -179,7 +178,7 @@ func createTestRemArgsWithExcludes() *remediateArgs {
 	}
 }
 
-func happyPathMockSetup(mockGitHub *mock_ghclient.MockGitHub) {
+func happyPathMockSetup(mockGitHub *mockghclient.MockGitHub) {
 	// no pull request so far
 	mockGitHub.EXPECT().
 		ListPullRequests(gomock.Any(), repoOwner, repoName, gomock.Any()).Return([]*github.PullRequest{}, nil)
@@ -191,7 +190,7 @@ func happyPathMockSetup(mockGitHub *mock_ghclient.MockGitHub) {
 		AddAuthToPushOptions(gomock.Any(), gomock.Any()).Return(nil)
 }
 
-func resolveActionMockSetup(t *testing.T, mockGitHub *mock_ghclient.MockGitHub, url, ref string) {
+func resolveActionMockSetup(t *testing.T, mockGitHub *mockghclient.MockGitHub, url, ref string) {
 	t.Helper()
 
 	mockGitHub.EXPECT().
@@ -364,7 +363,7 @@ func TestPullRequestRemediate(t *testing.T) {
 		newRemArgs       *newPullRequestRemediateArgs
 		remArgs          *remediateArgs
 		repoSetup        func(*testing.T) (*git.Repository, error)
-		mockSetup        func(*testing.T, *mock_ghclient.MockGitHub)
+		mockSetup        func(*testing.T, *mockghclient.MockGitHub)
 		expectedErr      error
 		wantInitErr      bool
 		expectedMetadata json.RawMessage
@@ -377,7 +376,7 @@ func TestPullRequestRemediate(t *testing.T) {
 			},
 			remArgs:   createTestRemArgs(),
 			repoSetup: defaultMockRepoSetup,
-			mockSetup: func(_ *testing.T, mockGitHub *mock_ghclient.MockGitHub) {
+			mockSetup: func(_ *testing.T, mockGitHub *mockghclient.MockGitHub) {
 				happyPathMockSetup(mockGitHub)
 
 				mockGitHub.EXPECT().
@@ -399,7 +398,7 @@ func TestPullRequestRemediate(t *testing.T) {
 			},
 			remArgs:   createTestRemArgs(),
 			repoSetup: defaultMockRepoSetup,
-			mockSetup: func(_ *testing.T, mockGitHub *mock_ghclient.MockGitHub) {
+			mockSetup: func(_ *testing.T, mockGitHub *mockghclient.MockGitHub) {
 				happyPathMockSetup(mockGitHub)
 
 				mockGitHub.EXPECT().
@@ -421,7 +420,7 @@ func TestPullRequestRemediate(t *testing.T) {
 			},
 			remArgs:   createTestRemArgs(),
 			repoSetup: mockRepoSetupWithBranch,
-			mockSetup: func(_ *testing.T, mockGitHub *mock_ghclient.MockGitHub) {
+			mockSetup: func(_ *testing.T, mockGitHub *mockghclient.MockGitHub) {
 				happyPathMockSetup(mockGitHub)
 
 				mockGitHub.EXPECT().
@@ -443,7 +442,7 @@ func TestPullRequestRemediate(t *testing.T) {
 			},
 			remArgs:   createTestRemArgs(),
 			repoSetup: defaultMockRepoSetup,
-			mockSetup: func(_ *testing.T, mockGitHub *mock_ghclient.MockGitHub) {
+			mockSetup: func(_ *testing.T, mockGitHub *mockghclient.MockGitHub) {
 				mockGitHub.EXPECT().
 					GetName(gomock.Any()).Return("stacklok-bot", nil)
 				mockGitHub.EXPECT().
@@ -504,7 +503,7 @@ func TestPullRequestRemediate(t *testing.T) {
 			},
 			remArgs:   createTestRemArgs(),
 			repoSetup: defaultMockRepoSetup,
-			mockSetup: func(t *testing.T, mockGitHub *mock_ghclient.MockGitHub) {
+			mockSetup: func(t *testing.T, mockGitHub *mockghclient.MockGitHub) {
 				t.Helper()
 
 				happyPathMockSetup(mockGitHub)
@@ -531,7 +530,7 @@ func TestPullRequestRemediate(t *testing.T) {
 			},
 			remArgs:   createTestRemArgs(),
 			repoSetup: defaultMockRepoSetup,
-			mockSetup: func(t *testing.T, mockGitHub *mock_ghclient.MockGitHub) {
+			mockSetup: func(t *testing.T, mockGitHub *mockghclient.MockGitHub) {
 				t.Helper()
 
 				happyPathMockSetup(mockGitHub)
@@ -556,7 +555,7 @@ func TestPullRequestRemediate(t *testing.T) {
 			},
 			remArgs:   createTestRemArgsWithExcludes(),
 			repoSetup: defaultMockRepoSetup,
-			mockSetup: func(t *testing.T, mockGitHub *mock_ghclient.MockGitHub) {
+			mockSetup: func(t *testing.T, mockGitHub *mockghclient.MockGitHub) {
 				t.Helper()
 
 				happyPathMockSetup(mockGitHub)
@@ -587,7 +586,7 @@ func TestPullRequestRemediate(t *testing.T) {
 				ctrl.Finish()
 			})
 
-			mockClient := mock_ghclient.NewMockGitHub(ctrl)
+			mockClient := mockghclient.NewMockGitHub(ctrl)
 
 			provider, err := testGithubProvider()
 			require.NoError(t, err)

--- a/internal/engine/actions/remediate/remediate.go
+++ b/internal/engine/actions/remediate/remediate.go
@@ -42,23 +42,35 @@ func NewRuleRemediator(rt *pb.RuleType, pbuild *providers.ProviderBuilder) (engi
 	// nolint:revive // let's keep the switch here, it would be nicer to extend a switch in the future
 	switch rem.GetType() {
 	case rest.RemediateType:
+		client, err := pbuild.GetHTTP()
+		if err != nil {
+			return nil, fmt.Errorf("could not instantiate provider: %w", err)
+		}
 		if rem.GetRest() == nil {
 			return nil, fmt.Errorf("remediations engine missing rest configuration")
 		}
-		return rest.NewRestRemediate(ActionType, rem.GetRest(), pbuild)
+		return rest.NewRestRemediate(ActionType, rem.GetRest(), client)
 
 	case gh_branch_protect.RemediateType:
+		client, err := pbuild.GetGitHub()
+		if err != nil {
+			return nil, fmt.Errorf("could not instantiate provider: %w", err)
+		}
 		if rem.GetGhBranchProtection() == nil {
 			return nil, fmt.Errorf("remediations engine missing gh_branch_protection configuration")
 		}
-		return gh_branch_protect.NewGhBranchProtectRemediator(ActionType, rem.GetGhBranchProtection(), pbuild)
+		return gh_branch_protect.NewGhBranchProtectRemediator(ActionType, rem.GetGhBranchProtection(), client)
 
 	case pull_request.RemediateType:
+		client, err := pbuild.GetGitHub()
+		if err != nil {
+			return nil, fmt.Errorf("could not instantiate provider: %w", err)
+		}
 		if rem.GetPullRequest() == nil {
 			return nil, fmt.Errorf("remediations engine missing pull request configuration")
 		}
 
-		return pull_request.NewPullRequestRemediate(ActionType, rem.GetPullRequest(), pbuild)
+		return pull_request.NewPullRequestRemediate(ActionType, rem.GetPullRequest(), client)
 	}
 
 	return nil, fmt.Errorf("unknown remediation type: %s", rem.GetType())

--- a/internal/engine/actions/remediate/remediate_test.go
+++ b/internal/engine/actions/remediate/remediate_test.go
@@ -19,6 +19,8 @@ package remediate_test
 import (
 	"database/sql"
 	"encoding/json"
+	"github.com/stacklok/minder/internal/engine/actions/remediate/noop"
+	"github.com/stacklok/minder/internal/engine/actions/remediate/rest"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -27,8 +29,6 @@ import (
 	serverconfig "github.com/stacklok/minder/internal/config/server"
 	"github.com/stacklok/minder/internal/db"
 	"github.com/stacklok/minder/internal/engine/actions/remediate"
-	"github.com/stacklok/minder/internal/engine/actions/remediate/noop"
-	"github.com/stacklok/minder/internal/engine/actions/remediate/rest"
 	engif "github.com/stacklok/minder/internal/engine/interfaces"
 	"github.com/stacklok/minder/internal/providers"
 	"github.com/stacklok/minder/internal/providers/credentials"
@@ -104,7 +104,8 @@ func TestNewRuleRemediator(t *testing.T) {
 					},
 				},
 			},
-			wantError: true,
+			provBuilder: validProviderBuilder,
+			wantError:   true,
 		},
 		{
 			name: "Test made up remediator",

--- a/internal/engine/actions/remediate/remediate_test.go
+++ b/internal/engine/actions/remediate/remediate_test.go
@@ -19,8 +19,6 @@ package remediate_test
 import (
 	"database/sql"
 	"encoding/json"
-	"github.com/stacklok/minder/internal/engine/actions/remediate/noop"
-	"github.com/stacklok/minder/internal/engine/actions/remediate/rest"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -29,6 +27,8 @@ import (
 	serverconfig "github.com/stacklok/minder/internal/config/server"
 	"github.com/stacklok/minder/internal/db"
 	"github.com/stacklok/minder/internal/engine/actions/remediate"
+	"github.com/stacklok/minder/internal/engine/actions/remediate/noop"
+	"github.com/stacklok/minder/internal/engine/actions/remediate/rest"
 	engif "github.com/stacklok/minder/internal/engine/interfaces"
 	"github.com/stacklok/minder/internal/providers"
 	"github.com/stacklok/minder/internal/providers/credentials"

--- a/internal/engine/actions/remediate/rest/rest.go
+++ b/internal/engine/actions/remediate/rest/rest.go
@@ -31,7 +31,6 @@ import (
 
 	engerrors "github.com/stacklok/minder/internal/engine/errors"
 	"github.com/stacklok/minder/internal/engine/interfaces"
-	"github.com/stacklok/minder/internal/providers"
 	"github.com/stacklok/minder/internal/util"
 	pb "github.com/stacklok/minder/pkg/api/protobuf/go/minder/v1"
 	provifv1 "github.com/stacklok/minder/pkg/providers/v1"
@@ -52,9 +51,7 @@ type Remediator struct {
 }
 
 // NewRestRemediate creates a new REST rule data ingest engine
-func NewRestRemediate(actionType interfaces.ActionType, restCfg *pb.RestType,
-	pbuild *providers.ProviderBuilder,
-) (*Remediator, error) {
+func NewRestRemediate(actionType interfaces.ActionType, restCfg *pb.RestType, cli provifv1.REST) (*Remediator, error) {
 	if actionType == "" {
 		return nil, fmt.Errorf("action type cannot be empty")
 	}
@@ -73,11 +70,6 @@ func NewRestRemediate(actionType interfaces.ActionType, restCfg *pb.RestType,
 	}
 
 	method := util.HttpMethodFromString(restCfg.Method, http.MethodPatch)
-
-	cli, err := pbuild.GetHTTP()
-	if err != nil {
-		return nil, fmt.Errorf("cannot get http client: %w", err)
-	}
 
 	return &Remediator{
 		cli:              cli,

--- a/internal/engine/actions/remediate/rest/rest_test.go
+++ b/internal/engine/actions/remediate/rest/rest_test.go
@@ -33,7 +33,6 @@ import (
 	"github.com/stacklok/minder/internal/engine/interfaces"
 	"github.com/stacklok/minder/internal/providers/credentials"
 	"github.com/stacklok/minder/internal/providers/github/clients"
-	github "github.com/stacklok/minder/internal/providers/github/oauth"
 	httpclient "github.com/stacklok/minder/internal/providers/http"
 	"github.com/stacklok/minder/internal/providers/telemetry"
 	pb "github.com/stacklok/minder/pkg/api/protobuf/go/minder/v1"
@@ -52,7 +51,7 @@ func testGithubProvider(baseURL string) (provifv1.REST, error) {
 		baseURL = baseURL + "/"
 	}
 
-	return github.NewRestClient(
+	return clients.NewRestClient(
 		&pb.GitHubProviderConfig{
 			Endpoint: baseURL,
 		},

--- a/internal/engine/eval/eval.go
+++ b/internal/engine/eval/eval.go
@@ -35,7 +35,7 @@ import (
 func NewRuleEvaluator(
 	ctx context.Context,
 	rt *pb.RuleType,
-	cli *providers.ProviderBuilder,
+	pbuild *providers.ProviderBuilder,
 ) (engif.Evaluator, error) {
 	e := rt.Def.GetEval()
 	if e == nil {
@@ -52,11 +52,23 @@ func NewRuleEvaluator(
 	case rego.RegoEvalType:
 		return rego.NewRegoEvaluator(e.GetRego())
 	case vulncheck.VulncheckEvalType:
-		return vulncheck.NewVulncheckEvaluator(e.GetVulncheck(), cli)
+		client, err := pbuild.GetGitHub()
+		if err != nil {
+			return nil, fmt.Errorf("could not instantiate provider: %w", err)
+		}
+		return vulncheck.NewVulncheckEvaluator(client)
 	case trusty.TrustyEvalType:
-		return trusty.NewTrustyEvaluator(ctx, cli)
+		client, err := pbuild.GetGitHub()
+		if err != nil {
+			return nil, fmt.Errorf("could not instantiate provider: %w", err)
+		}
+		return trusty.NewTrustyEvaluator(ctx, client)
 	case application.HomoglyphsEvalType:
-		return application.NewHomoglyphsEvaluator(e.GetHomoglyphs(), cli)
+		client, err := pbuild.GetGitHub()
+		if err != nil {
+			return nil, fmt.Errorf("could not instantiate provider: %w", err)
+		}
+		return application.NewHomoglyphsEvaluator(e.GetHomoglyphs(), client)
 	default:
 		return nil, fmt.Errorf("unsupported rule type engine: %s", rt.Def.Eval.Type)
 	}

--- a/internal/engine/eval/homoglyphs/application/homoglyphs_service.go
+++ b/internal/engine/eval/homoglyphs/application/homoglyphs_service.go
@@ -25,8 +25,8 @@ import (
 	"github.com/stacklok/minder/internal/engine/eval/homoglyphs/communication"
 	"github.com/stacklok/minder/internal/engine/eval/homoglyphs/domain"
 	engif "github.com/stacklok/minder/internal/engine/interfaces"
-	"github.com/stacklok/minder/internal/providers"
 	pb "github.com/stacklok/minder/pkg/api/protobuf/go/minder/v1"
+	provifv1 "github.com/stacklok/minder/pkg/providers/v1"
 )
 
 const (
@@ -40,9 +40,9 @@ const (
 // NewHomoglyphsEvaluator creates a new homoglyphs evaluator
 func NewHomoglyphsEvaluator(
 	reh *pb.RuleType_Definition_Eval_Homoglyphs,
-	pbuild *providers.ProviderBuilder,
+	ghClient provifv1.GitHub,
 ) (engif.Evaluator, error) {
-	if pbuild == nil {
+	if ghClient == nil {
 		return nil, fmt.Errorf("provider builder is nil")
 	}
 	if reh == nil {
@@ -51,9 +51,9 @@ func NewHomoglyphsEvaluator(
 
 	switch reh.Type {
 	case invisibleCharacters:
-		return NewInvisibleCharactersEvaluator(pbuild)
+		return NewInvisibleCharactersEvaluator(ghClient)
 	case mixedScript:
-		return NewMixedScriptEvaluator(pbuild)
+		return NewMixedScriptEvaluator(ghClient)
 	default:
 		return nil, fmt.Errorf("unsupported homoglyphs type: %s", reh.Type)
 	}

--- a/internal/engine/eval/homoglyphs/application/invisible_characters_eval.go
+++ b/internal/engine/eval/homoglyphs/application/invisible_characters_eval.go
@@ -16,13 +16,12 @@ package application
 
 import (
 	"context"
-	"fmt"
 
 	evalerrors "github.com/stacklok/minder/internal/engine/errors"
 	"github.com/stacklok/minder/internal/engine/eval/homoglyphs/communication"
 	"github.com/stacklok/minder/internal/engine/eval/homoglyphs/domain"
 	engif "github.com/stacklok/minder/internal/engine/interfaces"
-	"github.com/stacklok/minder/internal/providers"
+	provifv1 "github.com/stacklok/minder/pkg/providers/v1"
 )
 
 // InvisibleCharactersEvaluator is an evaluator for the invisible characters rule type
@@ -32,16 +31,7 @@ type InvisibleCharactersEvaluator struct {
 }
 
 // NewInvisibleCharactersEvaluator creates a new invisible characters evaluator
-func NewInvisibleCharactersEvaluator(pbuild *providers.ProviderBuilder) (*InvisibleCharactersEvaluator, error) {
-	if pbuild == nil {
-		return nil, fmt.Errorf("provider builder is nil")
-	}
-
-	ghClient, err := pbuild.GetGitHub()
-	if err != nil {
-		return nil, fmt.Errorf("could not fetch GitHub client: %w", err)
-	}
-
+func NewInvisibleCharactersEvaluator(ghClient provifv1.GitHub) (*InvisibleCharactersEvaluator, error) {
 	return &InvisibleCharactersEvaluator{
 		processor:     domain.NewInvisibleCharactersProcessor(),
 		reviewHandler: communication.NewGhReviewPrHandler(ghClient),

--- a/internal/engine/eval/homoglyphs/application/mixed_scripts_eval.go
+++ b/internal/engine/eval/homoglyphs/application/mixed_scripts_eval.go
@@ -22,7 +22,7 @@ import (
 	"github.com/stacklok/minder/internal/engine/eval/homoglyphs/communication"
 	"github.com/stacklok/minder/internal/engine/eval/homoglyphs/domain"
 	engif "github.com/stacklok/minder/internal/engine/interfaces"
-	"github.com/stacklok/minder/internal/providers"
+	provifv1 "github.com/stacklok/minder/pkg/providers/v1"
 )
 
 // MixedScriptsEvaluator is the evaluator for the mixed scripts rule type
@@ -32,16 +32,7 @@ type MixedScriptsEvaluator struct {
 }
 
 // NewMixedScriptEvaluator creates a new mixed scripts evaluator
-func NewMixedScriptEvaluator(pbuild *providers.ProviderBuilder) (*MixedScriptsEvaluator, error) {
-	if pbuild == nil {
-		return nil, fmt.Errorf("provider builder is nil")
-	}
-
-	ghClient, err := pbuild.GetGitHub()
-	if err != nil {
-		return nil, fmt.Errorf("could not fetch GitHub client: %w", err)
-	}
-
+func NewMixedScriptEvaluator(ghClient provifv1.GitHub) (*MixedScriptsEvaluator, error) {
 	msProcessor, err := domain.NewMixedScriptsProcessor()
 	if err != nil {
 		return nil, fmt.Errorf("could not create mixed scripts processor: %w", err)

--- a/internal/engine/eval/trusty/trusty.go
+++ b/internal/engine/eval/trusty/trusty.go
@@ -26,7 +26,6 @@ import (
 	evalerrors "github.com/stacklok/minder/internal/engine/errors"
 	"github.com/stacklok/minder/internal/engine/eval/pr_actions"
 	engif "github.com/stacklok/minder/internal/engine/interfaces"
-	"github.com/stacklok/minder/internal/providers"
 	pb "github.com/stacklok/minder/pkg/api/protobuf/go/minder/v1"
 	provifv1 "github.com/stacklok/minder/pkg/providers/v1"
 )
@@ -45,8 +44,8 @@ type Evaluator struct {
 }
 
 // NewTrustyEvaluator creates a new trusty evaluator
-func NewTrustyEvaluator(ctx context.Context, pbuild *providers.ProviderBuilder) (*Evaluator, error) {
-	if pbuild == nil {
+func NewTrustyEvaluator(ctx context.Context, ghcli provifv1.GitHub) (*Evaluator, error) {
+	if ghcli == nil {
 		return nil, fmt.Errorf("provider builder is nil")
 	}
 
@@ -58,11 +57,6 @@ func NewTrustyEvaluator(ctx context.Context, pbuild *providers.ProviderBuilder) 
 		zerolog.Ctx(ctx).Info().Str("trusty-endpoint", trustyEndpoint).Msg("using default trusty endpoint")
 	} else {
 		zerolog.Ctx(ctx).Info().Str("trusty-endpoint", trustyEndpoint).Msg("using trusty endpoint from environment")
-	}
-
-	ghcli, err := pbuild.GetGitHub()
-	if err != nil {
-		return nil, fmt.Errorf("failed to get github client: %w", err)
 	}
 
 	return &Evaluator{

--- a/internal/engine/eval/vulncheck/vulncheck.go
+++ b/internal/engine/eval/vulncheck/vulncheck.go
@@ -25,7 +25,6 @@ import (
 
 	evalerrors "github.com/stacklok/minder/internal/engine/errors"
 	engif "github.com/stacklok/minder/internal/engine/interfaces"
-	"github.com/stacklok/minder/internal/providers"
 	pb "github.com/stacklok/minder/pkg/api/protobuf/go/minder/v1"
 	provifv1 "github.com/stacklok/minder/pkg/providers/v1"
 )
@@ -41,14 +40,9 @@ type Evaluator struct {
 }
 
 // NewVulncheckEvaluator creates a new vulncheck evaluator
-func NewVulncheckEvaluator(_ *pb.RuleType_Definition_Eval_Vulncheck, pbuild *providers.ProviderBuilder) (*Evaluator, error) {
-	if pbuild == nil {
+func NewVulncheckEvaluator(ghcli provifv1.GitHub) (*Evaluator, error) {
+	if ghcli == nil {
 		return nil, fmt.Errorf("provider builder is nil")
-	}
-
-	ghcli, err := pbuild.GetGitHub()
-	if err != nil {
-		return nil, fmt.Errorf("failed to get github client: %w", err)
 	}
 
 	return &Evaluator{

--- a/internal/engine/ingester/artifact/artifact.go
+++ b/internal/engine/ingester/artifact/artifact.go
@@ -30,7 +30,6 @@ import (
 
 	evalerrors "github.com/stacklok/minder/internal/engine/errors"
 	engif "github.com/stacklok/minder/internal/engine/interfaces"
-	"github.com/stacklok/minder/internal/providers"
 	"github.com/stacklok/minder/internal/verifier"
 	"github.com/stacklok/minder/internal/verifier/sigstore/container"
 	"github.com/stacklok/minder/internal/verifier/verifyif"
@@ -75,16 +74,7 @@ type verifiedAttestation struct {
 }
 
 // NewArtifactDataIngest creates a new artifact rule data ingest engine
-func NewArtifactDataIngest(
-	_ *pb.ArtifactType,
-	pbuild *providers.ProviderBuilder,
-) (*Ingest, error) {
-
-	ghCli, err := pbuild.GetGitHub()
-	if err != nil {
-		return nil, fmt.Errorf("failed to get github client: %w", err)
-	}
-
+func NewArtifactDataIngest(ghCli provifv1.GitHub) (*Ingest, error) {
 	return &Ingest{
 		ghCli: ghCli,
 	}, nil

--- a/internal/engine/ingester/artifact/artifact_test.go
+++ b/internal/engine/ingester/artifact/artifact_test.go
@@ -28,8 +28,7 @@ import (
 	evalerrors "github.com/stacklok/minder/internal/engine/errors"
 	"github.com/stacklok/minder/internal/providers/credentials"
 	"github.com/stacklok/minder/internal/providers/github/clients"
-	mock_ghclient "github.com/stacklok/minder/internal/providers/github/mock"
-	"github.com/stacklok/minder/internal/providers/github/oauth"
+	mockghclient "github.com/stacklok/minder/internal/providers/github/mock"
 	"github.com/stacklok/minder/internal/providers/telemetry"
 	"github.com/stacklok/minder/internal/verifier/verifyif"
 	mockverify "github.com/stacklok/minder/internal/verifier/verifyif/mock"
@@ -44,7 +43,7 @@ func testGithubProvider() (provinfv1.GitHub, error) {
 
 	baseURL := ghApiUrl + "/"
 
-	return oauth.NewRestClient(
+	return clients.NewRestClient(
 		&pb.GitHubProviderConfig{
 			Endpoint: baseURL,
 		},
@@ -68,7 +67,7 @@ func TestArtifactIngestMatching(t *testing.T) {
 		wantErr       bool
 		wantNonNilRes bool
 		errType       error
-		mockSetup     func(*mock_ghclient.MockGitHub, *mockverify.MockArtifactVerifier)
+		mockSetup     func(*mockghclient.MockGitHub, *mockverify.MockArtifactVerifier)
 		artifact      *pb.Artifact
 		params        map[string]interface{}
 	}{
@@ -76,7 +75,7 @@ func TestArtifactIngestMatching(t *testing.T) {
 			name:          "matching-name",
 			wantErr:       false,
 			wantNonNilRes: true,
-			mockSetup: func(mockGhClient *mock_ghclient.MockGitHub, mockVerifier *mockverify.MockArtifactVerifier) {
+			mockSetup: func(mockGhClient *mockghclient.MockGitHub, mockVerifier *mockverify.MockArtifactVerifier) {
 				mockGhClient.EXPECT().
 					GetPackageVersions(gomock.Any(), "stacklok", "container", "matching-name").
 					Return([]*github.PackageVersion{
@@ -113,7 +112,7 @@ func TestArtifactIngestMatching(t *testing.T) {
 			name:          "matching-name-and-tag",
 			wantErr:       false,
 			wantNonNilRes: true,
-			mockSetup: func(mockGhClient *mock_ghclient.MockGitHub, mockVerifier *mockverify.MockArtifactVerifier) {
+			mockSetup: func(mockGhClient *mockghclient.MockGitHub, mockVerifier *mockverify.MockArtifactVerifier) {
 				mockGhClient.EXPECT().
 					GetPackageVersions(gomock.Any(), "stacklok", "container", "matching-name-and-tag").
 					Return([]*github.PackageVersion{
@@ -160,7 +159,7 @@ func TestArtifactIngestMatching(t *testing.T) {
 			name:          "matching-name-but-not-tags",
 			wantErr:       true,
 			wantNonNilRes: false,
-			mockSetup: func(mockGhClient *mock_ghclient.MockGitHub, _ *mockverify.MockArtifactVerifier) {
+			mockSetup: func(mockGhClient *mockghclient.MockGitHub, _ *mockverify.MockArtifactVerifier) {
 				mockGhClient.EXPECT().
 					GetPackageVersions(gomock.Any(), "stacklok", "container", "matching-name-but-not-tags").
 					Return([]*github.PackageVersion{
@@ -198,7 +197,7 @@ func TestArtifactIngestMatching(t *testing.T) {
 			name:          "multiple-tags-from-different-versions",
 			wantErr:       true,
 			wantNonNilRes: false,
-			mockSetup: func(mockGhClient *mock_ghclient.MockGitHub, _ *mockverify.MockArtifactVerifier) {
+			mockSetup: func(mockGhClient *mockghclient.MockGitHub, _ *mockverify.MockArtifactVerifier) {
 				mockGhClient.EXPECT().
 					GetPackageVersions(gomock.Any(), "stacklok", "container", "matching-name-but-not-tags").
 					Return([]*github.PackageVersion{
@@ -236,7 +235,7 @@ func TestArtifactIngestMatching(t *testing.T) {
 			name:          "multiple-tags-from-same-version",
 			wantErr:       true,
 			wantNonNilRes: false,
-			mockSetup: func(mockGhClient *mock_ghclient.MockGitHub, _ *mockverify.MockArtifactVerifier) {
+			mockSetup: func(mockGhClient *mockghclient.MockGitHub, _ *mockverify.MockArtifactVerifier) {
 				mockGhClient.EXPECT().
 					GetPackageVersions(gomock.Any(), "stacklok", "container", "matching-name-but-not-tags").
 					Return([]*github.PackageVersion{
@@ -274,7 +273,7 @@ func TestArtifactIngestMatching(t *testing.T) {
 			name:          "matching-multiple-tags-from-same-version",
 			wantErr:       false,
 			wantNonNilRes: true,
-			mockSetup: func(mockGhClient *mock_ghclient.MockGitHub, mockVerifier *mockverify.MockArtifactVerifier) {
+			mockSetup: func(mockGhClient *mockghclient.MockGitHub, mockVerifier *mockverify.MockArtifactVerifier) {
 				mockGhClient.EXPECT().
 					GetPackageVersions(gomock.Any(), "stacklok", "container", "matching-name-but-not-tags").
 					Return([]*github.PackageVersion{
@@ -322,7 +321,7 @@ func TestArtifactIngestMatching(t *testing.T) {
 			wantErr:       true,
 			wantNonNilRes: false,
 			errType:       evalerrors.ErrEvaluationSkipSilently,
-			mockSetup: func(_ *mock_ghclient.MockGitHub, _ *mockverify.MockArtifactVerifier) {
+			mockSetup: func(_ *mockghclient.MockGitHub, _ *mockverify.MockArtifactVerifier) {
 			},
 			artifact: &pb.Artifact{
 				Type:  "container",
@@ -337,7 +336,7 @@ func TestArtifactIngestMatching(t *testing.T) {
 			name:          "match-any-name",
 			wantErr:       false,
 			wantNonNilRes: true,
-			mockSetup: func(mockGhClient *mock_ghclient.MockGitHub, mockVerifier *mockverify.MockArtifactVerifier) {
+			mockSetup: func(mockGhClient *mockghclient.MockGitHub, mockVerifier *mockverify.MockArtifactVerifier) {
 				mockGhClient.EXPECT().
 					GetPackageVersions(gomock.Any(), "stacklok", "container", "matching-name").
 					Return([]*github.PackageVersion{
@@ -374,7 +373,7 @@ func TestArtifactIngestMatching(t *testing.T) {
 			name:          "test-matching-regex",
 			wantErr:       false,
 			wantNonNilRes: true,
-			mockSetup: func(mockGhClient *mock_ghclient.MockGitHub, mockVerifier *mockverify.MockArtifactVerifier) {
+			mockSetup: func(mockGhClient *mockghclient.MockGitHub, mockVerifier *mockverify.MockArtifactVerifier) {
 				mockGhClient.EXPECT().
 					GetPackageVersions(gomock.Any(), "stacklok", "container", "matching-name").
 					Return([]*github.PackageVersion{
@@ -412,7 +411,7 @@ func TestArtifactIngestMatching(t *testing.T) {
 			name:          "test-matching-regex-with-multiple-tags",
 			wantErr:       false,
 			wantNonNilRes: true,
-			mockSetup: func(mockGhClient *mock_ghclient.MockGitHub, mockVerifier *mockverify.MockArtifactVerifier) {
+			mockSetup: func(mockGhClient *mockghclient.MockGitHub, mockVerifier *mockverify.MockArtifactVerifier) {
 				mockGhClient.EXPECT().
 					GetPackageVersions(gomock.Any(), "stacklok", "container", "matching-name").
 					Return([]*github.PackageVersion{
@@ -450,7 +449,7 @@ func TestArtifactIngestMatching(t *testing.T) {
 			name:          "tag-doesnt-match-regex",
 			wantErr:       true,
 			wantNonNilRes: false,
-			mockSetup: func(mockGhClient *mock_ghclient.MockGitHub, _ *mockverify.MockArtifactVerifier) {
+			mockSetup: func(mockGhClient *mockghclient.MockGitHub, _ *mockverify.MockArtifactVerifier) {
 				mockGhClient.EXPECT().
 					GetPackageVersions(gomock.Any(), "stacklok", "container", "matching-name-but-not-tags").
 					Return([]*github.PackageVersion{
@@ -479,7 +478,7 @@ func TestArtifactIngestMatching(t *testing.T) {
 			name:          "multiple-tags-doesnt-match-regex",
 			wantErr:       true,
 			wantNonNilRes: false,
-			mockSetup: func(mockGhClient *mock_ghclient.MockGitHub, _ *mockverify.MockArtifactVerifier) {
+			mockSetup: func(mockGhClient *mockghclient.MockGitHub, _ *mockverify.MockArtifactVerifier) {
 				mockGhClient.EXPECT().
 					GetPackageVersions(gomock.Any(), "stacklok", "container", "matching-name-but-not-tags").
 					Return([]*github.PackageVersion{
@@ -512,7 +511,7 @@ func TestArtifactIngestMatching(t *testing.T) {
 			name:          "test-artifact-with-empty-tags",
 			wantErr:       true,
 			wantNonNilRes: false,
-			mockSetup: func(_ *mock_ghclient.MockGitHub, _ *mockverify.MockArtifactVerifier) {
+			mockSetup: func(_ *mockghclient.MockGitHub, _ *mockverify.MockArtifactVerifier) {
 			},
 			artifact: &pb.Artifact{
 				Type:  "container",
@@ -528,7 +527,7 @@ func TestArtifactIngestMatching(t *testing.T) {
 			name:          "test-artifact-version-with-no-tags",
 			wantErr:       true,
 			wantNonNilRes: false,
-			mockSetup: func(mockGhClient *mock_ghclient.MockGitHub, _ *mockverify.MockArtifactVerifier) {
+			mockSetup: func(mockGhClient *mockghclient.MockGitHub, _ *mockverify.MockArtifactVerifier) {
 				mockGhClient.EXPECT().
 					GetPackageVersions(gomock.Any(), "stacklok", "container", "matching-name-but-not-tags").
 					Return([]*github.PackageVersion{
@@ -561,7 +560,7 @@ func TestArtifactIngestMatching(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			mockGhClient := mock_ghclient.NewMockGitHub(ctrl)
+			mockGhClient := mockghclient.NewMockGitHub(ctrl)
 			mockVerifier := mockverify.NewMockArtifactVerifier(ctrl)
 
 			prov, err := testGithubProvider()

--- a/internal/engine/ingester/builtin/builtin.go
+++ b/internal/engine/ingester/builtin/builtin.go
@@ -29,7 +29,6 @@ import (
 
 	evalerrors "github.com/stacklok/minder/internal/engine/errors"
 	engif "github.com/stacklok/minder/internal/engine/interfaces"
-	"github.com/stacklok/minder/internal/providers"
 	"github.com/stacklok/minder/internal/util"
 	pb "github.com/stacklok/minder/pkg/api/protobuf/go/minder/v1"
 	"github.com/stacklok/minder/pkg/rule_methods"
@@ -48,10 +47,7 @@ type BuiltinRuleDataIngest struct {
 }
 
 // NewBuiltinRuleDataIngest creates a new builtin rule data ingest engine
-func NewBuiltinRuleDataIngest(
-	builtinCfg *pb.BuiltinType,
-	_ *providers.ProviderBuilder,
-) (*BuiltinRuleDataIngest, error) {
+func NewBuiltinRuleDataIngest(builtinCfg *pb.BuiltinType) (*BuiltinRuleDataIngest, error) {
 	return &BuiltinRuleDataIngest{
 		builtinCfg:  builtinCfg,
 		method:      builtinCfg.GetMethod(),

--- a/internal/engine/ingester/builtin/builtin_test.go
+++ b/internal/engine/ingester/builtin/builtin_test.go
@@ -26,7 +26,6 @@ import (
 	"google.golang.org/protobuf/reflect/protoreflect"
 
 	evalerrors "github.com/stacklok/minder/internal/engine/errors"
-	"github.com/stacklok/minder/internal/providers"
 	pb "github.com/stacklok/minder/pkg/api/protobuf/go/minder/v1"
 )
 
@@ -61,7 +60,7 @@ func TestBuiltInWorks(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			bi, err := NewBuiltinRuleDataIngest(nil, &providers.ProviderBuilder{})
+			bi, err := NewBuiltinRuleDataIngest(nil)
 			assert.NoError(t, err)
 			bi.method = tt.methodName
 
@@ -108,7 +107,7 @@ func TestBuiltinErrorCases(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			bi, err := NewBuiltinRuleDataIngest(nil, &providers.ProviderBuilder{})
+			bi, err := NewBuiltinRuleDataIngest(nil)
 			assert.NoError(t, err)
 			bi.method = tt.methodName
 

--- a/internal/engine/ingester/diff/diff.go
+++ b/internal/engine/ingester/diff/diff.go
@@ -28,7 +28,6 @@ import (
 	"google.golang.org/protobuf/reflect/protoreflect"
 
 	engif "github.com/stacklok/minder/internal/engine/interfaces"
-	"github.com/stacklok/minder/internal/providers"
 	pb "github.com/stacklok/minder/pkg/api/protobuf/go/minder/v1"
 	provifv1 "github.com/stacklok/minder/pkg/providers/v1"
 )
@@ -49,19 +48,14 @@ type Diff struct {
 // NewDiffIngester creates a new diff ingester
 func NewDiffIngester(
 	cfg *pb.DiffType,
-	pbuild *providers.ProviderBuilder,
+	cli provifv1.GitHub,
 ) (*Diff, error) {
 	if cfg == nil {
 		cfg = &pb.DiffType{}
 	}
 
-	if pbuild == nil {
-		return nil, fmt.Errorf("provider builder is nil")
-	}
-
-	cli, err := pbuild.GetGitHub()
-	if err != nil {
-		return nil, fmt.Errorf("failed to get github client: %w", err)
+	if cli == nil {
+		return nil, fmt.Errorf("provider is nil")
 	}
 
 	return &Diff{

--- a/internal/engine/ingester/git/git.go
+++ b/internal/engine/ingester/git/git.go
@@ -24,10 +24,8 @@ import (
 	"github.com/mitchellh/mapstructure"
 	"google.golang.org/protobuf/reflect/protoreflect"
 
-	"github.com/stacklok/minder/internal/db"
 	engerrors "github.com/stacklok/minder/internal/engine/errors"
 	engif "github.com/stacklok/minder/internal/engine/interfaces"
-	"github.com/stacklok/minder/internal/providers"
 	pb "github.com/stacklok/minder/pkg/api/protobuf/go/minder/v1"
 	provifv1 "github.com/stacklok/minder/pkg/providers/v1"
 )
@@ -45,22 +43,13 @@ type Git struct {
 }
 
 // NewGitIngester creates a new git rule data ingest engine
-func NewGitIngester(cfg *pb.GitType, pbuild *providers.ProviderBuilder) (*Git, error) {
-	if pbuild == nil {
-		return nil, fmt.Errorf("provider builder is nil")
-	}
-
-	if !pbuild.Implements(db.ProviderTypeGit) {
-		return nil, fmt.Errorf("provider builder does not implement git")
+func NewGitIngester(cfg *pb.GitType, gitprov provifv1.Git) (*Git, error) {
+	if gitprov == nil {
+		return nil, fmt.Errorf("provider is nil")
 	}
 
 	if cfg == nil {
 		cfg = &pb.GitType{}
-	}
-
-	gitprov, err := pbuild.GetGit()
-	if err != nil {
-		return nil, fmt.Errorf("could not get git provider: %w", err)
 	}
 
 	return &Git{

--- a/internal/engine/ingester/git/git_test.go
+++ b/internal/engine/ingester/git/git_test.go
@@ -17,40 +17,24 @@ package git_test
 import (
 	"bytes"
 	"context"
-	"database/sql"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 
-	serverconfig "github.com/stacklok/minder/internal/config/server"
-	"github.com/stacklok/minder/internal/db"
 	engerrors "github.com/stacklok/minder/internal/engine/errors"
 	gitengine "github.com/stacklok/minder/internal/engine/ingester/git"
-	"github.com/stacklok/minder/internal/providers"
 	"github.com/stacklok/minder/internal/providers/credentials"
+	gitclient "github.com/stacklok/minder/internal/providers/git"
 	pb "github.com/stacklok/minder/pkg/api/protobuf/go/minder/v1"
-	provifv1 "github.com/stacklok/minder/pkg/providers/v1"
 )
 
 func TestGitIngestWithCloneURLFromRepo(t *testing.T) {
 	t.Parallel()
 
-	gi, err := gitengine.NewGitIngester(&pb.GitType{
-		Branch: "master",
-	}, providers.NewProviderBuilder(
-		&db.Provider{
-			Name:    "git-provider",
-			Version: provifv1.V1,
-			Implements: []db.ProviderType{
-				"git",
-			},
-		},
-		sql.NullString{},
-		false,
-		credentials.NewEmptyCredential(),
-		&serverconfig.ProviderConfig{},
-		nil, // this is unused here
-	))
+	gi, err := gitengine.NewGitIngester(
+		&pb.GitType{Branch: "master"},
+		gitclient.NewGit(credentials.NewEmptyCredential()),
+	)
 	require.NoError(t, err, "expected no error")
 
 	got, err := gi.Ingest(context.Background(), &pb.Repository{
@@ -75,22 +59,10 @@ func TestGitIngestWithCloneURLFromRepo(t *testing.T) {
 func TestGitIngestWithCloneURLFromParams(t *testing.T) {
 	t.Parallel()
 
-	gi, err := gitengine.NewGitIngester(&pb.GitType{
-		Branch: "master",
-	}, providers.NewProviderBuilder(
-		&db.Provider{
-			Name:    "git-provider",
-			Version: provifv1.V1,
-			Implements: []db.ProviderType{
-				"git",
-			},
-		},
-		sql.NullString{},
-		false,
-		credentials.NewEmptyCredential(),
-		&serverconfig.ProviderConfig{},
-		nil, // this is unused here
-	))
+	gi, err := gitengine.NewGitIngester(
+		&pb.GitType{Branch: "master"},
+		gitclient.NewGit(credentials.NewEmptyCredential()),
+	)
 	require.NoError(t, err, "expected no error")
 
 	got, err := gi.Ingest(context.Background(), &pb.Artifact{}, map[string]any{
@@ -115,22 +87,10 @@ func TestGitIngestWithCloneURLFromParams(t *testing.T) {
 func TestGitIngestWithCustomBranchFromParams(t *testing.T) {
 	t.Parallel()
 
-	gi, err := gitengine.NewGitIngester(&pb.GitType{
-		Branch: "master",
-	}, providers.NewProviderBuilder(
-		&db.Provider{
-			Name:    "git-provider",
-			Version: provifv1.V1,
-			Implements: []db.ProviderType{
-				"git",
-			},
-		},
-		sql.NullString{},
-		false,
-		credentials.NewEmptyCredential(),
-		&serverconfig.ProviderConfig{},
-		nil, // this is unused here
-	))
+	gi, err := gitengine.NewGitIngester(
+		&pb.GitType{Branch: "master"},
+		gitclient.NewGit(credentials.NewEmptyCredential()),
+	)
 	require.NoError(t, err, "expected no error")
 
 	got, err := gi.Ingest(context.Background(), &pb.Artifact{}, map[string]any{
@@ -156,21 +116,11 @@ func TestGitIngestWithCustomBranchFromParams(t *testing.T) {
 func TestGitIngestWithBranchFromRepoEntity(t *testing.T) {
 	t.Parallel()
 
-	gi, err := gitengine.NewGitIngester(&pb.GitType{},
-		providers.NewProviderBuilder(
-			&db.Provider{
-				Name:    "git-provider",
-				Version: provifv1.V1,
-				Implements: []db.ProviderType{
-					"git",
-				},
-			},
-			sql.NullString{},
-			false,
-			credentials.NewEmptyCredential(),
-			&serverconfig.ProviderConfig{},
-			nil, // this is unused here
-		))
+	gi, err := gitengine.NewGitIngester(
+		//		&pb.GitType{Branch: "master"},
+		&pb.GitType{},
+		gitclient.NewGit(credentials.NewEmptyCredential()),
+	)
 	require.NoError(t, err, "expected no error")
 
 	got, err := gi.Ingest(context.Background(), &pb.Repository{
@@ -197,22 +147,11 @@ func TestGitIngestWithBranchFromRepoEntity(t *testing.T) {
 func TestGitIngestWithUnexistentBranchFromParams(t *testing.T) {
 	t.Parallel()
 
-	gi, err := gitengine.NewGitIngester(&pb.GitType{
-		Branch: "master",
-	}, providers.NewProviderBuilder(
-		&db.Provider{
-			Name:    "git-provider",
-			Version: provifv1.V1,
-			Implements: []db.ProviderType{
-				"git",
-			},
-		},
-		sql.NullString{},
-		false,
-		credentials.NewEmptyCredential(),
-		&serverconfig.ProviderConfig{},
-		nil, // this is unused here
-	))
+	gi, err := gitengine.NewGitIngester(
+		&pb.GitType{Branch: "master"},
+		gitclient.NewGit(credentials.NewEmptyCredential()),
+	)
+
 	require.NoError(t, err, "expected no error")
 
 	got, err := gi.Ingest(context.Background(), &pb.Artifact{}, map[string]any{
@@ -228,23 +167,11 @@ func TestGitIngestFailsBecauseOfAuthorization(t *testing.T) {
 	t.Parallel()
 
 	// foobar is not a valid token
-	gi, err := gitengine.NewGitIngester(&pb.GitType{
-		Branch: "master",
-	}, providers.NewProviderBuilder(
-		&db.Provider{
-			Name:    "git-provider",
-			Version: provifv1.V1,
-			Implements: []db.ProviderType{
-				"git",
-			},
-		},
-		sql.NullString{},
-		false,
-		credentials.NewGitHubTokenCredential("foobar"),
-		&serverconfig.ProviderConfig{},
-		nil, // this is unused here
-	),
+	gi, err := gitengine.NewGitIngester(
+		&pb.GitType{Branch: "master"},
+		gitclient.NewGit(credentials.NewGitHubTokenCredential("foobar")),
 	)
+
 	require.NoError(t, err, "expected no error")
 
 	got, err := gi.Ingest(context.Background(), &pb.Artifact{}, map[string]any{
@@ -257,22 +184,7 @@ func TestGitIngestFailsBecauseOfAuthorization(t *testing.T) {
 func TestGitIngestFailsBecauseOfUnexistentCloneUrl(t *testing.T) {
 	t.Parallel()
 
-	// foobar is not a valid token
-	gi, err := gitengine.NewGitIngester(&pb.GitType{}, providers.NewProviderBuilder(
-		&db.Provider{
-			Name:    "git-provider",
-			Version: provifv1.V1,
-			Implements: []db.ProviderType{
-				"git",
-			},
-		},
-		sql.NullString{},
-		false,
-		// No authentication is the right thing in this case.
-		credentials.NewEmptyCredential(),
-		&serverconfig.ProviderConfig{},
-		nil, // this is unused here
-	))
+	gi, err := gitengine.NewGitIngester(&pb.GitType{}, gitclient.NewGit(credentials.NewEmptyCredential()))
 	require.NoError(t, err, "expected no error")
 
 	got, err := gi.Ingest(context.Background(), &pb.Artifact{}, map[string]any{

--- a/internal/engine/ingester/ingester.go
+++ b/internal/engine/ingester/ingester.go
@@ -46,24 +46,40 @@ func NewRuleDataIngest(rt *pb.RuleType, pbuild *providers.ProviderBuilder) (engi
 		if rt.Def.Ingest.GetRest() == nil {
 			return nil, fmt.Errorf("rule type engine missing rest configuration")
 		}
+		client, err := pbuild.GetHTTP()
+		if err != nil {
+			return nil, fmt.Errorf("could not instantiate provider: %w", err)
+		}
 
-		return rest.NewRestRuleDataIngest(ing.GetRest(), pbuild)
+		return rest.NewRestRuleDataIngest(ing.GetRest(), client)
 	case builtin.BuiltinRuleDataIngestType:
 		if rt.Def.Ingest.GetBuiltin() == nil {
 			return nil, fmt.Errorf("rule type engine missing internal configuration")
 		}
-		return builtin.NewBuiltinRuleDataIngest(ing.GetBuiltin(), pbuild)
+		return builtin.NewBuiltinRuleDataIngest(ing.GetBuiltin())
 
 	case artifact.ArtifactRuleDataIngestType:
 		if rt.Def.Ingest.GetArtifact() == nil {
 			return nil, fmt.Errorf("rule type engine missing artifact configuration")
 		}
-		return artifact.NewArtifactDataIngest(ing.GetArtifact(), pbuild)
+		client, err := pbuild.GetGitHub()
+		if err != nil {
+			return nil, fmt.Errorf("could not instantiate provider: %w", err)
+		}
+		return artifact.NewArtifactDataIngest(client)
 
 	case git.GitRuleDataIngestType:
-		return git.NewGitIngester(ing.GetGit(), pbuild)
+		client, err := pbuild.GetGit()
+		if err != nil {
+			return nil, fmt.Errorf("could not instantiate provider: %w", err)
+		}
+		return git.NewGitIngester(ing.GetGit(), client)
 	case diff.DiffRuleDataIngestType:
-		return diff.NewDiffIngester(ing.GetDiff(), pbuild)
+		client, err := pbuild.GetGitHub()
+		if err != nil {
+			return nil, fmt.Errorf("could not instantiate provider: %w", err)
+		}
+		return diff.NewDiffIngester(ing.GetDiff(), client)
 	default:
 		return nil, fmt.Errorf("unsupported rule type engine: %s", rt.Def.Ingest.Type)
 	}

--- a/internal/engine/ingester/rest/rest.go
+++ b/internal/engine/ingester/rest/rest.go
@@ -32,7 +32,6 @@ import (
 	"google.golang.org/protobuf/reflect/protoreflect"
 
 	engif "github.com/stacklok/minder/internal/engine/interfaces"
-	"github.com/stacklok/minder/internal/providers"
 	"github.com/stacklok/minder/internal/util"
 	pb "github.com/stacklok/minder/pkg/api/protobuf/go/minder/v1"
 	provifv1 "github.com/stacklok/minder/pkg/providers/v1"
@@ -62,7 +61,7 @@ type Ingestor struct {
 // NewRestRuleDataIngest creates a new REST rule data ingest engine
 func NewRestRuleDataIngest(
 	restCfg *pb.RestType,
-	pbuild *providers.ProviderBuilder,
+	cli provifv1.REST,
 ) (*Ingestor, error) {
 	if len(restCfg.Endpoint) == 0 {
 		return nil, fmt.Errorf("missing endpoint")
@@ -74,11 +73,6 @@ func NewRestRuleDataIngest(
 	}
 
 	method := util.HttpMethodFromString(restCfg.Method, http.MethodGet)
-
-	cli, err := pbuild.GetHTTP()
-	if err != nil {
-		return nil, fmt.Errorf("cannot get http client: %w", err)
-	}
 
 	fallback := make([]ingestorFallback, len(restCfg.Fallback))
 	for _, fb := range restCfg.Fallback {

--- a/internal/engine/ingester/rest/rest_test.go
+++ b/internal/engine/ingester/rest/rest_test.go
@@ -30,7 +30,6 @@ import (
 	engif "github.com/stacklok/minder/internal/engine/interfaces"
 	"github.com/stacklok/minder/internal/providers/credentials"
 	"github.com/stacklok/minder/internal/providers/github/clients"
-	github "github.com/stacklok/minder/internal/providers/github/oauth"
 	httpclient "github.com/stacklok/minder/internal/providers/http"
 	"github.com/stacklok/minder/internal/providers/telemetry"
 	pb "github.com/stacklok/minder/pkg/api/protobuf/go/minder/v1"
@@ -109,7 +108,7 @@ func testGithubProviderBuilder(baseURL string) (provifv1.REST, error) {
 		baseURL = baseURL + "/"
 	}
 
-	return github.NewRestClient(
+	return clients.NewRestClient(
 		&pb.GitHubProviderConfig{
 			Endpoint: baseURL,
 		},

--- a/internal/providers/providers.go
+++ b/internal/providers/providers.go
@@ -241,24 +241,6 @@ func (pb *ProviderBuilder) GetGitHub() (provinfv1.GitHub, error) {
 	return cli, nil
 }
 
-// GetRepoLister returns a repo lister for the provider.
-func (pb *ProviderBuilder) GetRepoLister() (provinfv1.RepoLister, error) {
-	if !pb.Implements(db.ProviderTypeRepoLister) {
-		return nil, fmt.Errorf("provider does not implement repo lister")
-	}
-
-	if pb.p.Version != provinfv1.V1 {
-		return nil, fmt.Errorf("provider version not supported")
-	}
-
-	if pb.Implements(db.ProviderTypeGithub) {
-		return pb.GetGitHub()
-	}
-
-	// TODO: We'll need to add support for other providers here
-	return nil, fmt.Errorf("provider does not implement repo lister")
-}
-
 // DBToPBType converts a database provider type to a protobuf provider type.
 func DBToPBType(t db.ProviderType) (minderv1.ProviderType, bool) {
 	switch t {


### PR DESCRIPTION
Relates to #2845

When evaluating a policy, we instantiate a ProviderBuilder and then pass it around to various parts of the code. Once the specific trait is known, we get the specific trait we need from the ProviderBuilder.

While replacing the ProviderBuilder, I notice that there are many parts of the code where we continue to pass around the ProviderBuilder even though we know the specific provider trait which will be needed. I changed various code to explicitly require the provider trait it needs instead of taking the ProviderBuilder and getting an instance of the desired type. As a result of this change, test setup is simplified, and this will make my PR to replace the ProviderBuilder smaller.

# Summary

***Provide a brief overview of the changes and the issue being addressed. 
Explain the rationale and any background necessary for understanding the changes. 
List dependencies required by this change, if any.***

Fixes #(related issue)

## Change Type

***Mark the type of change your PR introduces:***

- [ ] Bug fix (resolves an issue without affecting existing features)
- [ ] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [x] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

***Outline how the changes were tested, including steps to reproduce and any relevant configurations. 
Attach screenshots if helpful.***

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [x] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [x] Included tests that validate the fix or feature.
- [ ] Checked that related changes are merged.
