### PR TITLE
Fix packer tests

### DIFF
--- a/pkg/mindpak/build/packer.go
+++ b/pkg/mindpak/build/packer.go
@@ -109,7 +109,7 @@ func (_ *Packer) InitBundle(opts *InitOptions) (*mindpak.Bundle, error) {
 	if err := bundle.Manifest.Write(f); err != nil {
 		return nil, fmt.Errorf("writing manifest data: %w", err)
 	}
-	fmt.Printf("wrote to %s", f.Name())
+	fmt.Printf("wrote to %s\n", f.Name())
 	return bundle, nil
 }
 


### PR DESCRIPTION
# Summary

fix mindpak's build.InitBundle() func to printf to separate lines, otherwise it confuses gotestfmt thinking tests that are using the func are failed

## Change Type

- [x] Bug fix (resolves an issue without affecting existing features)
- [ ] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [ ] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

base on the [make test[-silent]](https://github.com/stacklok/minder/blob/586144c00ddd9f86d829f52721cdee0540fca38b/.mk/test.mk#L26-L32):

## before

```
$ go test -json -race -v ./pkg/mindpak/build/ | gotestfmt
📦 github.com/stacklok/minder/pkg/mindpak/build
  ❌ TestPackerInitBundle (0s)
  ✅ TestPackerInitBundle/TestPackerInitBundle (0s)
wrote to /tmp/TestPackerInitBundleTestPackerInitBundle1680469268/001/manifest.json=== CONT  TestValidateInitOpts/invalid_name
  ✅ TestPackerInitBundle/TestPackerInitBundle#01 (0s)
  ✅ TestPackerInitBundle/TestPackerInitBundle#02 (0s)
wrote to /tmp/TestPackerInitBundleTestPackerInitBundle#012127442667/001/manifest.json--- PASS: TestValidateInitOpts (0.00s)
wrote to /tmp/TestPackerInitBundleTestPackerInitBundle#02472771335/001/manifest.json--- PASS: TestPackerInitBundle (0.00s)
  ✅ TestPackerInitBundle/TestPackerInitBundle#03 (0s)
  ✅ TestPackerInitBundle/TestPackerInitBundle#04 (0s)
  ✅ TestPackerInitBundle/TestPackerInitBundle#05 (0s)
  ✅ TestPackerInitBundle/TestPackerInitBundle#06 (0s)
  ❌ TestValidateInitOpts (0s)
  ✅ TestValidateInitOpts/dir-notexists (0s)
  ✅ TestValidateInitOpts/invalid_name (0s)
  ✅ TestValidateInitOpts/invalid_namespace (0s)
  ✅ TestValidateInitOpts/noerror (0s)
  ✅ TestValidateInitOpts/noname (0s)
```
these tests actually pass:
```
$ go test -race -v ./pkg/mindpak/build/
=== RUN   TestPackerInitBundle
=== PAUSE TestPackerInitBundle
=== RUN   TestValidateInitOpts
=== PAUSE TestValidateInitOpts
=== CONT  TestValidateInitOpts
=== CONT  TestPackerInitBundle
=== RUN   TestValidateInitOpts/noerror
=== PAUSE TestValidateInitOpts/noerror
=== RUN   TestPackerInitBundle/TestPackerInitBundle
=== RUN   TestValidateInitOpts/noname
=== PAUSE TestValidateInitOpts/noname
=== PAUSE TestPackerInitBundle/TestPackerInitBundle
=== RUN   TestValidateInitOpts/invalid_name
=== PAUSE TestValidateInitOpts/invalid_name
=== RUN   TestPackerInitBundle/TestPackerInitBundle#01
=== PAUSE TestPackerInitBundle/TestPackerInitBundle#01
=== RUN   TestValidateInitOpts/invalid_namespace
=== PAUSE TestValidateInitOpts/invalid_namespace
=== RUN   TestPackerInitBundle/TestPackerInitBundle#02
=== PAUSE TestPackerInitBundle/TestPackerInitBundle#02
=== RUN   TestPackerInitBundle/TestPackerInitBundle#03
=== RUN   TestValidateInitOpts/dir-notexists
=== PAUSE TestPackerInitBundle/TestPackerInitBundle#03
=== RUN   TestPackerInitBundle/TestPackerInitBundle#04
=== PAUSE TestValidateInitOpts/dir-notexists
=== PAUSE TestPackerInitBundle/TestPackerInitBundle#04
=== CONT  TestValidateInitOpts/noerror
=== CONT  TestValidateInitOpts/invalid_name
=== CONT  TestValidateInitOpts/noname
=== CONT  TestValidateInitOpts/invalid_namespace
=== RUN   TestPackerInitBundle/TestPackerInitBundle#05
=== PAUSE TestPackerInitBundle/TestPackerInitBundle#05
=== RUN   TestPackerInitBundle/TestPackerInitBundle#06
=== CONT  TestValidateInitOpts/dir-notexists
=== PAUSE TestPackerInitBundle/TestPackerInitBundle#06
=== CONT  TestPackerInitBundle/TestPackerInitBundle#02
=== CONT  TestPackerInitBundle/TestPackerInitBundle#06
=== CONT  TestPackerInitBundle/TestPackerInitBundle
=== CONT  TestPackerInitBundle/TestPackerInitBundle#01
=== CONT  TestPackerInitBundle/TestPackerInitBundle#03
=== CONT  TestPackerInitBundle/TestPackerInitBundle#04
=== CONT  TestPackerInitBundle/TestPackerInitBundle#05
--- PASS: TestValidateInitOpts (0.00s)
    --- PASS: TestValidateInitOpts/noerror (0.00s)
    --- PASS: TestValidateInitOpts/invalid_name (0.00s)
    --- PASS: TestValidateInitOpts/noname (0.00s)
    --- PASS: TestValidateInitOpts/invalid_namespace (0.00s)
    --- PASS: TestValidateInitOpts/dir-notexists (0.00s)
wrote to /tmp/TestPackerInitBundleTestPackerInitBundle#011386013840/001/manifest.jsonwrote to /tmp/TestPackerInitBundleTestPackerInitBundle2516479195/001/manifest.jsonwrote to /tmp/TestPackerInitBundleTestPackerInitBundle#021632416926/001/manifest.json--- PASS: TestPackerInitBundle (0.00s)
    --- PASS: TestPackerInitBundle/TestPackerInitBundle#06 (0.00s)
    --- PASS: TestPackerInitBundle/TestPackerInitBundle#04 (0.00s)
    --- PASS: TestPackerInitBundle/TestPackerInitBundle#05 (0.00s)
    --- PASS: TestPackerInitBundle/TestPackerInitBundle#03 (0.00s)
    --- PASS: TestPackerInitBundle/TestPackerInitBundle#01 (0.00s)
    --- PASS: TestPackerInitBundle/TestPackerInitBundle (0.00s)
    --- PASS: TestPackerInitBundle/TestPackerInitBundle#02 (0.00s)
PASS
ok      github.com/stacklok/minder/pkg/mindpak/build    (cached)
```
## after
```
$ go test -json -race -v ./pkg/mindpak/build/ | gotestfmt
📦 github.com/stacklok/minder/pkg/mindpak/build
  ✅ TestPackerInitBundle (0s)
  ✅ TestPackerInitBundle/TestPackerInitBundle (0s)
  ✅ TestPackerInitBundle/TestPackerInitBundle#01 (0s)
  ✅ TestPackerInitBundle/TestPackerInitBundle#02 (0s)
  ✅ TestPackerInitBundle/TestPackerInitBundle#03 (0s)
  ✅ TestPackerInitBundle/TestPackerInitBundle#04 (0s)
  ✅ TestPackerInitBundle/TestPackerInitBundle#05 (0s)
  ✅ TestPackerInitBundle/TestPackerInitBundle#06 (0s)
  ✅ TestValidateInitOpts (0s)
  ✅ TestValidateInitOpts/dir-notexists (0s)
  ✅ TestValidateInitOpts/invalid_name (0s)
  ✅ TestValidateInitOpts/invalid_namespace (0s)
  ✅ TestValidateInitOpts/noerror (0s)
  ✅ TestValidateInitOpts/noname (0s)
wrote to /tmp/TestPackerInitBundleTestPackerInitBundle#013783015715/001/manifest.json
wrote to /tmp/TestPackerInitBundleTestPackerInitBundle#02639231885/001/manifest.json
wrote to /tmp/TestPackerInitBundleTestPackerInitBundle3490298723/001/manifest.json
```
---
### note: consider completely removing the [printout](https://github.com/stacklok/minder/blob/586144c00ddd9f86d829f52721cdee0540fca38b/pkg/mindpak/build/packer.go#L112) if not needed


# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [ ] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [ ] Included tests that validate the fix or feature.
- [ ] Checked that related changes are merged.
