### PR TITLE
Implement process for migrating keys and algorithms

### DIFF
--- a/cmd/server/app/common.go
+++ b/cmd/server/app/common.go
@@ -1,0 +1,71 @@
+// Copyright 2024 Stacklok, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package app
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/rs/zerolog"
+	"github.com/spf13/cobra"
+
+	serverconfig "github.com/stacklok/minder/internal/config/server"
+	"github.com/stacklok/minder/internal/db"
+)
+
+// This file contains logic shared between different commands.
+
+func wireUpDB(ctx context.Context, cfg *serverconfig.Config) (db.Store, func(), error) {
+	dbConn, _, err := cfg.Database.GetDBConnection(ctx)
+	if err != nil {
+		return nil, nil, fmt.Errorf("unable to connect to database: %w", err)
+	}
+	closer := func() {
+		err := dbConn.Close()
+		if err != nil {
+			zerolog.Ctx(ctx).Error().Err(err).Msg("error closing database connection")
+		}
+	}
+
+	return db.NewStore(dbConn), closer, nil
+}
+
+func confirm(cmd *cobra.Command, message string) (bool, error) {
+	yes, err := cmd.Flags().GetBool("yes")
+	if err != nil {
+		cmd.Printf("Error while getting yes flag: %v", err)
+	}
+	if !yes {
+		cmd.Printf("WARNING: %s. Do you want to continue? (y/n): ", message)
+		var response string
+		_, err := fmt.Scanln(&response)
+		if err != nil {
+			return false, fmt.Errorf("error while reading user input: %w", err)
+		}
+
+		if response != "y" {
+			cmd.Printf("Exiting...")
+			return false, nil
+		}
+	}
+	return true, nil
+}
+
+// cliError prints the error and exits
+func cliErrorf(cmd *cobra.Command, message string, args ...any) {
+	cmd.Printf(message, args...)
+	os.Exit(1)
+}

--- a/cmd/server/app/common.go
+++ b/cmd/server/app/common.go
@@ -43,9 +43,10 @@ func wireUpDB(ctx context.Context, cfg *serverconfig.Config) (db.Store, func(), 
 	return db.NewStore(dbConn), closer, nil
 }
 
