### PR TITLE
Various changes to the eval history schema service

### DIFF
--- a/database/migrations/000069_evaluation_history_modifications.down.sql
+++ b/database/migrations/000069_evaluation_history_modifications.down.sql
@@ -1,0 +1,43 @@
+-- Copyright 2024 Stacklok, Inc
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--      http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+BEGIN;
+
+-- change tables back to old names
+ALTER TABLE evaluation_rule_entities RENAME TO rule_entity_evaluations;
+ALTER TABLE evaluation_statuses RENAME TO evaluation_history;
+ALTER TABLE latest_evaluation_statuses RENAME TO latest_evaluation_state;
+
+-- recreate FKs without ON DELETE CASCADE
+ALTER TABLE rule_entity_evaluations DROP CONSTRAINT evaluation_rule_entities_artifact_id_fkey;
+ALTER TABLE rule_entity_evaluations DROP CONSTRAINT evaluation_rule_entities_repository_id_fkey;
+ALTER TABLE rule_entity_evaluations DROP CONSTRAINT evaluation_rule_entities_pull_request_id_fkey;
+ALTER TABLE remediation_events DROP CONSTRAINT remediation_events_evaluation_id_fkey;
+ALTER TABLE alert_events DROP CONSTRAINT alert_events_evaluation_id_fkey;
+
+ALTER TABLE rule_entity_evaluations ADD FOREIGN KEY (artifact_id) REFERENCES artifacts(id);
+ALTER TABLE rule_entity_evaluations ADD FOREIGN KEY (repository_id) REFERENCES repositories(id);
+ALTER TABLE rule_entity_evaluations ADD FOREIGN KEY (pull_request_id) REFERENCES pull_requests(id);
+ALTER TABLE remediation_events ADD FOREIGN KEY (evaluation_id) REFERENCES evaluation_statuses(id);
+ALTER TABLE alert_events ADD FOREIGN KEY (evaluation_id) REFERENCES evaluation_statuses(id);
+
+-- recreate evaluation_instance table
+ALTER TABLE evaluation_history DROP COLUMN evaluation_times;
+CREATE TABLE evaluation_instance(
+    evaluation_id UUID NOT NULL REFERENCES evaluation_history(id) ON DELETE CASCADE,
+    evaluation_time TIMESTAMP NOT NULL DEFAULT NOW(),
+    PRIMARY KEY (evaluation_id, evaluation_time)
+);
+
+COMMIT;

--- a/database/migrations/000069_evaluation_history_modifications.up.sql
+++ b/database/migrations/000069_evaluation_history_modifications.up.sql
@@ -1,0 +1,43 @@
+-- Copyright 2024 Stacklok, Inc
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--      http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+BEGIN;
+
+-- these changes reflect feedback during design review plus some changes I've
+-- wanted to make after writing queries around these tables.
+
+-- give some of the tables better names
+-- these tables are not yet used in the codebase, so renaming them should be low risk
+ALTER TABLE rule_entity_evaluations RENAME TO evaluation_rule_entities;
+ALTER TABLE evaluation_history      RENAME TO evaluation_statuses;
+ALTER TABLE latest_evaluation_state RENAME to latest_evaluation_statuses;
+
+-- ensure FK cascades are set for entities, and for the alerts/remedations
+ALTER TABLE evaluation_rule_entities DROP CONSTRAINT rule_entity_evaluations_artifact_id_fkey;
+ALTER TABLE evaluation_rule_entities DROP CONSTRAINT rule_entity_evaluations_repository_id_fkey;
+ALTER TABLE evaluation_rule_entities DROP CONSTRAINT rule_entity_evaluations_pull_request_id_fkey;
+ALTER TABLE remediation_events DROP CONSTRAINT remediation_events_evaluation_id_fkey;
+ALTER TABLE alert_events DROP CONSTRAINT alert_events_evaluation_id_fkey;
+
+ALTER TABLE evaluation_rule_entities ADD FOREIGN KEY (artifact_id) REFERENCES artifacts(id) ON DELETE CASCADE;
+ALTER TABLE evaluation_rule_entities ADD FOREIGN KEY (repository_id) REFERENCES repositories(id) ON DELETE CASCADE;
+ALTER TABLE evaluation_rule_entities ADD FOREIGN KEY (pull_request_id) REFERENCES pull_requests(id) ON DELETE CASCADE;
+ALTER TABLE remediation_events ADD FOREIGN KEY (evaluation_id) REFERENCES evaluation_statuses(id) ON DELETE CASCADE;
+ALTER TABLE alert_events ADD FOREIGN KEY (evaluation_id) REFERENCES evaluation_statuses(id) ON DELETE CASCADE;
+
+-- use an array of timestamps instead of a separate table when tracking evaluation instances
+DROP TABLE IF EXISTS evaluation_instance;
+ALTER TABLE evaluation_statuses ADD COLUMN evaluation_times TIMESTAMP[] NOT NULL DEFAULT ARRAY[]::TIMESTAMP[];
+
+COMMIT;

