### PR TITLE
Handle nil values from Trusty API

### DIFF
--- a/internal/engine/eval/trusty/trusty.go
+++ b/internal/engine/eval/trusty/trusty.go
@@ -338,7 +338,7 @@ func readPackageDescription(resp *trustytypes.Reply) map[string]any {
 
 	// Ensure don't panic checking all fields are there
 	for _, fld := range []string{"activity", "provenance"} {
-		if _, ok := descr[fld]; !ok {
+		if _, ok := descr[fld]; !ok || descr[fld] == nil {
 			descr[fld] = float64(0)
 		}
 	}

--- a/internal/engine/eval/trusty/trusty_test.go
+++ b/internal/engine/eval/trusty/trusty_test.go
@@ -348,6 +348,24 @@ func TestClassifyDependency(t *testing.T) {
 			},
 			mustFilter: true,
 		},
+		{
+			name: "nil-activity",
+			score: &trustytypes.Reply{
+				PackageName: "test",
+				PackageType: "npm",
+				Summary: trustytypes.ScoreSummary{
+					Score: mkfloat(8.0),
+					Description: map[string]any{
+						"provenance": nil,
+					},
+				},
+			},
+			config: defaultConfig(),
+			expected: &dependencyAlternatives{
+				Reasons: []RuleViolationReason{},
+			},
+			mustFilter: false,
+		},
 	} {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
# Summary

Handle possible `nil` values in the `activity` and `provenance` scores returned by the Trusty API.
The Trusty team made a change today that allowed nil values in the response, while previously they would alway return a float.

## Change Type

***Mark the type of change your PR introduces:***

- [x] Bug fix (resolves an issue without affecting existing features)
- [ ] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [ ] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

***Outline how the changes were tested, including steps to reproduce and any relevant configurations. 
Attach screenshots if helpful.***

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [ ] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [x] Included tests that validate the fix or feature.
- [ ] Checked that related changes are merged.
