### PR TITLE
Refactor UpdateRole and add display names to invite-related responses

### DIFF
--- a/cmd/cli/app/auth/invite/invite_accept.go
+++ b/cmd/cli/app/auth/invite/invite_accept.go
@@ -51,7 +51,7 @@ func inviteAcceptCommand(ctx context.Context, cmd *cobra.Command, args []string,
 	if err != nil {
 		return cli.MessageAndError("Error resolving invitation", err)
 	}
-	cmd.Printf("Invitation %s for %s to become %s of project %s was accepted!\n", code, res.Email, res.Role, res.Project)
+	cmd.Printf("Invitation %s for %s to become %s of project %s was accepted!\n", code, res.Email, res.Role, res.ProjectDisplay)
 	return nil
 }
 

--- a/cmd/cli/app/auth/invite/invite_decline.go
+++ b/cmd/cli/app/auth/invite/invite_decline.go
@@ -51,7 +51,7 @@ func inviteDeclineCommand(ctx context.Context, cmd *cobra.Command, args []string
 	if err != nil {
 		return cli.MessageAndError("Error resolving invitation", err)
 	}
-	cmd.Printf("Invitation %s for %s to become %s of project %s was declined!\n", code, res.Email, res.Role, res.Project)
+	cmd.Printf("Invitation %s for %s to become %s of project %s was declined!\n", code, res.Email, res.Role, res.ProjectDisplay)
 	return nil
 }
 

--- a/cmd/cli/app/project/role/role_grant.go
+++ b/cmd/cli/app/project/role/role_grant.go
@@ -60,8 +60,8 @@ func GrantCommand(ctx context.Context, cmd *cobra.Command, _ []string, conn *grp
 			Role:  r,
 			Email: email,
 		}
