### PR TITLE
Define rule instance table for Minder

### DIFF
--- a/database/migrations/000060_rule_instances.down.sql
+++ b/database/migrations/000060_rule_instances.down.sql
@@ -1,0 +1,20 @@
+-- Copyright 2024 Stacklok, Inc
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--      http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+BEGIN;
+
+DROP TABLE rule_instances;
+ALTER TABLE entity_profiles DROP COLUMN migrated;
+
+COMMIT;

--- a/database/migrations/000060_rule_instances.up.sql
+++ b/database/migrations/000060_rule_instances.up.sql
@@ -28,6 +28,11 @@ CREATE TABLE IF NOT EXISTS rule_instances(
     UNIQUE (profile_id, entity_type, name)
 );
 
+-- this reflects likely access patterns for this table - retrieving all rule
+-- instances for a given profile, and all rules by profile and entity type
+CREATE INDEX idx_rule_instances_profile ON rule_instances(profile_id);
+CREATE INDEX idx_rule_instances_profile_entity ON rule_instances(profile_id, entity_type);
+
 -- this will be used for migration purposes
 ALTER TABLE entity_profiles ADD COLUMN migrated BOOL DEFAULT FALSE NOT NULL;
 

--- a/database/migrations/000060_rule_instances.up.sql
+++ b/database/migrations/000060_rule_instances.up.sql
@@ -24,8 +24,7 @@ CREATE TABLE IF NOT EXISTS rule_instances(
     params       JSONB NOT NULL,
     created_at   TIMESTAMP NOT NULL DEFAULT NOW(),
     updated_at   TIMESTAMP NOT NULL DEFAULT NOW(),
-    -- equivalent to constraint on entity_profile_rules
-    UNIQUE (profile_id, entity_type, rule_type_id),
+    -- equivalent to constraints enforced by rule validation
     UNIQUE (profile_id, entity_type, name)
 );
 

--- a/database/migrations/000060_rule_instances.up.sql
+++ b/database/migrations/000060_rule_instances.up.sql
@@ -1,0 +1,35 @@
+-- Copyright 2024 Stacklok, Inc
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--      http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS rule_instances(
+    id           UUID NOT NULL DEFAULT gen_random_uuid() PRIMARY KEY,
+    profile_id   UUID NOT NULL REFERENCES profiles(id) ON DELETE CASCADE,
+    rule_type_id UUID NOT NULL REFERENCES rule_type(id),
+    name         TEXT NOT NULL,
+    entity_type  entities NOT NULL,
+    def          JSONB NOT NULL,
+    params       JSONB NOT NULL,
+    created_at   TIMESTAMP NOT NULL DEFAULT NOW(),
+    updated_at   TIMESTAMP NOT NULL DEFAULT NOW(),
+    -- equivalent to constraint on entity_profile_rules
+    UNIQUE (profile_id, entity_type, rule_type_id),
+    UNIQUE (profile_id, entity_type, name)
+);
+
+-- this will be used for migration purposes
+ALTER TABLE entity_profiles ADD COLUMN migrated BOOL DEFAULT FALSE NOT NULL;
+
+COMMIT;

