### PR TITLE
Multi select list is now ordered.

### DIFF
--- a/internal/util/cli/multi_select.go
+++ b/internal/util/cli/multi_select.go
@@ -16,8 +16,10 @@
 package cli
 
 import (
+	"cmp"
 	"fmt"
 	"io"
+	"slices"
 	"strings"
 
 	"github.com/charmbracelet/bubbles/key"
@@ -36,6 +38,10 @@ func MultiSelect(choices []string) ([]string, error) {
 	for _, c := range choices {
 		items = append(items, item{title: c})
 	}
+
+	slices.SortFunc(items, func(a, b list.Item) int {
+		return cmp.Compare(a.(item).title, b.(item).title)
+	})
 
 	l := list.New(items, itemDelegate{}, 0, 0)
 	l.Title = "Select repos to register"


### PR DESCRIPTION
This behaviour is not configurable.

# Summary

List of available repositories during the interactive execution of `minder repo register` is now sorted.

This change was suggested by @rdimitrov 

## Change Type

- [ ] Bug fix (resolves an issue without affecting existing features)
- [x] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [ ] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

Ran the Minder CLI locally against Production and verified that the list of repositories presented to the user during interactive registration are sorted.

# Review Checklist:

- [X] Reviewed my own code for quality and clarity.
- [ ] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [ ] Included tests that validate the fix or feature.
- [X] Checked that related changes are merged.
