### PR TITLE
Add VerifyProviderTokenIdentity to the GitHubProviderService

### DIFF
--- a/internal/providers/github/service/mock/service.go
+++ b/internal/providers/github/service/mock/service.go
@@ -144,3 +144,17 @@ func (mr *MockGitHubProviderServiceMockRecorder) ValidateGitHubInstallationId(ct
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ValidateGitHubInstallationId", reflect.TypeOf((*MockGitHubProviderService)(nil).ValidateGitHubInstallationId), ctx, token, installationID)
 }
+
+// VerifyProviderTokenIdentity mocks base method.
+func (m *MockGitHubProviderService) VerifyProviderTokenIdentity(ctx context.Context, remoteUser, accessToken string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "VerifyProviderTokenIdentity", ctx, remoteUser, accessToken)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// VerifyProviderTokenIdentity indicates an expected call of VerifyProviderTokenIdentity.
+func (mr *MockGitHubProviderServiceMockRecorder) VerifyProviderTokenIdentity(ctx, remoteUser, accessToken any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "VerifyProviderTokenIdentity", reflect.TypeOf((*MockGitHubProviderService)(nil).VerifyProviderTokenIdentity), ctx, remoteUser, accessToken)
+}

--- a/internal/providers/github/service/service.go
+++ b/internal/providers/github/service/service.go
@@ -168,7 +168,7 @@ func (p *ghProviderService) CreateGitHubOAuthProvider(
 		if err != nil {
 			return nil, fmt.Errorf("unable to create github client: %w", err)
 		}
-		if err := verifyProviderTokenIdentity(ctx, stateData, delegate); err != nil {
+		if err := verifyProviderTokenIdentity(ctx, stateData.RemoteUser.String, delegate); err != nil {
 			return nil, ErrInvalidTokenIdentity
 		}
 	} else {
@@ -246,7 +246,7 @@ func (p *ghProviderService) CreateGitHubAppProvider(
 				if err != nil {
 					return fmt.Errorf("unable to create github client: %w", err)
 				}
-				if err := verifyProviderTokenIdentity(ctx, stateData, delegate); err != nil {
+				if err := verifyProviderTokenIdentity(ctx, stateData.RemoteUser.String, delegate); err != nil {
 					return ErrInvalidTokenIdentity
 				}
 			} else {
@@ -482,15 +482,15 @@ func (p *ghProviderService) DeleteInstallation(ctx context.Context, providerID u
 
 func verifyProviderTokenIdentity(
 	ctx context.Context,
-	stateData db.GetProjectIDBySessionStateRow,
+	remoteUser string,
 	client ghprov.Delegate,
 ) error {
 	userId, err := client.GetUserId(ctx)
 	if err != nil {
 		return fmt.Errorf("error getting user ID: %w", err)
 	}
-	if strconv.FormatInt(userId, 10) != stateData.RemoteUser.String {
-		return fmt.Errorf("user ID mismatch: %d != %s", userId, stateData.RemoteUser.String)
+	if strconv.FormatInt(userId, 10) != remoteUser {
+		return fmt.Errorf("user ID mismatch: %d != %s", userId, remoteUser)
 	}
 	return nil
 }

--- a/internal/providers/github/service/service.go
+++ b/internal/providers/github/service/service.go
@@ -68,6 +68,7 @@ type GitHubProviderService interface {
 	ValidateGitHubAppWebhookPayload(r *http.Request) (payload []byte, err error)
 	// DeleteInstallation deletes the installation from GitHub, if the provider has an associated installation
 	DeleteInstallation(ctx context.Context, providerID uuid.UUID) error
+	VerifyProviderTokenIdentity(ctx context.Context, remoteUser string, accessToken string) error
 }
 
 // TypeGitHubOrganization is the type returned from the GitHub API when the owner is an organization
@@ -492,6 +493,22 @@ func verifyProviderTokenIdentity(
 	if strconv.FormatInt(userId, 10) != remoteUser {
 		return fmt.Errorf("user ID mismatch: %d != %s", userId, remoteUser)
 	}
+	return nil
+}
+
+func (p *ghProviderService) VerifyProviderTokenIdentity(ctx context.Context, remoteUser string, accessToken string) error {
+	credential := credentials.NewGitHubTokenCredential(accessToken)
+
+	// owner is empty, as per original logic
+	_, delegate, err := p.ghClientFactory.BuildOAuthClient("", credential, "")
+	if err != nil {
+		return fmt.Errorf("unable to create github client: %w", err)
+	}
+
+	if err := verifyProviderTokenIdentity(ctx, remoteUser, delegate); err != nil {
+		return fmt.Errorf("error verifying provider token identity: %w", ErrInvalidTokenIdentity)
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
# Summary

These two commits will allow to pass provider configuration during OAuth enrollment

Related #3263

## Change Type

***Mark the type of change your PR introduces:***

- [ ] Bug fix (resolves an issue without affecting existing features)
- [x] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [ ] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

this will be properly tested in a follow-up patch

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [ ] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [x] Included tests that validate the fix or feature.
- [ ] Checked that related changes are merged.
