### PR TITLE
Branch Protection: Error out if an empty branch is given

### DIFF
--- a/internal/providers/github/common.go
+++ b/internal/providers/github/common.go
@@ -69,6 +69,8 @@ var (
 	// ErroNoCheckPermissions is a fixed error returned when the credentialed
 	// identity has not been authorized to use the checks API
 	ErroNoCheckPermissions = errors.New("missing permissions: check")
+	// ErrBranchNameEmpty is a fixed error returned when the branch name is empty
+	ErrBranchNameEmpty = errors.New("branch name cannot be empty")
 )
 
 // GitHub is the struct that contains the shared GitHub client operations
@@ -491,6 +493,9 @@ func (c *GitHub) GetRepository(ctx context.Context, owner string, name string) (
 func (c *GitHub) GetBranchProtection(ctx context.Context, owner string,
 	repo_name string, branch_name string) (*github.Protection, error) {
 	var respErr *github.ErrorResponse
+	if branch_name == "" {
+		return nil, ErrBranchNameEmpty
+	}
 
 	protection, _, err := c.client.Repositories.GetBranchProtection(ctx, owner, repo_name, branch_name)
 	if errors.As(err, &respErr) {
@@ -507,6 +512,9 @@ func (c *GitHub) GetBranchProtection(ctx context.Context, owner string,
 func (c *GitHub) UpdateBranchProtection(
 	ctx context.Context, owner, repo, branch string, preq *github.ProtectionRequest,
 ) error {
+	if branch == "" {
+		return ErrBranchNameEmpty
+	}
 	_, _, err := c.client.Repositories.UpdateBranchProtection(ctx, owner, repo, branch, preq)
 	return err
 }


### PR DESCRIPTION
# Summary

This surfaces the case where an empty branch is given to explicit branch
protection calls to GitHub. This is needed as GitHub does not properly
handle this case, and errors end up being slightly unpredictable (things
like segfaults).

Properly defaulting to non-empty branch names is handled in another PR.

Related-to: https://github.com/stacklok/minder/issues/3430

## Change Type

***Mark the type of change your PR introduces:***

- [x] Bug fix (resolves an issue without affecting existing features)
- [ ] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [x] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [ ] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [ ] Included tests that validate the fix or feature.
- [ ] Checked that related changes are merged.
