### PR TITLE
Move provider OAuth config under server.Config

### DIFF
--- a/cmd/server/app/root.go
+++ b/cmd/server/app/root.go
@@ -25,7 +25,6 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 
-	"github.com/stacklok/minder/internal/auth"
 	"github.com/stacklok/minder/internal/config"
 	serverconfig "github.com/stacklok/minder/internal/config/server"
 	"github.com/stacklok/minder/internal/util/cli"
@@ -54,9 +53,6 @@ func init() {
 	RootCmd.PersistentFlags().String("config", "", "config file (default is $PWD/server-config.yaml)")
 	if err := config.RegisterDatabaseFlags(viper.GetViper(), RootCmd.PersistentFlags()); err != nil {
 		log.Fatal().Err(err).Msg("Error registering database flags")
-	}
-	if err := auth.RegisterOAuthFlags(viper.GetViper(), RootCmd.PersistentFlags()); err != nil {
-		log.Fatal().Err(err).Msg("Error registering oauth flags")
 	}
 	if err := serverconfig.RegisterIdentityFlags(viper.GetViper(), RootCmd.PersistentFlags()); err != nil {
 		log.Fatal().Err(err).Msg("Error registering identity flags")

--- a/go.mod
+++ b/go.mod
@@ -178,7 +178,6 @@ require (
 )
 
 require (
-	cloud.google.com/go/compute/metadata v0.3.0 // indirect
 	dario.cat/mergo v1.0.0
 	github.com/Microsoft/go-winio v0.6.1 // indirect
 	github.com/OneOfOne/xxhash v1.2.8 // indirect

--- a/go.sum
+++ b/go.sum
@@ -25,6 +25,7 @@ cloud.google.com/go/bigquery v1.4.0/go.mod h1:S8dzgnTigyfTmLBfrtrhyYhwRxG72rYxvf
 cloud.google.com/go/bigquery v1.5.0/go.mod h1:snEHRnqQbz117VIFhE8bmtwIDY80NLUZUMb4Nv6dBIg=
 cloud.google.com/go/bigquery v1.7.0/go.mod h1://okPTzCYNXSlb24MZs83e2Do+h+VXtc4gLoIoXIAPc=
 cloud.google.com/go/bigquery v1.8.0/go.mod h1:J5hqkt3O0uAFnINi6JXValWIb1v0goeZM77hZzJN/fQ=
+cloud.google.com/go/compute v1.25.1 h1:ZRpHJedLtTpKgr3RV1Fx23NuaAEN1Zfx9hw1u4aJdjU=
 cloud.google.com/go/compute/metadata v0.3.0 h1:Tz+eQXMEqDIKRsmY3cHTL6FVaynIjX2QxYC4trgAKZc=
 cloud.google.com/go/compute/metadata v0.3.0/go.mod h1:zFmK7XCadkQkj6TtorcaGlCW1hT1fIilQDwofLpJ20k=
 cloud.google.com/go/datastore v1.0.0/go.mod h1:LXYbyblFSglQ5pkeyhO+Qmw7ukd3C+pD7TKLgZqpHYE=

--- a/internal/auth/oauth.go
+++ b/internal/auth/oauth.go
@@ -24,13 +24,11 @@ import (
 	"slices"
 
 	go_github "github.com/google/go-github/v61/github"
-	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
 	"golang.org/x/oauth2"
 	"golang.org/x/oauth2/github"
 	"golang.org/x/oauth2/google"
 
-	"github.com/stacklok/minder/internal/config"
 	"github.com/stacklok/minder/internal/db"
 )
 
@@ -168,28 +166,4 @@ func ValidateProviderToken(_ context.Context, provider db.ProviderClass, token s
 		return nil
 	}
 	return fmt.Errorf("invalid provider: %s", provider)
-}
-
-// RegisterOAuthFlags registers client ID and secret file flags for all known
-// providers.  This is pretty tied into the internal of the auth module, so it
-// lives here, but it would be nice if we have a consistent registration
-// pattern (database flags are registered in the config module).
-func RegisterOAuthFlags(v *viper.Viper, flags *pflag.FlagSet) error {
-	for _, provider := range knownProviders {
-		idFileKey := fmt.Sprintf("%s.client_id_file", provider)
-		idFileFlag := fmt.Sprintf("%s-client-id-file", provider)
-		idFileDesc := fmt.Sprintf("File containing %s client ID", provider)
-		secretFileKey := fmt.Sprintf("%s.client_secret_file", provider)
-		secretFileFlag := fmt.Sprintf("%s-client-secret-file", provider)
-		secretFileDesc := fmt.Sprintf("File containing %s client secret", provider)
-		if err := config.BindConfigFlag(
-			v, flags, idFileKey, idFileFlag, "", idFileDesc, flags.String); err != nil {
-			return err
-		}
-		if err := config.BindConfigFlag(
-			v, flags, secretFileKey, secretFileFlag, "", secretFileDesc, flags.String); err != nil {
-			return err
-		}
-	}
-	return nil
 }

--- a/internal/auth/oauth.go
+++ b/internal/auth/oauth.go
@@ -25,17 +25,12 @@ import (
 
 	go_github "github.com/google/go-github/v61/github"
 	"github.com/spf13/viper"
+	"github.com/stacklok/minder/internal/db"
 	"golang.org/x/oauth2"
 	"golang.org/x/oauth2/github"
-	"golang.org/x/oauth2/google"
-
-	"github.com/stacklok/minder/internal/db"
 )
 
 const (
-	// Google OAuth2 provider
-	Google = "google"
-
 	// Github OAuth2 provider
 	Github = "github"
 
@@ -44,7 +39,7 @@ const (
 )
 
 // TODO:
-var knownProviders = []string{Google, Github, GitHubApp}
+var knownProviders = []string{Github, GitHubApp}
 
 // NewOAuthConfig creates a new OAuth2 config for the given provider
 // and whether the client is a CLI or web client
@@ -62,9 +57,6 @@ func NewOAuthConfig(provider string, cli bool) (*oauth2.Config, error) {
 	}
 
 	scopes := func(provider string) []string {
-		if provider == Google {
-			return []string{"profile", "email"}
-		}
 		if provider == GitHubApp {
 			return []string{}
 		}
@@ -72,9 +64,6 @@ func NewOAuthConfig(provider string, cli bool) (*oauth2.Config, error) {
 	}
 
 	endpoint := func(provider string) oauth2.Endpoint {
-		if provider == Google {
-			return google.Endpoint
-		}
 		return github.Endpoint
 	}
 

--- a/internal/config/server/config.go
+++ b/internal/config/server/config.go
@@ -19,6 +19,8 @@ package server
 
 import (
 	"fmt"
+	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/spf13/viper"
@@ -65,4 +67,15 @@ func SetViperDefaults(v *viper.Viper) {
 	v.SetEnvPrefix("minder")
 	v.SetEnvKeyReplacer(strings.NewReplacer(".", "_", "-", "_"))
 	config.SetViperStructDefaults(v, "", Config{})
+}
+
+func fileOrArg(file, arg, desc string) (string, error) {
+	if file != "" {
+		data, err := os.ReadFile(filepath.Clean(file))
+		if err != nil {
+			return "", fmt.Errorf("failed to read %s from file: %w", desc, err)
+		}
+		return string(data), nil
+	}
+	return arg, nil
 }

--- a/internal/config/server/github.go
+++ b/internal/config/server/github.go
@@ -15,8 +15,7 @@
 
 package server
 
-// ProviderConfig is the configuration for the providers
-type ProviderConfig struct {
-	GitHubApp *GitHubAppConfig `mapstructure:"github-app"`
-	GitHub    *GitHubConfig    `mapstructure:"github"`
+// GitHubConfig is the configuration for the GitHub OAuth providers
+type GitHubConfig struct {
+	OAuthClientConfig
 }

--- a/internal/config/server/github.go
+++ b/internal/config/server/github.go
@@ -17,5 +17,5 @@ package server
 
 // GitHubConfig is the configuration for the GitHub OAuth providers
 type GitHubConfig struct {
-	OAuthClientConfig
+	OAuthClientConfig `mapstructure:",squash"`
 }

--- a/internal/config/server/github_app.go
+++ b/internal/config/server/github_app.go
@@ -25,6 +25,8 @@ import (
 
 // GitHubAppConfig is the configuration for the GitHub App providers
 type GitHubAppConfig struct {
+	OAuthClientConfig
+
 	// AppName is the name of the GitHub App
 	AppName string `mapstructure:"app_name"`
 	// AppID is the ID of the GitHub App

--- a/internal/config/server/github_app.go
+++ b/internal/config/server/github_app.go
@@ -18,9 +18,6 @@ package server
 import (
 	"crypto/rsa"
 	"fmt"
-	"os"
-	"path/filepath"
-
 	"github.com/golang-jwt/jwt/v4"
 
 	"github.com/stacklok/minder/internal/config"
@@ -63,24 +60,10 @@ func (ghcfg *GitHubAppConfig) GetPrivateKey() (*rsa.PrivateKey, error) {
 
 // GetWebhookSecret returns the GitHub App's webhook secret
 func (ghcfg *GitHubAppConfig) GetWebhookSecret() (string, error) {
-	if ghcfg.WebhookSecretFile != "" {
-		data, err := os.ReadFile(filepath.Clean(ghcfg.WebhookSecretFile))
-		if err != nil {
-			return "", fmt.Errorf("failed to read GitHub App webhook secret from file: %w", err)
-		}
-		return string(data), nil
-	}
-	return ghcfg.WebhookSecret, nil
+	return fileOrArg(ghcfg.WebhookSecretFile, ghcfg.WebhookSecret, "github app webhook secret")
 }
 
 // GetFallbackToken returns the GitHub App's fallback token
 func (ghcfg *GitHubAppConfig) GetFallbackToken() (string, error) {
-	if ghcfg.FallbackTokenFile != "" {
-		data, err := os.ReadFile(filepath.Clean(ghcfg.FallbackTokenFile))
-		if err != nil {
-			return "", fmt.Errorf("failed to read GitHub App fallback token from file: %w", err)
-		}
-		return string(data), nil
-	}
-	return ghcfg.FallbackToken, nil
+	return fileOrArg(ghcfg.FallbackTokenFile, ghcfg.FallbackToken, "github app fallback token")
 }

--- a/internal/config/server/github_app.go
+++ b/internal/config/server/github_app.go
@@ -18,6 +18,7 @@ package server
 import (
 	"crypto/rsa"
 	"fmt"
+
 	"github.com/golang-jwt/jwt/v4"
 
 	"github.com/stacklok/minder/internal/config"
@@ -25,7 +26,7 @@ import (
 
 // GitHubAppConfig is the configuration for the GitHub App providers
 type GitHubAppConfig struct {
-	OAuthClientConfig
+	OAuthClientConfig `mapstructure:",squash"`
 
 	// AppName is the name of the GitHub App
 	AppName string `mapstructure:"app_name"`

--- a/internal/config/server/identity.go
+++ b/internal/config/server/identity.go
@@ -17,17 +17,13 @@ package server
 
 import (
 	"context"
-	"fmt"
-	"io"
-	"net/http"
-	"net/url"
-	"os"
-	"path/filepath"
-
 	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
 	"golang.org/x/oauth2"
 	"golang.org/x/oauth2/clientcredentials"
+	"io"
+	"net/http"
+	"net/url"
 
 	"github.com/stacklok/minder/internal/config"
 )
@@ -51,14 +47,7 @@ type IdentityConfig struct {
 
 // GetClientSecret returns the minder-server client secret
 func (sic *IdentityConfig) GetClientSecret() (string, error) {
-	if sic.ClientSecretFile != "" {
-		data, err := os.ReadFile(filepath.Clean(sic.ClientSecretFile))
-		if err != nil {
-			return "", fmt.Errorf("failed to read minder secret from file: %w", err)
-		}
-		return string(data), nil
-	}
-	return sic.ClientSecret, nil
+	return fileOrArg(sic.ClientSecretFile, sic.ClientSecret, "client secret")
 }
 
 // RegisterIdentityFlags registers the flags for the identity server

--- a/internal/config/server/identity.go
+++ b/internal/config/server/identity.go
@@ -17,13 +17,14 @@ package server
 
 import (
 	"context"
+	"io"
+	"net/http"
+	"net/url"
+
 	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
 	"golang.org/x/oauth2"
 	"golang.org/x/oauth2/clientcredentials"
-	"io"
-	"net/http"
-	"net/url"
 
 	"github.com/stacklok/minder/internal/config"
 )

--- a/internal/config/server/oauth_client.go
+++ b/internal/config/server/oauth_client.go
@@ -17,14 +17,21 @@ package server
 
 import "fmt"
 
+// OAuthClientConfig is the configuration for the OAuth client
 type OAuthClientConfig struct {
-	ClientID         string `mapstructure:"client_id"`
-	ClientIDFile     string `mapstructure:"client_id_file"`
-	ClientSecret     string `mapstructure:"client_secret"`
+	// ClientID is the OAuth client ID
+	ClientID string `mapstructure:"client_id"`
+	// ClientIDFile is the location of the file containing the OAuth client ID
+	ClientIDFile string `mapstructure:"client_id_file"`
+	// ClientSecret is the OAuth client secret
+	ClientSecret string `mapstructure:"client_secret"`
+	// ClientSecretFile is the location of the file containing the OAuth client secret
 	ClientSecretFile string `mapstructure:"client_secret_file"`
-	RedirectURI      string `mapstructure:"redirect_uri"`
+	// RedirectURI is the OAuth redirect URI
+	RedirectURI string `mapstructure:"redirect_uri"`
 }
 
+// GetClientID returns the OAuth client ID from either the file or the argument
 func (cfg *OAuthClientConfig) GetClientID() (string, error) {
 	if cfg == nil {
 		return "", fmt.Errorf("OAuthClientConfig is nil")
@@ -32,6 +39,7 @@ func (cfg *OAuthClientConfig) GetClientID() (string, error) {
 	return fileOrArg(cfg.ClientIDFile, cfg.ClientID, "client ID")
 }
 
+// GetClientSecret returns the OAuth client secret from either the file or the argument
 func (cfg *OAuthClientConfig) GetClientSecret() (string, error) {
 	if cfg == nil {
 		return "", fmt.Errorf("OAuthClientConfig is nil")

--- a/internal/config/server/oauth_client.go
+++ b/internal/config/server/oauth_client.go
@@ -1,0 +1,40 @@
+//
+// Copyright 2024 Stacklok, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package server
+
+import "fmt"
+
+type OAuthClientConfig struct {
+	ClientID         string `mapstructure:"client_id"`
+	ClientIDFile     string `mapstructure:"client_id_file"`
+	ClientSecret     string `mapstructure:"client_secret"`
+	ClientSecretFile string `mapstructure:"client_secret_file"`
+	RedirectURI      string `mapstructure:"redirect_uri"`
+}
+
+func (cfg *OAuthClientConfig) GetClientID() (string, error) {
+	if cfg == nil {
+		return "", fmt.Errorf("OAuthClientConfig is nil")
+	}
+	return fileOrArg(cfg.ClientIDFile, cfg.ClientID, "client ID")
+}
+
+func (cfg *OAuthClientConfig) GetClientSecret() (string, error) {
+	if cfg == nil {
+		return "", fmt.Errorf("OAuthClientConfig is nil")
+	}
+	return fileOrArg(cfg.ClientSecretFile, cfg.ClientSecret, "client secret")
+}

--- a/internal/config/server/webhook.go
+++ b/internal/config/server/webhook.go
@@ -18,7 +18,6 @@ package server
 import (
 	"fmt"
 	"os"
-	"path/filepath"
 	"strings"
 )
 
@@ -53,12 +52,5 @@ func (wc *WebhookConfig) GetPreviousWebhookSecrets() ([]string, error) {
 
 // GetWebhookSecret returns the GitHub App's webhook secret
 func (wc *WebhookConfig) GetWebhookSecret() (string, error) {
-	if wc.WebhookSecretFile != "" {
-		data, err := os.ReadFile(filepath.Clean(wc.WebhookSecretFile))
-		if err != nil {
-			return "", fmt.Errorf("failed to read GitHub App webhook secret from file: %w", err)
-		}
-		return string(data), nil
-	}
-	return wc.WebhookSecret, nil
+	return fileOrArg(wc.WebhookSecretFile, wc.WebhookSecret, "webhook secret")
 }

--- a/internal/controlplane/handlers_oauth.go
+++ b/internal/controlplane/handlers_oauth.go
@@ -157,7 +157,7 @@ func (s *Server) GetAuthorizationURL(ctx context.Context,
 	}
 
 	// Create a new OAuth2 config for the given provider
-	oauthConfig, err := s.providerAuthFactory(providerClass, req.Cli)
+	oauthConfig, err := s.providerAuthFactory(&s.cfg.Provider, providerClass, req.Cli)
 	if err != nil {
 		return nil, err
 	}
@@ -405,7 +405,7 @@ func (s *Server) getValidSessionState(ctx context.Context, state string) (db.Get
 
 func (s *Server) exchangeCodeForToken(ctx context.Context, providerClass string, code string) (*oauth2.Token, error) {
 	// generate a new OAuth2 config for the given provider
-	oauthConfig, err := s.providerAuthFactory(providerClass, true)
+	oauthConfig, err := s.providerAuthFactory(&s.cfg.Provider, providerClass, true)
 	if err != nil {
 		return nil, fmt.Errorf("error creating OAuth config: %w", err)
 	}

--- a/internal/controlplane/server.go
+++ b/internal/controlplane/server.go
@@ -84,7 +84,7 @@ type Server struct {
 	mt                  metrics.Metrics
 	grpcServer          *grpc.Server
 	jwt                 auth.JwtValidator
-	providerAuthFactory func(string, bool) (*oauth2.Config, error)
+	providerAuthFactory func(*serverconfig.ProviderConfig, string, bool) (*oauth2.Config, error)
 	authzClient         authz.Client
 	idClient            auth.Resolver
 	cryptoEngine        crypto.Engine


### PR DESCRIPTION
# Summary

In the next PR (#3334) we need to move the OAuth config under providers
themselves, but in order to do that, we need to get rid of the oauth client
config code calling `viper.Get` directly or else we'll break all our tests.

This PR does that and gets rid of the Google OAuth configuration and other
now-unused code.

Because the next PR will move the OAuth client code around to providers, I
didn't get overboard with testing here.

Fixes #2798

## Change Type

- [ ] Bug fix (resolves an issue without affecting existing features)
- [ ] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [x] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

make test and provider enroll

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [x] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [x] Included tests that validate the fix or feature.
- [ ] Checked that related changes are merged.
