### PR TITLE
Webhook handler always logs contextual information.

### DIFF
--- a/internal/eea/eea.go
+++ b/internal/eea/eea.go
@@ -88,7 +88,9 @@ func (e *EEA) aggregate(msg *message.Message) (*message.Message, error) {
 
 	logger := zerolog.Ctx(ctx).With().
 		Str("component", "EEA").
-		Str("event", msg.UUID).
+		// This is added for consistency with how watermill
+		// tracks message UUID when logging.
+		Str("message_uuid", msg.UUID).
 		Str("entity", inf.Type.ToString()).
 		Logger()
 
@@ -195,7 +197,9 @@ func (e *EEA) FlushMessageHandler(msg *message.Message) error {
 	logger := zerolog.Ctx(ctx).With().
 		Str("component", "EEA").
 		Str("function", "FlushMessageHandler").
-		Str("event", msg.UUID).
+		// This is added for consistency with how watermill
+		// tracks message UUID when logging.
+		Str("message_uuid", msg.UUID).
 		Str("entity", inf.Type.ToString()).Logger()
 
 	logger.Debug().Msg("flushing event")


### PR DESCRIPTION
# Summary

This change makes uniform use of details stored in ctx when writing logs in the webhook handler. Additionally, it also moves watermill message UUID logging key from "event" to "message_uuid" to use the same one as watermill.

## Change Type

- [ ] Bug fix (resolves an issue without affecting existing features)
- [ ] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [X] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

* `make lint`
* local execution

# Review Checklist:

- [X] Reviewed my own code for quality and clarity.
- [X] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [ ] Included tests that validate the fix or feature.
- [X] Checked that related changes are merged.
