### PR TITLE
Initial KeyStore implementation

### DIFF
--- a/internal/crypto/algorithms/algorithm.go
+++ b/internal/crypto/algorithms/algorithm.go
@@ -1,0 +1,61 @@
+// Copyright 2024 Stacklok, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package algorithms contains implementations of various crypto algorithms
+// for the crypto engine.
+package algorithms
+
+import (
+	"errors"
+	"fmt"
+)
+
+// EncryptionAlgorithm represents a crypto algorithm used by the Engine
+type EncryptionAlgorithm interface {
+	Encrypt(data []byte, key []byte, salt []byte) ([]byte, error)
+	Decrypt(data []byte, key []byte, salt []byte) ([]byte, error)
+}
+
+// Type is an enum of supported encryption algorithms
+type Type string
+
+const (
+	// Aes256Cfb is the AES-256-CFB algorithm
+	Aes256Cfb Type = "aes-256-cfb"
+)
+
+const maxSize = 32 * 1024 * 1024
+
+// ErrUnknownAlgorithm is used when an incorrect algorithm name is used.
+var (
+	ErrUnknownAlgorithm = errors.New("unexpected encryption algorithm")
+)
+
+// TypeFromString attempts to map a string to a `Type` value.
+func TypeFromString(name string) (Type, error) {
+	// TODO: use switch when we support more than once type.
+	if name == string(Aes256Cfb) {
+		return Aes256Cfb, nil
+	}
+	return "", fmt.Errorf("%w: %s", ErrUnknownAlgorithm, name)
+}
+
+// NewFromType instantiates an encryption algorithm by name
+func NewFromType(algoType Type) (EncryptionAlgorithm, error) {
+	// TODO: use switch when we support more than once type.
+	if algoType == Aes256Cfb {
+		return &AES256CFBAlgorithm{}, nil
+	}
+	return nil, fmt.Errorf("%w: %s", ErrUnknownAlgorithm, algoType)
+}

