### PR TITLE
Improve Trusty integration

### DIFF
--- a/internal/engine/eval/trusty/actions.go
+++ b/internal/engine/eval/trusty/actions.go
@@ -53,6 +53,12 @@ Minder analyzed the dependencies introduced in this pull request and detected th
 
 ### 📦 Dependency: [{{ .PackageName }}]({{ .TrustyURL }})
 
+{{ if .Archived }}
+⚠️ __Archived Package:__ This package is marked as deprecated. Proceed with caution!
+{{ end }}
+{{ if .Deprecated }}
+⚠️ __Deprecated Package:__ This package is marked as archived. Proceed with caution!
+{{ end }}
 #### Trusty Score: {{ .Score }}
 {{ if .ScoreComponents }}
 <details>
@@ -114,6 +120,8 @@ type maliciousTemplateData struct {
 
 type templatePackage struct {
 	templatePackageData
+	Deprecated      bool
+	Archived        bool
 	ScoreComponents []templateScoreComponent
 	Alternatives    []templateAlternative
 }
@@ -236,6 +244,8 @@ func (sph *summaryPrHandler) generateSummary() (string, error) {
 
 			lowScorePackages[alternative.Dependency.Name] = templatePackage{
 				templatePackageData: packageData,
+				Deprecated:          alternative.trustyReply.PackageData.Deprecated,
+				Archived:            alternative.trustyReply.PackageData.Archived,
 				ScoreComponents:     scoreComp,
 				Alternatives:        []templateAlternative{},
 			}

--- a/internal/engine/eval/trusty/actions.go
+++ b/internal/engine/eval/trusty/actions.go
@@ -59,6 +59,24 @@ Based on [Trusty](https://www.trustypkg.dev/) dependency data, Minder detected t
 `
 )
 
+// RuleViolationReason are int constants that captures the various
+// reasons a package was considered unsafe when compared with trusty data
+type RuleViolationReason int
+
+const (
+	// TRUSTY_LOW_SCORE Overall score was lower than threshold
+	TRUSTY_LOW_SCORE RuleViolationReason = iota + 1
+
+	// TRUSTY_MALICIOUS_PKG Package is marked as malicious
+	TRUSTY_MALICIOUS_PKG
+
+	// TRUSTY_LOW_ACTIVITY The package does not have enough activity
+	TRUSTY_LOW_ACTIVITY
+
+	// TRUSTY_LOW_PROVENANCE Low trust in proof of origin
+	TRUSTY_LOW_PROVENANCE
+)
+
 type maliciousTemplateData struct {
 	PackageName string
 	TrustyURL   string
@@ -76,7 +94,10 @@ type lowScoreTemplateData struct {
 }
 
 type dependencyAlternatives struct {
-	Dependency  *pb.Dependency
+	Dependency *pb.Dependency
+
+	// Reason captures the reason why a package was flagged
+	Reasons     []RuleViolationReason
 	trustyReply *Reply
 }
 
@@ -92,10 +113,12 @@ type summaryPrHandler struct {
 
 func (sph *summaryPrHandler) trackAlternatives(
 	dep *pb.PrDependencies_ContextualDependency,
+	violationReasons []RuleViolationReason,
 	trustyReply *Reply,
 ) {
 	sph.trackedAlternatives = append(sph.trackedAlternatives, dependencyAlternatives{
 		Dependency:  dep.Dep,
+		Reasons:     violationReasons,
 		trustyReply: trustyReply,
 	})
 }

--- a/internal/engine/eval/trusty/actions.go
+++ b/internal/engine/eval/trusty/actions.go
@@ -33,9 +33,6 @@ import (
 
 const (
 	// nolint:lll
-	noLowScoresText = "Minder analyzed the changes in this pull request with <a href=\"https://www.trustypkg.dev/\">Trusty</a> and found no dependencies scored lower than your profile threshold."
-
-	// nolint:lll
 	commentTemplate = `{{- if .Malicious -}}
 ### ⚠️ MALICIOUS PACKAGES ⚠️
 
@@ -162,6 +159,10 @@ func (sph *summaryPrHandler) trackAlternatives(
 }
 
 func (sph *summaryPrHandler) submit(ctx context.Context) error {
+	if len(sph.trackedAlternatives) == 0 {
+		return nil
+	}
+
 	summary, err := sph.generateSummary()
 	if err != nil {
 		return fmt.Errorf("could not generate summary: %w", err)
@@ -176,11 +177,6 @@ func (sph *summaryPrHandler) submit(ctx context.Context) error {
 }
 
 func (sph *summaryPrHandler) generateSummary() (string, error) {
-	if len(sph.trackedAlternatives) == 0 {
-		var summary strings.Builder
-		summary.WriteString(noLowScoresText)
-		return summary.String(), nil
-	}
 	var malicious = []maliciousTemplateData{}
 	var lowScorePackages = map[string]templatePackage{}
 

--- a/internal/engine/eval/trusty/actions_test.go
+++ b/internal/engine/eval/trusty/actions_test.go
@@ -1,0 +1,33 @@
+// Copyright 2023 Stacklok, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package trusty provides an evaluator that uses the trusty API
+package trusty
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	v1 "github.com/stacklok/minder/pkg/api/protobuf/go/minder/v1"
+)
+
+func TestNewSummaryPrHandler(t *testing.T) {
+	t.Parallel()
+
+	// newSummaryPrHandler must never fail. The only failure point
+	// right now is the pr comment template
+	_, err := newSummaryPrHandler(&v1.PullRequest{}, nil, "")
+	require.NoError(t, err)
+}

--- a/internal/engine/eval/trusty/config.go
+++ b/internal/engine/eval/trusty/config.go
@@ -47,6 +47,14 @@ type ecosystemConfig struct {
 	// If `evaluate_score` is set to something else (e.g. `provenance`)
 	// then that score is used, which comes from the details field.
 	EvaluateScore string `json:"evaluate_score" mapstructure:"evaluate_score"`
+
+	// The provenance field contains the minimal provenance score
+	// to consider the origin of the package as trusted.
+	Provenance float64 `json:"provenance" mapstructure:"provenance"`
+
+	// Activity is the minimal activity score that minder needs to find to
+	// consider the package as trustworthy.
+	Activity float64 `json:"activity" mapstructure:"activity"`
 }
 
 // config is the configuration for the vulncheck evaluator

--- a/internal/engine/eval/trusty/config.go
+++ b/internal/engine/eval/trusty/config.go
@@ -60,16 +60,22 @@ func defaultConfig() *config {
 		Action: pr_actions.ActionSummary,
 		EcosystemConfig: []ecosystemConfig{
 			{
-				Name:  "npm",
-				Score: 5.0,
+				Name:       "npm",
+				Score:      5.0,
+				Provenance: 5.0,
+				Activity:   5.0,
 			},
 			{
-				Name:  "pypi",
-				Score: 5.0,
+				Name:       "pypi",
+				Score:      5.0,
+				Provenance: 5.0,
+				Activity:   5.0,
 			},
 			{
-				Name:  "go",
-				Score: 5.0,
+				Name:       "go",
+				Score:      5.0,
+				Provenance: 5.0,
+				Activity:   5.0,
 			},
 		},
 	}

--- a/internal/engine/eval/trusty/config.go
+++ b/internal/engine/eval/trusty/config.go
@@ -40,14 +40,6 @@ type ecosystemConfig struct {
 	// evaluated depends on the `evaluate_score` field.
 	Score float64 `json:"score" mapstructure:"score" validate:"required"`
 
-	// EvaluateScore tells the trusty executor which score to use
-	// for evaluation. This is useful when the trusty API returns.
-	// The default is the summary score. If `score` or an empty string, the
-	// summary score is used.
-	// If `evaluate_score` is set to something else (e.g. `provenance`)
-	// then that score is used, which comes from the details field.
-	EvaluateScore string `json:"evaluate_score" mapstructure:"evaluate_score"`
-
 	// The provenance field contains the minimal provenance score
 	// to consider the origin of the package as trusted.
 	Provenance float64 `json:"provenance" mapstructure:"provenance"`
@@ -116,31 +108,4 @@ func (c *config) getEcosystemConfig(ecosystem pb.DepEcosystem) *ecosystemConfig 
 	}
 
 	return nil
-}
-
-func (ec *ecosystemConfig) getScoreSource() string {
-	if ec.EvaluateScore == DefaultScore || ec.EvaluateScore == SummaryScore {
-		return SummaryScore
-	}
-
-	return ec.EvaluateScore
-}
-
-func (ec *ecosystemConfig) getScore(inSummary ScoreSummary) (float64, error) {
-	if inSummary.Score != nil && (ec.EvaluateScore == DefaultScore || ec.EvaluateScore == SummaryScore) {
-		return *inSummary.Score, nil
-	}
-
-	// If the score is not the summary score, then it must be in the details
-	rawScore, ok := inSummary.Description[ec.EvaluateScore]
-	if !ok {
-		return 0, fmt.Errorf("score %s not found in details", ec.EvaluateScore)
-	}
-
-	s, ok := rawScore.(float64)
-	if !ok {
-		return 0, fmt.Errorf("score %s is not a float64", ec.EvaluateScore)
-	}
-
-	return s, nil
 }

--- a/internal/engine/eval/trusty/trusty.go
+++ b/internal/engine/eval/trusty/trusty.go
@@ -41,6 +41,7 @@ const (
 type Evaluator struct {
 	cli      provifv1.GitHub
 	endpoint string
+	client   *trustyClient
 }
 
 // NewTrustyEvaluator creates a new trusty evaluator
@@ -59,119 +60,203 @@ func NewTrustyEvaluator(ctx context.Context, ghcli provifv1.GitHub) (*Evaluator,
 		zerolog.Ctx(ctx).Info().Str("trusty-endpoint", trustyEndpoint).Msg("using trusty endpoint from environment")
 	}
 
+	piCli := newPiClient(trustyEndpoint)
+	if piCli == nil {
+		return nil, fmt.Errorf("failed to create pi client")
+	}
+
 	return &Evaluator{
 		cli:      ghcli,
 		endpoint: trustyEndpoint,
+		client:   piCli,
 	}, nil
 }
 
 // Eval implements the Evaluator interface.
-//
-//nolint:gocyclo
 func (e *Evaluator) Eval(ctx context.Context, pol map[string]any, res *engif.Result) error {
-	var lowScoringPackages []string
-
-	//nolint:govet
-	prdeps, ok := res.Object.(*pb.PrDependencies)
-	if !ok {
-		return fmt.Errorf("invalid object type for vulncheck evaluator")
+	// Extract the dependency list from the PR
+	prDependencies, err := readPullRequestDependencies(res)
+	if err != nil {
+		return fmt.Errorf("reading pull request dependencies: %w", err)
 	}
-
-	if len(prdeps.Deps) == 0 {
+	if len(prDependencies.Deps) == 0 {
 		return nil
 	}
 
-	ruleConfig, err := parseConfig(pol)
-	if err != nil {
-		return fmt.Errorf("failed to parse config: %w", err)
-	}
-
-	if !isActionImplemented(ruleConfig.Action) {
-		return fmt.Errorf("action %s is not implemented", ruleConfig.Action)
-	}
-
 	logger := zerolog.Ctx(ctx).With().
-		Int64("pull-number", prdeps.Pr.Number).
-		Str("repo-owner", prdeps.Pr.RepoOwner).
-		Str("repo-name", prdeps.Pr.RepoName).
-		Logger()
+		Int64("pull-number", prDependencies.Pr.Number).
+		Str("repo-owner", prDependencies.Pr.RepoOwner).
+		Str("repo-name", prDependencies.Pr.RepoName).Logger()
 
-	prSummaryHandler, err := newSummaryPrHandler(prdeps.Pr, e.cli, e.endpoint)
+	// Parse the profile data to get the policy configuration
+	ruleConfig, err := parseRuleConfig(pol)
+	if err != nil {
+		return fmt.Errorf("parsing policy configuration: %w", err)
+	}
+
+	prSummaryHandler, err := newSummaryPrHandler(prDependencies.Pr, e.cli, e.endpoint)
 	if err != nil {
 		return fmt.Errorf("failed to create summary handler: %w", err)
 	}
 
-	piCli := newPiClient(e.endpoint)
-	if piCli == nil {
-		return fmt.Errorf("failed to create pi client")
+	// Classify all dependencies, tracking all that are malicious or scored low
+	for _, dep := range prDependencies.Deps {
+		if err := classifyDependency(ctx, &logger, e.client, ruleConfig, prSummaryHandler, dep); err != nil {
+			return fmt.Errorf("classifying dependency: %w", err)
+		}
 	}
 
-	for _, dep := range prdeps.Deps {
-		ecoConfig := ruleConfig.getEcosystemConfig(dep.Dep.Ecosystem)
-		if ecoConfig == nil {
-			logger.Info().
-				Str("dependency", dep.Dep.Name).
-				Str("ecosystem", dep.Dep.Ecosystem.AsString()).
-				Msgf("no config for ecosystem, skipping")
-			continue
-		}
+	if err := submitSummary(ctx, prSummaryHandler); err != nil {
+		logger.Err(err)
+		return fmt.Errorf("submitting pull request summary: %w", err)
+	}
 
-		resp, err := piCli.SendRecvRequest(ctx, dep.Dep)
-		if err != nil {
-			return fmt.Errorf("failed to send request: %w", err)
-		}
+	return buildEvalResult(prSummaryHandler)
+}
 
-		if resp == nil || resp.PackageName == "" {
-			logger.Info().
-				Str("dependency", dep.Dep.Name).
-				Msgf("no trusty data for dependency, skipping")
-			continue
+// readPullRequestDependencies returns the dependencies found in theingestion results
+func readPullRequestDependencies(res *engif.Result) (*pb.PrDependencies, error) {
+	prdeps, ok := res.Object.(*pb.PrDependencies)
+	if !ok {
+		return nil, fmt.Errorf("object type incompatible with the Trusty evaluator")
+	}
+
+	return prdeps, nil
+}
+
+// parseRuleConfig parses the profile configuration to build the policy
+func parseRuleConfig(pol map[string]any) (*config, error) {
+	ruleConfig, err := parseConfig(pol)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse config: %w", err)
+	}
+
+	if ruleConfig.Action != pr_actions.ActionSummary {
+		return nil, fmt.Errorf("action %s is not implemented", ruleConfig.Action)
+	}
+
+	return ruleConfig, nil
+}
+
+// submitSummary submits the pull request summary. It will return an error if
+// something fails.
+func submitSummary(ctx context.Context, prSummary *summaryPrHandler) error {
+	if err := prSummary.submit(ctx); err != nil {
+		return fmt.Errorf("failed to submit summary: %w", err)
+	}
+	return nil
+}
+
+// buildEvalResult returns nil or an EvaluationError with details about the
+// bad dependencies found by Trusty if any are found.
+func buildEvalResult(prSummary *summaryPrHandler) error {
+	// If we have malicious or lowscored packages, the evaluation fails.
+	// Craft an evaluation failed error with the dependency data:
+	var lowScoringPackages, maliciousPackages []string
+	for _, d := range prSummary.trackedAlternatives {
+		if d.trustyReply.PackageData.Malicious != nil &&
+			d.trustyReply.PackageData.Malicious.Published != nil &&
+			d.trustyReply.PackageData.Malicious.Published.String() != "" {
+			maliciousPackages = append(maliciousPackages, d.trustyReply.PackageName)
+		} else {
+			lowScoringPackages = append(lowScoringPackages, d.trustyReply.PackageName)
 		}
+	}
+
+	failedEvalMsg := ""
+
+	if len(maliciousPackages) > 0 {
+		failedEvalMsg = fmt.Sprintf(
+			"%d malicious packages: %s",
+			len(maliciousPackages), strings.Join(maliciousPackages, ","),
+		)
+	}
+
+	if len(lowScoringPackages) > 0 {
+		if failedEvalMsg != "" {
+			failedEvalMsg += " and "
+		}
+		failedEvalMsg += fmt.Sprintf(
+			"%d packages with low score: %s",
+			len(lowScoringPackages), strings.Join(lowScoringPackages, ","),
+		)
+	}
+
+	if failedEvalMsg != "" {
+		return evalerrors.NewErrEvaluationFailed(failedEvalMsg)
+	}
+
+	return nil
+}
+
+// classifyDependency checks the dependencies from the PR for maliciousness or
+// low scores and adds them to the summary if needed
+func classifyDependency(
+	ctx context.Context, logger *zerolog.Logger, trusty *trustyClient, ruleConfig *config,
+	prSummary *summaryPrHandler, dep *pb.PrDependencies_ContextualDependency,
+) error {
+	ecoConfig := ruleConfig.getEcosystemConfig(dep.Dep.Ecosystem)
+	if ecoConfig == nil {
+		logger.Info().
+			Str("dependency", dep.Dep.Name).
+			Str("ecosystem", dep.Dep.Ecosystem.AsString()).
+			Msgf("no config for ecosystem, skipping")
+		return nil
+	}
+
+	resp, err := trusty.SendRecvRequest(ctx, dep.Dep)
+	if err != nil {
+		return fmt.Errorf("failed to send request: %w", err)
+	}
+
+	if resp == nil || resp.PackageName == "" {
+		logger.Info().
+			Str("dependency", dep.Dep.Name).
+			Msgf("no trusty data for dependency, skipping")
+		return nil
+	}
+
+	if resp.PackageData.Malicious != nil && resp.PackageData.Malicious.Published.String() != "" {
+		logger.Debug().
+			Str("dependency", fmt.Sprintf("%s@%s", dep.Dep.Name, dep.Dep.Version)).
+			Str("malicious", "true").
+			Msgf("malicious dependency")
 
 		if resp.Summary.Score == nil {
-			logger.Info().
-				Str("dependency", dep.Dep.Name).
-				Msgf("the dependency has no score, skipping")
-			continue
+			s := float64(0)
+			resp.Summary.Score = &s
 		}
+	}
 
-		s, err := ecoConfig.getScore(resp.Summary)
-		if err != nil {
-			return fmt.Errorf("failed to get score: %w", err)
-		}
+	if resp.Summary.Score == nil {
+		logger.Info().
+			Str("dependency", dep.Dep.Name).
+			Msgf("the dependency has no score, skipping")
+		return nil
+	}
 
-		if s >= ecoConfig.Score {
-			logger.Debug().
-				Str("dependency", dep.Dep.Name).
-				Str("score-source", ecoConfig.getScoreSource()).
-				Float64("score", s).
-				Float64("threshold", ecoConfig.Score).
-				Msgf("the dependency has higher score than threshold, skipping")
-			continue
-		}
+	s, err := ecoConfig.getScore(resp.Summary)
+	if err != nil {
+		return fmt.Errorf("failed to get score: %w", err)
+	}
 
+	if s >= ecoConfig.Score {
 		logger.Debug().
 			Str("dependency", dep.Dep.Name).
 			Str("score-source", ecoConfig.getScoreSource()).
 			Float64("score", s).
 			Float64("threshold", ecoConfig.Score).
-			Msgf("the dependency has lower score than threshold, tracking")
-
-		lowScoringPackages = append(lowScoringPackages, dep.Dep.Name)
-
-		prSummaryHandler.trackAlternatives(dep, resp)
+			Msgf("the dependency has higher score than threshold, skipping")
+		return nil
 	}
 
-	if err := prSummaryHandler.submit(ctx); err != nil {
-		return fmt.Errorf("failed to submit summary: %w", err)
-	}
+	logger.Debug().
+		Str("dependency", dep.Dep.Name).
+		Str("score-source", ecoConfig.getScoreSource()).
+		Float64("score", s).
+		Float64("threshold", ecoConfig.Score).
+		Msgf("the dependency has lower score than threshold or is malicious, tracking")
 
-	if len(lowScoringPackages) > 0 {
-		return evalerrors.NewErrEvaluationFailed(fmt.Sprintf("packages with low score: %s", strings.Join(lowScoringPackages, ",")))
-	}
+	prSummary.trackAlternatives(dep, resp)
 	return nil
-}
-
-func isActionImplemented(action pr_actions.Action) bool {
-	return action == pr_actions.ActionSummary
 }

--- a/internal/engine/eval/trusty/trusty.go
+++ b/internal/engine/eval/trusty/trusty.go
@@ -253,14 +253,14 @@ func classifyDependency(
 		}
 	}
 
-	if ecoConfig.Score <= packageScore {
+	if ecoConfig.Score > packageScore {
 		reasons = append(reasons, TRUSTY_LOW_SCORE)
 	}
-	if ecoConfig.Provenance <= descr["provenance"].(float64) {
+	if ecoConfig.Provenance > descr["provenance"].(float64) {
 		reasons = append(reasons, TRUSTY_LOW_PROVENANCE)
 	}
 
-	if ecoConfig.Activity <= descr["activity"].(float64) {
+	if ecoConfig.Activity > descr["activity"].(float64) {
 		reasons = append(reasons, TRUSTY_LOW_ACTIVITY)
 	}
 	if len(reasons) > 0 {

--- a/internal/engine/eval/trusty/trusty.go
+++ b/internal/engine/eval/trusty/trusty.go
@@ -112,6 +112,7 @@ func (e *Evaluator) Eval(ctx context.Context, pol map[string]any, res *engif.Res
 	}
 
 	if err := submitSummary(ctx, prSummaryHandler); err != nil {
+		logger.Err(err).Msgf("Failed Generating PR Summary: %s", err.Error())
 		return fmt.Errorf("submitting pull request summary: %w", err)
 	}
 

--- a/internal/engine/eval/trusty/trusty.go
+++ b/internal/engine/eval/trusty/trusty.go
@@ -106,8 +106,12 @@ func (e *Evaluator) Eval(ctx context.Context, pol map[string]any, res *engif.Res
 		}
 	}
 
+	// If there are no problematic dependencies, return here
+	if len(prSummaryHandler.trackedAlternatives) == 0 {
+		return nil
+	}
+
 	if err := submitSummary(ctx, prSummaryHandler); err != nil {
-		logger.Err(err)
 		return fmt.Errorf("submitting pull request summary: %w", err)
 	}
 

--- a/internal/engine/eval/trusty/trusty.go
+++ b/internal/engine/eval/trusty/trusty.go
@@ -261,7 +261,6 @@ func classifyDependency(
 	if len(reasons) > 0 {
 		logger.Debug().
 			Str("dependency", dep.Dep.Name).
-			Str("score-source", ecoConfig.getScoreSource()).
 			Float64("score", packageScore).
 			Float64("threshold", ecoConfig.Score).
 			Msgf("the dependency has lower score than threshold or is malicious, tracking")
@@ -270,7 +269,6 @@ func classifyDependency(
 	} else {
 		logger.Debug().
 			Str("dependency", dep.Dep.Name).
-			Str("score-source", ecoConfig.getScoreSource()).
 			Float64("score", *resp.Summary.Score).
 			Float64("threshold", ecoConfig.Score).
 			Msgf("the dependency has lower score than threshold or is malicious, tracking")

--- a/internal/engine/eval/trusty/trusty.go
+++ b/internal/engine/eval/trusty/trusty.go
@@ -244,7 +244,7 @@ func classifyDependency(
 	// Ensure don't panic checking all fields are there
 	for _, fld := range []string{"activity", "provenance"} {
 		if _, ok := descr[fld]; !ok {
-			descr[fld] = 0
+			descr[fld] = float64(0)
 		}
 	}
 

--- a/internal/engine/eval/trusty/trusty_rest_handler.go
+++ b/internal/engine/eval/trusty/trusty_rest_handler.go
@@ -22,6 +22,7 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
+	"time"
 
 	pb "github.com/stacklok/minder/pkg/api/protobuf/go/minder/v1"
 )
@@ -74,6 +75,18 @@ type Reply struct {
 		Status   string        `json:"status"`
 		Packages []Alternative `json:"packages"`
 	} `json:"alternatives"`
+	PackageData struct {
+		Malicious *MaliciousData `json:"malicious"`
+	} `json:"package_data"`
+}
+
+// MaliciousData contains the security details when a dependency is malicious
+type MaliciousData struct {
+	Summary   string     `json:"summary"`
+	Details   string     `json:"details"`
+	Published *time.Time `json:"published"`
+	Modified  *time.Time `json:"modified"`
+	Source    string     `json:"source"`
 }
 
 func newPiClient(baseUrl string) *trustyClient {

--- a/internal/engine/eval/trusty/trusty_rest_handler.go
+++ b/internal/engine/eval/trusty/trusty_rest_handler.go
@@ -76,7 +76,9 @@ type Reply struct {
 		Packages []Alternative `json:"packages"`
 	} `json:"alternatives"`
 	PackageData struct {
-		Malicious *MaliciousData `json:"malicious"`
+		Archived   bool           `json:"archived"`
+		Deprecated bool           `json:"is_deprecated"`
+		Malicious  *MaliciousData `json:"malicious"`
 	} `json:"package_data"`
 }
 

--- a/internal/engine/eval/trusty/trusty_test.go
+++ b/internal/engine/eval/trusty/trusty_test.go
@@ -1,0 +1,227 @@
+// Copyright 2024 Stacklok, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package trusty
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/stacklok/minder/internal/engine/eval/pr_actions"
+	engif "github.com/stacklok/minder/internal/engine/interfaces"
+	mock_github "github.com/stacklok/minder/internal/providers/github/mock"
+	v1 "github.com/stacklok/minder/pkg/api/protobuf/go/minder/v1"
+	provifv1 "github.com/stacklok/minder/pkg/providers/v1"
+)
+
+func TestBuildEvalResult(t *testing.T) {
+	t.Parallel()
+	sg := float64(6.4)
+	now := time.Now()
+	for _, tc := range []struct {
+		name        string
+		sut         *summaryPrHandler
+		expectedNil bool
+		evalErr     bool
+	}{
+		{"normal", &summaryPrHandler{}, true, false},
+		{"malicious-package", &summaryPrHandler{
+			trackedAlternatives: []dependencyAlternatives{
+				{
+					Dependency: &v1.Dependency{
+						Ecosystem: v1.DepEcosystem_DEP_ECOSYSTEM_PYPI,
+						Name:      "requests",
+						Version:   "0.0.1",
+					},
+					trustyReply: &Reply{
+						PackageName: "requests",
+						PackageType: v1.DepEcosystem_DEP_ECOSYSTEM_PYPI.AsString(),
+						Summary: ScoreSummary{
+							Score: &sg,
+						},
+						PackageData: struct {
+							Malicious *MaliciousData `json:"malicious"`
+						}{
+							Malicious: &MaliciousData{
+								Summary:   "malicuous",
+								Published: &now,
+							},
+						},
+					},
+				},
+			},
+		}, false, true},
+		{"low-scored-package", &summaryPrHandler{
+			trackedAlternatives: []dependencyAlternatives{
+				{
+					Dependency: &v1.Dependency{
+						Ecosystem: v1.DepEcosystem_DEP_ECOSYSTEM_PYPI,
+						Name:      "requests",
+						Version:   "0.0.1",
+					},
+					trustyReply: &Reply{
+						PackageName: "requests",
+						PackageType: v1.DepEcosystem_DEP_ECOSYSTEM_PYPI.AsString(),
+						Summary: ScoreSummary{
+							Score: &sg,
+						},
+					},
+				},
+			},
+		}, false, true},
+		{"malicious-and-low-score", &summaryPrHandler{
+			trackedAlternatives: []dependencyAlternatives{
+				{
+					Dependency: &v1.Dependency{
+						Ecosystem: v1.DepEcosystem_DEP_ECOSYSTEM_PYPI,
+						Name:      "python-oauth",
+						Version:   "0.0.1",
+					},
+					trustyReply: &Reply{
+						PackageName: "requests",
+						PackageType: v1.DepEcosystem_DEP_ECOSYSTEM_PYPI.AsString(),
+						Summary: ScoreSummary{
+							Score: &sg,
+						},
+					},
+				},
+				{
+					Dependency: &v1.Dependency{
+						Ecosystem: v1.DepEcosystem_DEP_ECOSYSTEM_PYPI,
+						Name:      "requestts",
+						Version:   "0.0.1",
+					},
+					trustyReply: &Reply{
+						PackageName: "requests",
+						PackageType: v1.DepEcosystem_DEP_ECOSYSTEM_PYPI.AsString(),
+						Summary: ScoreSummary{
+							Score: &sg,
+						},
+						PackageData: struct {
+							Malicious *MaliciousData `json:"malicious"`
+						}{
+							Malicious: &MaliciousData{
+								Summary:   "malicuous",
+								Published: &now,
+							},
+						},
+					},
+				},
+			},
+		}, false, true},
+	} {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			res := buildEvalResult(tc.sut)
+			if tc.expectedNil {
+				require.Nil(t, res)
+				return
+			}
+			require.Equal(t, tc.evalErr, fmt.Sprintf("%T", res) == "*errors.EvaluationError", fmt.Sprintf("%T", res))
+		})
+	}
+}
+
+func TestParseRuleConfig(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		name    string
+		sut     map[string]any
+		mustErr bool
+	}{
+		{
+			"normal", map[string]any{
+				"action":           pr_actions.ActionSummary,
+				"ecosystem_config": []ecosystemConfig{},
+			}, false,
+		},
+		{
+			"unsupported-action", map[string]any{
+				"action":           pr_actions.Action("a"),
+				"ecosystem_config": []ecosystemConfig{},
+			}, true,
+		},
+		{
+			"invalid-config", map[string]any{
+				"hey": "you",
+			}, true,
+		},
+	} {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			res, err := parseRuleConfig(tc.sut)
+			if tc.mustErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.NotNil(t, res)
+		})
+	}
+}
+
+func TestReadPullRequestDependencies(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		name    string
+		sut     *engif.Result
+		mustErr bool
+	}{
+		{name: "normal", sut: &engif.Result{Object: &v1.PrDependencies{}}, mustErr: false},
+		{name: "invalid-object", sut: &engif.Result{Object: context.Background()}, mustErr: true},
+	} {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			deps, err := readPullRequestDependencies(tc.sut)
+			if tc.mustErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.NotNil(t, deps)
+		})
+	}
+}
+
+func TestNewTrustyEvaluator(t *testing.T) {
+	ghProvider := mock_github.NewMockGitHub(nil)
+	t.Parallel()
+	for _, tc := range []struct {
+		name    string
+		prv     provifv1.GitHub
+		mustErr bool
+	}{
+		{"normal", ghProvider, false},
+		{"no-provider", nil, true},
+	} {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			c, err := NewTrustyEvaluator(context.Background(), tc.prv)
+			if tc.mustErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.NotNil(t, c)
+		})
+	}
+}

--- a/internal/engine/eval/trusty/trusty_test.go
+++ b/internal/engine/eval/trusty/trusty_test.go
@@ -55,8 +55,12 @@ func TestBuildEvalResult(t *testing.T) {
 							Score: &sg,
 						},
 						PackageData: struct {
-							Malicious *MaliciousData `json:"malicious"`
+							Archived   bool           `json:"archived"`
+							Deprecated bool           `json:"is_deprecated"`
+							Malicious  *MaliciousData `json:"malicious"`
 						}{
+							Archived:   false,
+							Deprecated: false,
 							Malicious: &MaliciousData{
 								Summary:   "malicuous",
 								Published: &now,
@@ -113,8 +117,12 @@ func TestBuildEvalResult(t *testing.T) {
 							Score: &sg,
 						},
 						PackageData: struct {
-							Malicious *MaliciousData `json:"malicious"`
+							Archived   bool           `json:"archived"`
+							Deprecated bool           `json:"is_deprecated"`
+							Malicious  *MaliciousData `json:"malicious"`
 						}{
+							Archived:   false,
+							Deprecated: false,
 							Malicious: &MaliciousData{
 								Summary:   "malicuous",
 								Published: &now,


### PR DESCRIPTION
# Summary

This PR surfaces the Trusty maliciousness data on the comment added by minder when analyzing dependencies. It also adds the required piping to add the data to the rest of the required low scored dependencies.

I've broken the Trusty evaluator to more scoped utility functions to make them more testable and added a few initial unit tests. It needs a little bit more mocking to write an integration test and the rest of the unit tests

I've simplified the comment template, we now have a single template instead of 3 and it is now pure markdown which is smaller. Here' is a screenshot of the output with malicious dependencies:

![image](https://github.com/stacklok/minder/assets/3935899/1f95c523-feac-4d12-84f5-e288364eb23a)

Demo PRs showing

- [A malicious dependency](https://github.com/puerco/demo-repo-python/pull/29)
- [A low score dependency](https://github.com/puerco/demo-repo-python/pull/27)
- [Both malicious and low score](https://github.com/puerco/demo-repo-python/pull/28)


## Change Type

***Mark the type of change your PR introduces:***

- [ ] Bug fix (resolves an issue without affecting existing features)
- [x] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [x] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

Added initial tests (up to 22% from 0 :) )

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [x] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [x] Included tests that validate the fix or feature.
- [ ] Checked that related changes are merged.
