### PR TITLE
Fix Makefiles

### DIFF
--- a/.mk/test.mk
+++ b/.mk/test.mk
@@ -20,8 +20,8 @@ COVERAGE_EXCLUSIONS="internal/db\|/mock/\|internal/auth/keycloak/client"
 COVERAGE_PACKAGES=./internal/...
 
 .PHONY: clean
-clean: ## clean up environment
-	rm -rf dist/* & rm -rf bin/*
+clean:: ## clean up environment
+	rm -rf dist/* && rm -rf bin/*
 
 .PHONY: test
 test: clean init-examples ## run tests in verbose mode

--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+default: help
+
 SHELL       ?= /bin/bash
 .SHELLFLAGS ?= -ec
 
@@ -50,10 +52,8 @@ KO_PLATFORMS=linux/amd64,linux/arm64
 # Helm package version
 HELM_PACKAGE_VERSION?=0.1.0
 
-default: help
-
 .PHONY: help
 help: ## list makefile targets
-	@echo "Usage: make [target] ...\n"
+	@echo "Usage: make [target] ..."
 	@echo "Available targets:"
 	@awk 'BEGIN {FS = ":.*##";} /^[$$()% a-zA-Z_-]+:.*?##/ { printf "  \033[36m%-20s\033[0m %s\n", $$1, $$2 } /^##@/ { printf "\n\033[1m%s\033[0m\n", substr($$0, 5) } ' $(MAKEFILE_LIST) | sort

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -13,8 +13,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-default: init-examples
+
+## use absolute makefile location
+MAKEFILE_DIR_LOCATION := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
+
+.PHONY: clean
+clean:: ## clean up environment
+	rm -rf $(MAKEFILE_DIR_LOCATION)rules-and-profiles
 
 .PHONY: init-examples
-init-examples: ## clone example rules and profiles
-	git clone https://github.com/stacklok/minder-rules-and-profiles.git examples/rules-and-profiles | true
+init-examples: clean ## clone example rules and profiles
+	git clone https://github.com/stacklok/minder-rules-and-profiles.git $(MAKEFILE_DIR_LOCATION)rules-and-profiles || true

--- a/examples/README.md
+++ b/examples/README.md
@@ -2,7 +2,7 @@
 
 ## Bootstrap the examples directory
 
-Run `make` to clone the examples from the [https://github.com/stacklok/minder-rules-and-profiles](https://github.com/stacklok/minder-rules-and-profiles)
+Run `make init-examples` to clone the examples from the [https://github.com/stacklok/minder-rules-and-profiles](https://github.com/stacklok/minder-rules-and-profiles)
 ```bash
-make 
+make init-examples
 ```


### PR DESCRIPTION
# Summary

 - sole make should only call help
 - fix command concatenation and remove unnecessary end-of-line in
   main Makefile
 - add make clean to init-examples and aggregate it with main Makefile
 - enable init-examples to be run from main Makefile and its own
   Makefile

## Change Type

- [x] Bug fix (resolves an issue without affecting existing features)
- [ ] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [ ] Refactoring or test improvements (no bug fixes or new functionality)

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [ ] Added comments to complex or tricky code sections.
- [x] Updated any affected documentation.
- [ ] Included tests that validate the fix or feature.
- [ ] Checked that related changes are merged.