-		failMsg = "Error creating/updating an invite"
-		successMsg = "Invite created/updated successfully."
+		failMsg = "Error creating an invite"
+		successMsg = "Invite created successfully."
 	}
 
 	ret, err := client.AssignRole(ctx, &minderv1.AssignRoleRequest{

--- a/database/mock/store.go
+++ b/database/mock/store.go
@@ -809,10 +809,10 @@ func (mr *MockStoreMockRecorder) GetInstallationIDByProviderID(arg0, arg1 any) *
 }
 
 // GetInvitationByCode mocks base method.
-func (m *MockStore) GetInvitationByCode(arg0 context.Context, arg1 string) (db.UserInvite, error) {
+func (m *MockStore) GetInvitationByCode(arg0 context.Context, arg1 string) (db.GetInvitationByCodeRow, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetInvitationByCode", arg0, arg1)
-	ret0, _ := ret[0].(db.UserInvite)
+	ret0, _ := ret[0].(db.GetInvitationByCodeRow)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -823,26 +823,11 @@ func (mr *MockStoreMockRecorder) GetInvitationByCode(arg0, arg1 any) *gomock.Cal
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetInvitationByCode", reflect.TypeOf((*MockStore)(nil).GetInvitationByCode), arg0, arg1)
 }
 
-// GetInvitationByEmailAndProjectAndRole mocks base method.
-func (m *MockStore) GetInvitationByEmailAndProjectAndRole(arg0 context.Context, arg1 db.GetInvitationByEmailAndProjectAndRoleParams) (db.UserInvite, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetInvitationByEmailAndProjectAndRole", arg0, arg1)
-	ret0, _ := ret[0].(db.UserInvite)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetInvitationByEmailAndProjectAndRole indicates an expected call of GetInvitationByEmailAndProjectAndRole.
-func (mr *MockStoreMockRecorder) GetInvitationByEmailAndProjectAndRole(arg0, arg1 any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetInvitationByEmailAndProjectAndRole", reflect.TypeOf((*MockStore)(nil).GetInvitationByEmailAndProjectAndRole), arg0, arg1)
-}
-
 // GetInvitationsByEmail mocks base method.
-func (m *MockStore) GetInvitationsByEmail(arg0 context.Context, arg1 string) ([]db.UserInvite, error) {
+func (m *MockStore) GetInvitationsByEmail(arg0 context.Context, arg1 string) ([]db.GetInvitationsByEmailRow, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetInvitationsByEmail", arg0, arg1)
-	ret0, _ := ret[0].([]db.UserInvite)
+	ret0, _ := ret[0].([]db.GetInvitationsByEmailRow)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -851,6 +836,21 @@ func (m *MockStore) GetInvitationsByEmail(arg0 context.Context, arg1 string) ([]
 func (mr *MockStoreMockRecorder) GetInvitationsByEmail(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetInvitationsByEmail", reflect.TypeOf((*MockStore)(nil).GetInvitationsByEmail), arg0, arg1)
+}
+
+// GetInvitationsByEmailAndProject mocks base method.
+func (m *MockStore) GetInvitationsByEmailAndProject(arg0 context.Context, arg1 db.GetInvitationsByEmailAndProjectParams) ([]db.GetInvitationsByEmailAndProjectRow, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetInvitationsByEmailAndProject", arg0, arg1)
+	ret0, _ := ret[0].([]db.GetInvitationsByEmailAndProjectRow)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetInvitationsByEmailAndProject indicates an expected call of GetInvitationsByEmailAndProject.
+func (mr *MockStoreMockRecorder) GetInvitationsByEmailAndProject(arg0, arg1 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetInvitationsByEmailAndProject", reflect.TypeOf((*MockStore)(nil).GetInvitationsByEmailAndProject), arg0, arg1)
 }
 
 // GetLatestEvalStateForRuleEntity mocks base method.

--- a/database/query/invitations.sql
+++ b/database/query/invitations.sql
@@ -4,7 +4,7 @@
 -- the invitee.
 
 -- name: ListInvitationsForProject :many
-SELECT user_invites.email, role, users.identity_subject, user_invites.created_at, user_invites.updated_at
+SELECT user_invites.email, role, users.identity_subject, user_invites.created_at, user_invites.updated_at, user_invites.code
 FROM user_invites
   JOIN users ON user_invites.sponsor = users.id
 WHERE project = $1;
@@ -14,15 +14,22 @@ WHERE project = $1;
 -- to allow them to accept invitations even if email delivery was not working.
 -- Note that this requires that the destination email address matches the email
 -- address of the logged in user in the external identity service / auth token.
+-- This clarification is related solely for user's ListInvitations calls and does
+-- not affect to resolving invitations intended for other mail addresses.
 
 -- name: GetInvitationsByEmail :many
-SELECT * FROM user_invites WHERE email = $1;
+SELECT user_invites.*, users.identity_subject
+FROM user_invites
+  JOIN users ON user_invites.sponsor = users.id
+WHERE email = $1;
 
--- GetInvitationByEmailAndProjectAndRole retrieves an invitation by email, project,
--- and role.
+-- GetInvitationsByEmailAndProject retrieves all invitations by email and project.
 
--- name: GetInvitationByEmailAndProjectAndRole :one
-SELECT * FROM user_invites WHERE email = $1 AND project = $2 AND role = $3;
+-- name: GetInvitationsByEmailAndProject :many
+SELECT user_invites.*, users.identity_subject
+FROM user_invites
+  JOIN users ON user_invites.sponsor = users.id
+WHERE email = $1 AND project = $2;
 
 -- GetInvitationByCode retrieves an invitation by its code. This is intended to
 -- be called by a user who has received an invitation email and is following the
@@ -30,7 +37,10 @@ SELECT * FROM user_invites WHERE email = $1 AND project = $2 AND role = $3;
 -- invitation.
 
 -- name: GetInvitationByCode :one
-SELECT * FROM user_invites WHERE code = $1;
+SELECT user_invites.*, users.identity_subject
+FROM user_invites
+  JOIN users ON user_invites.sponsor = users.id
+WHERE code = $1;
 
 -- CreateInvitation creates a new invitation. The code is a secret that is sent
 -- to the invitee, and the email is the address to which the invitation will be

--- a/internal/controlplane/handlers_authz_test.go
+++ b/internal/controlplane/handlers_authz_test.go
@@ -324,13 +324,15 @@ func TestRoleManagement(t *testing.T) {
 		}},
 		result: &minder.ListRoleAssignmentsResponse{
 			RoleAssignments: []*minder.RoleAssignment{{
-				Role:    authz.AuthzRoleAdmin.String(),
-				Subject: user1.String(),
-				Project: proto.String(project.String()),
+				Role:        authz.AuthzRoleAdmin.String(),
+				Subject:     user1.String(),
+				DisplayName: "user1",
+				Project:     proto.String(project.String()),
 			}, {
-				Role:    authz.AuthzRoleAdmin.String(),
-				Subject: user2.String(),
-				Project: proto.String(project.String()),
+				Role:        authz.AuthzRoleAdmin.String(),
+				DisplayName: "user2",
+				Subject:     user2.String(),
+				Project:     proto.String(project.String()),
 			}},
 		},
 		stored: []*minder.RoleAssignment{{
@@ -357,9 +359,10 @@ func TestRoleManagement(t *testing.T) {
 		}},
 		result: &minder.ListRoleAssignmentsResponse{
 			RoleAssignments: []*minder.RoleAssignment{{
-				Role:    authz.AuthzRoleAdmin.String(),
-				Subject: user1.String(),
-				Project: proto.String(project.String()),
+				Role:        authz.AuthzRoleAdmin.String(),
+				DisplayName: "user1",
+				Subject:     user1.String(),
+				Project:     proto.String(project.String()),
 			}},
 		},
 	}, {
@@ -374,13 +377,15 @@ func TestRoleManagement(t *testing.T) {
 		}},
 		result: &minder.ListRoleAssignmentsResponse{
 			RoleAssignments: []*minder.RoleAssignment{{
-				Role:    authz.AuthzRoleAdmin.String(),
-				Subject: "user1",
-				Project: proto.String(project.String()),
+				Role:        authz.AuthzRoleAdmin.String(),
+				Subject:     user1.String(),
+				DisplayName: "user1",
+				Project:     proto.String(project.String()),
 			}, {
-				Role:    authz.AuthzRoleAdmin.String(),
-				Subject: "user2",
-				Project: proto.String(project.String()),
+				Role:        authz.AuthzRoleAdmin.String(),
+				Subject:     user2.String(),
+				DisplayName: "user2",
+				Project:     proto.String(project.String()),
 			}},
 		},
 		stored: []*minder.RoleAssignment{{
@@ -483,7 +488,6 @@ func TestRoleManagement(t *testing.T) {
 
 			featureClient := &flags.FakeClient{}
 			featureClient.Data = map[string]any{
-				"idp_resolver":    tc.idpFlag,
 				"user_management": tc.userManagementFlag,
 			}
 

--- a/internal/db/querier.go
+++ b/internal/db/querier.go
@@ -83,16 +83,17 @@ type Querier interface {
 	// be called by a user who has received an invitation email and is following the
 	// link to accept the invitation or when querying for additional info about the
 	// invitation.
-	GetInvitationByCode(ctx context.Context, code string) (UserInvite, error)
-	// GetInvitationByEmailAndProjectAndRole retrieves an invitation by email, project,
-	// and role.
-	GetInvitationByEmailAndProjectAndRole(ctx context.Context, arg GetInvitationByEmailAndProjectAndRoleParams) (UserInvite, error)
+	GetInvitationByCode(ctx context.Context, code string) (GetInvitationByCodeRow, error)
 	// GetInvitationsByEmail retrieves all invitations for a given email address.
 	// This is intended to be called by a logged in user with their own email address,
 	// to allow them to accept invitations even if email delivery was not working.
 	// Note that this requires that the destination email address matches the email
 	// address of the logged in user in the external identity service / auth token.
-	GetInvitationsByEmail(ctx context.Context, email string) ([]UserInvite, error)
+	// This clarification is related solely for user's ListInvitations calls and does
+	// not affect to resolving invitations intended for other mail addresses.
+	GetInvitationsByEmail(ctx context.Context, email string) ([]GetInvitationsByEmailRow, error)
+	// GetInvitationsByEmailAndProject retrieves all invitations by email and project.
+	GetInvitationsByEmailAndProject(ctx context.Context, arg GetInvitationsByEmailAndProjectParams) ([]GetInvitationsByEmailAndProjectRow, error)
 	// Copyright 2024 Stacklok, Inc
 	//
 	// Licensed under the Apache License, Version 2.0 (the "License");

--- a/internal/flags/constants.go
+++ b/internal/flags/constants.go
@@ -16,8 +16,6 @@
 package flags
 
 const (
-	// IDPResolver enables identity provider name resolution, see https://github.com/stacklok/minder/issues/3150
-	IDPResolver Experiment = "idp_resolver"
 	// UserManagement enables user management, i.e. invitations, role assignments, etc.
 	UserManagement Experiment = "user_management"
 )

--- a/internal/flags/flags_test.go
+++ b/internal/flags/flags_test.go
@@ -35,7 +35,7 @@ import (
 // nolint: tparallel
 func TestOpenFeatureProviderFromFlags(t *testing.T) {
 	t.Parallel()
-
+	const testFlag = Experiment("test_flag")
 	testFile := filepath.Clean(filepath.Join(t.TempDir(), "testfile.yaml"))
 	tempFile, err := os.Create(testFile)
 	if err != nil {
@@ -43,7 +43,7 @@ func TestOpenFeatureProviderFromFlags(t *testing.T) {
 	}
 	t.Cleanup(func() { _ = tempFile.Close() })
 	configFile := `
-idp_resolver:
+test_flag:
   variations:
     FlagOn: true
     FlagOff: false
@@ -99,7 +99,7 @@ idp_resolver:
 				Provider: engine.Provider{Name: "testing"},
 			})
 
-			flagResult := Bool(ctx, client, IDPResolver)
+			flagResult := Bool(ctx, client, testFlag)
 			if flagResult != tt.expectedFlag {
 				t.Errorf("expected %v, got %v", tt.expectedFlag, flagResult)
 			}


### PR DESCRIPTION
# Summary

The following PR includes a few updates on the user management implementation. 

The changes that are introduced are:
* Moved the invite update logic to happen under the UpdateRole handler instead of being part of the AssignRole handler
* Added a few display names based on the FE feedback
* Reflected these changes on the CLI
* Refactored the part of create/deleting an invitation to ensure proper behaviour
* Added a protection so minder discards processing the invite if the user tries to accept an invite for a role he already has and another one where we delete his current role assignment and accept the new one ensuring he should have only one assignment per project.
* Fixed the missing invite code in ListRoleAssignments and a bug where the Sponsor field was empty
* Updated the `minder role grant list` command to also print current invitations along with current role assignments
* Removed the checks for `flags.IDPResolver`

## Change Type

***Mark the type of change your PR introduces:***

- [x] Bug fix (resolves an issue without affecting existing features)
- [ ] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [ ] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

Locally.

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [ ] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [ ] Included tests that validate the fix or feature.
- [ ] Checked that related changes are merged.
