### PR TITLE
verifier: Move registry to authenticator

### DIFF
--- a/cmd/dev/app/image/cmd_verify.go
+++ b/cmd/dev/app/image/cmd_verify.go
@@ -99,7 +99,7 @@ func runCmdVerify(cmd *cobra.Command, _ []string) error {
 		return fmt.Errorf("error getting sigstore verifier: %w", err)
 	}
 
-	res, err := artifactVerifier.Verify(context.Background(), verifyif.ArtifactTypeContainer, "",
+	res, err := artifactVerifier.Verify(context.Background(), verifyif.ArtifactTypeContainer,
 		owner.Value.String(), name.Value.String(), digest.Value.String())
 	if err != nil {
 		return fmt.Errorf("error verifying container: %w", err)

--- a/internal/engine/ingester/artifact/artifact.go
+++ b/internal/engine/ingester/artifact/artifact.go
@@ -176,7 +176,7 @@ func (i *Ingest) getVerificationResult(
 	// Loop through all artifact versions that apply to this rule and get the provenance info for each
 	for _, artifactVersion := range versions {
 		// Try getting provenance info for the artifact version
-		results, err := artifactVerifier.Verify(ctx, verifyif.ArtifactTypeContainer, "",
+		results, err := artifactVerifier.Verify(ctx, verifyif.ArtifactTypeContainer,
 			artifact.Owner, artifact.Name, artifactVersion)
 		if err != nil {
 			// We consider err != nil as a fatal error, so we'll fail the rule evaluation here

--- a/internal/engine/ingester/artifact/artifact_test.go
+++ b/internal/engine/ingester/artifact/artifact_test.go
@@ -91,7 +91,7 @@ func TestArtifactIngestMatching(t *testing.T) {
 						},
 					}, nil)
 				mockVerifier.EXPECT().
-					Verify(gomock.Any(), verifyif.ArtifactTypeContainer, verifyif.ArtifactRegistry(""), "stacklok", "matching-name", "sha256:1234").
+					Verify(gomock.Any(), verifyif.ArtifactTypeContainer, "stacklok", "matching-name", "sha256:1234").
 					Return([]verifyif.Result{
 						{
 							IsSigned:   false,
@@ -138,7 +138,7 @@ func TestArtifactIngestMatching(t *testing.T) {
 					}, nil)
 
 				mockVerifier.EXPECT().
-					Verify(gomock.Any(), verifyif.ArtifactTypeContainer, verifyif.ArtifactRegistry(""), "stacklok", "matching-name-and-tag", "sha256:1234").
+					Verify(gomock.Any(), verifyif.ArtifactTypeContainer, "stacklok", "matching-name-and-tag", "sha256:1234").
 					Return([]verifyif.Result{
 						{
 							IsSigned:   false,
@@ -299,7 +299,7 @@ func TestArtifactIngestMatching(t *testing.T) {
 					}, nil)
 
 				mockVerifier.EXPECT().
-					Verify(gomock.Any(), verifyif.ArtifactTypeContainer, verifyif.ArtifactRegistry(""), "stacklok", "matching-name-but-not-tags", "sha256:1234").
+					Verify(gomock.Any(), verifyif.ArtifactTypeContainer, "stacklok", "matching-name-but-not-tags", "sha256:1234").
 					Return([]verifyif.Result{
 						{
 							IsSigned:   false,
@@ -353,7 +353,7 @@ func TestArtifactIngestMatching(t *testing.T) {
 					}, nil)
 
 				mockVerifier.EXPECT().
-					Verify(gomock.Any(), verifyif.ArtifactTypeContainer, verifyif.ArtifactRegistry(""), "stacklok", "matching-name", "sha256:1234").
+					Verify(gomock.Any(), verifyif.ArtifactTypeContainer, "stacklok", "matching-name", "sha256:1234").
 					Return([]verifyif.Result{
 						{
 							IsSigned:   false,
@@ -390,7 +390,7 @@ func TestArtifactIngestMatching(t *testing.T) {
 					}, nil)
 
 				mockVerifier.EXPECT().
-					Verify(gomock.Any(), verifyif.ArtifactTypeContainer, verifyif.ArtifactRegistry(""), "stacklok", "matching-name", "sha256:1234").
+					Verify(gomock.Any(), verifyif.ArtifactTypeContainer, "stacklok", "matching-name", "sha256:1234").
 					Return([]verifyif.Result{
 						{
 							IsSigned:   false,
@@ -428,7 +428,7 @@ func TestArtifactIngestMatching(t *testing.T) {
 					}, nil)
 
 				mockVerifier.EXPECT().
-					Verify(gomock.Any(), verifyif.ArtifactTypeContainer, verifyif.ArtifactRegistry(""), "stacklok", "matching-name", "sha256:1234").
+					Verify(gomock.Any(), verifyif.ArtifactTypeContainer, "stacklok", "matching-name", "sha256:1234").
 					Return([]verifyif.Result{
 						{
 							IsSigned:   false,

--- a/internal/verifier/sigstore/sigstore.go
+++ b/internal/verifier/sigstore/sigstore.go
@@ -147,17 +147,17 @@ func verifierOptions(trustedRoot string) ([]verify.VerifierOption, error) {
 }
 
 // Verify verifies an artifact
-func (s *Sigstore) Verify(ctx context.Context, artifactType verifyif.ArtifactType, registry verifyif.ArtifactRegistry,
+func (s *Sigstore) Verify(ctx context.Context, artifactType verifyif.ArtifactType,
 	owner, artifact, version string) ([]verifyif.Result, error) {
 	var err error
 	var res []verifyif.Result
 	// Sanitize the input
-	sanitizeInput(&registry, &owner)
+	sanitizeInput(&owner)
 
 	// Process verification based on the artifact type
 	switch artifactType {
 	case verifyif.ArtifactTypeContainer:
-		res, err = s.VerifyContainer(ctx, string(registry), owner, artifact, version)
+		res, err = s.VerifyContainer(ctx, owner, artifact, version)
 	default:
 		err = fmt.Errorf("unknown artifact type: %s", artifactType)
 	}
@@ -166,17 +166,13 @@ func (s *Sigstore) Verify(ctx context.Context, artifactType verifyif.ArtifactTyp
 }
 
 // VerifyContainer verifies a container artifact using sigstore
-func (s *Sigstore) VerifyContainer(ctx context.Context, registry, owner, artifact, version string) (
+func (s *Sigstore) VerifyContainer(ctx context.Context, owner, artifact, version string) (
 	[]verifyif.Result, error) {
-	return container.Verify(ctx, s.verifier, registry, owner, artifact, version, s.authOpts...)
+	return container.Verify(ctx, s.verifier, owner, artifact, version, s.authOpts...)
 }
 
 // sanitizeInput sanitizes the input parameters
-func sanitizeInput(registry *verifyif.ArtifactRegistry, owner *string) {
-	// Default the registry to GHCR for the time being
-	if *registry == "" {
-		*registry = verifyif.ArtifactRegistryGHCR
-	}
+func sanitizeInput(owner *string) {
 	// (jaosorior): The owner can't be upper-cased, normalize the owner.
 	*owner = strings.ToLower(*owner)
 }

--- a/internal/verifier/verifyif/mock/verifyif.go
+++ b/internal/verifier/verifyif/mock/verifyif.go
@@ -41,31 +41,31 @@ func (m *MockArtifactVerifier) EXPECT() *MockArtifactVerifierMockRecorder {
 }
 
 // Verify mocks base method.
-func (m *MockArtifactVerifier) Verify(ctx context.Context, artifactType verifyif.ArtifactType, registry verifyif.ArtifactRegistry, owner, name, version string) ([]verifyif.Result, error) {
+func (m *MockArtifactVerifier) Verify(ctx context.Context, artifactType verifyif.ArtifactType, owner, name, version string) ([]verifyif.Result, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Verify", ctx, artifactType, registry, owner, name, version)
+	ret := m.ctrl.Call(m, "Verify", ctx, artifactType, owner, name, version)
 	ret0, _ := ret[0].([]verifyif.Result)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // Verify indicates an expected call of Verify.
-func (mr *MockArtifactVerifierMockRecorder) Verify(ctx, artifactType, registry, owner, name, version any) *gomock.Call {
+func (mr *MockArtifactVerifierMockRecorder) Verify(ctx, artifactType, owner, name, version any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Verify", reflect.TypeOf((*MockArtifactVerifier)(nil).Verify), ctx, artifactType, registry, owner, name, version)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Verify", reflect.TypeOf((*MockArtifactVerifier)(nil).Verify), ctx, artifactType, owner, name, version)
 }
 
 // VerifyContainer mocks base method.
-func (m *MockArtifactVerifier) VerifyContainer(ctx context.Context, registry, owner, artifact, version string) ([]verifyif.Result, error) {
+func (m *MockArtifactVerifier) VerifyContainer(ctx context.Context, owner, artifact, version string) ([]verifyif.Result, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "VerifyContainer", ctx, registry, owner, artifact, version)
+	ret := m.ctrl.Call(m, "VerifyContainer", ctx, owner, artifact, version)
 	ret0, _ := ret[0].([]verifyif.Result)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // VerifyContainer indicates an expected call of VerifyContainer.
-func (mr *MockArtifactVerifierMockRecorder) VerifyContainer(ctx, registry, owner, artifact, version any) *gomock.Call {
+func (mr *MockArtifactVerifierMockRecorder) VerifyContainer(ctx, owner, artifact, version any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "VerifyContainer", reflect.TypeOf((*MockArtifactVerifier)(nil).VerifyContainer), ctx, registry, owner, artifact, version)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "VerifyContainer", reflect.TypeOf((*MockArtifactVerifier)(nil).VerifyContainer), ctx, owner, artifact, version)
 }

--- a/internal/verifier/verifyif/verifyif.go
+++ b/internal/verifier/verifyif/verifyif.go
@@ -24,14 +24,6 @@ import (
 
 //go:generate go run go.uber.org/mock/mockgen -package mock_$GOPACKAGE -destination=./mock/$GOFILE -source=./$GOFILE
 
-// ArtifactRegistry supported artifact registries
-type ArtifactRegistry string
-
-const (
-	// ArtifactRegistryGHCR is the GitHub Container Registry
-	ArtifactRegistryGHCR ArtifactRegistry = "ghcr.io"
-)
-
 // ArtifactType represents the type of artifact, i.e., container, npm, etc.
 type ArtifactType string
 
@@ -49,8 +41,8 @@ type Result struct {
 
 // ArtifactVerifier is the interface for artifact verifiers
 type ArtifactVerifier interface {
-	Verify(ctx context.Context, artifactType ArtifactType, registry ArtifactRegistry,
+	Verify(ctx context.Context, artifactType ArtifactType,
 		owner, name, version string) ([]Result, error)
 	VerifyContainer(ctx context.Context,
-		registry, owner, artifact, version string) ([]Result, error)
+		owner, artifact, version string) ([]Result, error)
 }


### PR DESCRIPTION
# Summary

Since auth is related to the registry itself, this moves the registry
reference to the container authenticator struct instead.

## Change Type

***Mark the type of change your PR introduces:***

- [ ] Bug fix (resolves an issue without affecting existing features)
- [x] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [ ] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [ ] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [ ] Included tests that validate the fix or feature.
- [ ] Checked that related changes are merged.
