### PR TITLE
Replace unpinned actions with pinned action

### DIFF
--- a/.github/workflows/cifuzz.yml
+++ b/.github/workflows/cifuzz.yml
@@ -14,14 +14,14 @@ jobs:
     steps:
     - name: Build Fuzzers (${{ matrix.sanitizer }})
       id: build
-      uses: google/clusterfuzzlite/actions/build_fuzzers@v1
+      uses: google/clusterfuzzlite/actions/build_fuzzers@82652fb49e77bc29c35da1167bb286e93c6bcc05 # v1
       with:
         sanitizer: ${{ matrix.sanitizer }}
         language: go
         bad-build-check: false
     - name: Run Fuzzers (${{ matrix.sanitizer }})
       id: run
-      uses: google/clusterfuzzlite/actions/run_fuzzers@v1
+      uses: google/clusterfuzzlite/actions/run_fuzzers@82652fb49e77bc29c35da1167bb286e93c6bcc05 # v1
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}
         fuzz-seconds: 100


### PR DESCRIPTION
This is a Minder automated pull request.

This pull request replaces references to actions by tag to references to actions by SHA.

Verifies that any actions use pinned tags
Pinning an action to a full length commit SHA is currently the only way to use
an action as an immutable release. Pinning to a particular SHA helps mitigate
the risk of a bad actor adding a backdoor to the action's repository, as they
would need to generate a SHA-1 collision for a valid Git object payload.
When selecting a SHA, you should verify it is from the action's repository
and not a repository fork.

For more information, see
https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions
