### PR TITLE
Migrate existing rule instances into rule_instances table

### DIFF
--- a/database/migrations/000062_migrate_entity_profiles.down.sql
+++ b/database/migrations/000062_migrate_entity_profiles.down.sql
@@ -12,5 +12,12 @@
 -- See the License for the specific language governing permissions and
 -- limitations under the License.
 
--- Undoing the `up` query automatically is probably not a good idea.
--- Leaving this as a no-op.
+BEGIN;
+
+-- in case we need rollback, wipe out the rule_instances table and mark all rows
+-- in entity_profiles as unmigrated. A re-run of the migration will recreate all
+-- rows in the rule_instances of table since we are dual writing at this point.
+DELETE FROM rule_instances;
+UPDATE entity_profiles SET migrated = FALSE;
+
+COMMIT;

--- a/database/migrations/000062_migrate_entity_profiles.down.sql
+++ b/database/migrations/000062_migrate_entity_profiles.down.sql
@@ -14,7 +14,7 @@
 
 BEGIN;
 
--- in case we need rollback, wipe out the rule_instances table and mark all rows
+-- in case we need to rollback, wipe out the rule_instances table and mark all rows
 -- in entity_profiles as unmigrated. A re-run of the migration will recreate all
 -- rows in the rule_instances of table since we are dual writing at this point.
 DELETE FROM rule_instances;

--- a/database/migrations/000062_migrate_entity_profiles.down.sql
+++ b/database/migrations/000062_migrate_entity_profiles.down.sql
@@ -1,0 +1,16 @@
+-- Copyright 2024 Stacklok, Inc
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--      http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+-- Undoing the `up` query automatically is probably not a good idea.
+-- Leaving this as a no-op.

--- a/database/migrations/000062_migrate_entity_profiles.up.sql
+++ b/database/migrations/000062_migrate_entity_profiles.up.sql
@@ -1,0 +1,60 @@
+-- Copyright 2024 Stacklok, Inc
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--      http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+BEGIN;
+
+-- This backfills the rule_instances table using information about the rule
+-- instances stored in various tables in Minder.
+-- The migration query takes the following approach:
+--
+-- 1) Flatten each list of rules in the entity_profiles table by using
+--    JSONB_ARRAY_ELEMENTS() with a lateral cross join.
+--    This allows us to join each JSON object with the row in which it is stored.
+-- 2) Get the rule type ID by querying rule_type using name and project ID. The
+--    rule name comes from each JSON object. To get the project ID, we need to
+--    join entity_profiles to profiles on profile ID, and use the project_id
+--    column from profiles.
+--
+-- We also reuse the created_at timestamp from entity_profiles in rule_instances
+-- for the sake of consistency.
+
+INSERT INTO rule_instances (
+    profile_id,
+    entity_type,
+    rule_type_id,
+    name,
+    def,
+    params,
+    created_at
+)
+SELECT
+    ep.profile_id,
+    ep.entity AS entity_type,
+    rt.id AS rule_type_id,
+    cr->>'name' AS rule_name,
+    COALESCE(cr->'def', '{}'::jsonb) AS def,
+    COALESCE(cr->'params', '{}'::jsonb) AS params,
+    ep.created_at
+FROM entity_profiles AS ep
+    CROSS JOIN LATERAL JSONB_ARRAY_ELEMENTS(ep.contextual_rules) AS cr
+    JOIN profiles AS pf ON pf.id = ep.profile_id
+    JOIN rule_type AS rt ON rt.project_id = pf.project_id AND cr->>'type' = rt.name
+WHERE ep.migrated = FALSE;
+
+-- As of the previous PR, all new rows are written to both rule_instances and
+-- entities. By the time that we get to this part of the transaction, all rows
+-- will have been migrated.
+UPDATE entity_profiles SET migrated = TRUE;
+
+COMMIT;


### PR DESCRIPTION
Depends on #3486

This PR adds a migration script to move all rule instances created before PR #3486 to the rule_instances table.

Tested locally.

# Summary

***Provide a brief overview of the changes and the issue being addressed. 
Explain the rationale and any background necessary for understanding the changes. 
List dependencies required by this change, if any.***

Fixes #(related issue)

## Change Type

***Mark the type of change your PR introduces:***

- [ ] Bug fix (resolves an issue without affecting existing features)
- [x] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [ ] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

***Outline how the changes were tested, including steps to reproduce and any relevant configurations. 
Attach screenshots if helpful.***

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [ ] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [x] Included tests that validate the fix or feature.
- [ ] Checked that related changes are merged.
