### PR TITLE
Validate provider config when creating the OAuth provider or the GitHub App provider.

### DIFF
--- a/internal/controlplane/handlers_providers_test.go
+++ b/internal/controlplane/handlers_providers_test.go
@@ -447,6 +447,12 @@ func TestCreateProviderFailures(t *testing.T) {
 		})
 		assert.Error(t, err)
 		require.ErrorContains(t, err, "error validating provider config: auto_registration: invalid entity type: blah")
+
+		// test special-casing of the invalid config error
+		st, ok := status.FromError(err)
+		require.True(t, ok)
+		assert.Equal(t, codes.InvalidArgument, st.Code())
+		require.ErrorContains(t, err, "invalid provider config")
 	})
 }
 

--- a/internal/providers/github/service/service.go
+++ b/internal/providers/github/service/service.go
@@ -262,6 +262,11 @@ func (p *ghProviderService) CreateGitHubAppProvider(
 			return nil, fmt.Errorf("error getting provider config: %w", err)
 		}
 
+		_, _, err = clients.ParseV1AppConfig(finalConfig)
+		if err != nil {
+			return nil, providers.NewErrProviderInvalidConfig(err.Error())
+		}
+
 		provider, err := createGitHubApp(
 			ctx,
 			qtx,

--- a/internal/providers/manager/manager.go
+++ b/internal/providers/manager/manager.go
@@ -156,7 +156,7 @@ func (p *providerManager) CreateFromConfig(
 
 	err = manager.ValidateConfig(ctx, providerClass, provConfig)
 	if err != nil {
-		return nil, fmt.Errorf("error validating provider config: %w", err)
+		return nil, providers.NewErrProviderInvalidConfig(err.Error())
 	}
 
 	return p.store.Create(ctx, providerClass, name, projectID, provConfig)

--- a/internal/providers/manager/manager_test.go
+++ b/internal/providers/manager/manager_test.go
@@ -61,7 +61,7 @@ func TestProviderManager_CreateFromConfig(t *testing.T) {
 			Name:              "CreateFromConfig returns an error when the config is invalid",
 			Provider:          providerWithClass(db.ProviderClassGithub, providerWithConfig(json.RawMessage(`{ github: { key: value} }`))),
 			Config:            json.RawMessage(`{ github: { key: value} }`),
-			ExpectedError:     "error validating provider config",
+			ExpectedError:     "invalid provider configuration",
 			ValidateConfigErr: true,
 		},
 	}

--- a/internal/providers/providers.go
+++ b/internal/providers/providers.go
@@ -35,6 +35,22 @@ import (
 	provinfv1 "github.com/stacklok/minder/pkg/providers/v1"
 )
 
+// ErrProviderInvalidConfig is an error type which is returned when a provider configuration is invalid
+type ErrProviderInvalidConfig struct {
+	Details string
+}
+
+func (e ErrProviderInvalidConfig) Error() string {
+	return fmt.Sprintf("invalid provider configuration: %s", e.Details)
+}
+
+// NewErrProviderInvalidConfig returns a new instance of ErrProviderInvalidConfig with details
+// about the invalid configuration. This is meant for user-facing errors so that the only thing
+// displayed to the user is the details of the error.
+func NewErrProviderInvalidConfig(details string) ErrProviderInvalidConfig {
+	return ErrProviderInvalidConfig{Details: details}
+}
+
 // DBToPBType converts a database provider type to a protobuf provider type.
 func DBToPBType(t db.ProviderType) (minderv1.ProviderType, bool) {
 	switch t {


### PR DESCRIPTION
# Summary

Adds a special error code as well as means to catch it in the provider
handlers on provider creation so that we disallow creating providers with bad
config.

Fixes #3510

## Change Type

***Mark the type of change your PR introduces:***

- [x] Bug fix (resolves an issue without affecting existing features)
- [ ] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [ ] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

unit tests + manual

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [x] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [x] Included tests that validate the fix or feature.
- [ ] Checked that related changes are merged.
