### PR TITLE
Recover from panics in policy engine

### DIFF
--- a/internal/engine/errors/errors.go
+++ b/internal/engine/errors/errors.go
@@ -24,6 +24,9 @@ import (
 	"github.com/stacklok/minder/internal/db"
 )
 
+// ErrInternal is an error that occurs when there is an internal error in the minder engine.
+var ErrInternal = errors.New("internal minder error")
+
 // EvaluationError is a custom error type for evaluation errors.
 type EvaluationError struct {
 	Base error


### PR DESCRIPTION
# Summary

Currently, if there's a panic caused by the evaluation of a policy or
execution of an action, Minder panics and restarts. This is not ideal.
We instead explicitly recover from panics and surface the error up to
the user.

A user will only see that there was an internal error in Minder, but a
relevant log entry will be written.

## Change Type

***Mark the type of change your PR introduces:***

- [x] Bug fix (resolves an issue without affecting existing features)
- [ ] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [ ] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

***Outline how the changes were tested, including steps to reproduce and any relevant configurations. 
Attach screenshots if helpful.***

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [ ] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [ ] Included tests that validate the fix or feature.
- [ ] Checked that related changes are merged.
