### PR TITLE
Add provider store and provider manager code to create new providers

### DIFF
--- a/internal/providers/dockerhub/manager.go
+++ b/internal/providers/dockerhub/manager.go
@@ -17,6 +17,7 @@ package dockerhub
 import (
 	"context"
 	"database/sql"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"slices"
@@ -109,4 +110,22 @@ func (m *providerClassManager) getProviderCredentials(
 	}
 
 	return credentials.NewOAuth2TokenCredential(decryptedToken.AccessToken), nil
+}
+
+func (m *providerClassManager) GetConfig(
+	_ context.Context, class db.ProviderClass, userConfig json.RawMessage,
+) (json.RawMessage, error) {
+	if !slices.Contains(m.GetSupportedClasses(), class) {
+		return nil, fmt.Errorf("provider does not implement %s", string(class))
+	}
+
+	const defaultConfig = `{"dockerhub": {}}`
+
+	if len(userConfig) == 0 {
+		return json.RawMessage(defaultConfig), nil
+	}
+
+	// in the future, we may want to validate the user config and merge it with the default config. Right now
+	// we just return the user config as is
+	return userConfig, nil
 }

--- a/internal/providers/github/manager/manager.go
+++ b/internal/providers/github/manager/manager.go
@@ -18,6 +18,7 @@ package manager
 import (
 	"context"
 	"database/sql"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"slices"
@@ -291,4 +292,29 @@ type credentialDetails struct {
 	credential  v1.GitHubCredential
 	ownerFilter sql.NullString
 	isOrg       bool
+}
+
+func (g *githubProviderManager) GetConfig(
+	_ context.Context, class db.ProviderClass, userConfig json.RawMessage,
+) (json.RawMessage, error) {
+	if !slices.Contains(g.GetSupportedClasses(), class) {
+		return nil, fmt.Errorf("provider does not implement %s", string(class))
+	}
+
+	var defaultConfig string
+	// nolint:exhaustive // we really want handle only the two
+	switch class {
+	case db.ProviderClassGithub:
+		defaultConfig = `{"github": {}}`
+	case db.ProviderClassGithubApp:
+		defaultConfig = `{"github-app": {}}`
+	default:
+		return nil, fmt.Errorf("unsupported provider class %s", class)
+	}
+
+	if len(userConfig) == 0 {
+		return json.RawMessage(defaultConfig), nil
+	}
+
+	return userConfig, nil
 }

--- a/internal/providers/manager/manager.go
+++ b/internal/providers/manager/manager.go
@@ -172,7 +172,7 @@ func (p *providerManager) DeleteByName(ctx context.Context, name string, project
 }
 
 func (p *providerManager) deleteByRecord(ctx context.Context, config *db.Provider) error {
-	manager, err := p.getClassManager(config)
+	manager, err := p.getClassManager(config.Class)
 	if err != nil {
 		return err
 	}
@@ -190,15 +190,14 @@ func (p *providerManager) deleteByRecord(ctx context.Context, config *db.Provide
 }
 
 func (p *providerManager) buildFromDBRecord(ctx context.Context, config *db.Provider) (v1.Provider, error) {
-	manager, err := p.getClassManager(config)
+	manager, err := p.getClassManager(config.Class)
 	if err != nil {
 		return nil, err
 	}
 	return manager.Build(ctx, config)
 }
 
-func (p *providerManager) getClassManager(config *db.Provider) (ProviderClassManager, error) {
-	class := config.Class
+func (p *providerManager) getClassManager(class db.ProviderClass) (ProviderClassManager, error) {
 	manager, ok := p.classManagers[class]
 	if !ok {
 		return nil, fmt.Errorf("unexpected provider class: %s", class)

--- a/internal/providers/manager/manager.go
+++ b/internal/providers/manager/manager.go
@@ -17,6 +17,7 @@ package manager
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 
@@ -63,6 +64,7 @@ type ProviderManager interface {
 // specific Provider class. The idea is that ProviderManager determines the
 // class of the Provider, and delegates to the appropraite ProviderClassManager
 type ProviderClassManager interface {
+	GetConfig(ctx context.Context, class db.ProviderClass, userConfig json.RawMessage) (json.RawMessage, error)
 	// Build creates an instance of Provider based on the config in the DB
 	Build(ctx context.Context, config *db.Provider) (v1.Provider, error)
 	// Delete deletes an instance of this provider

--- a/internal/providers/manager/mock/manager.go
+++ b/internal/providers/manager/mock/manager.go
@@ -59,6 +59,21 @@ func (mr *MockProviderManagerMockRecorder) BulkInstantiateByTrait(ctx, projectID
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BulkInstantiateByTrait", reflect.TypeOf((*MockProviderManager)(nil).BulkInstantiateByTrait), ctx, projectID, trait, name)
 }
 
+// CreateFromConfig mocks base method.
+func (m *MockProviderManager) CreateFromConfig(ctx context.Context, providerClass db.ProviderClass, projectID uuid.UUID, name string, config json.RawMessage) (*db.Provider, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CreateFromConfig", ctx, providerClass, projectID, name, config)
+	ret0, _ := ret[0].(*db.Provider)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// CreateFromConfig indicates an expected call of CreateFromConfig.
+func (mr *MockProviderManagerMockRecorder) CreateFromConfig(ctx, providerClass, projectID, name, config any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateFromConfig", reflect.TypeOf((*MockProviderManager)(nil).CreateFromConfig), ctx, providerClass, projectID, name, config)
+}
+
 // DeleteByID mocks base method.
 func (m *MockProviderManager) DeleteByID(ctx context.Context, providerID, projectID uuid.UUID) error {
 	m.ctrl.T.Helper()

--- a/internal/providers/manager/mock/manager.go
+++ b/internal/providers/manager/mock/manager.go
@@ -11,6 +11,7 @@ package mock_manager
 
 import (
 	context "context"
+	json "encoding/json"
 	reflect "reflect"
 
 	uuid "github.com/google/uuid"
@@ -166,6 +167,21 @@ func (m *MockProviderClassManager) Delete(ctx context.Context, config *db.Provid
 func (mr *MockProviderClassManagerMockRecorder) Delete(ctx, config any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Delete", reflect.TypeOf((*MockProviderClassManager)(nil).Delete), ctx, config)
+}
+
+// GetConfig mocks base method.
+func (m *MockProviderClassManager) GetConfig(ctx context.Context, class db.ProviderClass, userConfig json.RawMessage) (json.RawMessage, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetConfig", ctx, class, userConfig)
+	ret0, _ := ret[0].(json.RawMessage)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetConfig indicates an expected call of GetConfig.
+func (mr *MockProviderClassManagerMockRecorder) GetConfig(ctx, class, userConfig any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetConfig", reflect.TypeOf((*MockProviderClassManager)(nil).GetConfig), ctx, class, userConfig)
 }
 
 // GetSupportedClasses mocks base method.

--- a/internal/providers/mock/store.go
+++ b/internal/providers/mock/store.go
@@ -11,6 +11,7 @@ package mock_providers
 
 import (
 	context "context"
+	json "encoding/json"
 	reflect "reflect"
 
 	uuid "github.com/google/uuid"
@@ -39,6 +40,21 @@ func NewMockProviderStore(ctrl *gomock.Controller) *MockProviderStore {
 // EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockProviderStore) EXPECT() *MockProviderStoreMockRecorder {
 	return m.recorder
+}
+
+// Create mocks base method.
+func (m *MockProviderStore) Create(ctx context.Context, providerClass db.ProviderClass, name string, projectID uuid.UUID, config json.RawMessage) (*db.Provider, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Create", ctx, providerClass, name, projectID, config)
+	ret0, _ := ret[0].(*db.Provider)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// Create indicates an expected call of Create.
+func (mr *MockProviderStoreMockRecorder) Create(ctx, providerClass, name, projectID, config any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Create", reflect.TypeOf((*MockProviderStore)(nil).Create), ctx, providerClass, name, projectID, config)
 }
 
 // Delete mocks base method.


### PR DESCRIPTION
# Summary

For both the provider auto-enrollment feature and for the OCI providers, we need
to create providers in the database. This PR implements the required provider store
and provider manager changes and will be followed by a patch to expose the functionality
through an RPC call.

Related: #3376

## Change Type

***Mark the type of change your PR introduces:***

- [ ] Bug fix (resolves an issue without affecting existing features)
- [x] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [ ] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

unit tests and as part of a larger patchset

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [ ] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [x] Included tests that validate the fix or feature.
- [ ] Checked that related changes are merged.
