### PR TITLE
Bump go to v1.22.3

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,5 +1,4 @@
 run:
-  go: "1.22"
   issues-exit-code: 1
   timeout: 5m
 

--- a/docker/minder/Dockerfile
+++ b/docker/minder/Dockerfile
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.22.2@sha256:aca60c1f21de99aa3a34e653f0cdc8c8ea8fe6480359229809d5bcb974f599ec AS builder
+FROM golang:1.22.3@sha256:f43c6f049f04cbbaeb28f0aad3eea15274a7d0a7899a617d0037aec48d7ab010 AS builder
 ENV APP_ROOT=/opt/app-root
 ENV GOPATH=$APP_ROOT
 

--- a/docker/reminder/Dockerfile
+++ b/docker/reminder/Dockerfile
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.22.2@sha256:aca60c1f21de99aa3a34e653f0cdc8c8ea8fe6480359229809d5bcb974f599ec AS builder
+FROM golang:1.22.3@sha256:f43c6f049f04cbbaeb28f0aad3eea15274a7d0a7899a617d0037aec48d7ab010 AS builder
 ENV APP_ROOT=/opt/app-root
 ENV GOPATH=$APP_ROOT
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/stacklok/minder
 
-go 1.22.2
+go 1.22.3
 
 require (
 	github.com/ThreeDotsLabs/watermill v1.3.5

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -1,8 +1,6 @@
 module github.com/stacklok/minder/tools
 
-go 1.22
-
-toolchain go1.22.0
+go 1.22.3
 
 require (
 	github.com/bufbuild/buf v1.32.1


### PR DESCRIPTION
# Summary

 - Bump go (toolchain) to v1.22.3

 - Remove specific go version from the run configuration in .golangci.yml as the Default is to "use Go version from the go.mod file" (https://golangci-lint.run/usage/configuration/#run-configuration)

 - Bump go base images to v1.22.3

## Change Type

- [ ] Bug fix (resolves an issue without affecting existing features)
- [x] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [ ] Refactoring or test improvements (no bug fixes or new functionality)

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [ ] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [ ] Included tests that validate the fix or feature.
- [ ] Checked that related changes are merged.