--- a/internal/crypto/engine.go
+++ b/internal/crypto/engine.go
@@ -86,6 +86,7 @@ func NewEngineFromAuthConfig(config *serverconfig.AuthConfig) (Engine, error) {
 		keystore:            keystore,
 		supportedAlgorithms: supportedAlgorithms,
 		defaultAlgorithm:    algorithms.Aes256Cfb,
+		// Use the key filename as the key ID.
 		// This will be cleaned up in a future PR
 		// Right now, by the time we get here, this should return a valid result
 		defaultKeyID: filepath.Base(config.TokenKey),

--- a/internal/crypto/engine.go
+++ b/internal/crypto/engine.go
@@ -146,7 +146,7 @@ func (e *engine) encrypt(data []byte) (EncryptedData, error) {
 		return EncryptedData{}, fmt.Errorf("unable to find preferred algorithm: %s", e.defaultAlgorithm)
 	}
 
-	key, err := e.keystore.GetKey(e.defaultAlgorithm, e.defaultKeyID)
+	key, err := e.keystore.GetKey(e.defaultKeyID)
 	if err != nil {
 		return EncryptedData{}, fmt.Errorf("unable to find preferred key with ID: %s", e.defaultKeyID)
 	}
@@ -172,7 +172,7 @@ func (e *engine) decrypt(data EncryptedData) ([]byte, error) {
 		return nil, fmt.Errorf("%w: %s", algorithms.ErrUnknownAlgorithm, e.defaultAlgorithm)
 	}
 
-	key, err := e.keystore.GetKey(e.defaultAlgorithm, e.defaultKeyID)
+	key, err := e.keystore.GetKey(e.defaultKeyID)
 	if err != nil {
 		// error from keystore is good enough - we do not need more context
 		return nil, err

--- a/internal/crypto/keystores/keystore.go
+++ b/internal/crypto/keystores/keystore.go
@@ -1,0 +1,76 @@
+// Copyright 2024 Stacklok, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package keystores contains logic for loading encryption keys from a keystores
+package keystores
+
+import (
+	"errors"
+	"fmt"
+	"path/filepath"
+
+	serverconfig "github.com/stacklok/minder/internal/config/server"
+	"github.com/stacklok/minder/internal/crypto/algorithms"
+)
+
+//go:generate go run go.uber.org/mock/mockgen -package mock_$GOPACKAGE -destination=./mock/$GOFILE -source=./$GOFILE
+
+// KeyStore represents a struct which stores or can fetch encryption keys.
+type KeyStore interface {
+	// GetKey retrieves the key for the specified algorithm by key ID.
+	GetKey(algorithm algorithms.Type, id string) ([]byte, error)
+}
+
+// ErrUnknownKeyID is returned when the Key ID cannot be found by the keystore.
+var ErrUnknownKeyID = errors.New("unknown key id")
+
+// This structure is used by the keystore implementation to manage keys.
+type keysByAlgorithmAndID map[algorithms.Type]map[string][]byte
+
+// NewKeyStoreFromConfig creates an instance of a KeyStore based on the
+// AuthConfig in Minder.
+// Since our only implementation is based on reading from the local disk, do
+// all key loading during construction of the struct.
+// TODO: allow support for multiple keys/algos
+func NewKeyStoreFromConfig(config *serverconfig.AuthConfig) (KeyStore, error) {
+	key, err := config.GetTokenKey()
+	if err != nil {
+		return nil, fmt.Errorf("unable to read encryption key from %s: %w", config.TokenKey, err)
+	}
+	name := filepath.Base(config.TokenKey)
+	keys := map[algorithms.Type]map[string][]byte{
+		algorithms.Aes256Cfb: {
+			name: key,
+		},
+	}
+	return &localFileKeyStore{
+		keys: keys,
+	}, nil
+}
+
+type localFileKeyStore struct {
+	keys keysByAlgorithmAndID
+}
+
+func (l *localFileKeyStore) GetKey(algorithm algorithms.Type, id string) ([]byte, error) {
+	algorithmKeys, ok := l.keys[algorithm]
+	if !ok {
+		return nil, fmt.Errorf("%w: %s", algorithms.ErrUnknownAlgorithm, algorithm)
+	}
+	key, ok := algorithmKeys[id]
+	if !ok {
+		return nil, fmt.Errorf("%w: %s", ErrUnknownKeyID, id)
+	}
+	return key, nil
+}

--- a/internal/crypto/keystores/keystore.go
+++ b/internal/crypto/keystores/keystore.go
@@ -48,6 +48,7 @@ func NewKeyStoreFromConfig(config *serverconfig.AuthConfig) (KeyStore, error) {
 	if err != nil {
 		return nil, fmt.Errorf("unable to read encryption key from %s: %w", config.TokenKey, err)
 	}
+	// Use the key filename as the key ID.
 	name := filepath.Base(config.TokenKey)
 	keys := map[algorithms.Type]map[string][]byte{
 		algorithms.Aes256Cfb: {

--- a/internal/crypto/models.go
+++ b/internal/crypto/models.go
@@ -17,13 +17,15 @@ package crypto
 import (
 	"encoding/json"
 	"fmt"
+
+	"github.com/stacklok/minder/internal/crypto/algorithms"
 )
 
 // EncryptedData represents the structure we use to store encrypted data in the
 // database.
 type EncryptedData struct {
 	// The type of encryption used.
-	Algorithm EncryptionAlgorithmType
+	Algorithm algorithms.Type
 	// The encrypted data represented as a base64 encoded string.
 	EncodedData string
 	// The salt used in the encryption.
@@ -44,7 +46,7 @@ func (e *EncryptedData) Serialize() (json.RawMessage, error) {
 // and should be removed once we migrate to the new encryption model.
 func NewBackwardsCompatibleEncryptedData(encryptedData string) EncryptedData {
 	return EncryptedData{
-		Algorithm:   Aes256Cfb,
+		Algorithm:   algorithms.Aes256Cfb,
 		EncodedData: encryptedData,
 		Salt:        legacySalt,
 		KeyVersion:  "",


### PR DESCRIPTION
Relates to #3304

Implement an interface which hides the specifics of loading an encryption key. This allows us to use a secret store or a key store directly in future.

Right now, the implementation uses a single key loaded from the config. In my next PR, I will generalize it to support multiple keys. This will require a new config structure.

# Summary

***Provide a brief overview of the changes and the issue being addressed. 
Explain the rationale and any background necessary for understanding the changes. 
List dependencies required by this change, if any.***

Fixes #(related issue)

## Change Type

***Mark the type of change your PR introduces:***

- [ ] Bug fix (resolves an issue without affecting existing features)
- [x] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [ ] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

***Outline how the changes were tested, including steps to reproduce and any relevant configurations. 
Attach screenshots if helpful.***

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [x] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [x] Included tests that validate the fix or feature.
- [ ] Checked that related changes are merged.
