### PR TITLE
Resolve test flake in flags_test

### DIFF
--- a/internal/flags/flags_test.go
+++ b/internal/flags/flags_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/stacklok/minder/internal/engine"
 )
 
+// nolint: tparallel
 func TestOpenFeatureProviderFromFlags(t *testing.T) {
 	t.Parallel()
 
@@ -76,9 +77,14 @@ idp_resolver:
 		},
 		expectedFlag: true,
 	}}
+	//nolint: paralleltest
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
+			// These tests need to be exclusive with each other, because openfeature
+			// uses a global variable to store the provider.
+			// Other tests can mock the openfeature client to avoid this, but this test
+			// specifically tests our interaction with the library, so we need exclusion here.
+
 			ctx := context.Background()
 			OpenFeatureProviderFromFlags(ctx, tt.cfg)
 


### PR DESCRIPTION
# Summary

Don flagged this issue the other day.  The simplest fix is to not run the sub-tests in parallel; I've also filed a comment on the upstream that it would be nice to be able to avoid the singleton, in the way that the `net/http` library has something like a "default ServeMux", but you can also create your own.

## Change Type

***Mark the type of change your PR introduces:***

- [ ] Bug fix (resolves an issue without affecting existing features)
- [ ] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [x] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

Fix in tests, the tests are the test.

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [x] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [x] Included tests that validate the fix or feature.
- [ ] Checked that related changes are merged.
