### PR TITLE
Provider update should let back end infer the project ID

### DIFF
--- a/cmd/cli/app/provider/provider_update.go
+++ b/cmd/cli/app/provider/provider_update.go
@@ -36,7 +36,6 @@ import (
 
 var (
 	errMissingProviderName = errors.New("provider name flag is missing")
-	errMissingProject      = errors.New("project flag is missing")
 )
 
 var updateCmd = &cobra.Command{
@@ -135,12 +134,6 @@ func UpdateProviderCommand(
 		)
 	}
 	project := viper.GetString("project")
-	if project == "" {
-		return cli.MessageAndError(
-			"invalid option",
-			errMissingProject,
-		)
-	}
 
 	fields := make(map[string]any)
 


### PR DESCRIPTION
# Summary

We're able to infer which project ID to use if it's not specified
explicitly by inferring who the caller is and using their "root"
project.

Related: #3509

## Change Type

***Mark the type of change your PR introduces:***

- [x] Bug fix (resolves an issue without affecting existing features)
- [ ] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [ ] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

manually

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [ ] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [ ] Included tests that validate the fix or feature.
- [ ] Checked that related changes are merged.
