### PR TITLE
Skip alerts if provider does not support it

### DIFF
--- a/internal/engine/actions/actions.go
+++ b/internal/engine/actions/actions.go
@@ -45,6 +45,7 @@ type RuleActionsEngine struct {
 
 // NewRuleActions creates a new rule actions engine
 func NewRuleActions(
+	ctx context.Context,
 	profile *minderv1.Profile,
 	ruletype *minderv1.RuleType,
 	provider provinfv1.Provider,
@@ -56,7 +57,7 @@ func NewRuleActions(
 	}
 
 	// Create the alert engine
-	alertEngine, err := alert.NewRuleAlert(ruletype, provider)
+	alertEngine, err := alert.NewRuleAlert(ctx, ruletype, provider)
 	if err != nil {
 		return nil, fmt.Errorf("cannot create rule alerter: %w", err)
 	}

--- a/internal/engine/rule_type_engine.go
+++ b/internal/engine/rule_type_engine.go
@@ -100,7 +100,7 @@ func NewRuleTypeEngine(
 		return nil, fmt.Errorf("cannot create rule evaluator: %w", err)
 	}
 
-	ae, err := actions.NewRuleActions(profile, ruletype, provider)
+	ae, err := actions.NewRuleActions(ctx, profile, ruletype, provider)
 	if err != nil {
 		return nil, fmt.Errorf("cannot create rule actions engine: %w", err)
 	}


### PR DESCRIPTION
# Summary

The idea is to make artifact rules more re-usable. This detects if the
provider implements `GitHub` and if it doesn't it merely returns a no-op
alert engine. This is handy to be able to test `artifact_signature` rule
types with DockerHub or any othe provider that's not GitHub.

## Change Type

***Mark the type of change your PR introduces:***

- [ ] Bug fix (resolves an issue without affecting existing features)
- [x] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [ ] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [ ] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [ ] Included tests that validate the fix or feature.
- [ ] Checked that related changes are merged.
