### PR TITLE
Move profile and ruletype logic out of engine package

### DIFF
--- a/cmd/cli/app/profile/common.go
+++ b/cmd/cli/app/profile/common.go
@@ -21,7 +21,7 @@ import (
 
 	"github.com/spf13/viper"
 
-	"github.com/stacklok/minder/internal/engine"
+	"github.com/stacklok/minder/internal/profiles"
 	"github.com/stacklok/minder/internal/util"
 	"github.com/stacklok/minder/internal/util/cli"
 	"github.com/stacklok/minder/internal/util/cli/table"
@@ -57,7 +57,7 @@ func ExecOnOneProfile(ctx context.Context, t table.Table, f string, dashOpen io.
 }
 
 func parseProfile(r io.Reader, proj string) (*minderv1.Profile, error) {
-	p, err := engine.ParseYAML(r)
+	p, err := profiles.ParseYAML(r)
 	if err != nil {
 		return nil, fmt.Errorf("error reading profile from file: %w", err)
 	}

--- a/cmd/cli/app/quickstart/quickstart.go
+++ b/cmd/cli/app/quickstart/quickstart.go
@@ -35,7 +35,7 @@ import (
 	"github.com/stacklok/minder/cmd/cli/app/profile"
 	minderprov "github.com/stacklok/minder/cmd/cli/app/provider"
 	"github.com/stacklok/minder/cmd/cli/app/repo"
-	"github.com/stacklok/minder/internal/engine"
+	"github.com/stacklok/minder/internal/profiles"
 	ghclient "github.com/stacklok/minder/internal/providers/github/clients"
 	"github.com/stacklok/minder/internal/util/cli"
 	minderv1 "github.com/stacklok/minder/pkg/api/protobuf/go/minder/v1"
@@ -325,7 +325,7 @@ func quickstartCommand(_ context.Context, cmd *cobra.Command, _ []string, conn *
 	}
 
 	// Load the profile from the embedded file system
-	p, err := engine.ParseYAML(reader)
+	p, err := profiles.ParseYAML(reader)
 	if err != nil {
 		return cli.MessageAndError("error parsing profile", err)
 	}

--- a/cmd/dev/app/rule_type/rttst.go
+++ b/cmd/dev/app/rule_type/rttst.go
@@ -37,6 +37,7 @@ import (
 	"github.com/stacklok/minder/internal/engine/eval/rego"
 	engif "github.com/stacklok/minder/internal/engine/interfaces"
 	"github.com/stacklok/minder/internal/logger"
+	"github.com/stacklok/minder/internal/profiles"
 	"github.com/stacklok/minder/internal/providers/credentials"
 	"github.com/stacklok/minder/internal/providers/dockerhub"
 	"github.com/stacklok/minder/internal/providers/github/clients"
@@ -121,7 +122,7 @@ func testCmdRun(cmd *cobra.Command, _ []string) error {
 		return fmt.Errorf("error reading entity from file: %w", err)
 	}
 
-	profile, err := engine.ReadProfileFromFile(ppath.Value.String())
+	profile, err := profiles.ReadProfileFromFile(ppath.Value.String())
 	if err != nil {
 		return fmt.Errorf("error reading fragment from file: %w", err)
 	}

--- a/internal/controlplane/handlers_profile.go
+++ b/internal/controlplane/handlers_profile.go
@@ -143,7 +143,7 @@ func (s *Server) ListProfiles(ctx context.Context,
 
 	var resp minderv1.ListProfilesResponse
 	resp.Profiles = make([]*minderv1.Profile, 0, len(profiles))
-	profileMap := engine.MergeDatabaseListIntoProfiles(profiles)
+	profileMap := prof.MergeDatabaseListIntoProfiles(profiles)
 
 	// Sort the profiles by name to get a consistent order. This is important for UI.
 	profileNames := make([]string, 0, len(profileMap))
@@ -211,7 +211,7 @@ func getProfilePBFromDB(
 		return nil, err
 	}
 
-	pols := engine.MergeDatabaseGetIntoProfiles(profiles)
+	pols := prof.MergeDatabaseGetIntoProfiles(profiles)
 	if len(pols) == 0 {
 		return nil, fmt.Errorf("profile not found")
 	} else if len(pols) > 1 {

--- a/internal/controlplane/handlers_ruletype.go
+++ b/internal/controlplane/handlers_ruletype.go
@@ -54,7 +54,7 @@ func (s *Server) ListRuleTypes(
 
 	for idx := range lrt {
 		rt := lrt[idx]
-		rtpb, err := engine.RuleTypePBFromDB(&rt)
+		rtpb, err := ruletypes.RuleTypePBFromDB(&rt)
 		if err != nil {
 			return nil, fmt.Errorf("cannot convert rule type %s to pb: %v", rt.Name, err)
 		}
@@ -92,7 +92,7 @@ func (s *Server) GetRuleTypeByName(
 		return nil, status.Errorf(codes.Unknown, "failed to get rule type: %s", err)
 	}
 
-	rt, err := engine.RuleTypePBFromDB(&rtdb)
+	rt, err := ruletypes.RuleTypePBFromDB(&rtdb)
 	if err != nil {
 		return nil, fmt.Errorf("cannot convert rule type %s to pb: %v", rtdb.Name, err)
 	}
@@ -132,7 +132,7 @@ func (s *Server) GetRuleTypeById(
 		return nil, status.Errorf(codes.Unknown, "failed to get rule type: %s", err)
 	}
 
-	rt, err := engine.RuleTypePBFromDB(&rtdb)
+	rt, err := ruletypes.RuleTypePBFromDB(&rtdb)
 	if err != nil {
 		return nil, fmt.Errorf("cannot convert rule type %s to pb: %v", rtdb.Name, err)
 	}

--- a/internal/engine/rule_type_engine.go
+++ b/internal/engine/rule_type_engine.go
@@ -21,9 +21,7 @@ import (
 	"strings"
 
 	"github.com/rs/zerolog"
-	"google.golang.org/protobuf/encoding/protojson"
 
-	"github.com/stacklok/minder/internal/db"
 	"github.com/stacklok/minder/internal/engine/actions"
 	"github.com/stacklok/minder/internal/engine/entities"
 	enginerr "github.com/stacklok/minder/internal/engine/errors"
@@ -31,6 +29,7 @@ import (
 	"github.com/stacklok/minder/internal/engine/ingestcache"
 	"github.com/stacklok/minder/internal/engine/ingester"
 	engif "github.com/stacklok/minder/internal/engine/interfaces"
+	"github.com/stacklok/minder/internal/profiles"
 	minderv1 "github.com/stacklok/minder/pkg/api/protobuf/go/minder/v1"
 	provinfv1 "github.com/stacklok/minder/pkg/providers/v1"
 )
@@ -69,7 +68,7 @@ type RuleTypeEngine struct {
 	// actionsEngine is the rule actions engine
 	actionsEngine *actions.RuleActionsEngine
 
-	ruleValidator *RuleValidator
+	ruleValidator *profiles.RuleValidator
 
 	ruletype *minderv1.RuleType
 
@@ -85,7 +84,7 @@ func NewRuleTypeEngine(
 	ruletype *minderv1.RuleType,
 	provider provinfv1.Provider,
 ) (*RuleTypeEngine, error) {
-	rval, err := NewRuleValidator(ruletype)
+	rval, err := profiles.NewRuleValidator(ruletype)
 	if err != nil {
 		return nil, fmt.Errorf("cannot create rule validator: %w", err)
 	}
@@ -142,7 +141,7 @@ func (r *RuleTypeEngine) GetID() string {
 
 // GetRuleInstanceValidator returns the rule instance validator for this rule type.
 // By instance we mean a rule that has been instantiated in a profile from a given rule type.
-func (r *RuleTypeEngine) GetRuleInstanceValidator() *RuleValidator {
+func (r *RuleTypeEngine) GetRuleInstanceValidator() *profiles.RuleValidator {
 	return r.ruleValidator
 }
 
@@ -193,67 +192,15 @@ func (r *RuleTypeEngine) GetActionsOnOff() map[engif.ActionType]engif.ActionOpt 
 	return r.actionsEngine.GetOnOffState()
 }
 
-// RuleDefFromDB converts a rule type definition from the database to a protobuf
-// rule type definition
-func RuleDefFromDB(r *db.RuleType) (*minderv1.RuleType_Definition, error) {
-	def := &minderv1.RuleType_Definition{}
-
-	if err := protojson.Unmarshal(r.Definition, def); err != nil {
-		return nil, fmt.Errorf("cannot unmarshal rule type definition: %w", err)
-	}
-	return def, nil
-}
-
-// RuleTypePBFromDB converts a rule type from the database to a protobuf
-// rule type
-func RuleTypePBFromDB(rt *db.RuleType) (*minderv1.RuleType, error) {
-	def, err := RuleDefFromDB(rt)
-	if err != nil {
-		return nil, fmt.Errorf("cannot get rule type definition: %w", err)
-	}
-
-	id := rt.ID.String()
-	project := rt.ProjectID.String()
-
-	var seval minderv1.Severity_Value
-
-	if err := seval.FromString(string(rt.SeverityValue)); err != nil {
-		seval = minderv1.Severity_VALUE_UNKNOWN
-	}
-
-	displayName := rt.DisplayName
-	if displayName == "" {
-		displayName = rt.Name
-	}
-
-	// TODO: (2024/03/28) this is for compatibility with old CLI versions that expect provider, remove this eventually
-	noProvider := ""
-	return &minderv1.RuleType{
-		Id:          &id,
-		Name:        rt.Name,
-		DisplayName: displayName,
-		Context: &minderv1.Context{
-			Provider: &noProvider,
-			Project:  &project,
-		},
-		Description: rt.Description,
-		Guidance:    rt.Guidance,
-		Def:         def,
-		Severity: &minderv1.Severity{
-			Value: seval,
-		},
-	}, nil
-}
-
 // GetRulesFromProfileOfType returns the rules from the profile of the given type
 func GetRulesFromProfileOfType(p *minderv1.Profile, rt *minderv1.RuleType) ([]*minderv1.Profile_Rule, error) {
-	contextualRules, err := GetRulesForEntity(p, minderv1.EntityFromString(rt.Def.InEntity))
+	contextualRules, err := profiles.GetRulesForEntity(p, minderv1.EntityFromString(rt.Def.InEntity))
 	if err != nil {
 		return nil, fmt.Errorf("error getting rules for entity: %w", err)
 	}
 
 	rules := []*minderv1.Profile_Rule{}
-	err = TraverseRules(contextualRules, func(r *minderv1.Profile_Rule) error {
+	err = profiles.TraverseRules(contextualRules, func(r *minderv1.Profile_Rule) error {
 		if r.Type == rt.Name {
 			rules = append(rules, r)
 		}

--- a/internal/profiles/rule_names.go
+++ b/internal/profiles/rule_names.go
@@ -15,7 +15,6 @@
 package profiles
 
 import (
-	"github.com/stacklok/minder/internal/engine"
 	minderv1 "github.com/stacklok/minder/pkg/api/protobuf/go/minder/v1"
 )
 
@@ -32,7 +31,7 @@ func ComputeRuleName(rule *minderv1.Profile_Rule) string {
 
 // PopulateRuleNames fills in the rule name for all rule instances in a profile
 func PopulateRuleNames(profile *minderv1.Profile) {
-	_ = engine.TraverseAllRulesForPipeline(profile, func(r *minderv1.Profile_Rule) error {
+	_ = TraverseAllRulesForPipeline(profile, func(r *minderv1.Profile_Rule) error {
 		r.Name = ComputeRuleName(r)
 		return nil
 	},

--- a/internal/profiles/rule_validator.go
+++ b/internal/profiles/rule_validator.go
@@ -13,7 +13,7 @@
 // limitations under the License.
 // Package rule provides the CLI subcommand for managing rules
 
-package engine
+package profiles
 
 import (
 	"fmt"

--- a/internal/profiles/rule_validator_test.go
+++ b/internal/profiles/rule_validator_test.go
@@ -13,7 +13,7 @@
 // limitations under the License.
 // Package rule provides the CLI subcommand for managing rules
 
-package engine_test
+package profiles_test
 
 import (
 	"os"
@@ -23,6 +23,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/stacklok/minder/internal/engine"
+	"github.com/stacklok/minder/internal/profiles"
 	minderv1 "github.com/stacklok/minder/pkg/api/protobuf/go/minder/v1"
 )
 
@@ -30,7 +31,7 @@ func TestExampleRulesAreValidatedCorrectly(t *testing.T) {
 	t.Parallel()
 
 	t.Log("parsing example profile")
-	pol, err := engine.ReadProfileFromFile("../../examples/rules-and-profiles/profiles/github/profile.yaml")
+	pol, err := profiles.ReadProfileFromFile("../../examples/rules-and-profiles/profiles/github/profile.yaml")
 	require.NoError(t, err, "failed to parse example profile, make sure to do - make init-examples")
 
 	// open rules in example directory
@@ -63,7 +64,7 @@ func TestExampleRulesAreValidatedCorrectly(t *testing.T) {
 			require.NoError(t, rt.Validate(), "failed to validate rule type %s", path)
 
 			t.Log("creating rule validator")
-			rval, err := engine.NewRuleValidator(rt)
+			rval, err := profiles.NewRuleValidator(rt)
 			require.NoError(t, err, "failed to create rule validator for rule type %s", path)
 
 			rules, err := engine.GetRulesFromProfileOfType(pol, rt)

--- a/internal/profiles/service.go
+++ b/internal/profiles/service.go
@@ -33,12 +33,12 @@ import (
 	"google.golang.org/protobuf/types/known/fieldmaskpb"
 
 	"github.com/stacklok/minder/internal/db"
-	"github.com/stacklok/minder/internal/engine"
 	"github.com/stacklok/minder/internal/engine/entities"
 	"github.com/stacklok/minder/internal/events"
 	"github.com/stacklok/minder/internal/logger"
 	"github.com/stacklok/minder/internal/marketplaces/namespaces"
 	"github.com/stacklok/minder/internal/reconcilers"
+	"github.com/stacklok/minder/internal/ruletypes"
 	"github.com/stacklok/minder/internal/util"
 	"github.com/stacklok/minder/internal/util/ptr"
 	minderv1 "github.com/stacklok/minder/pkg/api/protobuf/go/minder/v1"
@@ -501,7 +501,7 @@ func getProfilePBFromDB(
 		return nil, err
 	}
 
-	pols := engine.MergeDatabaseGetIntoProfiles(profiles)
+	pols := MergeDatabaseGetIntoProfiles(profiles)
 	if len(pols) == 0 {
 		return nil, fmt.Errorf("profile not found")
 	} else if len(pols) > 1 {
@@ -526,7 +526,7 @@ func (_ *profileService) getRulesFromProfile(
 	// track them in the db later.
 	rulesInProf := make(RuleMapping)
 
-	err := engine.TraverseAllRulesForPipeline(profile, func(r *minderv1.Profile_Rule) error {
+	err := TraverseAllRulesForPipeline(profile, func(r *minderv1.Profile_Rule) error {
 		// TODO: This will need to be updated to support
 		// the hierarchy tree once that's settled in.
 		rtdb, err := qtx.GetRuleTypeByName(ctx, db.GetRuleTypeByNameParams{
@@ -537,7 +537,7 @@ func (_ *profileService) getRulesFromProfile(
 			return fmt.Errorf("error getting rule type %s: %w", r.GetType(), err)
 		}
 
-		rtyppb, err := engine.RuleTypePBFromDB(&rtdb)
+		rtyppb, err := ruletypes.RuleTypePBFromDB(&rtdb)
 		if err != nil {
 			return fmt.Errorf("cannot convert rule type %s to pb: %w", rtdb.Name, err)
 		}

--- a/internal/profiles/util.go
+++ b/internal/profiles/util.go
@@ -11,9 +11,8 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-// Package rule provides the CLI subcommand for managing rules
 
-package engine
+package profiles
 
 import (
 	"bytes"

--- a/internal/profiles/util_test.go
+++ b/internal/profiles/util_test.go
@@ -13,7 +13,7 @@
 // limitations under the License.
 // Package rule provides the CLI subcommand for managing rules
 
-package engine_test
+package profiles_test
 
 import (
 	"strings"
@@ -22,7 +22,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/types/known/structpb"
 
-	"github.com/stacklok/minder/internal/engine"
+	"github.com/stacklok/minder/internal/profiles"
 	minderv1 "github.com/stacklok/minder/pkg/api/protobuf/go/minder/v1"
 )
 
@@ -314,7 +314,7 @@ repository:
 
 			r := strings.NewReader(tt.profile)
 
-			got, err := engine.ParseYAML(r)
+			got, err := profiles.ParseYAML(r)
 			if tt.wantErr {
 				require.Error(t, err, "ParseYAML should have errored")
 				if tt.errIs != nil {
@@ -499,7 +499,7 @@ func TestGetRulesForEntity(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			got, err := engine.GetRulesForEntity(tt.args.p, tt.args.entity)
+			got, err := profiles.GetRulesForEntity(tt.args.p, tt.args.entity)
 			if tt.wantErr {
 				require.Error(t, err, "should have gotten error")
 				return
@@ -619,7 +619,7 @@ func TestFilterRulesForType(t *testing.T) {
 			t.Parallel()
 
 			got := []*minderv1.Profile_Rule{}
-			err := engine.TraverseRules(tt.args.cr, func(pp *minderv1.Profile_Rule) error {
+			err := profiles.TraverseRules(tt.args.cr, func(pp *minderv1.Profile_Rule) error {
 				if pp.Type == tt.args.rt.Name {
 					got = append(got, pp)
 				}

--- a/internal/ruletypes/service.go
+++ b/internal/ruletypes/service.go
@@ -25,7 +25,6 @@ import (
 	"github.com/google/uuid"
 
 	"github.com/stacklok/minder/internal/db"
-	"github.com/stacklok/minder/internal/engine"
 	"github.com/stacklok/minder/internal/logger"
 	"github.com/stacklok/minder/internal/marketplaces/namespaces"
 	"github.com/stacklok/minder/internal/util"
@@ -152,7 +151,7 @@ func (_ *ruleTypeService) CreateRuleType(
 
 	logger.BusinessRecord(ctx).RuleType = logger.RuleType{Name: newDBRecord.Name, ID: newDBRecord.ID}
 
-	rt, err := engine.RuleTypePBFromDB(&newDBRecord)
+	rt, err := RuleTypePBFromDB(&newDBRecord)
 	if err != nil {
 		return nil, fmt.Errorf("cannot convert rule type %s to pb: %w", newDBRecord.Name, err)
 	}
@@ -223,7 +222,7 @@ func (_ *ruleTypeService) UpdateRuleType(
 
 	logger.BusinessRecord(ctx).RuleType = logger.RuleType{Name: oldRuleType.Name, ID: oldRuleType.ID}
 
-	result, err := engine.RuleTypePBFromDB(&updatedRuleType)
+	result, err := RuleTypePBFromDB(&updatedRuleType)
 	if err != nil {
 		return nil, fmt.Errorf("cannot convert rule type %s to pb: %w", oldRuleType.Name, err)
 	}
@@ -271,7 +270,7 @@ func getRuleTypeSeverity(severity *pb.Severity) (*db.Severity, error) {
 }
 
 func validateRuleUpdate(existingRecord *db.RuleType, newRuleType *pb.RuleType) error {
-	oldRuleType, err := engine.RuleTypePBFromDB(existingRecord)
+	oldRuleType, err := RuleTypePBFromDB(existingRecord)
 	if err != nil {
 		return fmt.Errorf("cannot convert rule type %s to pb: %w", newRuleType.GetName(), err)
 	}

--- a/internal/ruletypes/util.go
+++ b/internal/ruletypes/util.go
@@ -1,0 +1,76 @@
+// Copyright 2024 Stacklok, Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ruletypes
+
+import (
+	"fmt"
+
+	"google.golang.org/protobuf/encoding/protojson"
+
+	"github.com/stacklok/minder/internal/db"
+	minderv1 "github.com/stacklok/minder/pkg/api/protobuf/go/minder/v1"
+)
+
+// RuleDefFromDB converts a rule type definition from the database to a protobuf
+// rule type definition
+func RuleDefFromDB(r *db.RuleType) (*minderv1.RuleType_Definition, error) {
+	def := &minderv1.RuleType_Definition{}
+
+	if err := protojson.Unmarshal(r.Definition, def); err != nil {
+		return nil, fmt.Errorf("cannot unmarshal rule type definition: %w", err)
+	}
+	return def, nil
+}
+
+// RuleTypePBFromDB converts a rule type from the database to a protobuf
+// rule type
+func RuleTypePBFromDB(rt *db.RuleType) (*minderv1.RuleType, error) {
+	def, err := RuleDefFromDB(rt)
+	if err != nil {
+		return nil, fmt.Errorf("cannot get rule type definition: %w", err)
+	}
+
+	id := rt.ID.String()
+	project := rt.ProjectID.String()
+
+	var seval minderv1.Severity_Value
+
+	if err := seval.FromString(string(rt.SeverityValue)); err != nil {
+		seval = minderv1.Severity_VALUE_UNKNOWN
+	}
+
+	displayName := rt.DisplayName
+	if displayName == "" {
+		displayName = rt.Name
+	}
+
+	// TODO: (2024/03/28) this is for compatibility with old CLI versions that expect provider, remove this eventually
+	noProvider := ""
+	return &minderv1.RuleType{
+		Id:          &id,
+		Name:        rt.Name,
+		DisplayName: displayName,
+		Context: &minderv1.Context{
+			Provider: &noProvider,
+			Project:  &project,
+		},
+		Description: rt.Description,
+		Guidance:    rt.Guidance,
+		Def:         def,
+		Severity: &minderv1.Severity{
+			Value: seval,
+		},
+	}, nil
+}

--- a/pkg/mindpak/reader/reader.go
+++ b/pkg/mindpak/reader/reader.go
@@ -20,7 +20,7 @@ import (
 	"io/fs"
 	"strings"
 
-	"github.com/stacklok/minder/internal/engine"
+	"github.com/stacklok/minder/internal/profiles"
 	v1 "github.com/stacklok/minder/pkg/api/protobuf/go/minder/v1"
 	"github.com/stacklok/minder/pkg/mindpak"
 )
@@ -40,25 +40,25 @@ type BundleReader interface {
 	ForEachRuleType(func(*v1.RuleType) error) error
 }
 
-type profileSet = map[string]struct{}
+type profileSetType = map[string]struct{}
 type bundleReader struct {
 	original *mindpak.Bundle
-	profiles profileSet
+	profiles profileSetType
 }
 
 // NewBundleReader creates an instance of BundleReader from mindpak.Bundle
 func NewBundleReader(bundle *mindpak.Bundle) BundleReader {
 	bundleProfiles := bundle.Files.Profiles
-	profiles := make(profileSet, len(bundleProfiles))
+	profileSet := make(profileSetType, len(bundleProfiles))
 	// build a set of profile names for `GetProfile`
 	// this saves us from searching the manifest each time this method is used
 	for _, profile := range bundleProfiles {
-		profiles[profile.Name] = struct{}{}
+		profileSet[profile.Name] = struct{}{}
 	}
 
 	return &bundleReader{
 		original: bundle,
-		profiles: profiles,
+		profiles: profileSet,
 	}
 }
 
@@ -89,7 +89,7 @@ func (b *bundleReader) GetProfile(name string) (*v1.Profile, error) {
 	defer file.Close()
 
 	// parse profile from YAML
-	profile, err := engine.ParseYAML(file)
+	profile, err := profiles.ParseYAML(file)
 	if err != nil {
 		return nil, fmt.Errorf("error parsing profile yaml: %w", err)
 	}


### PR DESCRIPTION
A bunch of profile and rule type logic lives in the `engine` package. This PR moves those functions into the profiles and ruletypes packages.

This avoids circular dependencies in a future PR, and also groups logic for specific domain concepts in their own packages.

# Summary

***Provide a brief overview of the changes and the issue being addressed. 
Explain the rationale and any background necessary for understanding the changes. 
List dependencies required by this change, if any.***

Fixes #(related issue)

## Change Type

***Mark the type of change your PR introduces:***

- [ ] Bug fix (resolves an issue without affecting existing features)
- [ ] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [x] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

***Outline how the changes were tested, including steps to reproduce and any relevant configurations. 
Attach screenshots if helpful.***

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [x] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [x] Included tests that validate the fix or feature.
- [ ] Checked that related changes are merged.
