### PR TITLE
Use fallback key ID when key version is empty

### DIFF
--- a/internal/crypto/engine.go
+++ b/internal/crypto/engine.go
@@ -194,12 +194,6 @@ func (e *engine) decrypt(data EncryptedData) ([]byte, error) {
 		return nil, fmt.Errorf("%w: %s", algorithms.ErrUnknownAlgorithm, e.defaultAlgorithm)
 	}
 
-	// for backwards compatibility with encrypted data which doesn't have the
-	// key ID stored in the DB.
-	if data.KeyVersion == "" {
-		data.KeyVersion = e.defaultKeyID
-	}
-
 	key, err := e.keystore.GetKey(data.KeyVersion)
 	if err != nil {
 		// error from keystore is good enough - we do not need more context

--- a/internal/crypto/engine_test.go
+++ b/internal/crypto/engine_test.go
@@ -179,6 +179,22 @@ func TestDecryptBadEncoding(t *testing.T) {
 	engine, err := NewEngineFromConfig(config)
 	require.NoError(t, err)
 	encryptedToken := EncryptedData{
+		Algorithm:   algorithms.Aes256Cfb,
+		EncodedData: "abc",
+		KeyVersion:  "test_encryption_key",
+	}
+	require.NoError(t, err)
+
+	_, err = engine.DecryptString(encryptedToken)
+	require.ErrorContains(t, err, "error decoding secret")
+}
+
+func TestDecryptNoVersionNoFallback(t *testing.T) {
+	t.Parallel()
+
+	engine, err := NewEngineFromConfig(config)
+	require.NoError(t, err)
+	encryptedToken := EncryptedData{
 		Algorithm: algorithms.Aes256Cfb,
 		// Unicode snowman is _not_ a valid base64 character
 		EncodedData: "☃☃☃☃☃☃☃☃☃☃☃☃☃☃☃",
@@ -187,7 +203,7 @@ func TestDecryptBadEncoding(t *testing.T) {
 	require.NoError(t, err)
 
 	_, err = engine.DecryptString(encryptedToken)
-	require.ErrorContains(t, err, "error decoding secret")
+	require.ErrorContains(t, err, "empty key ID with no config defined")
 }
 
 func TestDecryptFailedDecryption(t *testing.T) {
@@ -199,7 +215,7 @@ func TestDecryptFailedDecryption(t *testing.T) {
 		Algorithm: algorithms.Aes256Cfb,
 		// too small of a value - will trigger the ciphertext length check
 		EncodedData: "abcdef0123456789",
-		KeyVersion:  "",
+		KeyVersion:  "test_encryption_key",
 	}
 	require.NoError(t, err)
 

--- a/internal/crypto/keystores/keystore_test.go
+++ b/internal/crypto/keystores/keystore_test.go
@@ -96,9 +96,6 @@ func TestNewKeyStoreFromConfig(t *testing.T) {
 func TestLocalFileKeyStore_GetKey(t *testing.T) {
 	t.Parallel()
 
-	keyID := "my_key"
-	key := []byte{0, 1, 2, 3, 4, 5, 6, 7, 8, 9}
-
 	keystore := keystores.NewKeyStoreFromMap(
 		map[string][]byte{
 			keyID: key,
@@ -116,9 +113,6 @@ func TestLocalFileKeyStore_GetKey(t *testing.T) {
 
 func TestLocalFileKeyStore_GetKeyEmptyString(t *testing.T) {
 	t.Parallel()
-
-	keyID := "my_key"
-	key := []byte{0, 1, 2, 3, 4, 5, 6, 7, 8, 9}
 
 	keystore := keystores.NewKeyStoreFromMap(
 		map[string][]byte{
@@ -138,9 +132,6 @@ func TestLocalFileKeyStore_GetKeyEmptyString(t *testing.T) {
 func TestLocalFileKeyStore_GetKeyEmptyStringNoFallback(t *testing.T) {
 	t.Parallel()
 
-	keyID := "my_key"
-	key := []byte{0, 1, 2, 3, 4, 5, 6, 7, 8, 9}
-
 	keystore := keystores.NewKeyStoreFromMap(
 		map[string][]byte{
 			keyID: key,
@@ -151,3 +142,11 @@ func TestLocalFileKeyStore_GetKeyEmptyStringNoFallback(t *testing.T) {
 	_, err := keystore.GetKey("")
 	require.ErrorContains(t, err, "empty key ID with no config defined")
 }
+
+const (
+	keyID = "my_key"
+)
+
+var (
+	key = []byte{0, 1, 2, 3, 4, 5, 6, 7, 8, 9}
+)

--- a/internal/crypto/keystores/keystore_test.go
+++ b/internal/crypto/keystores/keystore_test.go
@@ -125,8 +125,9 @@ func TestLocalFileKeyStore_GetKeyEmptyString(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, key, result)
 
-	_, err = keystore.GetKey("foobar")
-	require.ErrorIs(t, err, keystores.ErrUnknownKeyID)
+	result, err = keystore.GetKey(keyID)
+	require.NoError(t, err)
+	require.Equal(t, key, result)
 }
 
 func TestLocalFileKeyStore_GetKeyEmptyStringNoFallback(t *testing.T) {

--- a/internal/crypto/keystores/keystore_test.go
+++ b/internal/crypto/keystores/keystore_test.go
@@ -99,9 +99,12 @@ func TestLocalFileKeyStore_GetKey(t *testing.T) {
 	keyID := "my_key"
 	key := []byte{0, 1, 2, 3, 4, 5, 6, 7, 8, 9}
 
-	keystore := keystores.NewKeyStoreFromMap(map[string][]byte{
-		keyID: key,
-	})
+	keystore := keystores.NewKeyStoreFromMap(
+		map[string][]byte{
+			keyID: key,
+		},
+		"",
+	)
 
 	result, err := keystore.GetKey(keyID)
 	require.NoError(t, err)
@@ -109,4 +112,42 @@ func TestLocalFileKeyStore_GetKey(t *testing.T) {
 
 	_, err = keystore.GetKey("foobar")
 	require.ErrorIs(t, err, keystores.ErrUnknownKeyID)
+}
+
+func TestLocalFileKeyStore_GetKeyEmptyString(t *testing.T) {
+	t.Parallel()
+
+	keyID := "my_key"
+	key := []byte{0, 1, 2, 3, 4, 5, 6, 7, 8, 9}
+
+	keystore := keystores.NewKeyStoreFromMap(
+		map[string][]byte{
+			keyID: key,
+		},
+		keyID,
+	)
+
+	result, err := keystore.GetKey("")
+	require.NoError(t, err)
+	require.Equal(t, key, result)
+
+	_, err = keystore.GetKey("foobar")
+	require.ErrorIs(t, err, keystores.ErrUnknownKeyID)
+}
+
+func TestLocalFileKeyStore_GetKeyEmptyStringNoFallback(t *testing.T) {
+	t.Parallel()
+
+	keyID := "my_key"
+	key := []byte{0, 1, 2, 3, 4, 5, 6, 7, 8, 9}
+
+	keystore := keystores.NewKeyStoreFromMap(
+		map[string][]byte{
+			keyID: key,
+		},
+		"",
+	)
+
+	_, err := keystore.GetKey("")
+	require.ErrorContains(t, err, "empty key ID with no config defined")
 }


### PR DESCRIPTION
This addresses a bug preventing the decryption of old secrets when the default key has been rotated.

# Summary

***Provide a brief overview of the changes and the issue being addressed. 
Explain the rationale and any background necessary for understanding the changes. 
List dependencies required by this change, if any.***

Fixes #(related issue)

## Change Type

***Mark the type of change your PR introduces:***

- [x] Bug fix (resolves an issue without affecting existing features)
- [ ] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [ ] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

***Outline how the changes were tested, including steps to reproduce and any relevant configurations. 
Attach screenshots if helpful.***

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [ ] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [x] Included tests that validate the fix or feature.
- [ ] Checked that related changes are merged.
