### PR TITLE
Fix crash in 3259, add test

### DIFF
--- a/deployment/helm/templates/deployment.yaml
+++ b/deployment/helm/templates/deployment.yaml
@@ -81,6 +81,8 @@ spec:
             value: "/secrets/github-app/github_app_webhook_secret"
           - name: "MINDER_PROVIDER_GITHUB_APP_FALLBACK_TOKEN_FILE"
             value: "/secrets/github-app/github_app_fallback_token"
+          - name: "MINDER_FLAGS_GO_FEATURE_FILE_PATH"
+            value: "/flags/flags-config.yaml"
           - name: "MINDER_WEBHOOK_CONFIG_WEBHOOK_SECRET_FILE"
             value: "/secrets/app/github_repo_webhook_secret"
           - name: "MINDER_WEBHOOK_CONFIG_PREVIOUS_WEBHOOK_SECRET_FILE"

--- a/internal/flags/flags.go
+++ b/internal/flags/flags.go
@@ -71,6 +71,7 @@ func OpenFeatureProviderFromFlags(ctx context.Context, cfg config.FlagsConfig) {
 		})
 		if err != nil {
 			zerolog.Ctx(ctx).Error().Err(err).Msg("Unable to create GoFeatureFlag provider")
+			flagProvider = nil // Need to explicitly reset the value, see #3259
 		}
 	}
 

--- a/internal/flags/flags_test.go
+++ b/internal/flags/flags_test.go
@@ -1,0 +1,99 @@
+//
+// Copyright 2024 Stacklok, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package flags containts utilities for managing feature flags.
+package flags
+
+import (
+	"context"
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/lestrrat-go/jwx/v2/jwt/openid"
+	"github.com/open-feature/go-sdk/openfeature"
+	"github.com/stacklok/minder/internal/auth"
+	"github.com/stacklok/minder/internal/engine"
+
+	config "github.com/stacklok/minder/internal/config/server"
+)
+
+func TestOpenFeatureProviderFromFlags(t *testing.T) {
+	t.Parallel()
+
+	testFile := filepath.Join(t.TempDir(), "testfile.yaml")
+	tempFile, err := os.Create(testFile)
+	if err != nil {
+		t.Fatalf("failed to create temp file: %v", err)
+	}
+	t.Cleanup(func() { tempFile.Close() })
+	configFile := `
+idp_resolver:
+  variations:
+    FlagOn: true
+    FlagOff: false
+  defaultRule:
+    variation: FlagOn
+`
+	if _, err := io.WriteString(tempFile, configFile); err != nil {
+		t.Fatalf("failed to write to temp file: %v", err)
+	}
+
+	tests := []struct {
+		name         string
+		cfg          config.FlagsConfig
+		expectedFlag bool
+	}{{
+		name: "No Config",
+		cfg:  config.FlagsConfig{},
+	}, {
+		name: "No File",
+		cfg: config.FlagsConfig{
+			GoFeature: config.GoFeatureConfig{
+				FilePath: "non-existent-file",
+			},
+		},
+	}, {
+		name: "File exists",
+		cfg: config.FlagsConfig{
+			GoFeature: config.GoFeatureConfig{
+				FilePath: testFile,
+			},
+		},
+		expectedFlag: true,
+	}}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			OpenFeatureProviderFromFlags(ctx, tt.cfg)
+
+			client := openfeature.NewClient("test")
+			userJWT := openid.New()
+			userJWT.Set("sub", "user-1")
+			ctx = auth.WithAuthTokenContext(ctx, userJWT)
+			ctx = engine.WithEntityContext(ctx, &engine.EntityContext{
+				Project:  engine.Project{uuid.New()},
+				Provider: engine.Provider{"testing"},
+			})
+
+			flagResult := Bool(ctx, client, IDPResolver)
+			if flagResult != tt.expectedFlag {
+				t.Errorf("expected %v, got %v", tt.expectedFlag, flagResult)
+			}
+		})
+	}
+}


### PR DESCRIPTION
# Summary

Fix crash when evaluating flags with `nil` GoFeatureFlag interface.  This is an interface of type `go-feature-flag.Provider`, with a `nil` value.  The interface itself is _not_ `nil`, because it has the type stored.

Fixes #3259

## Change Type

***Mark the type of change your PR introduces:***

- [x] Bug fix (resolves an issue without affecting existing features)
- [ ] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [ ] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

Added unit tests, verified they reproduced the panic, then fixed the panic.

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [x] Added comments to complex or tricky code sections.
- [x] Updated any affected documentation.
- [x] Included tests that validate the fix or feature.
- [x] Checked that related changes are merged.
