### PR TITLE
Actually return an error on branch protection get

### DIFF
--- a/internal/providers/github/common.go
+++ b/internal/providers/github/common.go
@@ -502,6 +502,8 @@ func (c *GitHub) GetBranchProtection(ctx context.Context, owner string,
 		if respErr.Message == githubBranchNotFoundMsg {
 			return nil, ErrBranchNotFound
 		}
+
+		return nil, fmt.Errorf("error getting branch protection: %w", err)
 	} else if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
# Summary

We were accidentally skipping error returning since we had missed a
`return` statement in that function.

## Change Type

***Mark the type of change your PR introduces:***

- [x] Bug fix (resolves an issue without affecting existing features)
- [ ] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [ ] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

***Outline how the changes were tested, including steps to reproduce and any relevant configurations. 
Attach screenshots if helpful.***

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [ ] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [ ] Included tests that validate the fix or feature.
- [ ] Checked that related changes are merged.