-func confirm(cmd *cobra.Command, message string) (bool, error) {
+func confirm(cmd *cobra.Command, message string) bool {
 	yes, err := cmd.Flags().GetBool("yes")
 	if err != nil {
+		// non-fatal error
 		cmd.Printf("Error while getting yes flag: %v", err)
 	}
 	if !yes {
@@ -53,15 +54,17 @@ func confirm(cmd *cobra.Command, message string) (bool, error) {
 		var response string
 		_, err := fmt.Scanln(&response)
 		if err != nil {
-			return false, fmt.Errorf("error while reading user input: %w", err)
+			// for sake of simplicity, exit instead of returning error
+			cmd.Printf("error while reading user input: %s", err)
+			os.Exit(-1)
 		}
 
 		if response != "y" {
 			cmd.Printf("Exiting...")
-			return false, nil
+			return false
 		}
 	}
-	return true, nil
+	return true
 }
 
 // cliError prints the error and exits

--- a/cmd/server/app/encryption.go
+++ b/cmd/server/app/encryption.go
@@ -1,0 +1,34 @@
+// Copyright 2024 Stacklok, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package app
+
+import (
+	"github.com/spf13/cobra"
+)
+
+// encryptionCmd groups together the encryption-related commands
+var encryptionCmd = &cobra.Command{
+	Use:   "encryption",
+	Short: "Tools for managing encryption keys",
+	Long:  `Use with rotate to re-encrypt provider access tokens with new keys/algorithms`,
+	RunE: func(cmd *cobra.Command, _ []string) error {
+		return cmd.Usage()
+	},
+}
+
+func init() {
+	RootCmd.AddCommand(encryptionCmd)
+	encryptionCmd.PersistentFlags().BoolP("yes", "y", false, "Answer yes to all questions")
+}

--- a/cmd/server/app/encryption_purge_sessions.go
+++ b/cmd/server/app/encryption_purge_sessions.go
@@ -1,0 +1,106 @@
+// Copyright 2024 Stacklok, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package app provides the entrypoint for the minder migrations
+package app
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	_ "github.com/golang-migrate/migrate/v4/database/postgres" // nolint
+	_ "github.com/golang-migrate/migrate/v4/source/file"       // nolint
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+
+	"github.com/stacklok/minder/internal/config"
+	serverconfig "github.com/stacklok/minder/internal/config/server"
+	"github.com/stacklok/minder/internal/db"
+	"github.com/stacklok/minder/internal/logger"
+)
+
+// purgeCmd represents the `encryption purge-sessions` command
+var purgeCmd = &cobra.Command{
+	Use:   "purge-sessions",
+	Short: "Purge stale session states",
+	Long:  `deletes all session states which are more than 24 hours old`,
+	RunE: func(cmd *cobra.Command, _ []string) error {
+		cfg, err := config.ReadConfigFromViper[serverconfig.Config](viper.GetViper())
+		if err != nil {
+			cliErrorf(cmd, "unable to read config: %s", err)
+		}
+
+		ctx := logger.FromFlags(cfg.LoggingConfig).WithContext(context.Background())
+
+		// instantiate `db.Store` so we can run queries
+		store, closer, err := wireUpDB(ctx, cfg)
+		if err != nil {
+			cliErrorf(cmd, "unable to connect to database: %s", err)
+		}
+		defer closer()
+
+		yes := confirm(cmd, "Running this command will purge stale sessions")
+		if !yes {
+			return nil
+		}
+
+		// Clean up old session states (along with their secrets)
+		sessionsDeleted, err := deleteStaleSessions(ctx, cmd, store)
+		if err != nil {
+			// if we cancel or have nothing to migrate...
+			if errors.Is(err, errCancelRotation) {
+				cmd.Printf("Cleanup canceled, exiting\n")
+				return nil
+			}
+			cliErrorf(cmd, "error while deleting stale sessions: %s", err)
+		}
+		if sessionsDeleted != 0 {
+			cmd.Printf("Successfully deleted %d stale sessions\n", sessionsDeleted)
+		}
+
+		return nil
+	},
+}
+
+func deleteStaleSessions(
+	ctx context.Context,
+	cmd *cobra.Command,
+	store db.Store,
+) (int64, error) {
+	return db.WithTransaction[int64](store, func(qtx db.ExtendQuerier) (int64, error) {
+		// delete any sessions more than one day old
+		deleted, err := qtx.DeleteExpiredSessionStates(ctx)
+		if err != nil {
+			return 0, err
+		}
+
+		// skip the confirmation if there's nothing to do
+		if deleted == 0 {
+			cmd.Printf("No stale sessions to delete\n")
+			return 0, nil
+		}
+
+		// one last chance to reconsider your choices
+		yes := confirm(cmd, fmt.Sprintf("About to delete %d stale sessions", deleted))
+		if !yes {
+			return 0, errCancelRotation
+		}
+		return deleted, nil
+	})
+}
+
+func init() {
+	encryptionCmd.AddCommand(purgeCmd)
+}

--- a/cmd/server/app/encryption_rotate.go
+++ b/cmd/server/app/encryption_rotate.go
@@ -77,7 +77,7 @@ var rotateCmd = &cobra.Command{
 				cmd.Printf("Cleanup canceled, exiting\n")
 				return nil
 			}
-			cliErrorf(cmd, "error while cleanup up stale sessions: %s", err)
+			cliErrorf(cmd, "error while deleting stale sessions: %s", err)
 		}
 		if sessionsDeleted != 0 {
 			cmd.Printf("Successfully deleted %d stale sessions\n", sessionsDeleted)

--- a/cmd/server/app/encryption_rotate.go
+++ b/cmd/server/app/encryption_rotate.go
@@ -1,0 +1,255 @@
+// Copyright 2024 Stacklok, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package app provides the entrypoint for the minder migrations
+package app
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	_ "github.com/golang-migrate/migrate/v4/database/postgres" // nolint
+	_ "github.com/golang-migrate/migrate/v4/source/file"       // nolint
+	"github.com/rs/zerolog"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+
+	"github.com/stacklok/minder/internal/config"
+	serverconfig "github.com/stacklok/minder/internal/config/server"
+	"github.com/stacklok/minder/internal/crypto"
+	"github.com/stacklok/minder/internal/db"
+	"github.com/stacklok/minder/internal/logger"
+)
+
+// number of secrets to re-encrypt per batch
+const batchSize = 100
+
+// used if rotation is cancelled before commit for one reason or another
+var errCancelRotation = errors.New("cancelling rotation process")
+
+// rotateCmd represents the up command
+var rotateCmd = &cobra.Command{
+	Use:   "rotate",
+	Short: "Rotate keys and encryption algorithms",
+	Long:  `re-encrypt all provider access tokens with the default key version and algorithm`,
+	RunE: func(cmd *cobra.Command, _ []string) error {
+		cfg, err := config.ReadConfigFromViper[serverconfig.Config](viper.GetViper())
+		if err != nil {
+			cliErrorf(cmd, "unable to read config: %w", err)
+		}
+
+		ctx := logger.FromFlags(cfg.LoggingConfig).WithContext(context.Background())
+
+		// instantiate `db.Store` so we can run queries
+		store, closer, err := wireUpDB(ctx, cfg)
+		if err != nil {
+			cliErrorf(cmd, "unable to connect to database: %s", err)
+		}
+		defer closer()
+
+		yes, err := confirm(cmd, "Running this command will change encrypted secrets")
+		if err != nil {
+			cmd.Printf("Exiting without migrating\n")
+			cliErrorf(cmd, err.Error())
+		}
+		if !yes {
+			return nil
+		}
+
+		// Clean up old session secrets instead of migrating
+		sessionsDeleted, err := deleteStaleSessions(ctx, cmd, store)
+		if err != nil {
+			// if we cancel or have nothing to migrate...
+			if errors.Is(err, errCancelRotation) {
+				cmd.Printf("Cleanup canceled, exiting\n")
+				return nil
+			}
+			cliErrorf(cmd, "error while cleanup up stale sessions: %s", err)
+		}
+		if sessionsDeleted != 0 {
+			cmd.Printf("Successfully deleted %d stale sessions\n", sessionsDeleted)
+		}
+
+		// rotate the provider access tokens
+		totalRotated, err := rotateSecrets(ctx, cmd, store, cfg)
+		if err != nil {
+			// if we cancel or have nothing to migrate...
+			if errors.Is(err, errCancelRotation) {
+				cmd.Printf("Nothing to migrate, exiting\n")
+				return nil
+			}
+			cliErrorf(cmd, "error while attempting to rotate secrets: %s", err)
+		}
+
+		cmd.Printf("Successfully rotated %d secrets\n", totalRotated)
+		return nil
+	},
+}
+
+func deleteStaleSessions(
+	ctx context.Context,
+	cmd *cobra.Command,
+	store db.Store,
+) (int64, error) {
+	return db.WithTransaction[int64](store, func(qtx db.ExtendQuerier) (int64, error) {
+		// delete any sessions more than one day old
+		deleted, err := qtx.DeleteExpiredSessionStates(ctx)
+		if err != nil {
+			return 0, err
+		}
+
+		// skip the confirmation if there's nothing to do
+		if deleted == 0 {
+			cmd.Printf("No stale sessions to delete\n")
+			return 0, nil
+		}
+
+		// one last chance to reconsider your choices
+		yes, err := confirm(cmd, fmt.Sprintf("About to delete %d stale sessions", deleted))
+		if err != nil {
+			return 0, err
+		}
+		if !yes {
+			return 0, errCancelRotation
+		}
+		return deleted, nil
+	})
+}
+
+func rotateSecrets(
+	ctx context.Context,
+	cmd *cobra.Command,
+	store db.Store,
+	cfg *serverconfig.Config,
+) (int64, error) {
+	// ensure that the new config structure is set - otherwise bad things will happen
+	if cfg.Crypto.Default.KeyID == "" || cfg.Crypto.Default.Algorithm == "" {
+		cliErrorf(cmd, "defaults not defined in crypto config - exiting")
+	}
+
+	// instantiate crypto engine so that we can decrypt and re-encrypt
+	cryptoEngine, err := crypto.NewEngineFromConfig(cfg)
+	if err != nil {
+		cliErrorf(cmd, "unable to instantiate crypto engine: %s", err)
+	}
+
+	return db.WithTransaction[int64](store, func(qtx db.ExtendQuerier) (int64, error) {
+		var rotated int64 = 0
+
+		for {
+			updated, err := runRotationBatch(ctx, rotated, qtx, cryptoEngine, &cfg.Crypto)
+			if err != nil {
+				return rotated, err
+			}
+			// nothing more to do - exit loop
+			if updated == 0 {
+				break
+			}
+			rotated += updated
+		}
+
+		// print useful status for the case where there is nothing to rotate
+		if rotated == 0 {
+			return 0, errCancelRotation
+		}
+		// one last chance to reconsider your choices
+		yes, err := confirm(cmd, fmt.Sprintf("About to rotate %d secrets, do you want to continue?", rotated))
+		if err != nil {
+			return 0, err
+		}
+		if !yes {
+			return 0, errCancelRotation
+		}
+		return rotated, nil
+	})
+}
+
+func runRotationBatch(
+	ctx context.Context,
+	offset int64,
+	store db.ExtendQuerier,
+	engine crypto.Engine,
+	cfg *serverconfig.CryptoConfig,
+) (int64, error) {
+	batch, err := store.ListTokensToMigrate(ctx, db.ListTokensToMigrateParams{
+		DefaultAlgorithm:  cfg.Default.Algorithm,
+		DefaultKeyVersion: cfg.Default.KeyID,
+		BatchOffset:       offset,
+		BatchSize:         batchSize,
+	})
+	if err != nil {
+		return 0, err
+	}
+
+	zerolog.Ctx(ctx).
+		Debug().
+		Msgf("processing batch of %d tokens", len(batch))
+
+	for _, token := range batch {
+		var oldSecret crypto.EncryptedData
+		if token.EncryptedAccessToken.Valid {
+			deserialized, err := crypto.DeserializeEncryptedData(token.EncryptedAccessToken.RawMessage)
+			if err != nil {
+				return 0, tokenError(token.ID, err)
+			}
+			oldSecret = deserialized
+		} else if token.EncryptedToken.Valid {
+			oldSecret = crypto.NewBackwardsCompatibleEncryptedData(token.EncryptedToken.String)
+		} else {
+			// this should never happen
+			return 0, tokenError(token.ID, errors.New("no encrypted secret found"))
+		}
+
+		// decrypt the secret
+		decrypted, err := engine.DecryptOAuthToken(oldSecret)
+		if err != nil {
+			return 0, tokenError(token.ID, err)
+		}
+
+		// re-encrypt it with new key/algorithm
+		encrypted, err := engine.EncryptOAuthToken(&decrypted)
+		if err != nil {
+			return 0, tokenError(token.ID, err)
+		}
+
+		// update DB
+		serialized, err := encrypted.Serialize()
+		if err != nil {
+			return 0, tokenError(token.ID, err)
+		}
+
+		zerolog.Ctx(ctx).
+			Debug().
+			Msgf("updating provider token %d", token.ID)
+
+		err = store.UpdateEncryptedSecret(ctx, db.UpdateEncryptedSecretParams{
+			ID:     token.ID,
+			Secret: serialized,
+		})
+		if err != nil {
+			return 0, tokenError(token.ID, err)
+		}
+	}
+
+	return int64(len(batch)), nil
+}
+
+func tokenError(tokenID int32, err error) error {
+	return fmt.Errorf("unable to re-encrypt provider token %d: %s", tokenID, err)
+}
+
+func init() {
+	encryptionCmd.AddCommand(rotateCmd)
+}

