### PR TITLE
Make artifacts ingester work with both GitHub and OCI providers

### DIFF
--- a/cmd/dev/app/image/list_tags.go
+++ b/cmd/dev/app/image/list_tags.go
@@ -37,6 +37,7 @@ func CmdListTags() *cobra.Command {
 	}
 
 	listCmd.Flags().StringP("base-url", "b", "", "base URL for the OCI registry")
+	listCmd.Flags().StringP("owner", "o", "", "owner of the artifact")
 	listCmd.Flags().StringP("container", "c", "", "container name to list tags for")
 	//nolint:goconst // let's not use a const for this one
 	listCmd.Flags().StringP("token", "t", "", "token to authenticate to the provider."+
@@ -57,6 +58,7 @@ func runCmdListTags(cmd *cobra.Command, _ []string) error {
 
 	// get the provider
 	baseURL := cmd.Flag("base-url")
+	owner := cmd.Flag("owner")
 	contname := cmd.Flag("container")
 
 	if baseURL.Value.String() == "" {
@@ -66,8 +68,10 @@ func runCmdListTags(cmd *cobra.Command, _ []string) error {
 		return fmt.Errorf("container name is required")
 	}
 
+	regWithOwner := fmt.Sprintf("%s/%s", owner.Value.String(), baseURL.Value.String())
+
 	cred := credentials.NewOAuth2TokenCredential(viper.GetString("auth.token"))
-	prov := oci.New(cred, baseURL.Value.String())
+	prov := oci.New(cred, baseURL.Value.String(), regWithOwner)
 
 	// get the containers
 	containers, err := prov.ListTags(ctx, contname.Value.String())

--- a/go.mod
+++ b/go.mod
@@ -254,7 +254,7 @@ require (
 	github.com/muesli/termenv v0.15.2 // indirect
 	github.com/oklog/ulid v1.3.1 // indirect
 	github.com/opencontainers/go-digest v1.0.0
-	github.com/opencontainers/image-spec v1.1.0 // indirect
+	github.com/opencontainers/image-spec v1.1.0
 	github.com/opentracing/opentracing-go v1.2.0 // indirect
 	github.com/pelletier/go-toml/v2 v2.1.1 // indirect
 	github.com/pjbgf/sha1cd v0.3.0 // indirect

--- a/internal/engine/ingester/artifact/artifact.go
+++ b/internal/engine/ingester/artifact/artifact.go
@@ -318,7 +318,7 @@ func getAndFilterArtifactVersions(
 
 		// If the artifact version is applicable to this rule, add it to the list
 		zerolog.Ctx(ctx).Debug().Str("name", name).Strs("tags", tags).Msg("artifact version matched")
-		res = append(res, name)
+		res = append(res, tags...)
 	}
 
 	// If no applicable artifact versions were found for this rule, we can go ahead and fail the rule evaluation here

--- a/internal/engine/ingester/artifact/artifact.go
+++ b/internal/engine/ingester/artifact/artifact.go
@@ -255,6 +255,17 @@ func getVerifier(i *Ingest, cfg *ingesterConfig) (verifyif.ArtifactVerifier, err
 			return nil, fmt.Errorf("unable to get github provider from provider configuration")
 		}
 		verifieropts = append(verifieropts, container.WithGitHubClient(ghcli))
+	} else if i.prov.CanImplement(pb.ProviderType_PROVIDER_TYPE_OCI) {
+		ocicli, err := provifv1.As[provifv1.OCI](i.prov)
+		if err != nil {
+			return nil, fmt.Errorf("unable to get oci provider from provider configuration")
+		}
+		cauthn, err := ocicli.GetAuthenticator()
+		if err != nil {
+			return nil, fmt.Errorf("unable to get oci authenticator: %w", err)
+		}
+		verifieropts = append(verifieropts, container.WithRegistry(ocicli.GetRegistry()),
+			container.WithAuthenticator(cauthn))
 	}
 
 	artifactVerifier, err := verifier.NewVerifier(

--- a/internal/engine/ingester/artifact/artifact.go
+++ b/internal/engine/ingester/artifact/artifact.go
@@ -303,7 +303,7 @@ func getAndFilterArtifactVersions(
 	name := artifact.GetName()
 
 	// Loop through all and filter out the versions that don't apply to this rule
-	for _, version := range upstreamVersions {
+	for vname, version := range upstreamVersions {
 		// Decide if the artifact version should be skipped or not
 		tags := version.GetTags()
 		tagsopt := map[string]interface{}{"tags": tags}
@@ -318,7 +318,7 @@ func getAndFilterArtifactVersions(
 
 		// If the artifact version is applicable to this rule, add it to the list
 		zerolog.Ctx(ctx).Debug().Str("name", name).Strs("tags", tags).Msg("artifact version matched")
-		res = append(res, tags...)
+		res = append(res, vname)
 	}
 
 	// If no applicable artifact versions were found for this rule, we can go ahead and fail the rule evaluation here

--- a/internal/engine/ingester/artifact/artifact_test.go
+++ b/internal/engine/ingester/artifact/artifact_test.go
@@ -569,7 +569,7 @@ func TestArtifactIngestMatching(t *testing.T) {
 			ing, err := NewArtifactDataIngest(prov)
 			require.NoError(t, err, "expected no error")
 
-			ing.ghCli = mockGhClient
+			ing.prov = mockGhClient
 			ing.artifactVerifier = mockVerifier
 
 			tt.mockSetup(mockGhClient, mockVerifier)

--- a/internal/engine/ingester/artifact/versioner.go
+++ b/internal/engine/ingester/artifact/versioner.go
@@ -32,7 +32,7 @@ import (
 
 type versioner interface {
 	// Gets the available versions of a given artifact
-	GetVersions(ctx context.Context) ([]*minderv1.ArtifactVersion, error)
+	GetVersions(ctx context.Context) (map[string]*minderv1.ArtifactVersion, error)
 }
 
 func getVersioner(prov provifv1.Provider, a *minderv1.Artifact) (versioner, error) {
@@ -62,7 +62,7 @@ type githubVersioner struct {
 
 // in case of the GitHub provider, a package version may be
 // linked to multiple tags
-func (gv *githubVersioner) GetVersions(ctx context.Context) ([]*minderv1.ArtifactVersion, error) {
+func (gv *githubVersioner) GetVersions(ctx context.Context) (map[string]*minderv1.ArtifactVersion, error) {
 	artifactName := url.QueryEscape(gv.artifact.GetName())
 	upstreamVersions, err := gv.ghCli.GetPackageVersions(
 		ctx, gv.artifact.GetOwner(), gv.artifact.GetTypeLower(), artifactName,
@@ -71,16 +71,16 @@ func (gv *githubVersioner) GetVersions(ctx context.Context) ([]*minderv1.Artifac
 		return nil, fmt.Errorf("error retrieving artifact versions: %w", err)
 	}
 
-	out := make([]*minderv1.ArtifactVersion, 0, 10)
+	out := make(map[string]*minderv1.ArtifactVersion, len(upstreamVersions))
 	for _, uv := range upstreamVersions {
 		tags := uv.Metadata.Container.Tags
 		sort.Strings(tags)
 
 		// only the tags and creation time is relevant to us.
-		out = append(out, &minderv1.ArtifactVersion{
+		out[*uv.Name] = &minderv1.ArtifactVersion{
 			Tags:      tags,
 			CreatedAt: timestamppb.New(uv.CreatedAt.Time),
-		})
+		}
 	}
 
 	return out, nil
@@ -91,13 +91,13 @@ type ociVersioner struct {
 	artifact *minderv1.Artifact
 }
 
-func (ov *ociVersioner) GetVersions(ctx context.Context) ([]*minderv1.ArtifactVersion, error) {
+func (ov *ociVersioner) GetVersions(ctx context.Context) (map[string]*minderv1.ArtifactVersion, error) {
 	tags, err := ov.ocicli.ListTags(ctx, ov.artifact.GetName())
 	if err != nil {
 		return nil, fmt.Errorf("error retrieving artifact versions: %w", err)
 	}
 
-	out := make([]*minderv1.ArtifactVersion, 0, 10)
+	out := make(map[string]*minderv1.ArtifactVersion, len(tags))
 	for _, t := range tags {
 		// TODO: We probably should try to surface errors while returning a subset
 		// of manifests.
@@ -130,11 +130,11 @@ func (ov *ociVersioner) GetVersions(ctx context.Context) ([]*minderv1.ArtifactVe
 			return nil, fmt.Errorf("unable to get digest")
 		}
 
-		out = append(out, &minderv1.ArtifactVersion{
+		out[t] = &minderv1.ArtifactVersion{
 			Tags:      []string{t},
 			Sha:       digest,
 			CreatedAt: timestamppb.New(createdAt),
-		})
+		}
 	}
 
 	return out, nil

--- a/internal/engine/ingester/artifact/versioner.go
+++ b/internal/engine/ingester/artifact/versioner.go
@@ -1,0 +1,141 @@
+// Copyright 2024 Stacklok, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// Package rule provides the CLI subcommand for managing rules
+
+// Package artifact provides the artifact ingestion engine
+package artifact
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"sort"
+	"time"
+
+	v1 "github.com/opencontainers/image-spec/specs-go/v1"
+	"google.golang.org/protobuf/types/known/timestamppb"
+
+	minderv1 "github.com/stacklok/minder/pkg/api/protobuf/go/minder/v1"
+	provifv1 "github.com/stacklok/minder/pkg/providers/v1"
+)
+
+type versioner interface {
+	// Gets the available versions of a given artifact
+	GetVersions(ctx context.Context) ([]*minderv1.ArtifactVersion, error)
+}
+
+func getVersioner(prov provifv1.Provider, a *minderv1.Artifact) (versioner, error) {
+	ghprov, err := provifv1.As[provifv1.GitHub](prov)
+	if err == nil {
+		return &githubVersioner{
+			ghCli:    ghprov,
+			artifact: a,
+		}, nil
+	}
+
+	ociprov, err := provifv1.As[provifv1.OCI](prov)
+	if err == nil {
+		return &ociVersioner{
+			ocicli:   ociprov,
+			artifact: a,
+		}, nil
+	}
+
+	return nil, fmt.Errorf("Unable to get version lister from provider implementation")
+}
+
+type githubVersioner struct {
+	ghCli    provifv1.GitHub
+	artifact *minderv1.Artifact
+}
+
+// in case of the GitHub provider, a package version may be
+// linked to multiple tags
+func (gv *githubVersioner) GetVersions(ctx context.Context) ([]*minderv1.ArtifactVersion, error) {
+	artifactName := url.QueryEscape(gv.artifact.GetName())
+	upstreamVersions, err := gv.ghCli.GetPackageVersions(
+		ctx, gv.artifact.GetOwner(), gv.artifact.GetTypeLower(), artifactName,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("error retrieving artifact versions: %w", err)
+	}
+
+	out := make([]*minderv1.ArtifactVersion, 0, 10)
+	for _, uv := range upstreamVersions {
+		tags := uv.Metadata.Container.Tags
+		sort.Strings(tags)
+
+		// only the tags and creation time is relevant to us.
+		out = append(out, &minderv1.ArtifactVersion{
+			Tags:      tags,
+			CreatedAt: timestamppb.New(uv.CreatedAt.Time),
+		})
+	}
+
+	return out, nil
+}
+
+type ociVersioner struct {
+	ocicli   provifv1.OCI
+	artifact *minderv1.Artifact
+}
+
+func (ov *ociVersioner) GetVersions(ctx context.Context) ([]*minderv1.ArtifactVersion, error) {
+	tags, err := ov.ocicli.ListTags(ctx, ov.artifact.GetName())
+	if err != nil {
+		return nil, fmt.Errorf("error retrieving artifact versions: %w", err)
+	}
+
+	out := make([]*minderv1.ArtifactVersion, 0, 10)
+	for _, t := range tags {
+		// TODO: We probably should try to surface errors while returning a subset
+		// of manifests.
+		man, err := ov.ocicli.GetManifest(ctx, ov.artifact.GetName(), t)
+		if err != nil {
+			return nil, err
+		}
+
+		// NOTE/FIXME: This is going to be a hassle as not a lot of
+		// container images have the needed annotations. We'd need
+		// go down to a specific image configuration (e.g. for _some_
+		// architecture) to actually verify the creation date...
+		// Anybody has other ideas?
+		strcreated, ok := man.Annotations[v1.AnnotationCreated]
+		var createdAt time.Time
+		if ok {
+			// TODO: Verify if this is correct
+			createdAt, err = time.Parse(time.RFC3339, strcreated)
+			if err != nil {
+				return nil, fmt.Errorf("unable to get creation time for tag %s: %w", t, err)
+			}
+		} else {
+			// FIXME: This is a hack
+			createdAt = time.Now()
+		}
+
+		// TODO: Consider caching
+		digest, err := ov.ocicli.GetDigest(ctx, ov.artifact.GetName(), t)
+		if err != nil {
+			return nil, fmt.Errorf("unable to get digest")
+		}
+
+		out = append(out, &minderv1.ArtifactVersion{
+			Tags:      []string{t},
+			Sha:       digest,
+			CreatedAt: timestamppb.New(createdAt),
+		})
+	}
+
+	return out, nil
+}

--- a/internal/engine/ingester/ingester.go
+++ b/internal/engine/ingester/ingester.go
@@ -63,11 +63,7 @@ func NewRuleDataIngest(rt *pb.RuleType, provider provinfv1.Provider) (engif.Inge
 		if rt.Def.Ingest.GetArtifact() == nil {
 			return nil, fmt.Errorf("rule type engine missing artifact configuration")
 		}
-		client, err := provinfv1.As[provinfv1.GitHub](provider)
-		if err != nil {
-			return nil, errors.New("provider does not implement github trait")
-		}
-		return artifact.NewArtifactDataIngest(client)
+		return artifact.NewArtifactDataIngest(provider)
 
 	case git.GitRuleDataIngestType:
 		client, err := provinfv1.As[provinfv1.Git](provider)

--- a/internal/providers/dockerhub/dockerhub.go
+++ b/internal/providers/dockerhub/dockerhub.go
@@ -75,7 +75,7 @@ func New(cred provifv1.OAuth2TokenCredential, cfg *minderv1.DockerHubProviderCon
 	ns := cfg.GetNamespace()
 	t := u.JoinPath(ns)
 
-	o := oci.New(cred, path.Join(dockerioBaseURL, cfg.GetNamespace()))
+	o := oci.New(cred, dockerioBaseURL, path.Join(dockerioBaseURL, cfg.GetNamespace()))
 	return &dockerHubImageLister{
 		OCI:       o,
 		namespace: ns,

--- a/internal/providers/github/mock/github.go
+++ b/internal/providers/github/mock/github.go
@@ -15,6 +15,7 @@ import (
 	reflect "reflect"
 
 	git "github.com/go-git/go-git/v5"
+	authn "github.com/google/go-containerregistry/pkg/authn"
 	v1 "github.com/google/go-containerregistry/pkg/v1"
 	github "github.com/google/go-github/v61/github"
 	v10 "github.com/stacklok/minder/pkg/api/protobuf/go/minder/v1"
@@ -992,6 +993,21 @@ func (mr *MockOCIMockRecorder) CanImplement(trait any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CanImplement", reflect.TypeOf((*MockOCI)(nil).CanImplement), trait)
 }
 
+// GetAuthenticator mocks base method.
+func (m *MockOCI) GetAuthenticator() (authn.Authenticator, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetAuthenticator")
+	ret0, _ := ret[0].(authn.Authenticator)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetAuthenticator indicates an expected call of GetAuthenticator.
+func (mr *MockOCIMockRecorder) GetAuthenticator() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAuthenticator", reflect.TypeOf((*MockOCI)(nil).GetAuthenticator))
+}
+
 // GetDigest mocks base method.
 func (m *MockOCI) GetDigest(ctx context.Context, name, tag string) (string, error) {
 	m.ctrl.T.Helper()
@@ -1035,6 +1051,20 @@ func (m *MockOCI) GetReferrer(ctx context.Context, name, tag, artifactType strin
 func (mr *MockOCIMockRecorder) GetReferrer(ctx, name, tag, artifactType any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetReferrer", reflect.TypeOf((*MockOCI)(nil).GetReferrer), ctx, name, tag, artifactType)
+}
+
+// GetRegistry mocks base method.
+func (m *MockOCI) GetRegistry() string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetRegistry")
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
+// GetRegistry indicates an expected call of GetRegistry.
+func (mr *MockOCIMockRecorder) GetRegistry() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRegistry", reflect.TypeOf((*MockOCI)(nil).GetRegistry))
 }
 
 // ListTags mocks base method.

--- a/internal/providers/github/mock/github.go
+++ b/internal/providers/github/mock/github.go
@@ -15,9 +15,10 @@ import (
 	reflect "reflect"
 
 	git "github.com/go-git/go-git/v5"
+	v1 "github.com/google/go-containerregistry/pkg/v1"
 	github "github.com/google/go-github/v61/github"
-	v1 "github.com/stacklok/minder/pkg/api/protobuf/go/minder/v1"
-	v10 "github.com/stacklok/minder/pkg/providers/v1"
+	v10 "github.com/stacklok/minder/pkg/api/protobuf/go/minder/v1"
+	v11 "github.com/stacklok/minder/pkg/providers/v1"
 	gomock "go.uber.org/mock/gomock"
 )
 
@@ -45,7 +46,7 @@ func (m *MockProvider) EXPECT() *MockProviderMockRecorder {
 }
 
 // CanImplement mocks base method.
-func (m *MockProvider) CanImplement(trait v1.ProviderType) bool {
+func (m *MockProvider) CanImplement(trait v10.ProviderType) bool {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CanImplement", trait)
 	ret0, _ := ret[0].(bool)
@@ -82,7 +83,7 @@ func (m *MockGit) EXPECT() *MockGitMockRecorder {
 }
 
 // CanImplement mocks base method.
-func (m *MockGit) CanImplement(trait v1.ProviderType) bool {
+func (m *MockGit) CanImplement(trait v10.ProviderType) bool {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CanImplement", trait)
 	ret0, _ := ret[0].(bool)
@@ -134,7 +135,7 @@ func (m *MockREST) EXPECT() *MockRESTMockRecorder {
 }
 
 // CanImplement mocks base method.
-func (m *MockREST) CanImplement(trait v1.ProviderType) bool {
+func (m *MockREST) CanImplement(trait v10.ProviderType) bool {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CanImplement", trait)
 	ret0, _ := ret[0].(bool)
@@ -215,7 +216,7 @@ func (m *MockRepoLister) EXPECT() *MockRepoListerMockRecorder {
 }
 
 // CanImplement mocks base method.
-func (m *MockRepoLister) CanImplement(trait v1.ProviderType) bool {
+func (m *MockRepoLister) CanImplement(trait v10.ProviderType) bool {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CanImplement", trait)
 	ret0, _ := ret[0].(bool)
@@ -229,10 +230,10 @@ func (mr *MockRepoListerMockRecorder) CanImplement(trait any) *gomock.Call {
 }
 
 // ListAllRepositories mocks base method.
-func (m *MockRepoLister) ListAllRepositories(arg0 context.Context) ([]*v1.Repository, error) {
+func (m *MockRepoLister) ListAllRepositories(arg0 context.Context) ([]*v10.Repository, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListAllRepositories", arg0)
-	ret0, _ := ret[0].([]*v1.Repository)
+	ret0, _ := ret[0].([]*v10.Repository)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -281,7 +282,7 @@ func (mr *MockGitHubMockRecorder) AddAuthToPushOptions(ctx, options any) *gomock
 }
 
 // CanImplement mocks base method.
-func (m *MockGitHub) CanImplement(trait v1.ProviderType) bool {
+func (m *MockGitHub) CanImplement(trait v10.ProviderType) bool {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CanImplement", trait)
 	ret0, _ := ret[0].(bool)
@@ -503,10 +504,10 @@ func (mr *MockGitHubMockRecorder) GetBranchProtection(arg0, arg1, arg2, arg3 any
 }
 
 // GetCredential mocks base method.
-func (m *MockGitHub) GetCredential() v10.GitHubCredential {
+func (m *MockGitHub) GetCredential() v11.GitHubCredential {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetCredential")
-	ret0, _ := ret[0].(v10.GitHubCredential)
+	ret0, _ := ret[0].(v11.GitHubCredential)
 	return ret0
 }
 
@@ -695,10 +696,10 @@ func (mr *MockGitHubMockRecorder) IsOrg() *gomock.Call {
 }
 
 // ListAllRepositories mocks base method.
-func (m *MockGitHub) ListAllRepositories(arg0 context.Context) ([]*v1.Repository, error) {
+func (m *MockGitHub) ListAllRepositories(arg0 context.Context) ([]*v10.Repository, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListAllRepositories", arg0)
-	ret0, _ := ret[0].([]*v1.Repository)
+	ret0, _ := ret[0].([]*v10.Repository)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -912,7 +913,7 @@ func (m *MockImageLister) EXPECT() *MockImageListerMockRecorder {
 }
 
 // CanImplement mocks base method.
-func (m *MockImageLister) CanImplement(trait v1.ProviderType) bool {
+func (m *MockImageLister) CanImplement(trait v10.ProviderType) bool {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CanImplement", trait)
 	ret0, _ := ret[0].(bool)
@@ -978,7 +979,7 @@ func (m *MockOCI) EXPECT() *MockOCIMockRecorder {
 }
 
 // CanImplement mocks base method.
-func (m *MockOCI) CanImplement(trait v1.ProviderType) bool {
+func (m *MockOCI) CanImplement(trait v10.ProviderType) bool {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CanImplement", trait)
 	ret0, _ := ret[0].(bool)
@@ -1007,10 +1008,10 @@ func (mr *MockOCIMockRecorder) GetDigest(ctx, name, tag any) *gomock.Call {
 }
 
 // GetManifest mocks base method.
-func (m *MockOCI) GetManifest(ctx context.Context, name, tag string) (any, error) {
+func (m *MockOCI) GetManifest(ctx context.Context, name, tag string) (*v1.Manifest, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetManifest", ctx, name, tag)
-	ret0, _ := ret[0].(any)
+	ret0, _ := ret[0].(*v1.Manifest)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }

--- a/internal/providers/oci/oci.go
+++ b/internal/providers/oci/oci.go
@@ -34,17 +34,19 @@ import (
 type OCI struct {
 	cred provifv1.Credential
 
-	baseURL string
+	registry string
+	baseURL  string
 }
 
 // Ensure that the OCI client implements the OCI interface
 var _ provifv1.OCI = (*OCI)(nil)
 
 // New creates a new OCI client
-func New(cred provifv1.Credential, baseURL string) *OCI {
+func New(cred provifv1.Credential, registry, baseURL string) *OCI {
 	return &OCI{
-		cred:    cred,
-		baseURL: baseURL,
+		cred:     cred,
+		registry: registry,
+		baseURL:  baseURL,
 	}
 }
 
@@ -157,7 +159,7 @@ func (o *OCI) GetManifest(ctx context.Context, contname, tag string) (*v1.Manife
 
 // GetRegistry returns the registry name
 func (o *OCI) GetRegistry() string {
-	return o.baseURL
+	return o.registry
 }
 
 // GetAuthenticator returns the authenticator for the OCI provider

--- a/internal/providers/oci/oci.go
+++ b/internal/providers/oci/oci.go
@@ -21,6 +21,7 @@ import (
 	"strings"
 
 	"github.com/google/go-containerregistry/pkg/name"
+	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/remote"
 
 	"github.com/stacklok/minder/internal/constants"
@@ -134,20 +135,20 @@ func (o *OCI) GetReferrer(ctx context.Context, contname, tag, artifactType strin
 
 // GetManifest returns the manifest for the given tag of the given container in the given namespace
 // for the OCI provider. It returns the manifest as a golang struct given the OCI spec.
-func (o *OCI) GetManifest(ctx context.Context, contname, tag string) (any, error) {
+func (o *OCI) GetManifest(ctx context.Context, contname, tag string) (*v1.Manifest, error) {
 	ref, err := o.getReference(contname, tag)
 	if err != nil {
-		return "", fmt.Errorf("failed to get reference: %w", err)
+		return nil, fmt.Errorf("failed to get reference: %w", err)
 	}
 
 	img, err := remote.Image(ref, remote.WithContext(ctx), remote.WithUserAgent(constants.ServerUserAgent))
 	if err != nil {
-		return "", fmt.Errorf("failed to get image: %w", err)
+		return nil, fmt.Errorf("failed to get image: %w", err)
 	}
 
 	man, err := img.Manifest()
 	if err != nil {
-		return "", fmt.Errorf("failed to get manifest: %w", err)
+		return nil, fmt.Errorf("failed to get manifest: %w", err)
 	}
 
 	return man, nil

--- a/internal/verifier/sigstore/sigstore.go
+++ b/internal/verifier/sigstore/sigstore.go
@@ -148,7 +148,7 @@ func verifierOptions(trustedRoot string) ([]verify.VerifierOption, error) {
 
 // Verify verifies an artifact
 func (s *Sigstore) Verify(ctx context.Context, artifactType verifyif.ArtifactType,
-	owner, artifact, version string) ([]verifyif.Result, error) {
+	owner, artifact, checksumref string) ([]verifyif.Result, error) {
 	var err error
 	var res []verifyif.Result
 	// Sanitize the input
@@ -157,7 +157,7 @@ func (s *Sigstore) Verify(ctx context.Context, artifactType verifyif.ArtifactTyp
 	// Process verification based on the artifact type
 	switch artifactType {
 	case verifyif.ArtifactTypeContainer:
-		res, err = s.VerifyContainer(ctx, owner, artifact, version)
+		res, err = s.VerifyContainer(ctx, owner, artifact, checksumref)
 	default:
 		err = fmt.Errorf("unknown artifact type: %s", artifactType)
 	}
@@ -166,9 +166,9 @@ func (s *Sigstore) Verify(ctx context.Context, artifactType verifyif.ArtifactTyp
 }
 
 // VerifyContainer verifies a container artifact using sigstore
-func (s *Sigstore) VerifyContainer(ctx context.Context, owner, artifact, version string) (
+func (s *Sigstore) VerifyContainer(ctx context.Context, owner, artifact, checksumref string) (
 	[]verifyif.Result, error) {
-	return container.Verify(ctx, s.verifier, owner, artifact, version, s.authOpts...)
+	return container.Verify(ctx, s.verifier, owner, artifact, checksumref, s.authOpts...)
 }
 
 // sanitizeInput sanitizes the input parameters

--- a/internal/verifier/verifyif/verifyif.go
+++ b/internal/verifier/verifyif/verifyif.go
@@ -42,7 +42,7 @@ type Result struct {
 // ArtifactVerifier is the interface for artifact verifiers
 type ArtifactVerifier interface {
 	Verify(ctx context.Context, artifactType ArtifactType,
-		owner, name, version string) ([]Result, error)
+		owner, name, checksumref string) ([]Result, error)
 	VerifyContainer(ctx context.Context,
-		owner, artifact, version string) ([]Result, error)
+		owner, artifact, checksumref string) ([]Result, error)
 }

--- a/pkg/providers/v1/providers.go
+++ b/pkg/providers/v1/providers.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/go-git/go-git/v5"
 	"github.com/go-playground/validator/v10"
+	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-github/v61/github"
 
 	minderv1 "github.com/stacklok/minder/pkg/api/protobuf/go/minder/v1"
@@ -153,7 +154,7 @@ type OCI interface {
 	// GetManifest returns the manifest for the given tag of the given container in the given namespace
 	// for the OCI provider. It returns the manifest as a golang struct given the OCI spec.
 	// TODO - Define the manifest struct
-	GetManifest(ctx context.Context, name, tag string) (any, error)
+	GetManifest(ctx context.Context, name, tag string) (*v1.Manifest, error)
 }
 
 // ParseAndValidate parses the given provider configuration and validates it.

--- a/pkg/providers/v1/providers.go
+++ b/pkg/providers/v1/providers.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/go-git/go-git/v5"
 	"github.com/go-playground/validator/v10"
+	"github.com/google/go-containerregistry/pkg/authn"
 	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-github/v61/github"
 
@@ -155,6 +156,12 @@ type OCI interface {
 	// for the OCI provider. It returns the manifest as a golang struct given the OCI spec.
 	// TODO - Define the manifest struct
 	GetManifest(ctx context.Context, name, tag string) (*v1.Manifest, error)
+
+	// GetRegistry returns the registry name
+	GetRegistry() string
+
+	// GetAuthenticator returns the authenticator for the OCI provider
+	GetAuthenticator() (authn.Authenticator, error)
 }
 
 // ParseAndValidate parses the given provider configuration and validates it.


### PR DESCRIPTION
# Summary

This modifies the ingester to change its behavior depending on whether
the provider is an OCI provider or a github one.

Closes: https://github.com/stacklok/minder/issues/3322

## Change Type

***Mark the type of change your PR introduces:***

- [ ] Bug fix (resolves an issue without affecting existing features)
- [x] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [ ] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [ ] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [ ] Included tests that validate the fix or feature.
- [ ] Checked that related changes are merged.
