### PR TITLE
Provider classes self-register webhooks

### DIFF
--- a/internal/controlplane/handlers_providers_test.go
+++ b/internal/controlplane/handlers_providers_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/stacklok/minder/internal/auth"
 	"github.com/stacklok/minder/internal/authz/mock"
 	serverconfig "github.com/stacklok/minder/internal/config/server"
+	"github.com/stacklok/minder/internal/controlplane/metrics"
 	"github.com/stacklok/minder/internal/crypto"
 	"github.com/stacklok/minder/internal/crypto/algorithms"
 	mockcrypto "github.com/stacklok/minder/internal/crypto/mock"
@@ -128,6 +129,7 @@ func TestDeleteProvider(t *testing.T) {
 		whManager,
 		mockStore,
 		mockProvidersSvc,
+		metrics.NewNoopMetrics(),
 	)
 	providerManager, err := manager.NewProviderManager(providerStore, githubProviderManager)
 	require.NoError(t, err)
@@ -241,6 +243,7 @@ func TestDeleteProviderByID(t *testing.T) {
 		whManager,
 		mockStore,
 		mockProvidersSvc,
+		metrics.NewNoopMetrics(),
 	)
 	providerManager, err := manager.NewProviderManager(providerStore, githubProviderManager)
 	require.NoError(t, err)

--- a/internal/engine/executor_test.go
+++ b/internal/engine/executor_test.go
@@ -327,6 +327,7 @@ default allow = true`,
 		nil,
 		mockStore,
 		ghProviderService,
+		metrics.NewNoopMetrics(),
 	)
 
 	providerStore := providers.NewProviderStore(mockStore)

--- a/internal/providers/dockerhub/manager.go
+++ b/internal/providers/dockerhub/manager.go
@@ -25,6 +25,7 @@ import (
 	"github.com/stacklok/minder/internal/crypto"
 	"github.com/stacklok/minder/internal/db"
 	"github.com/stacklok/minder/internal/providers/credentials"
+	m "github.com/stacklok/minder/internal/providers/manager"
 	v1 "github.com/stacklok/minder/pkg/providers/v1"
 )
 
@@ -82,6 +83,12 @@ func (g *providerClassManager) Build(ctx context.Context, config *db.Provider) (
 // TODO: Implement this
 func (_ *providerClassManager) Delete(_ context.Context, _ *db.Provider) error {
 	return nil
+}
+
+func (_ *providerClassManager) RegisterWebhookHandlers(webhook m.HandlerRegisterer) {
+}
+
+func (_ *providerClassManager) RegisterOtherHandlers(handler m.HandlerRegisterer) {
 }
 
 func (m *providerClassManager) getProviderCredentials(

--- a/internal/providers/github/manager/handlers_githubwebhooks_test.go
+++ b/internal/providers/github/manager/handlers_githubwebhooks_test.go
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package controlplane
+package manager
 
 import (
 	"bytes"

--- a/internal/providers/manager/mock/manager.go
+++ b/internal/providers/manager/mock/manager.go
@@ -16,6 +16,7 @@ import (
 
 	uuid "github.com/google/uuid"
 	db "github.com/stacklok/minder/internal/db"
+	manager "github.com/stacklok/minder/internal/providers/manager"
 	v1 "github.com/stacklok/minder/pkg/providers/v1"
 	gomock "go.uber.org/mock/gomock"
 )
@@ -132,6 +133,30 @@ func (mr *MockProviderManagerMockRecorder) InstantiateFromNameProject(ctx, name,
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InstantiateFromNameProject", reflect.TypeOf((*MockProviderManager)(nil).InstantiateFromNameProject), ctx, name, projectID)
 }
 
+// RegisterOtherHandlers mocks base method.
+func (m *MockProviderManager) RegisterOtherHandlers(handler manager.HandlerRegisterer) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "RegisterOtherHandlers", handler)
+}
+
+// RegisterOtherHandlers indicates an expected call of RegisterOtherHandlers.
+func (mr *MockProviderManagerMockRecorder) RegisterOtherHandlers(handler any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RegisterOtherHandlers", reflect.TypeOf((*MockProviderManager)(nil).RegisterOtherHandlers), handler)
+}
+
+// RegisterWebhookHandlers mocks base method.
+func (m *MockProviderManager) RegisterWebhookHandlers(webhook manager.HandlerRegisterer) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "RegisterWebhookHandlers", webhook)
+}
+
+// RegisterWebhookHandlers indicates an expected call of RegisterWebhookHandlers.
+func (mr *MockProviderManagerMockRecorder) RegisterWebhookHandlers(webhook any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RegisterWebhookHandlers", reflect.TypeOf((*MockProviderManager)(nil).RegisterWebhookHandlers), webhook)
+}
+
 // MockProviderClassManager is a mock of ProviderClassManager interface.
 type MockProviderClassManager struct {
 	ctrl     *gomock.Controller
@@ -211,4 +236,28 @@ func (m *MockProviderClassManager) GetSupportedClasses() []db.ProviderClass {
 func (mr *MockProviderClassManagerMockRecorder) GetSupportedClasses() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSupportedClasses", reflect.TypeOf((*MockProviderClassManager)(nil).GetSupportedClasses))
+}
+
+// RegisterOtherHandlers mocks base method.
+func (m *MockProviderClassManager) RegisterOtherHandlers(handler manager.HandlerRegisterer) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "RegisterOtherHandlers", handler)
+}
+
+// RegisterOtherHandlers indicates an expected call of RegisterOtherHandlers.
+func (mr *MockProviderClassManagerMockRecorder) RegisterOtherHandlers(handler any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RegisterOtherHandlers", reflect.TypeOf((*MockProviderClassManager)(nil).RegisterOtherHandlers), handler)
+}
+
+// RegisterWebhookHandlers mocks base method.
+func (m *MockProviderClassManager) RegisterWebhookHandlers(webhook manager.HandlerRegisterer) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "RegisterWebhookHandlers", webhook)
+}
+
+// RegisterWebhookHandlers indicates an expected call of RegisterWebhookHandlers.
+func (mr *MockProviderClassManagerMockRecorder) RegisterWebhookHandlers(webhook any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RegisterWebhookHandlers", reflect.TypeOf((*MockProviderClassManager)(nil).RegisterWebhookHandlers), webhook)
 }

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -107,11 +107,14 @@ func AllInOneServerService(
 		restClientCache,
 		ghClientFactory,
 		&cfg.Provider,
+		&cfg.WebhookConfig,
 		fallbackTokenClient,
 		cryptoEngine,
 		whManager,
 		store,
 		ghProviders,
+		serverMetrics,
+		evt,
 	)
 	dockerhubProviderManager := dockerhub.NewDockerHubProviderClassManager(
 		cryptoEngine,


### PR DESCRIPTION
# Summary

This change makes provider classes self-register webhooks. This means
that a provider class manager now has to implement a registration method
as well as an HTTP handler for the webhook of the given provider.

general webhooks have the following path prefix: `/api/v1/webhook/`.
And, with this change, we now formalize the `/api/v1/webhook/github`
which we had already been using for webhooks for the github provider.

There is also a method of registering "other" handlers, which pertains
to paths that are not the main webhook, but require handling anyway.
GitHub registers two: `ghapp` and `gh-marketplace`. These have the
`/api/v1` prefix, which works with the same paths we already had.

Related-to: https://github.com/stacklok/minder/issues/3325

## Change Type

***Mark the type of change your PR introduces:***

- [ ] Bug fix (resolves an issue without affecting existing features)
- [x] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [ ] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [ ] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [ ] Included tests that validate the fix or feature.
- [ ] Checked that related changes are merged.