--- a/cmd/server/app/encryption_rotate.go
+++ b/cmd/server/app/encryption_rotate.go
@@ -50,6 +50,11 @@ var rotateCmd = &cobra.Command{
 			cliErrorf(cmd, "unable to read config: %s", err)
 		}
 
+		// ensure that the new config structure is set - otherwise bad things will happen
+		if cfg.Crypto.Default.KeyID == "" || cfg.Crypto.Default.Algorithm == "" {
+			cliErrorf(cmd, "defaults not defined in crypto config - exiting")
+		}
+
 		ctx := logger.FromFlags(cfg.LoggingConfig).WithContext(context.Background())
 
 		// instantiate `db.Store` so we can run queries
@@ -127,11 +132,6 @@ func rotateSecrets(
 	store db.Store,
 	cfg *serverconfig.Config,
 ) (int64, error) {
-	// ensure that the new config structure is set - otherwise bad things will happen
-	if cfg.Crypto.Default.KeyID == "" || cfg.Crypto.Default.Algorithm == "" {
-		cliErrorf(cmd, "defaults not defined in crypto config - exiting")
-	}
-
 	// instantiate crypto engine so that we can decrypt and re-encrypt
 	cryptoEngine, err := crypto.NewEngineFromConfig(cfg)
 	if err != nil {

--- a/cmd/server/app/encryption_rotate.go
+++ b/cmd/server/app/encryption_rotate.go
@@ -47,7 +47,7 @@ var rotateCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, _ []string) error {
 		cfg, err := config.ReadConfigFromViper[serverconfig.Config](viper.GetViper())
 		if err != nil {
-			cliErrorf(cmd, "unable to read config: %w", err)
+			cliErrorf(cmd, "unable to read config: %s", err)
 		}
 
 		ctx := logger.FromFlags(cfg.LoggingConfig).WithContext(context.Background())
@@ -59,11 +59,7 @@ var rotateCmd = &cobra.Command{
 		}
 		defer closer()
 
-		yes, err := confirm(cmd, "Running this command will change encrypted secrets")
-		if err != nil {
-			cmd.Printf("Exiting without migrating\n")
-			cliErrorf(cmd, err.Error())
-		}
+		yes := confirm(cmd, "Running this command will change encrypted secrets")
 		if !yes {
 			return nil
 		}
@@ -117,10 +113,7 @@ func deleteStaleSessions(
 		}
 
 		// one last chance to reconsider your choices
-		yes, err := confirm(cmd, fmt.Sprintf("About to delete %d stale sessions", deleted))
-		if err != nil {
-			return 0, err
-		}
+		yes := confirm(cmd, fmt.Sprintf("About to delete %d stale sessions", deleted))
 		if !yes {
 			return 0, errCancelRotation
 		}
@@ -165,10 +158,7 @@ func rotateSecrets(
 			return 0, errCancelRotation
 		}
 		// one last chance to reconsider your choices
-		yes, err := confirm(cmd, fmt.Sprintf("About to rotate %d secrets, do you want to continue?", rotated))
-		if err != nil {
-			return 0, err
-		}
+		yes := confirm(cmd, fmt.Sprintf("About to rotate %d secrets, do you want to continue?", rotated))
 		if !yes {
 			return 0, errCancelRotation
 		}

--- a/cmd/server/app/migrate_down.go
+++ b/cmd/server/app/migrate_down.go
@@ -49,10 +49,7 @@ var downCmd = &cobra.Command{
 		}
 		defer dbConn.Close()
 
-		yes, err := confirm(cmd, "Running this command will change the database structure")
-		if err != nil {
-			return err
-		}
+		yes := confirm(cmd, "Running this command will change the database structure")
 		if !yes {
 			return nil
 		}

--- a/cmd/server/app/migrate_up.go
+++ b/cmd/server/app/migrate_up.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"os"
 
 	"github.com/golang-migrate/migrate/v4"
 	_ "github.com/golang-migrate/migrate/v4/database/postgres" // nolint
@@ -56,28 +55,17 @@ var upCmd = &cobra.Command{
 		}
 		defer dbConn.Close()
 
-		yes, err := cmd.Flags().GetBool("yes")
+		yes, err := confirm(cmd, "Running this command will change the database structure")
 		if err != nil {
-			cmd.Printf("Error while getting yes flag: %v", err)
+			return err
 		}
 		if !yes {
-			cmd.Print("WARNING: Running this command will change the database structure. Are you want to continue? (y/n): ")
-			var response string
-			_, err := fmt.Scanln(&response)
-			if err != nil {
-				return fmt.Errorf("error while reading user input: %w", err)
-			}
-
-			if response == "n" {
-				cmd.Printf("Exiting...")
-				return nil
-			}
+			return nil
 		}
 
 		m, err := database.NewFromConnectionString(connString)
 		if err != nil {
-			cmd.Printf("Error while creating migration instance: %v\n", err)
-			os.Exit(1)
+			cliErrorf(cmd, "Error while creating migration instance: %v\n", err)
 		}
 
 		var usteps uint
@@ -94,8 +82,7 @@ var upCmd = &cobra.Command{
 
 		if err != nil {
 			if !errors.Is(err, migrate.ErrNoChange) {
-				cmd.Printf("Error while migrating database: %v\n", err)
-				os.Exit(1)
+				cliErrorf(cmd, "Error while migrating database: %v\n", err)
 			} else {
 				cmd.Println("Database already up-to-date")
 			}

--- a/cmd/server/app/migrate_up.go
+++ b/cmd/server/app/migrate_up.go
@@ -55,10 +55,7 @@ var upCmd = &cobra.Command{
 		}
 		defer dbConn.Close()
 
-		yes, err := confirm(cmd, "Running this command will change the database structure")
-		if err != nil {
-			return err
-		}
+		yes := confirm(cmd, "Running this command will change the database structure")
 		if !yes {
 			return nil
 		}

--- a/database/mock/store.go
+++ b/database/mock/store.go
@@ -326,11 +326,12 @@ func (mr *MockStoreMockRecorder) DeleteArtifact(arg0, arg1 any) *gomock.Call {
 }
 
 // DeleteExpiredSessionStates mocks base method.
-func (m *MockStore) DeleteExpiredSessionStates(arg0 context.Context) error {
+func (m *MockStore) DeleteExpiredSessionStates(arg0 context.Context) (int64, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteExpiredSessionStates", arg0)
-	ret0, _ := ret[0].(error)
-	return ret0
+	ret0, _ := ret[0].(int64)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
 // DeleteExpiredSessionStates indicates an expected call of DeleteExpiredSessionStates.
@@ -1422,6 +1423,21 @@ func (mr *MockStoreMockRecorder) ListRuleTypesByProject(arg0, arg1 any) *gomock.
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListRuleTypesByProject", reflect.TypeOf((*MockStore)(nil).ListRuleTypesByProject), arg0, arg1)
 }
 
+// ListTokensToMigrate mocks base method.
+func (m *MockStore) ListTokensToMigrate(arg0 context.Context, arg1 db.ListTokensToMigrateParams) ([]db.ProviderAccessToken, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListTokensToMigrate", arg0, arg1)
+	ret0, _ := ret[0].([]db.ProviderAccessToken)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListTokensToMigrate indicates an expected call of ListTokensToMigrate.
+func (mr *MockStoreMockRecorder) ListTokensToMigrate(arg0, arg1 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListTokensToMigrate", reflect.TypeOf((*MockStore)(nil).ListTokensToMigrate), arg0, arg1)
+}
+
 // ListUsers mocks base method.
 func (m *MockStore) ListUsers(arg0 context.Context, arg1 db.ListUsersParams) ([]db.User, error) {
 	m.ctrl.T.Helper()
@@ -1507,6 +1523,20 @@ func (m *MockStore) SetCurrentVersion(arg0 context.Context, arg1 db.SetCurrentVe
 func (mr *MockStoreMockRecorder) SetCurrentVersion(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetCurrentVersion", reflect.TypeOf((*MockStore)(nil).SetCurrentVersion), arg0, arg1)
+}
+
+// UpdateEncryptedSecret mocks base method.
+func (m *MockStore) UpdateEncryptedSecret(arg0 context.Context, arg1 db.UpdateEncryptedSecretParams) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpdateEncryptedSecret", arg0, arg1)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// UpdateEncryptedSecret indicates an expected call of UpdateEncryptedSecret.
+func (mr *MockStoreMockRecorder) UpdateEncryptedSecret(arg0, arg1 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateEncryptedSecret", reflect.TypeOf((*MockStore)(nil).UpdateEncryptedSecret), arg0, arg1)
 }
 
 // UpdateLease mocks base method.

--- a/database/query/session_store.sql
+++ b/database/query/session_store.sql
@@ -7,5 +7,5 @@ SELECT provider, project_id, remote_user, owner_filter, provider_config, redirec
 -- name: DeleteSessionStateByProjectID :exec
 DELETE FROM session_store WHERE provider = $1 AND project_id = $2;
 
--- name: DeleteExpiredSessionStates :exec
+-- name: DeleteExpiredSessionStates :execrows
 DELETE FROM session_store WHERE created_at < NOW() - INTERVAL '1 day';

--- a/internal/db/session_store.sql.go
+++ b/internal/db/session_store.sql.go
@@ -54,13 +54,16 @@ func (q *Queries) CreateSessionState(ctx context.Context, arg CreateSessionState
 	return i, err
 }
 
-const deleteExpiredSessionStates = `-- name: DeleteExpiredSessionStates :exec
+const deleteExpiredSessionStates = `-- name: DeleteExpiredSessionStates :execrows
 DELETE FROM session_store WHERE created_at < NOW() - INTERVAL '1 day'
 `
 
-func (q *Queries) DeleteExpiredSessionStates(ctx context.Context) error {
-	_, err := q.db.ExecContext(ctx, deleteExpiredSessionStates)
-	return err
+func (q *Queries) DeleteExpiredSessionStates(ctx context.Context) (int64, error) {
+	result, err := q.db.ExecContext(ctx, deleteExpiredSessionStates)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected()
 }
 
 const deleteSessionStateByProjectID = `-- name: DeleteSessionStateByProjectID :exec


### PR DESCRIPTION
Fixes #3315

Implement CLI command which is used to migrate keys and algorithms. This will:

1) Open connection to the DB
2) Query for secrets which do not have the default key ID or algorithm 3) Decrypts and re-encrypts with new data
4) Wraps all the above in a transaction which asks permission before
   commiting

State secrets in the session state table are deleted. Since they are short-lived secrets, there is no point in migrating them.

Tested locally.

# Summary

***Provide a brief overview of the changes and the issue being addressed. 
Explain the rationale and any background necessary for understanding the changes. 
List dependencies required by this change, if any.***

Fixes #(related issue)

## Change Type

***Mark the type of change your PR introduces:***

- [ ] Bug fix (resolves an issue without affecting existing features)
- [x] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [ ] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

***Outline how the changes were tested, including steps to reproduce and any relevant configurations. 
Attach screenshots if helpful.***

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [x] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [ ] Included tests that validate the fix or feature.
- [ ] Checked that related changes are merged.
