### PR TITLE
Trusty: Block on deprecated, expose provenance

### DIFF
--- a/internal/engine/eval/trusty/actions.go
+++ b/internal/engine/eval/trusty/actions.go
@@ -106,6 +106,9 @@ const (
 
 	// TRUSTY_LOW_PROVENANCE Low trust in proof of origin
 	TRUSTY_LOW_PROVENANCE
+
+	// TRUSTY_DEPRECATED means a package was marked upstream as deprecated
+	TRUSTY_DEPRECATED
 )
 
 type templatePackageData struct {

--- a/internal/engine/eval/trusty/config.go
+++ b/internal/engine/eval/trusty/config.go
@@ -50,6 +50,9 @@ type ecosystemConfig struct {
 
 	// AllowMalicious disables blocking PRs introducing malicious dependencies
 	AllowMalicious bool `json:"allow_malicious" mapstructure:"allow_malicious"`
+
+	// AllowDeprecated disables blocking pull requests introducing deprecated packages
+	AllowDeprecated bool `json:"allow_deprecated" mapstructure:"allow_deprecated"`
 }
 
 // config is the configuration for the trusty evaluator
@@ -63,25 +66,26 @@ func defaultConfig() *config {
 		Action: pr_actions.ActionReviewPr,
 		EcosystemConfig: []ecosystemConfig{
 			{
-				Name:           "npm",
-				Score:          5.0,
-				Provenance:     5.0,
-				Activity:       5.0,
-				AllowMalicious: false,
+				Name:            "npm",
+				Score:           5.0,
+				Provenance:      5.0,
+				Activity:        5.0,
+				AllowMalicious:  false,
+				AllowDeprecated: false,
 			},
 			{
-				Name:           "pypi",
-				Score:          5.0,
-				Provenance:     5.0,
-				Activity:       5.0,
-				AllowMalicious: false,
+				Name:            "pypi",
+				Score:           5.0,
+				Provenance:      5.0,
+				Activity:        5.0,
+				AllowDeprecated: false,
 			},
 			{
-				Name:           "go",
-				Score:          5.0,
-				Provenance:     5.0,
-				Activity:       5.0,
-				AllowMalicious: false,
+				Name:            "go",
+				Score:           5.0,
+				Provenance:      5.0,
+				Activity:        5.0,
+				AllowDeprecated: false,
 			},
 		},
 	}

--- a/internal/engine/eval/trusty/trusty.go
+++ b/internal/engine/eval/trusty/trusty.go
@@ -104,6 +104,7 @@ func (e *Evaluator) Eval(ctx context.Context, pol map[string]any, res *engif.Res
 	for _, dep := range prDependencies.Deps {
 		depscore, err := getDependencyScore(ctx, e.client, dep)
 		if err != nil {
+			logger.Error().Msgf("error fetching trusty data: %s", err)
 			return fmt.Errorf("getting dependency score: %w", err)
 		}
 
@@ -111,7 +112,7 @@ func (e *Evaluator) Eval(ctx context.Context, pol map[string]any, res *engif.Res
 			logger.Info().
 				Str("dependency", dep.Dep.Name).
 				Msgf("no trusty data for dependency, skipping")
-			return nil
+			continue
 		}
 
 		classifyDependency(ctx, &logger, depscore, ruleConfig, prSummaryHandler, dep)
@@ -119,6 +120,7 @@ func (e *Evaluator) Eval(ctx context.Context, pol map[string]any, res *engif.Res
 
 	// If there are no problematic dependencies, return here
 	if len(prSummaryHandler.trackedAlternatives) == 0 {
+		logger.Debug().Msgf("no action, no packages tracked")
 		return nil
 	}
 

--- a/internal/engine/eval/trusty/trusty_rest_handler.go
+++ b/internal/engine/eval/trusty/trusty_rest_handler.go
@@ -86,6 +86,7 @@ type Reply struct {
 	Summary      ScoreSummary     `json:"summary"`
 	Alternatives AlternativesList `json:"alternatives"`
 	PackageData  PackageData      `json:"package_data"`
+	Provenance   *Provenance      `json:"provenance"`
 }
 
 // MaliciousData contains the security details when a dependency is malicious
@@ -95,6 +96,36 @@ type MaliciousData struct {
 	Published *time.Time `json:"published"`
 	Modified  *time.Time `json:"modified"`
 	Source    string     `json:"source"`
+}
+
+// Provenance has the package's provenance score and provenance type components
+type Provenance struct {
+	Score       float64               `json:"score"`
+	Description ProvenanceDescription `json:"description"`
+}
+
+// ProvenanceDescription contians the provenance types
+type ProvenanceDescription struct {
+	Historical HistoricalProvenance `json:"hp"`
+	Sigstore   SigstoreProvenance   `json:"provenance"`
+}
+
+// HistoricalProvenance has the historical provenance components from a package
+type HistoricalProvenance struct {
+	Tags     float64 `json:"tags"`
+	Common   float64 `json:"common"`
+	Overlap  float64 `json:"overlap"`
+	Versions float64 `json:"versions"`
+}
+
+// SigstoreProvenance has the sigstore certificate data when a package was signed
+// using a github actions workflow
+type SigstoreProvenance struct {
+	Issuer           string `json:"issuer"`
+	Workflow         string `json:"workflow"`
+	SourceRepository string `json:"source_repo"`
+	TokenIssuer      string `json:"token_issuer"`
+	Transparency     string `json:"transparency"`
 }
 
 func newPiClient(baseUrl string) *trustyClient {

--- a/internal/engine/eval/trusty/trusty_test.go
+++ b/internal/engine/eval/trusty/trusty_test.go
@@ -479,3 +479,42 @@ func TestBuildScoreMatrix(t *testing.T) {
 		})
 	}
 }
+
+func TestReadPackageDescription(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		name string
+		sut  *Reply
+	}{
+		{
+			name: "normal",
+			sut:  &Reply{},
+		},
+		{
+			name: "no-provenance",
+			sut: &Reply{
+				Summary: ScoreSummary{
+					Description: map[string]any{
+						"provenance": 1,
+					},
+				},
+			},
+		},
+		{
+			name: "nil-response",
+			sut:  nil,
+		},
+	} {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			data := readPackageDescription(tc.sut)
+			require.NotNil(t, data)
+			require.NotNil(t, data)
+			_, ok := data["provenance"]
+			require.True(t, ok)
+			_, ok = data["activity"]
+			require.True(t, ok)
+		})
+	}
+}


### PR DESCRIPTION
# Summary

This PR adds support for blocking pull requests introducing pull requests.

It also adds support to show provenance data (historical and sigstore) when trusty supplies it for the new dependencies. 

Fixes #3379
Fixes #3382

## Change Type

***Mark the type of change your PR introduces:***

- [ ] Bug fix (resolves an issue without affecting existing features)
- [x] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [ ] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

Added a new test for the function that computes the provenance data 

Heres the new improved section showing the deprecated flag and the provenance data:

![image](https://github.com/stacklok/minder/assets/3935899/7a4f7bfe-7760-41b2-8d83-5eee35c97f5c)


# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [x] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [x] Included tests that validate the fix or feature.
- [ ] Checked that related changes are merged.
