### PR TITLE
Fix issue with multiple entity IDs

### DIFF
--- a/internal/entities/utils.go
+++ b/internal/entities/utils.go
@@ -17,6 +17,7 @@ package entities
 
 import (
 	"errors"
+
 	"github.com/google/uuid"
 
 	"github.com/stacklok/minder/internal/db"


### PR DESCRIPTION
Spotted by @eleftherias in smoke tests. When evaluating a PR, the repo ID is also passed around. This violated the assumption that only one entity type would be specified.

Change the logic so that we try and find a PR or artifact ID first, then a repo ID later.

# Summary

***Provide a brief overview of the changes and the issue being addressed. 
Explain the rationale and any background necessary for understanding the changes. 
List dependencies required by this change, if any.***

Fixes #(related issue)

## Change Type

***Mark the type of change your PR introduces:***

- [x] Bug fix (resolves an issue without affecting existing features)
- [ ] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [ ] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

***Outline how the changes were tested, including steps to reproduce and any relevant configurations. 
Attach screenshots if helpful.***

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [x] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [ ] Included tests that validate the fix or feature.
- [ ] Checked that related changes are merged.
