### PR TITLE
Trusty: Support blocking PRs through reviews

### DIFF
--- a/internal/engine/eval/trusty/config.go
+++ b/internal/engine/eval/trusty/config.go
@@ -47,9 +47,12 @@ type ecosystemConfig struct {
 	// Activity is the minimal activity score that minder needs to find to
 	// consider the package as trustworthy.
 	Activity float64 `json:"activity" mapstructure:"activity"`
+
+	// AllowMalicious disables blocking PRs introducing malicious dependencies
+	AllowMalicious bool `json:"allow_malicious" mapstructure:"allow_malicious"`
 }
 
-// config is the configuration for the vulncheck evaluator
+// config is the configuration for the trusty evaluator
 type config struct {
 	Action          pr_actions.Action `json:"action" mapstructure:"action" validate:"required"`
 	EcosystemConfig []ecosystemConfig `json:"ecosystem_config" mapstructure:"ecosystem_config" validate:"required"`
@@ -57,25 +60,28 @@ type config struct {
 
 func defaultConfig() *config {
 	return &config{
-		Action: pr_actions.ActionSummary,
+		Action: pr_actions.ActionReviewPr,
 		EcosystemConfig: []ecosystemConfig{
 			{
-				Name:       "npm",
-				Score:      5.0,
-				Provenance: 5.0,
-				Activity:   5.0,
+				Name:           "npm",
+				Score:          5.0,
+				Provenance:     5.0,
+				Activity:       5.0,
+				AllowMalicious: false,
 			},
 			{
-				Name:       "pypi",
-				Score:      5.0,
-				Provenance: 5.0,
-				Activity:   5.0,
+				Name:           "pypi",
+				Score:          5.0,
+				Provenance:     5.0,
+				Activity:       5.0,
+				AllowMalicious: false,
 			},
 			{
-				Name:       "go",
-				Score:      5.0,
-				Provenance: 5.0,
-				Activity:   5.0,
+				Name:           "go",
+				Score:          5.0,
+				Provenance:     5.0,
+				Activity:       5.0,
+				AllowMalicious: false,
 			},
 		},
 	}


### PR DESCRIPTION
# Summary

Minder now has the capability to request changes in PRs when it finds something odd based on Trusty dependency data.

This PR  also introduces a new setting in the trusty ruletype configuration to disable blocking when malicious deps are detected (all power to the users, but why would you want that?!).

Fixes https://github.com/stacklok/minder/issues/3380
Part of https://github.com/stacklok/minder/issues/3379

## Change Type

***Mark the type of change your PR introduces:***

- [ ] Bug fix (resolves an issue without affecting existing features)
- [x] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [ ] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

![image](https://github.com/stacklok/minder/assets/3935899/38b64510-3397-49f7-9d17-5ce5fc048d57)

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [ ] Added comments to complex or tricky code sections.
- [x] Updated any affected documentation.
- [ ] Included tests that validate the fix or feature.
- [ ] Checked that related changes are merged.
