### PR TITLE
Remove the now-unused CreateGitHubOAuthProvider

### DIFF
--- a/internal/providers/github/service/mock/service.go
+++ b/internal/providers/github/service/mock/service.go
@@ -74,21 +74,6 @@ func (mr *MockGitHubProviderServiceMockRecorder) CreateGitHubAppWithoutInvitatio
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateGitHubAppWithoutInvitation", reflect.TypeOf((*MockGitHubProviderService)(nil).CreateGitHubAppWithoutInvitation), ctx, qtx, userID, installationID)
 }
 
-// CreateGitHubOAuthProvider mocks base method.
-func (m *MockGitHubProviderService) CreateGitHubOAuthProvider(ctx context.Context, providerName string, providerClass db.ProviderClass, token oauth2.Token, stateData db.GetProjectIDBySessionStateRow, state string) (*db.Provider, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CreateGitHubOAuthProvider", ctx, providerName, providerClass, token, stateData, state)
-	ret0, _ := ret[0].(*db.Provider)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// CreateGitHubOAuthProvider indicates an expected call of CreateGitHubOAuthProvider.
-func (mr *MockGitHubProviderServiceMockRecorder) CreateGitHubOAuthProvider(ctx, providerName, providerClass, token, stateData, state any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateGitHubOAuthProvider", reflect.TypeOf((*MockGitHubProviderService)(nil).CreateGitHubOAuthProvider), ctx, providerName, providerClass, token, stateData, state)
-}
-
 // DeleteGitHubAppInstallation mocks base method.
 func (m *MockGitHubProviderService) DeleteGitHubAppInstallation(ctx context.Context, installationID int64) error {
 	m.ctrl.T.Helper()

--- a/internal/providers/github/service/service_test.go
+++ b/internal/providers/github/service/service_test.go
@@ -22,7 +22,6 @@ import (
 	"crypto/rsa"
 	"crypto/x509"
 	"database/sql"
-	"encoding/base64"
 	"encoding/json"
 	"encoding/pem"
 	"errors"
@@ -42,7 +41,6 @@ import (
 
 	"github.com/stacklok/minder/internal/config/server"
 	"github.com/stacklok/minder/internal/controlplane/metrics"
-	"github.com/stacklok/minder/internal/crypto"
 	mockcrypto "github.com/stacklok/minder/internal/crypto/mock"
 	"github.com/stacklok/minder/internal/db"
 	"github.com/stacklok/minder/internal/db/embedded"
@@ -126,119 +124,6 @@ func testCreatePrivateKeyFile(t *testing.T) *os.File {
 	require.NoError(t, err)
 
 	return tmpFile
-}
-
-func TestProviderService_CreateGitHubOAuthProvider(t *testing.T) {
-	t.Parallel()
-
-	const (
-		stateNonce       = "test-oauth-nonce"
-		stateNonceUpdate = "test-oauth-nonce-update"
-		accountID        = 12345
-	)
-	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
-
-	cfg := &server.ProviderConfig{}
-
-	delegate := mockgh.NewMockDelegate(ctrl)
-	delegate.EXPECT().
-		GetUserId(gomock.Any()).
-		Return(int64(accountID), nil)
-	clientFactory := mockclients.NewMockGitHubClientFactory(ctrl)
-	clientFactory.EXPECT().
-		BuildOAuthClient(gomock.Any(), gomock.Any(), gomock.Any()).
-		Return(nil, delegate, nil)
-
-	provSvc, mocks := testNewGitHubProviderService(t, ctrl, cfg, nil, clientFactory)
-	dbproj, err := mocks.fakeStore.CreateProject(context.Background(),
-		db.CreateProjectParams{
-			Name:     "test",
-			Metadata: []byte(`{}`),
-		})
-	require.NoError(t, err)
-
-	encryptedValue := base64.StdEncoding.EncodeToString([]byte("my-encrypted-token"))
-	encryptedToken := crypto.NewBackwardsCompatibleEncryptedData(encryptedValue)
-	mocks.cryptoMocks.EXPECT().
-		EncryptOAuthToken(gomock.Any()).
-		Return(encryptedToken, nil)
-
-	dbProv, err := provSvc.CreateGitHubOAuthProvider(
-		context.Background(),
-		clients.Github,
-		db.ProviderClassGithub,
-		oauth2.Token{
-			AccessToken: "my-access",
-			TokenType:   "Bearer",
-		},
-		db.GetProjectIDBySessionStateRow{
-			ProjectID: dbproj.ID,
-			OwnerFilter: sql.NullString{
-				Valid:  true,
-				String: "testorg",
-			},
-			RemoteUser: sql.NullString{
-				Valid:  true,
-				String: strconv.Itoa(accountID),
-			},
-		},
-		stateNonce)
-	require.NoError(t, err)
-	require.NotNil(t, dbProv)
-	require.Equal(t, dbProv.ProjectID, dbproj.ID)
-	require.Equal(t, dbProv.AuthFlows, clients.OAuthAuthorizationFlows)
-	require.Equal(t, dbProv.Implements, clients.OAuthImplements)
-
-	dbToken, err := mocks.fakeStore.GetAccessTokenByProvider(context.Background(), dbProv.Name)
-	require.NoError(t, err)
-	require.Len(t, dbToken, 1)
-	require.True(t, dbToken[0].EncryptedAccessToken.Valid)
-	deserialized, err := crypto.DeserializeEncryptedData(dbToken[0].EncryptedAccessToken.RawMessage)
-	require.NoError(t, err)
-	require.Equal(t, deserialized, encryptedToken)
-	require.Equal(t, dbToken[0].OwnerFilter, sql.NullString{String: "testorg", Valid: true})
-	require.Equal(t, dbToken[0].EnrollmentNonce, sql.NullString{String: stateNonce, Valid: true})
-
-	// test updating token
-	mocks.cryptoMocks.EXPECT().
-		EncryptOAuthToken(gomock.Any()).
-		Return(encryptedToken, nil)
-
-	dbProvUpdated, err := provSvc.CreateGitHubOAuthProvider(
-		context.Background(),
-		clients.Github,
-		db.ProviderClassGithub,
-		oauth2.Token{
-			AccessToken: "my-access2",
-			TokenType:   "Bearer",
-		},
-		db.GetProjectIDBySessionStateRow{
-			ProjectID: dbproj.ID,
-			OwnerFilter: sql.NullString{
-				Valid:  true,
-				String: "testorg",
-			},
-			RemoteUser: sql.NullString{
-				Valid: false,
-			},
-		},
-		stateNonceUpdate)
-	require.NoError(t, err)
-	require.NotNil(t, dbProv)
-	require.Equal(t, dbProvUpdated.ProjectID, dbProv.ProjectID)
-	require.Equal(t, dbProvUpdated.AuthFlows, dbProv.AuthFlows)
-	require.Equal(t, dbProvUpdated.Implements, dbProv.Implements)
-
-	dbTokenUpdate, err := mocks.fakeStore.GetAccessTokenByProvider(context.Background(), dbProv.Name)
-	require.NoError(t, err)
-	require.Len(t, dbTokenUpdate, 1)
-	require.True(t, dbToken[0].EncryptedAccessToken.Valid)
-	deserialized, err = crypto.DeserializeEncryptedData(dbToken[0].EncryptedAccessToken.RawMessage)
-	require.NoError(t, err)
-	require.Equal(t, deserialized, encryptedToken)
-	require.Equal(t, dbTokenUpdate[0].OwnerFilter, sql.NullString{String: "testorg", Valid: true})
-	require.Equal(t, dbTokenUpdate[0].EnrollmentNonce, sql.NullString{String: stateNonceUpdate, Valid: true})
 }
 
 func TestProviderService_VerifyProviderTokenIdentity(t *testing.T) {


### PR DESCRIPTION

# Summary

We now use the provided-agnostic code to create a github provider,
introduced in e578bf8b281c3c0e3ae842ec67341c030f26ced9, so let's remove
the unused code.

Related: #3263

## Change Type

***Mark the type of change your PR introduces:***

- [ ] Bug fix (resolves an issue without affecting existing features)
- [ ] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [x] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

make

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [ ] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [ ] Included tests that validate the fix or feature.
- [ ] Checked that related changes are merged.
