### PR TITLE
Consider project hierarchy in profile evaluation

### DIFF
--- a/internal/engine/executor_test.go
+++ b/internal/engine/executor_test.go
@@ -168,6 +168,10 @@ func TestExecutor_handleEntityEvent(t *testing.T) {
 	require.NoError(t, err, "expected no error")
 
 	mockStore.EXPECT().
+		GetParentProjects(gomock.Any(), projectID).
+		Return([]uuid.UUID{projectID}, nil)
+
+	mockStore.EXPECT().
 		ListProfilesByProjectID(gomock.Any(), projectID).
 		Return([]db.ListProfilesByProjectIDRow{
 			{


### PR DESCRIPTION
# Summary

This makes it so that profiles now take into account the project
hierarchy when evaluating for an entity. That is, profiles that apply to
the entity via the hierarchy (same project and parents) are evaluated
when the executor gets an event.

This iterates in steps, so the profile may only use rule types that
exist in its same project. A Further iteration will also take the
hierarchy into account when searching for rule types.

Note that hierarchy operations are still under a feature flag, so this
is not generally available.

Closes: https://github.com/stacklok/minder/issues/3498

## Change Type

- [ ] Bug fix (resolves an issue without affecting existing features)
- [x] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [ ] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

***Outline how the changes were tested, including steps to reproduce and any relevant configurations. 
Attach screenshots if helpful.***

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [ ] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [ ] Included tests that validate the fix or feature.
- [ ] Checked that related changes are merged.
