### PR TITLE
Remove salt field from EncryptedData

### DIFF
--- a/internal/controlplane/handlers_repositories_test.go
+++ b/internal/controlplane/handlers_repositories_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 
 	"github.com/google/uuid"
+	"github.com/sqlc-dev/pqtype"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 
@@ -549,7 +550,10 @@ func createServer(
 		store.EXPECT().
 			GetAccessTokenByProjectID(gomock.Any(), gomock.Any()).
 			Return(db.ProviderAccessToken{
-				EncryptedToken: "encryptedToken",
+				EncryptedAccessToken: pqtype.NullRawMessage{
+					Valid:      true,
+					RawMessage: make(json.RawMessage, 16),
+				},
 			}, nil).AnyTimes()
 		store.EXPECT().
 			ListRepositoriesByProjectID(gomock.Any(), gomock.Any()).

--- a/internal/crypto/algorithms/algorithm.go
+++ b/internal/crypto/algorithms/algorithm.go
@@ -23,8 +23,8 @@ import (
 
 // EncryptionAlgorithm represents a crypto algorithm used by the Engine
 type EncryptionAlgorithm interface {
-	Encrypt(data []byte, key []byte, salt []byte) ([]byte, error)
-	Decrypt(data []byte, key []byte, salt []byte) ([]byte, error)
+	Encrypt(plaintext []byte, key []byte) ([]byte, error)
+	Decrypt(ciphertext []byte, key []byte) ([]byte, error)
 }
 
 // Type is an enum of supported encryption algorithms

--- a/internal/crypto/engine_test.go
+++ b/internal/crypto/engine_test.go
@@ -167,20 +167,6 @@ func TestDecryptEmpty(t *testing.T) {
 	require.ErrorContains(t, err, "cannot decrypt empty data")
 }
 
-func TestDecryptEmptySalt(t *testing.T) {
-	t.Parallel()
-
-	engine, err := NewEngineFromConfig(config)
-	require.NoError(t, err)
-	encryptedToken := EncryptedData{
-		EncodedData: "abc",
-		Salt:        nil,
-	}
-
-	_, err = engine.DecryptString(encryptedToken)
-	require.ErrorContains(t, err, "cannot decrypt data with empty salt")
-}
-
 func TestDecryptBadAlgorithm(t *testing.T) {
 	t.Parallel()
 
@@ -189,7 +175,6 @@ func TestDecryptBadAlgorithm(t *testing.T) {
 	encryptedToken := EncryptedData{
 		Algorithm:   "I'm a little teapot",
 		EncodedData: "abc",
-		Salt:        legacySalt,
 		KeyVersion:  "",
 	}
 	require.NoError(t, err)
@@ -207,7 +192,6 @@ func TestDecryptBadEncoding(t *testing.T) {
 		Algorithm: algorithms.Aes256Cfb,
 		// Unicode snowman is _not_ a valid base64 character
 		EncodedData: "☃☃☃☃☃☃☃☃☃☃☃☃☃☃☃",
-		Salt:        legacySalt,
 		KeyVersion:  "",
 	}
 	require.NoError(t, err)
@@ -225,7 +209,6 @@ func TestDecryptFailedDecryption(t *testing.T) {
 		Algorithm: algorithms.Aes256Cfb,
 		// too small of a value - will trigger the ciphertext length check
 		EncodedData: "abcdef0123456789",
-		Salt:        legacySalt,
 		KeyVersion:  "",
 	}
 	require.NoError(t, err)

--- a/internal/crypto/models.go
+++ b/internal/crypto/models.go
@@ -28,8 +28,6 @@ type EncryptedData struct {
 	Algorithm algorithms.Type
 	// The encrypted data represented as a base64 encoded string.
 	EncodedData string
-	// The salt used in the encryption.
-	Salt []byte
 	// An identifier which specifies the key used.
 	// Used to handle multiple keys during key rotation.
 	KeyVersion string
@@ -48,7 +46,6 @@ func NewBackwardsCompatibleEncryptedData(encryptedData string) EncryptedData {
 	return EncryptedData{
 		Algorithm:   algorithms.Aes256Cfb,
 		EncodedData: encryptedData,
-		Salt:        legacySalt,
 		KeyVersion:  "",
 	}
 }

--- a/internal/db/provider_access_tokens_test.go
+++ b/internal/db/provider_access_tokens_test.go
@@ -20,7 +20,11 @@ import (
 	"database/sql"
 	"testing"
 
+	"github.com/sqlc-dev/pqtype"
 	"github.com/stretchr/testify/require"
+
+	"github.com/stacklok/minder/internal/crypto"
+	"github.com/stacklok/minder/internal/crypto/algorithms"
 )
 
 func TestUpsertProviderAccessToken(t *testing.T) {
@@ -30,11 +34,15 @@ func TestUpsertProviderAccessToken(t *testing.T) {
 	project := createRandomProject(t, org.ID)
 	prov := createRandomProvider(t, project.ID)
 
+	secret := createSecret(t, "abc")
+	serialized := serializeSecret(t, secret)
+
 	tok, err := testQueries.UpsertAccessToken(context.Background(), UpsertAccessTokenParams{
-		ProjectID:      project.ID,
-		Provider:       prov.Name,
-		EncryptedToken: "abc",
-		OwnerFilter:    sql.NullString{},
+		ProjectID:            project.ID,
+		Provider:             prov.Name,
+		EncryptedToken:       "abc",
+		EncryptedAccessToken: serialized,
+		OwnerFilter:          sql.NullString{},
 	})
 
 	require.NoError(t, err)
@@ -45,6 +53,7 @@ func TestUpsertProviderAccessToken(t *testing.T) {
 	require.Equal(t, project.ID, tok.ProjectID)
 	require.Equal(t, prov.Name, tok.Provider)
 	require.Equal(t, "abc", tok.EncryptedToken)
+	require.Equal(t, secret, deserializeSecret(t, tok.EncryptedAccessToken))
 	require.Equal(t, sql.NullString{}, tok.OwnerFilter)
 
 	tokUpdate, err := testQueries.UpsertAccessToken(context.Background(), UpsertAccessTokenParams{
@@ -62,4 +71,33 @@ func TestUpsertProviderAccessToken(t *testing.T) {
 	require.Equal(t, tok.ID, tokUpdate.ID)
 	require.Equal(t, tok.CreatedAt, tokUpdate.CreatedAt)
 	require.NotEqual(t, tok.UpdatedAt, tokUpdate.UpdatedAt)
+}
+
+func createSecret(t *testing.T, encryptedData string) crypto.EncryptedData {
+	t.Helper()
+
+	return crypto.EncryptedData{
+		Algorithm:   algorithms.Aes256Cfb,
+		EncodedData: encryptedData,
+		KeyVersion:  "12345",
+	}
+}
+
+func serializeSecret(t *testing.T, data crypto.EncryptedData) pqtype.NullRawMessage {
+	t.Helper()
+
+	serialized, err := data.Serialize()
+	require.NoError(t, err)
+	return pqtype.NullRawMessage{
+		RawMessage: serialized,
+		Valid:      true,
+	}
+}
+
+func deserializeSecret(t *testing.T, data pqtype.NullRawMessage) crypto.EncryptedData {
+	t.Helper()
+
+	result, err := crypto.DeserializeEncryptedData(data.RawMessage)
+	require.NoError(t, err)
+	return result
 }


### PR DESCRIPTION
Relates to #3317

Previously EncryptedData had a dedicated salt field. As part of investigating AES-256-GCM, I have decided to follow the Go crypto library's convention of prepending the nonce/salt to the ciphertext. As a result, the salt field is no longer needed.

Since we are still using the hardcoded salt at this time, this will not impact any data in production.

Also tweaked some unit tests to use the new encrypted data structure instead of relying on the old DB columns which will be deleted in a future PR.

# Summary

***Provide a brief overview of the changes and the issue being addressed. 
Explain the rationale and any background necessary for understanding the changes. 
List dependencies required by this change, if any.***

Fixes #(related issue)

## Change Type

***Mark the type of change your PR introduces:***

- [ ] Bug fix (resolves an issue without affecting existing features)
- [ ] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [ ] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

***Outline how the changes were tested, including steps to reproduce and any relevant configurations. 
Attach screenshots if helpful.***

# Review Checklist:

- [ ] Reviewed my own code for quality and clarity.
- [ ] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [ ] Included tests that validate the fix or feature.
- [ ] Checked that related changes are merged.