--- a/database/migrations/000060_rule_instances.up.sql
+++ b/database/migrations/000060_rule_instances.up.sql
@@ -20,8 +20,8 @@ CREATE TABLE IF NOT EXISTS rule_instances(
     rule_type_id UUID NOT NULL REFERENCES rule_type(id),
     name         TEXT NOT NULL,
     entity_type  entities NOT NULL,
-    def          JSONB NOT NULL,
-    params       JSONB NOT NULL,
+    def          JSONB, -- stores the values needed by the rule type's `def`
+    params       JSONB, -- stores the values needed by the rule type's `params`
     created_at   TIMESTAMP NOT NULL DEFAULT NOW(),
     updated_at   TIMESTAMP NOT NULL DEFAULT NOW(),
     -- equivalent to constraints enforced by rule validation

--- a/database/query/profiles.sql
+++ b/database/query/profiles.sql
@@ -22,7 +22,14 @@ WHERE id = $1 AND project_id = $2 RETURNING *;
 INSERT INTO entity_profiles (
     entity,
     profile_id,
-    contextual_rules) VALUES ($1, $2, sqlc.arg(contextual_rules)::jsonb) RETURNING *;
+    contextual_rules,
+    migrated
+) VALUES (
+    $1,
+    $2,
+    sqlc.arg(contextual_rules)::jsonb,
+    FALSE
+) RETURNING *;
 
 -- name: UpsertProfileForEntity :one
 INSERT INTO entity_profiles (
@@ -33,7 +40,7 @@ INSERT INTO entity_profiles (
 ) VALUES ($1, $2, sqlc.arg(contextual_rules)::jsonb, false)
 ON CONFLICT (entity, profile_id) DO UPDATE SET
     contextual_rules = sqlc.arg(contextual_rules)::jsonb,
-    migrated = false
+    migrated = FALSE
 RETURNING *;
 
 -- name: DeleteProfileForEntity :exec

--- a/database/query/profiles.sql
+++ b/database/query/profiles.sql
@@ -28,9 +28,12 @@ INSERT INTO entity_profiles (
 INSERT INTO entity_profiles (
     entity,
     profile_id,
-    contextual_rules) VALUES ($1, $2, sqlc.arg(contextual_rules)::jsonb)
+    contextual_rules,
+    migrated
+) VALUES ($1, $2, sqlc.arg(contextual_rules)::jsonb, false)
 ON CONFLICT (entity, profile_id) DO UPDATE SET
-    contextual_rules = sqlc.arg(contextual_rules)::jsonb
+    contextual_rules = sqlc.arg(contextual_rules)::jsonb,
+    migrated = false
 RETURNING *;
 
 -- name: DeleteProfileForEntity :exec

--- a/internal/db/models.go
+++ b/internal/db/models.go
@@ -639,15 +639,15 @@ type RuleEvaluation struct {
 }
 
 type RuleInstance struct {
-	ID         uuid.UUID       `json:"id"`
-	ProfileID  uuid.UUID       `json:"profile_id"`
-	RuleTypeID uuid.UUID       `json:"rule_type_id"`
-	Name       string          `json:"name"`
-	EntityType Entities        `json:"entity_type"`
-	Def        json.RawMessage `json:"def"`
-	Params     json.RawMessage `json:"params"`
-	CreatedAt  time.Time       `json:"created_at"`
-	UpdatedAt  time.Time       `json:"updated_at"`
+	ID         uuid.UUID             `json:"id"`
+	ProfileID  uuid.UUID             `json:"profile_id"`
+	RuleTypeID uuid.UUID             `json:"rule_type_id"`
+	Name       string                `json:"name"`
+	EntityType Entities              `json:"entity_type"`
+	Def        pqtype.NullRawMessage `json:"def"`
+	Params     pqtype.NullRawMessage `json:"params"`
+	CreatedAt  time.Time             `json:"created_at"`
+	UpdatedAt  time.Time             `json:"updated_at"`
 }
 
 type RuleType struct {

--- a/internal/db/models.go
+++ b/internal/db/models.go
@@ -462,6 +462,7 @@ type EntityProfile struct {
 	ContextualRules json.RawMessage `json:"contextual_rules"`
 	CreatedAt       time.Time       `json:"created_at"`
 	UpdatedAt       time.Time       `json:"updated_at"`
+	Migrated        bool            `json:"migrated"`
 }
 
 type EntityProfileRule struct {
@@ -635,6 +636,18 @@ type RuleEvaluation struct {
 	ArtifactID    uuid.NullUUID `json:"artifact_id"`
 	PullRequestID uuid.NullUUID `json:"pull_request_id"`
 	RuleName      string        `json:"rule_name"`
+}
+
+type RuleInstance struct {
+	ID         uuid.UUID       `json:"id"`
+	ProfileID  uuid.UUID       `json:"profile_id"`
+	RuleTypeID uuid.UUID       `json:"rule_type_id"`
+	Name       string          `json:"name"`
+	EntityType Entities        `json:"entity_type"`
+	Def        json.RawMessage `json:"def"`
+	Params     json.RawMessage `json:"params"`
+	CreatedAt  time.Time       `json:"created_at"`
+	UpdatedAt  time.Time       `json:"updated_at"`
 }
 
 type RuleType struct {

--- a/internal/db/profiles.sql.go
+++ b/internal/db/profiles.sql.go
@@ -114,7 +114,7 @@ const createProfileForEntity = `-- name: CreateProfileForEntity :one
 INSERT INTO entity_profiles (
     entity,
     profile_id,
-    contextual_rules) VALUES ($1, $2, $3::jsonb) RETURNING id, entity, profile_id, contextual_rules, created_at, updated_at
+    contextual_rules) VALUES ($1, $2, $3::jsonb) RETURNING id, entity, profile_id, contextual_rules, created_at, updated_at, migrated
 `
 
 type CreateProfileForEntityParams struct {
@@ -133,6 +133,7 @@ func (q *Queries) CreateProfileForEntity(ctx context.Context, arg CreateProfileF
 		&i.ContextualRules,
 		&i.CreatedAt,
 		&i.UpdatedAt,
+		&i.Migrated,
 	)
 	return i, err
 }
@@ -326,7 +327,7 @@ func (q *Queries) GetProfileByProjectAndID(ctx context.Context, arg GetProfileBy
 }
 
 const getProfileForEntity = `-- name: GetProfileForEntity :one
-SELECT id, entity, profile_id, contextual_rules, created_at, updated_at FROM entity_profiles WHERE profile_id = $1 AND entity = $2
+SELECT id, entity, profile_id, contextual_rules, created_at, updated_at, migrated FROM entity_profiles WHERE profile_id = $1 AND entity = $2
 `
 
 type GetProfileForEntityParams struct {
@@ -344,6 +345,7 @@ func (q *Queries) GetProfileForEntity(ctx context.Context, arg GetProfileForEnti
 		&i.ContextualRules,
 		&i.CreatedAt,
 		&i.UpdatedAt,
+		&i.Migrated,
 	)
 	return i, err
 }
@@ -564,10 +566,13 @@ const upsertProfileForEntity = `-- name: UpsertProfileForEntity :one
 INSERT INTO entity_profiles (
     entity,
     profile_id,
-    contextual_rules) VALUES ($1, $2, $3::jsonb)
+    contextual_rules,
+    migrated
+) VALUES ($1, $2, $3::jsonb, false)
 ON CONFLICT (entity, profile_id) DO UPDATE SET
-    contextual_rules = $3::jsonb
-RETURNING id, entity, profile_id, contextual_rules, created_at, updated_at
+    contextual_rules = $3::jsonb,
+    migrated = false
+RETURNING id, entity, profile_id, contextual_rules, created_at, updated_at, migrated
 `
 
 type UpsertProfileForEntityParams struct {
@@ -586,6 +591,7 @@ func (q *Queries) UpsertProfileForEntity(ctx context.Context, arg UpsertProfileF
 		&i.ContextualRules,
 		&i.CreatedAt,
 		&i.UpdatedAt,
+		&i.Migrated,
 	)
 	return i, err
 }

--- a/internal/db/profiles.sql.go
+++ b/internal/db/profiles.sql.go
@@ -114,7 +114,14 @@ const createProfileForEntity = `-- name: CreateProfileForEntity :one
 INSERT INTO entity_profiles (
     entity,
     profile_id,
-    contextual_rules) VALUES ($1, $2, $3::jsonb) RETURNING id, entity, profile_id, contextual_rules, created_at, updated_at, migrated
+    contextual_rules,
+    migrated
+) VALUES (
+    $1,
+    $2,
+    $3::jsonb,
+    FALSE
+) RETURNING id, entity, profile_id, contextual_rules, created_at, updated_at, migrated
 `
 
 type CreateProfileForEntityParams struct {
@@ -571,7 +578,7 @@ INSERT INTO entity_profiles (
 ) VALUES ($1, $2, $3::jsonb, false)
 ON CONFLICT (entity, profile_id) DO UPDATE SET
     contextual_rules = $3::jsonb,
-    migrated = false
+    migrated = FALSE
 RETURNING id, entity, profile_id, contextual_rules, created_at, updated_at, migrated
 `
 


### PR DESCRIPTION
Rule instances are currently stored as serialized protobuf structures in the database, grouped by entity type. A separate join table exists to track the relationship between a profile-entity and the rule types which are used. This arrangement leads to some rather awkward code and database queries making the profile-related code in Minder more complex than it should be.

This PR adds in a definition of a dedicated rule instance table. Subsequent PRs will migrate data over to it and then change the codebase to query this table instead of the current tables.

# Summary

***Provide a brief overview of the changes and the issue being addressed. 
Explain the rationale and any background necessary for understanding the changes. 
List dependencies required by this change, if any.***

Fixes #(related issue)

## Change Type

***Mark the type of change your PR introduces:***

- [ ] Bug fix (resolves an issue without affecting existing features)
- [ ] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [x] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

***Outline how the changes were tested, including steps to reproduce and any relevant configurations. 
Attach screenshots if helpful.***

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [x] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [ ] Included tests that validate the fix or feature.
- [ ] Checked that related changes are merged.