--- a/database/migrations/000069_evaluation_history_modifications.up.sql
+++ b/database/migrations/000069_evaluation_history_modifications.up.sql
@@ -23,7 +23,7 @@ ALTER TABLE rule_entity_evaluations RENAME TO evaluation_rule_entities;
 ALTER TABLE evaluation_history      RENAME TO evaluation_statuses;
 ALTER TABLE latest_evaluation_state RENAME to latest_evaluation_statuses;
 
--- ensure FK cascades are set for entities, and for the alerts/remedations
+-- ensure FK cascades are set for entities, and for the alerts/remediations
 ALTER TABLE evaluation_rule_entities DROP CONSTRAINT rule_entity_evaluations_artifact_id_fkey;
 ALTER TABLE evaluation_rule_entities DROP CONSTRAINT rule_entity_evaluations_repository_id_fkey;
 ALTER TABLE evaluation_rule_entities DROP CONSTRAINT rule_entity_evaluations_pull_request_id_fkey;

--- a/database/migrations/000069_evaluation_history_modifications.up.sql
+++ b/database/migrations/000069_evaluation_history_modifications.up.sql
@@ -38,6 +38,6 @@ ALTER TABLE alert_events ADD FOREIGN KEY (evaluation_id) REFERENCES evaluation_s
 
 -- use an array of timestamps instead of a separate table when tracking evaluation instances
 DROP TABLE IF EXISTS evaluation_instance;
-ALTER TABLE evaluation_statuses ADD COLUMN evaluation_times TIMESTAMP[] NOT NULL DEFAULT ARRAY[]::TIMESTAMP[];
+ALTER TABLE evaluation_statuses ADD COLUMN evaluation_times TIMESTAMP[] NOT NULL DEFAULT ARRAY[NOW()]::TIMESTAMP[];
 
 COMMIT;

--- a/internal/db/models.go
+++ b/internal/db/models.go
@@ -481,16 +481,20 @@ type EntityProfileRule struct {
 	CreatedAt       time.Time `json:"created_at"`
 }
 
-type EvaluationHistory struct {
-	ID           uuid.UUID       `json:"id"`
-	RuleEntityID uuid.UUID       `json:"rule_entity_id"`
-	Status       EvalStatusTypes `json:"status"`
-	Details      string          `json:"details"`
+type EvaluationRuleEntity struct {
+	ID            uuid.UUID     `json:"id"`
+	RuleID        uuid.UUID     `json:"rule_id"`
+	RepositoryID  uuid.NullUUID `json:"repository_id"`
+	PullRequestID uuid.NullUUID `json:"pull_request_id"`
+	ArtifactID    uuid.NullUUID `json:"artifact_id"`
 }
 
-type EvaluationInstance struct {
-	EvaluationID   uuid.UUID `json:"evaluation_id"`
-	EvaluationTime time.Time `json:"evaluation_time"`
+type EvaluationStatus struct {
+	ID              uuid.UUID       `json:"id"`
+	RuleEntityID    uuid.UUID       `json:"rule_entity_id"`
+	Status          EvalStatusTypes `json:"status"`
+	Details         string          `json:"details"`
+	EvaluationTimes []time.Time     `json:"evaluation_times"`
 }
 
 type Feature struct {
@@ -510,7 +514,7 @@ type FlushCache struct {
 	ProjectID     uuid.NullUUID `json:"project_id"`
 }
 
-type LatestEvaluationState struct {
+type LatestEvaluationStatus struct {
 	RuleEntityID        uuid.UUID `json:"rule_entity_id"`
 	EvaluationHistoryID uuid.UUID `json:"evaluation_history_id"`
 }
@@ -661,14 +665,6 @@ type RuleDetailsRemediate struct {
 	Details     string                 `json:"details"`
 	LastUpdated time.Time              `json:"last_updated"`
 	Metadata    json.RawMessage        `json:"metadata"`
-}
-
-type RuleEntityEvaluation struct {
-	ID            uuid.UUID     `json:"id"`
-	RuleID        uuid.UUID     `json:"rule_id"`
-	RepositoryID  uuid.NullUUID `json:"repository_id"`
-	PullRequestID uuid.NullUUID `json:"pull_request_id"`
-	ArtifactID    uuid.NullUUID `json:"artifact_id"`
 }
 
 type RuleEvaluation struct {


### PR DESCRIPTION
These relate to feedback from the design review, plus making some changes in light of writing code which uses these tables:

1) Use `ON DELETE CASCADE` for all foreign key references.
2) Use an array of timestamps to store the evaluation instances instead
   of keeping them in a separate table.
3) Change some of the table names. The original names were not
   particularly consistent or intuitive.

Since Minder does not use any of these tables at this point, there should be no impact from these changes.

# Summary

***Provide a brief overview of the changes and the issue being addressed. 
Explain the rationale and any background necessary for understanding the changes. 
List dependencies required by this change, if any.***

Fixes #(related issue)

## Change Type

***Mark the type of change your PR introduces:***

- [ ] Bug fix (resolves an issue without affecting existing features)
- [x] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [ ] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

***Outline how the changes were tested, including steps to reproduce and any relevant configurations. 
Attach screenshots if helpful.***

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [x] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [ ] Included tests that validate the fix or feature.
- [ ] Checked that related changes are merged.
