### PR TITLE
hides CLI profile list label flag

### DIFF
--- a/cmd/cli/app/profile/list.go
+++ b/cmd/cli/app/profile/list.go
@@ -18,6 +18,7 @@ package profile
 import (
 	"context"
 	"fmt"
+	"os"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -90,7 +91,10 @@ func listCommand(ctx context.Context, cmd *cobra.Command, _ []string, conn *grpc
 func init() {
 	ProfileCmd.AddCommand(listCmd)
 	listCmd.Flags().StringP("label", "l", "", "Profile label to filter on")
-	listCmd.Flags().MarkHidden("label")
+	if err := listCmd.Flags().MarkHidden("label"); err != nil {
+		listCmd.Printf("Error hiding flag: %s", err)
+		os.Exit(1)
+	}
 
 	// Flags
 	listCmd.Flags().StringP("output", "o", app.Table,

--- a/cmd/cli/app/profile/list.go
+++ b/cmd/cli/app/profile/list.go
@@ -90,6 +90,7 @@ func listCommand(ctx context.Context, cmd *cobra.Command, _ []string, conn *grpc
 func init() {
 	ProfileCmd.AddCommand(listCmd)
 	listCmd.Flags().StringP("label", "l", "", "Profile label to filter on")
+	listCmd.Flags().MarkHidden("label")
 
 	// Flags
 	listCmd.Flags().StringP("output", "o", app.Table,


### PR DESCRIPTION
# Summary

At the moment, there are some labels that minder uses internally, but we don't expose label managements to the end user. Therefore the `--label` flag in profile list is confusing. We should make the flag hidden. We should use cobra's hidden attribute to hide the flag.

Fixes #3300 

## Change Type

***Mark the type of change your PR introduces:***

- [x] Bug fix (resolves an issue without affecting existing features)
- [ ] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [ ] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

Run `make test`, there are failures but not entirely sure they are related to the change made in the PR, and may be due to a local setup issue. I could not see any test change needed to be made, it is my first PR so I welcome any correction to my understanding.

When building the CLI, the `label` flag does not appear anymore in the help information
![image](https://github.com/stacklok/minder/assets/29541485/aa659744-98ab-48ce-b6cd-6274047c53a0)

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [ ] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [ ] Included tests that validate the fix or feature.
- [ ] Checked that related changes are merged.
