### PR TITLE
Marshall provider config back to JSON from parsed structures to strip extra keys

### DIFF
--- a/internal/controlplane/handlers_providers_test.go
+++ b/internal/controlplane/handlers_providers_test.go
@@ -144,14 +144,15 @@ func TestCreateProvider(t *testing.T) {
 			providerClass: db.ProviderClassGithub,
 			userConfig: newPbStruct(t, map[string]interface{}{
 				"github": map[string]interface{}{
-					"key": "value",
+					"key":      "value", // will be ignored
+					"endpoint": "my.little.github",
 				},
 			}),
 			expected: minder.Provider{
 				Name: "test-github-config",
 				Config: newPbStruct(t, map[string]interface{}{
 					"github": map[string]interface{}{
-						"key": "value",
+						"endpoint": "my.little.github",
 					},
 				}),
 				Class: string(db.ProviderClassGithub),
@@ -173,14 +174,15 @@ func TestCreateProvider(t *testing.T) {
 			providerClass: db.ProviderClassGithubApp,
 			userConfig: newPbStruct(t, map[string]interface{}{
 				"github-app": map[string]interface{}{
-					"key": "value",
+					"key":      "value", // will be ignored
+					"endpoint": "my.little.github",
 				},
 			}),
 			expected: minder.Provider{
 				Name: "test-github-app-config",
 				Config: newPbStruct(t, map[string]interface{}{
 					"github-app": map[string]interface{}{
-						"key": "value",
+						"endpoint": "my.little.github",
 					},
 				}),
 				Class: string(db.ProviderClassGithubApp),
@@ -191,7 +193,7 @@ func TestCreateProvider(t *testing.T) {
 			providerClass: db.ProviderClassDockerhub,
 			userConfig: newPbStruct(t, map[string]interface{}{
 				"dockerhub": map[string]interface{}{
-					"key":       "value",
+					"key":       "value", // will be ignored
 					"namespace": "myproject",
 				},
 			}),
@@ -199,7 +201,6 @@ func TestCreateProvider(t *testing.T) {
 				Name: "test-dockerhub-config",
 				Config: newPbStruct(t, map[string]interface{}{
 					"dockerhub": map[string]interface{}{
-						"key":       "value",
 						"namespace": "myproject",
 					},
 				}),

--- a/internal/providers/dockerhub/dockerhub.go
+++ b/internal/providers/dockerhub/dockerhub.go
@@ -86,13 +86,13 @@ func New(cred provifv1.OAuth2TokenCredential, cfg *minderv1.DockerHubProviderCon
 	}, nil
 }
 
+type dhConfigWrapper struct {
+	DockerHub *minderv1.DockerHubProviderConfig `json:"dockerhub" yaml:"dockerhub" mapstructure:"dockerhub" validate:"required"`
+}
+
 // ParseV1Config parses the raw config into a DockerHubProviderConfig struct
 func ParseV1Config(rawCfg json.RawMessage) (*minderv1.DockerHubProviderConfig, error) {
-	type wrapper struct {
-		DockerHub *minderv1.DockerHubProviderConfig `json:"dockerhub" yaml:"dockerhub" mapstructure:"dockerhub" validate:"required"`
-	}
-
-	var w wrapper
+	var w dhConfigWrapper
 	if err := provifv1.ParseAndValidate(rawCfg, &w); err != nil {
 		return nil, err
 	}
@@ -103,6 +103,14 @@ func ParseV1Config(rawCfg json.RawMessage) (*minderv1.DockerHubProviderConfig, e
 	}
 
 	return w.DockerHub, nil
+}
+
+// MarshalV1Config marshals the DockerHubProviderConfig struct into a raw config
+func MarshalV1Config(cfg *minderv1.DockerHubProviderConfig) (json.RawMessage, error) {
+	w := dhConfigWrapper{
+		DockerHub: cfg,
+	}
+	return json.Marshal(w)
 }
 
 func (d *dockerHubImageLister) GetNamespaceURL() string {

--- a/internal/providers/dockerhub/manager.go
+++ b/internal/providers/dockerhub/manager.go
@@ -132,7 +132,7 @@ func (m *providerClassManager) GetConfig(
 	return userConfig, nil
 }
 
-func (m *providerClassManager) ValidateConfig(
+func (m *providerClassManager) MarshallConfig(
 	_ context.Context, class db.ProviderClass, config json.RawMessage,
 ) error {
 	if !slices.Contains(m.GetSupportedClasses(), class) {

--- a/internal/providers/dockerhub/manager.go
+++ b/internal/providers/dockerhub/manager.go
@@ -134,11 +134,15 @@ func (m *providerClassManager) GetConfig(
 
 func (m *providerClassManager) MarshallConfig(
 	_ context.Context, class db.ProviderClass, config json.RawMessage,
-) error {
+) (json.RawMessage, error) {
 	if !slices.Contains(m.GetSupportedClasses(), class) {
-		return fmt.Errorf("provider does not implement %s", string(class))
+		return nil, fmt.Errorf("provider does not implement %s", string(class))
 	}
 
-	_, err := ParseV1Config(config)
-	return err
+	dc, err := ParseV1Config(config)
+	if err != nil {
+		return nil, err
+	}
+
+	return MarshalV1Config(dc)
 }

--- a/internal/providers/github/clients/app.go
+++ b/internal/providers/github/clients/app.go
@@ -110,19 +110,19 @@ func NewGitHubAppProvider(
 	), nil
 }
 
+// embedding the struct to expose its JSON tags
+type appConfigWrapper struct {
+	*minderv1.ProviderConfig
+	GitHubApp *minderv1.GitHubAppProviderConfig `json:"github-app" yaml:"github-app" mapstructure:"github-app" validate:"required"`
+}
+
 // ParseV1AppConfig parses the raw config into a GitHubAppProviderConfig struct
 func ParseV1AppConfig(rawCfg json.RawMessage) (
 	*minderv1.ProviderConfig,
 	*minderv1.GitHubAppProviderConfig,
 	error,
 ) {
-	// embedding the struct to expose its JSON tags
-	type wrapper struct {
-		*minderv1.ProviderConfig
-		GitHubApp *minderv1.GitHubAppProviderConfig `json:"github-app" yaml:"github-app" mapstructure:"github-app" validate:"required"`
-	}
-
-	var w wrapper
+	var w appConfigWrapper
 	if err := provifv1.ParseAndValidate(rawCfg, &w); err != nil {
 		return nil, nil, err
 	}
@@ -139,6 +139,19 @@ func ParseV1AppConfig(rawCfg json.RawMessage) (
 	}
 
 	return w.ProviderConfig, w.GitHubApp, nil
+}
+
+// MarshalV1AppConfig marshals the GitHubAppProviderConfig struct into a raw config
+func MarshalV1AppConfig(
+	providerCfg *minderv1.ProviderConfig,
+	appCfg *minderv1.GitHubAppProviderConfig,
+) (json.RawMessage, error) {
+	w := appConfigWrapper{
+		ProviderConfig: providerCfg,
+		GitHubApp:      appCfg,
+	}
+
+	return json.Marshal(w)
 }
 
 // Ensure that the GitHubAppDelegate client implements the GitHub Delegate interface

--- a/internal/providers/github/clients/oauth.go
+++ b/internal/providers/github/clients/oauth.go
@@ -95,13 +95,13 @@ func NewRestClient(
 	), nil
 }
 
+type oauthConfigWrapper struct {
+	GitHub *minderv1.GitHubProviderConfig `json:"github" yaml:"github" mapstructure:"github" validate:"required"`
+}
+
 // ParseV1OAuthConfig parses the raw config into a GitHubConfig struct
 func ParseV1OAuthConfig(rawCfg json.RawMessage) (*minderv1.GitHubProviderConfig, error) {
-	type wrapper struct {
-		GitHub *minderv1.GitHubProviderConfig `json:"github" yaml:"github" mapstructure:"github" validate:"required"`
-	}
-
-	var w wrapper
+	var w oauthConfigWrapper
 	if err := provifv1.ParseAndValidate(rawCfg, &w); err != nil {
 		return nil, err
 	}
@@ -112,6 +112,14 @@ func ParseV1OAuthConfig(rawCfg json.RawMessage) (*minderv1.GitHubProviderConfig,
 	}
 
 	return w.GitHub, nil
+}
+
+// MarshalV1OAuthConfig marshals the GitHubConfig struct into a raw config
+func MarshalV1OAuthConfig(cfg *minderv1.GitHubProviderConfig) (json.RawMessage, error) {
+	w := oauthConfigWrapper{
+		GitHub: cfg,
+	}
+	return json.Marshal(w)
 }
 
 // GetCredential returns the GitHub OAuth credential

--- a/internal/providers/github/manager/manager.go
+++ b/internal/providers/github/manager/manager.go
@@ -308,7 +308,7 @@ func (g *githubProviderManager) GetConfig(
 	return g.ghService.GetConfig(ctx, class, userConfig)
 }
 
-func (g *githubProviderManager) ValidateConfig(
+func (g *githubProviderManager) MarshallConfig(
 	_ context.Context, class db.ProviderClass, config json.RawMessage,
 ) error {
 	var err error

--- a/internal/providers/github/manager/manager.go
+++ b/internal/providers/github/manager/manager.go
@@ -310,24 +310,38 @@ func (g *githubProviderManager) GetConfig(
 
 func (g *githubProviderManager) MarshallConfig(
 	_ context.Context, class db.ProviderClass, config json.RawMessage,
-) error {
-	var err error
+) (json.RawMessage, error) {
+	var marshalledConfig json.RawMessage
 
 	if !slices.Contains(g.GetSupportedClasses(), class) {
-		return fmt.Errorf("provider does not implement %s", string(class))
+		return nil, fmt.Errorf("provider does not implement %s", string(class))
 	}
 
 	// nolint:exhaustive // we really want handle only the two
 	switch class {
 	case db.ProviderClassGithub:
-		_, err = clients.ParseV1OAuthConfig(config)
+		oauthCfg, err := clients.ParseV1OAuthConfig(config)
+		if err != nil {
+			return nil, err
+		}
+		marshalledConfig, err = clients.MarshalV1OAuthConfig(oauthCfg)
+		if err != nil {
+			return nil, err
+		}
 	case db.ProviderClassGithubApp:
-		_, _, err = clients.ParseV1AppConfig(config)
+		pcfg, appCfg, err := clients.ParseV1AppConfig(config)
+		if err != nil {
+			return nil, err
+		}
+		marshalledConfig, err = clients.MarshalV1AppConfig(pcfg, appCfg)
+		if err != nil {
+			return nil, err
+		}
 	default:
-		return fmt.Errorf("unsupported provider class %s", class)
+		return nil, fmt.Errorf("unsupported provider class %s", class)
 	}
 
-	return err
+	return marshalledConfig, nil
 }
 
 func (g *githubProviderManager) NewOAuthConfig(providerClass db.ProviderClass, cli bool) (*oauth2.Config, error) {

--- a/internal/providers/github/service/service.go
+++ b/internal/providers/github/service/service.go
@@ -149,14 +149,19 @@ func (p *ghProviderService) CreateGitHubAppProvider(
 			return nil
 		}
 
-		finalConfig, err := p.GetConfig(ctx, db.ProviderClassGithubApp, stateData.ProviderConfig)
+		providerConfig, err := p.GetConfig(ctx, db.ProviderClassGithubApp, stateData.ProviderConfig)
 		if err != nil {
 			return nil, fmt.Errorf("error getting provider config: %w", err)
 		}
 
-		_, _, err = clients.ParseV1AppConfig(finalConfig)
+		pcfg, appCfg, err := clients.ParseV1AppConfig(providerConfig)
 		if err != nil {
 			return nil, providers.NewErrProviderInvalidConfig(err.Error())
+		}
+
+		marshalledConfig, err := clients.MarshalV1AppConfig(pcfg, appCfg)
+		if err != nil {
+			return nil, err
 		}
 
 		provider, err := createGitHubApp(
@@ -165,7 +170,7 @@ func (p *ghProviderService) CreateGitHubAppProvider(
 			stateData.ProjectID,
 			installationOwner,
 			installationID,
-			finalConfig,
+			marshalledConfig,
 			validateOwnership,
 			sql.NullString{
 				String: state,

--- a/internal/providers/manager/manager.go
+++ b/internal/providers/manager/manager.go
@@ -71,7 +71,7 @@ type ProviderClassManager interface {
 	providerClassAuthManager
 
 	GetConfig(ctx context.Context, class db.ProviderClass, userConfig json.RawMessage) (json.RawMessage, error)
-	ValidateConfig(ctx context.Context, class db.ProviderClass, config json.RawMessage) error
+	MarshallConfig(ctx context.Context, class db.ProviderClass, config json.RawMessage) error
 	// Build creates an instance of Provider based on the config in the DB
 	Build(ctx context.Context, config *db.Provider) (v1.Provider, error)
 	// Delete deletes an instance of this provider
@@ -154,7 +154,7 @@ func (p *providerManager) CreateFromConfig(
 		return nil, fmt.Errorf("error getting provider config: %w", err)
 	}
 
-	err = manager.ValidateConfig(ctx, providerClass, provConfig)
+	err = manager.MarshallConfig(ctx, providerClass, provConfig)
 	if err != nil {
 		return nil, providers.NewErrProviderInvalidConfig(err.Error())
 	}

--- a/internal/providers/manager/manager.go
+++ b/internal/providers/manager/manager.go
@@ -71,7 +71,8 @@ type ProviderClassManager interface {
 	providerClassAuthManager
 
 	GetConfig(ctx context.Context, class db.ProviderClass, userConfig json.RawMessage) (json.RawMessage, error)
-	MarshallConfig(ctx context.Context, class db.ProviderClass, config json.RawMessage) error
+	// MarshallConfig validates the config and marshalls it into a format that can be stored in the database
+	MarshallConfig(ctx context.Context, class db.ProviderClass, config json.RawMessage) (json.RawMessage, error)
 	// Build creates an instance of Provider based on the config in the DB
 	Build(ctx context.Context, config *db.Provider) (v1.Provider, error)
 	// Delete deletes an instance of this provider
@@ -154,12 +155,12 @@ func (p *providerManager) CreateFromConfig(
 		return nil, fmt.Errorf("error getting provider config: %w", err)
 	}
 
-	err = manager.MarshallConfig(ctx, providerClass, provConfig)
+	marshalledConfig, err := manager.MarshallConfig(ctx, providerClass, provConfig)
 	if err != nil {
 		return nil, providers.NewErrProviderInvalidConfig(err.Error())
 	}
 
-	return p.store.Create(ctx, providerClass, name, projectID, provConfig)
+	return p.store.Create(ctx, providerClass, name, projectID, marshalledConfig)
 }
 
 func (p *providerManager) InstantiateFromID(ctx context.Context, providerID uuid.UUID) (v1.Provider, error) {

--- a/internal/providers/manager/manager_test.go
+++ b/internal/providers/manager/manager_test.go
@@ -79,9 +79,11 @@ func TestProviderManager_CreateFromConfig(t *testing.T) {
 			classManager.EXPECT().GetSupportedClasses().Return([]db.ProviderClass{db.ProviderClassGithub}).MaxTimes(1)
 			classManager.EXPECT().GetConfig(gomock.Any(), scenario.Provider.Class, gomock.Any()).Return(scenario.Config, nil).MaxTimes(1)
 			if scenario.ValidateConfigErr {
-				classManager.EXPECT().ValidateConfig(gomock.Any(), scenario.Provider.Class, scenario.Config).Return(fmt.Errorf("invalid config")).MaxTimes(1)
+				classManager.EXPECT().MarshallConfig(gomock.Any(), scenario.Provider.Class, scenario.Config).
+					Return(nil, fmt.Errorf("invalid config")).MaxTimes(1)
 			} else {
-				classManager.EXPECT().ValidateConfig(gomock.Any(), scenario.Provider.Class, scenario.Config).Return(nil).MaxTimes(1)
+				classManager.EXPECT().MarshallConfig(gomock.Any(), scenario.Provider.Class, scenario.Config).
+					Return(scenario.Config, nil).MaxTimes(1)
 			}
 
 			expectedProvider := providerWithClass(scenario.Provider.Class, providerWithConfig(scenario.Config))

--- a/internal/providers/manager/mock/auth_manager.go
+++ b/internal/providers/manager/mock/auth_manager.go
@@ -182,6 +182,21 @@ func (mr *MockproviderClassOAuthManagerMockRecorder) GetSupportedClasses() *gomo
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSupportedClasses", reflect.TypeOf((*MockproviderClassOAuthManager)(nil).GetSupportedClasses))
 }
 
+// MarshallConfig mocks base method.
+func (m *MockproviderClassOAuthManager) MarshallConfig(ctx context.Context, class db.ProviderClass, config json.RawMessage) (json.RawMessage, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "MarshallConfig", ctx, class, config)
+	ret0, _ := ret[0].(json.RawMessage)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// MarshallConfig indicates an expected call of MarshallConfig.
+func (mr *MockproviderClassOAuthManagerMockRecorder) MarshallConfig(ctx, class, config any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MarshallConfig", reflect.TypeOf((*MockproviderClassOAuthManager)(nil).MarshallConfig), ctx, class, config)
+}
+
 // NewOAuthConfig mocks base method.
 func (m *MockproviderClassOAuthManager) NewOAuthConfig(providerClass db.ProviderClass, cli bool) (*oauth2.Config, error) {
 	m.ctrl.T.Helper()
@@ -195,20 +210,6 @@ func (m *MockproviderClassOAuthManager) NewOAuthConfig(providerClass db.Provider
 func (mr *MockproviderClassOAuthManagerMockRecorder) NewOAuthConfig(providerClass, cli any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewOAuthConfig", reflect.TypeOf((*MockproviderClassOAuthManager)(nil).NewOAuthConfig), providerClass, cli)
-}
-
-// ValidateConfig mocks base method.
-func (m *MockproviderClassOAuthManager) MarshallConfig(ctx context.Context, class db.ProviderClass, config json.RawMessage) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "MarshallConfig", ctx, class, config)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// ValidateConfig indicates an expected call of ValidateConfig.
-func (mr *MockproviderClassOAuthManagerMockRecorder) ValidateConfig(ctx, class, config any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MarshallConfig", reflect.TypeOf((*MockproviderClassOAuthManager)(nil).MarshallConfig), ctx, class, config)
 }
 
 // ValidateCredentials mocks base method.

--- a/internal/providers/manager/mock/auth_manager.go
+++ b/internal/providers/manager/mock/auth_manager.go
@@ -198,9 +198,9 @@ func (mr *MockproviderClassOAuthManagerMockRecorder) NewOAuthConfig(providerClas
 }
 
 // ValidateConfig mocks base method.
-func (m *MockproviderClassOAuthManager) ValidateConfig(ctx context.Context, class db.ProviderClass, config json.RawMessage) error {
+func (m *MockproviderClassOAuthManager) MarshallConfig(ctx context.Context, class db.ProviderClass, config json.RawMessage) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ValidateConfig", ctx, class, config)
+	ret := m.ctrl.Call(m, "MarshallConfig", ctx, class, config)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
@@ -208,7 +208,7 @@ func (m *MockproviderClassOAuthManager) ValidateConfig(ctx context.Context, clas
 // ValidateConfig indicates an expected call of ValidateConfig.
 func (mr *MockproviderClassOAuthManagerMockRecorder) ValidateConfig(ctx, class, config any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ValidateConfig", reflect.TypeOf((*MockproviderClassOAuthManager)(nil).ValidateConfig), ctx, class, config)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MarshallConfig", reflect.TypeOf((*MockproviderClassOAuthManager)(nil).MarshallConfig), ctx, class, config)
 }
 
 // ValidateCredentials mocks base method.

--- a/internal/providers/manager/mock/manager.go
+++ b/internal/providers/manager/mock/manager.go
@@ -213,16 +213,17 @@ func (mr *MockProviderClassManagerMockRecorder) GetSupportedClasses() *gomock.Ca
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSupportedClasses", reflect.TypeOf((*MockProviderClassManager)(nil).GetSupportedClasses))
 }
 
-// ValidateConfig mocks base method.
-func (m *MockProviderClassManager) ValidateConfig(ctx context.Context, class db.ProviderClass, config json.RawMessage) error {
+// MarshallConfig mocks base method.
+func (m *MockProviderClassManager) MarshallConfig(ctx context.Context, class db.ProviderClass, config json.RawMessage) (json.RawMessage, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ValidateConfig", ctx, class, config)
-	ret0, _ := ret[0].(error)
-	return ret0
+	ret := m.ctrl.Call(m, "MarshallConfig", ctx, class, config)
+	ret0, _ := ret[0].(json.RawMessage)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
-// ValidateConfig indicates an expected call of ValidateConfig.
-func (mr *MockProviderClassManagerMockRecorder) ValidateConfig(ctx, class, config any) *gomock.Call {
+// MarshallConfig indicates an expected call of MarshallConfig.
+func (mr *MockProviderClassManagerMockRecorder) MarshallConfig(ctx, class, config any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ValidateConfig", reflect.TypeOf((*MockProviderClassManager)(nil).ValidateConfig), ctx, class, config)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MarshallConfig", reflect.TypeOf((*MockProviderClassManager)(nil).MarshallConfig), ctx, class, config)
 }


### PR DESCRIPTION
# Summary

Right now, we parse the user-provided provider configuration, but if it passes validation, we save the user-provided config verbatim. This means that if there are any extra keys, we save them as well because Go ignores extra attributes when unmarshalling JSON.

We need to fix this or else we risk our users flood our database with large configs.

Credit to @blkt for bringing this up.

Fixes #3543

## Change Type

- [x] Bug fix (resolves an issue without affecting existing features)
- [ ] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [ ] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

manual + make test

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [ ] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [x] Included tests that validate the fix or feature.
- [ ] Checked that related changes are merged.
