### PR TITLE
Reuse the previous invite code when updating an invitation

### DIFF
--- a/database/mock/store.go
+++ b/database/mock/store.go
@@ -1807,19 +1807,19 @@ func (mr *MockStoreMockRecorder) UpdateEvaluationTimes(arg0, arg1 any) *gomock.C
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateEvaluationTimes", reflect.TypeOf((*MockStore)(nil).UpdateEvaluationTimes), arg0, arg1)
 }
 
-// UpdateInvitation mocks base method.
-func (m *MockStore) UpdateInvitation(arg0 context.Context, arg1 string) (db.UserInvite, error) {
+// UpdateInvitationRole mocks base method.
+func (m *MockStore) UpdateInvitationRole(arg0 context.Context, arg1 db.UpdateInvitationRoleParams) (db.UserInvite, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UpdateInvitation", arg0, arg1)
+	ret := m.ctrl.Call(m, "UpdateInvitationRole", arg0, arg1)
 	ret0, _ := ret[0].(db.UserInvite)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// UpdateInvitation indicates an expected call of UpdateInvitation.
-func (mr *MockStoreMockRecorder) UpdateInvitation(arg0, arg1 any) *gomock.Call {
+// UpdateInvitationRole indicates an expected call of UpdateInvitationRole.
+func (mr *MockStoreMockRecorder) UpdateInvitationRole(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateInvitation", reflect.TypeOf((*MockStore)(nil).UpdateInvitation), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateInvitationRole", reflect.TypeOf((*MockStore)(nil).UpdateInvitationRole), arg0, arg1)
 }
 
 // UpdateLease mocks base method.

--- a/database/query/invitations.sql
+++ b/database/query/invitations.sql
@@ -58,9 +58,9 @@ INSERT INTO user_invites (code, email, role, project, sponsor) VALUES ($1, $2, $
 -- name: DeleteInvitation :one
 DELETE FROM user_invites WHERE code = $1 RETURNING *;
 
--- UpdateInvitation updates an invitation by its code. This is intended to be
--- called by a user who has issued an invitation and then decided to bump its
--- expiration.
+-- UpdateInvitationRole updates an invitation by its code. This is intended to be
+-- called by a user who has issued an invitation and then decided to change the
+-- role of the invitee.
 
--- name: UpdateInvitation :one
-UPDATE user_invites SET updated_at = NOW() WHERE code = $1 RETURNING *;
+-- name: UpdateInvitationRole :one
+UPDATE user_invites SET role = $2, updated_at = NOW() WHERE code = $1 RETURNING *;

--- a/internal/db/querier.go
+++ b/internal/db/querier.go
@@ -211,10 +211,10 @@ type Querier interface {
 	SetCurrentVersion(ctx context.Context, arg SetCurrentVersionParams) error
 	UpdateEncryptedSecret(ctx context.Context, arg UpdateEncryptedSecretParams) error
 	UpdateEvaluationTimes(ctx context.Context, arg UpdateEvaluationTimesParams) error
-	// UpdateInvitation updates an invitation by its code. This is intended to be
-	// called by a user who has issued an invitation and then decided to bump its
-	// expiration.
-	UpdateInvitation(ctx context.Context, code string) (UserInvite, error)
+	// UpdateInvitationRole updates an invitation by its code. This is intended to be
+	// called by a user who has issued an invitation and then decided to change the
+	// role of the invitee.
+	UpdateInvitationRole(ctx context.Context, arg UpdateInvitationRoleParams) (UserInvite, error)
 	UpdateLease(ctx context.Context, arg UpdateLeaseParams) error
 	UpdateProfile(ctx context.Context, arg UpdateProfileParams) (Profile, error)
 	UpdateProjectMeta(ctx context.Context, arg UpdateProjectMetaParams) (Project, error)


### PR DESCRIPTION
# Summary

The following PR reuses the previous invite code when updating an invitation. This would allow for older invitations to still work. The initial email content may not reflect the new state, but we are okay with this (synced with Evan) there'll be a follow up email being send in case the role changed

- [ ] Waiting for confirmation from @ethomson in case we don't want this behavior. 

## Change Type

***Mark the type of change your PR introduces:***

- [ ] Bug fix (resolves an issue without affecting existing features)
- [x] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [ ] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

***Outline how the changes were tested, including steps to reproduce and any relevant configurations. 
Attach screenshots if helpful.***

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [ ] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [ ] Included tests that validate the fix or feature.
- [ ] Checked that related changes are merged.
