### PR TITLE
Update the auth invite CLI commands

### DIFF
--- a/cmd/cli/app/auth/invite/invite_accept.go
+++ b/cmd/cli/app/auth/invite/invite_accept.go
@@ -36,7 +36,7 @@ var inviteAcceptCmd = &cobra.Command{
 	Args:   cobra.ExactArgs(1),
 }
 
-// inviteAcceptCommand is the whoami subcommand
+// inviteAcceptCommand is the "invite accept" subcommand
 func inviteAcceptCommand(ctx context.Context, cmd *cobra.Command, args []string, conn *grpc.ClientConn) error {
 	client := minderv1.NewUserServiceClient(conn)
 	code := args[0]

--- a/cmd/cli/app/auth/invite/invite_decline.go
+++ b/cmd/cli/app/auth/invite/invite_decline.go
@@ -36,7 +36,7 @@ var inviteDeclineCmd = &cobra.Command{
 	Args:   cobra.ExactArgs(1),
 }
 
-// inviteAcceptCommand is the whoami subcommand
+// inviteDeclineCommand is the "invite decline" subcommand
 func inviteDeclineCommand(ctx context.Context, cmd *cobra.Command, args []string, conn *grpc.ClientConn) error {
 	client := minderv1.NewUserServiceClient(conn)
 	code := args[0]


### PR DESCRIPTION
# Summary

The following PR updates the `minder auth invite` CLI commands used for accepting, declining, listing and getting invitation info.

Will be made visible in a follow up once we merge all relevant PRs.

Fixes #(related issue)

## Change Type

***Mark the type of change your PR introduces:***

- [ ] Bug fix (resolves an issue without affecting existing features)
- [x] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [ ] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

***Outline how the changes were tested, including steps to reproduce and any relevant configurations. 
Attach screenshots if helpful.***

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [ ] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [ ] Included tests that validate the fix or feature.
- [ ] Checked that related changes are merged.
