### PR TITLE
Fall back to `$XDG_CONFIG_PATH/minder/config.yaml` when reading configuration

### DIFF
--- a/cmd/reminder/app/root.go
+++ b/cmd/reminder/app/root.go
@@ -67,22 +67,25 @@ func init() {
 
 func initConfig() {
 	cfgFile := viper.GetString("config")
-	cfgFileData, err := config.GetConfigFileData(cfgFile, filepath.Join(".", configFileName))
-	if err != nil {
-		log.Fatal().Err(err).Msg("Error reading config file")
-	}
-
-	keysWithNullValue := config.GetKeysWithNullValueFromYAML(cfgFileData, "")
-	if len(keysWithNullValue) > 0 {
-		RootCmd.PrintErrln("Error: The following configuration keys are missing values:")
-		for _, key := range keysWithNullValue {
-			RootCmd.PrintErrln("Null Value at: " + key)
+	cfgFilePath := config.GetRelevantCfgPath(append([]string{cfgFile},
+		filepath.Join(".", configFileName),
+	))
+	if cfgFilePath != "" {
+		cfgFileData, err := config.GetConfigFileData(cfgFilePath)
+		if err != nil {
+			log.Fatal().Err(err).Msg("Error reading config file")
 		}
-		os.Exit(1)
-	}
 
-	if cfgFile != "" {
-		viper.SetConfigFile(cfgFile)
+		keysWithNullValue := config.GetKeysWithNullValueFromYAML(cfgFileData, "")
+		if len(keysWithNullValue) > 0 {
+			RootCmd.PrintErrln("Error: The following configuration keys are missing values:")
+			for _, key := range keysWithNullValue {
+				RootCmd.PrintErrln("Null Value at: " + key)
+			}
+			os.Exit(1)
+		}
+
+		viper.SetConfigFile(cfgFilePath)
 	} else {
 		// use defaults
 		viper.SetConfigName(strings.TrimSuffix(configFileName, filepath.Ext(configFileName)))
@@ -91,7 +94,7 @@ func initConfig() {
 	viper.SetConfigType("yaml")
 	viper.AutomaticEnv()
 
-	if err = viper.ReadInConfig(); err != nil {
+	if err := viper.ReadInConfig(); err != nil {
 		fmt.Println("Error reading config file:", err)
 	}
 }

--- a/internal/util/helpers.go
+++ b/internal/util/helpers.go
@@ -64,7 +64,8 @@ type OpenIdCredentials struct {
 	AccessTokenExpiresAt time.Time `json:"expiry"`
 }
 
-func getCredentialsPath() (string, error) {
+// GetConfigDirPath returns the path to the config directory
+func GetConfigDirPath() (string, error) {
 	// Get the XDG_CONFIG_HOME environment variable
 	xdgConfigHome := os.Getenv("XDG_CONFIG_HOME")
 
@@ -77,7 +78,17 @@ func getCredentialsPath() (string, error) {
 		xdgConfigHome = filepath.Join(homeDir, ".config")
 	}
 
-	filePath := filepath.Join(xdgConfigHome, "minder", "credentials.json")
+	filePath := filepath.Join(xdgConfigHome, "minder")
+	return filePath, nil
+}
+
+func getCredentialsPath() (string, error) {
+	cfgPath, err := GetConfigDirPath()
+	if err != nil {
+		return "", fmt.Errorf("error getting config path: %v", err)
+	}
+
+	filePath := filepath.Join(cfgPath, "credentials.json")
 	return filePath, nil
 }
 


### PR DESCRIPTION
# Summary

This allows us to have a predictable configuration file when reading the
client minder configuration. The idea is that we could set up
`$XDG_CONFIG_PATH/minder/config.yaml` and that would serve as an entrypoint.

In the future, we could modify this if we want to dynamically change
the current working project.

## Change Type

***Mark the type of change your PR introduces:***

- [ ] Bug fix (resolves an issue without affecting existing features)
- [x] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [ ] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [ ] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [x] Included tests that validate the fix or feature.
- [ ] Checked that related changes are merged.
