### PR TITLE
Extend the Profile List database calls to include selectors

### DIFF
--- a/database/migrations/000072_profile_selector_type.down.sql
+++ b/database/migrations/000072_profile_selector_type.down.sql
@@ -1,0 +1,19 @@
+-- Copyright 2024 Stacklok, Inc
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--      http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+BEGIN;
+
+DROP TYPE IF EXISTS profile_selector;
+
+COMMIT;

--- a/database/migrations/000072_profile_selectors_type.up.sql
+++ b/database/migrations/000072_profile_selectors_type.up.sql
@@ -1,0 +1,25 @@
+-- Copyright 2024 Stacklok, Inc
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--      http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+BEGIN;
+
+CREATE TYPE profile_selector AS (
+    id UUID,
+    profile_id UUID,
+    entity entities,
+    selector TEXT,
+    comment TEXT
+);
+
+COMMIT;

--- a/database/query/profiles.sql
+++ b/database/query/profiles.sql
@@ -65,9 +65,9 @@ SELECT * FROM profiles WHERE lower(name) = lower(sqlc.arg(name)) AND project_id 
 -- name: ListProfilesByProjectID :many
 WITH helper AS(
      SELECT pr.id as profid,
-            ARRAY_AGG(ROW(ps.id, ps.profile_id, ps.entity, ps.selector, ps.comment)::profile_selector) FILTER (WHERE ps.id IS NOT NULL) AS selectors
+            ARRAY_AGG(ROW(ps.id, ps.profile_id, ps.entity, ps.selector, ps.comment)::profile_selector) AS selectors
        FROM profiles pr
-       LEFT JOIN profile_selectors ps
+       JOIN profile_selectors ps
          ON pr.id = ps.profile_id
       WHERE pr.project_id = $1
       GROUP BY pr.id
@@ -78,15 +78,15 @@ SELECT
     helper.selectors::profile_selector[] AS profiles_with_selectors
 FROM profiles
 JOIN profiles_with_entity_profiles ON profiles.id = profiles_with_entity_profiles.profid
-JOIN helper ON profiles.id = helper.profid
+LEFT JOIN helper ON profiles.id = helper.profid
 WHERE profiles.project_id = $1;
 
 -- name: ListProfilesByProjectIDAndLabel :many
 WITH helper AS(
      SELECT pr.id as profid,
-     ARRAY_AGG(ROW(ps.id, ps.profile_id, ps.entity, ps.selector, ps.comment)::profile_selector) FILTER (WHERE ps.id IS NOT NULL) AS selectors
+     ARRAY_AGG(ROW(ps.id, ps.profile_id, ps.entity, ps.selector, ps.comment)::profile_selector) AS selectors
        FROM profiles pr
-       LEFT JOIN profile_selectors ps
+       JOIN profile_selectors ps
          ON pr.id = ps.profile_id
       WHERE pr.project_id = $1
       GROUP BY pr.id
@@ -96,7 +96,7 @@ SELECT sqlc.embed(profiles),
        helper.selectors::profile_selector[] AS profiles_with_selectors
 FROM profiles
 JOIN profiles_with_entity_profiles ON profiles.id = profiles_with_entity_profiles.profid
-JOIN helper ON profiles.id = helper.profid
+LEFT JOIN helper ON profiles.id = helper.profid
 WHERE profiles.project_id = $1
 AND (
     -- the most common case first, if the include_labels is empty, we list profiles with no labels

--- a/internal/db/profile_selector_scan.go
+++ b/internal/db/profile_selector_scan.go
@@ -1,0 +1,69 @@
+// Copyright 2024 Stacklok, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package db
+
+import (
+	"fmt"
+	"strings"
+)
+
+// Scan implements the sql.Scanner interface for the SelectorInfo struct
+func (s *ProfileSelector) Scan(value interface{}) error {
+	if value == nil {
+		return nil
+	}
+
+	// Convert the value to a string
+	bytes, ok := value.([]byte)
+	if !ok {
+		return fmt.Errorf("failed to scan SelectorInfo: %v", value)
+	}
+	str := string(bytes)
+
+	// Remove the parentheses
+	str = strings.TrimPrefix(str, "(")
+	str = strings.TrimSuffix(str, ")")
+
+	// Split the string by commas to get the individual field values
+	parts := strings.Split(str, ",")
+
+	// Assign the values to the struct fields
+	if len(parts) != 5 {
+		return fmt.Errorf("failed to scan SelectorInfo: unexpected number of fields")
+	}
+
+	if err := s.ID.Scan(parts[0]); err != nil {
+		return fmt.Errorf("failed to scan id: %v", err)
+	}
+
+	if err := s.ProfileID.Scan(parts[1]); err != nil {
+		return fmt.Errorf("failed to scan profile_id: %v", err)
+	}
+
+	s.Entity = NullEntities{}
+	if parts[2] != "" {
+		if err := s.Entity.Scan(parts[2]); err != nil {
+			return fmt.Errorf("failed to scan entity: %v", err)
+		}
+	}
+
+	selector := strings.TrimPrefix(parts[3], "\"")
+	selector = strings.TrimSuffix(selector, "\"")
+	s.Selector = selector
+
+	s.Comment = parts[4]
+
+	return nil
+}

--- a/internal/db/profiles.sql.go
+++ b/internal/db/profiles.sql.go
@@ -358,13 +358,29 @@ func (q *Queries) GetProfileForEntity(ctx context.Context, arg GetProfileForEnti
 }
 
 const listProfilesByProjectID = `-- name: ListProfilesByProjectID :many
-SELECT profiles.id, profiles.name, profiles.provider, profiles.project_id, profiles.remediate, profiles.alert, profiles.created_at, profiles.updated_at, profiles.provider_id, profiles.subscription_id, profiles.display_name, profiles.labels, profiles_with_entity_profiles.id, profiles_with_entity_profiles.entity, profiles_with_entity_profiles.profile_id, profiles_with_entity_profiles.contextual_rules, profiles_with_entity_profiles.created_at, profiles_with_entity_profiles.updated_at, profiles_with_entity_profiles.profid FROM profiles JOIN profiles_with_entity_profiles ON profiles.id = profiles_with_entity_profiles.profid
+WITH helper AS(
+     SELECT pr.id as profid,
+            ARRAY_AGG(ROW(ps.id, ps.profile_id, ps.entity, ps.selector, ps.comment)::profile_selector) FILTER (WHERE ps.id IS NOT NULL) AS selectors
+       FROM profiles pr
+       LEFT JOIN profile_selectors ps
+         ON pr.id = ps.profile_id
+      WHERE pr.project_id = $1
+      GROUP BY pr.id
+)
+SELECT
+    profiles.id, profiles.name, profiles.provider, profiles.project_id, profiles.remediate, profiles.alert, profiles.created_at, profiles.updated_at, profiles.provider_id, profiles.subscription_id, profiles.display_name, profiles.labels,
+    profiles_with_entity_profiles.id, profiles_with_entity_profiles.entity, profiles_with_entity_profiles.profile_id, profiles_with_entity_profiles.contextual_rules, profiles_with_entity_profiles.created_at, profiles_with_entity_profiles.updated_at, profiles_with_entity_profiles.profid,
+    helper.selectors::profile_selector[] AS profiles_with_selectors
+FROM profiles
+JOIN profiles_with_entity_profiles ON profiles.id = profiles_with_entity_profiles.profid
+JOIN helper ON profiles.id = helper.profid
 WHERE profiles.project_id = $1
 `
 
 type ListProfilesByProjectIDRow struct {
 	Profile                   Profile                   `json:"profile"`
 	ProfilesWithEntityProfile ProfilesWithEntityProfile `json:"profiles_with_entity_profile"`
+	ProfilesWithSelectors     []ProfileSelector         `json:"profiles_with_selectors"`
 }
 
 func (q *Queries) ListProfilesByProjectID(ctx context.Context, projectID uuid.UUID) ([]ListProfilesByProjectIDRow, error) {
@@ -396,6 +412,7 @@ func (q *Queries) ListProfilesByProjectID(ctx context.Context, projectID uuid.UU
 			&i.ProfilesWithEntityProfile.CreatedAt,
 			&i.ProfilesWithEntityProfile.UpdatedAt,
 			&i.ProfilesWithEntityProfile.Profid,
+			pq.Array(&i.ProfilesWithSelectors),
 		); err != nil {
 			return nil, err
 		}
@@ -411,7 +428,21 @@ func (q *Queries) ListProfilesByProjectID(ctx context.Context, projectID uuid.UU
 }
 
 const listProfilesByProjectIDAndLabel = `-- name: ListProfilesByProjectIDAndLabel :many
-SELECT profiles.id, profiles.name, profiles.provider, profiles.project_id, profiles.remediate, profiles.alert, profiles.created_at, profiles.updated_at, profiles.provider_id, profiles.subscription_id, profiles.display_name, profiles.labels, profiles_with_entity_profiles.id, profiles_with_entity_profiles.entity, profiles_with_entity_profiles.profile_id, profiles_with_entity_profiles.contextual_rules, profiles_with_entity_profiles.created_at, profiles_with_entity_profiles.updated_at, profiles_with_entity_profiles.profid FROM profiles JOIN profiles_with_entity_profiles ON profiles.id = profiles_with_entity_profiles.profid
+WITH helper AS(
+     SELECT pr.id as profid,
+     ARRAY_AGG(ROW(ps.id, ps.profile_id, ps.entity, ps.selector, ps.comment)::profile_selector) FILTER (WHERE ps.id IS NOT NULL) AS selectors
+       FROM profiles pr
+       LEFT JOIN profile_selectors ps
+         ON pr.id = ps.profile_id
+      WHERE pr.project_id = $1
+      GROUP BY pr.id
+)
+SELECT profiles.id, profiles.name, profiles.provider, profiles.project_id, profiles.remediate, profiles.alert, profiles.created_at, profiles.updated_at, profiles.provider_id, profiles.subscription_id, profiles.display_name, profiles.labels,
+       profiles_with_entity_profiles.id, profiles_with_entity_profiles.entity, profiles_with_entity_profiles.profile_id, profiles_with_entity_profiles.contextual_rules, profiles_with_entity_profiles.created_at, profiles_with_entity_profiles.updated_at, profiles_with_entity_profiles.profid,
+       helper.selectors::profile_selector[] AS profiles_with_selectors
+FROM profiles
+JOIN profiles_with_entity_profiles ON profiles.id = profiles_with_entity_profiles.profid
+JOIN helper ON profiles.id = helper.profid
 WHERE profiles.project_id = $1
 AND (
     -- the most common case first, if the include_labels is empty, we list profiles with no labels
@@ -438,6 +469,7 @@ type ListProfilesByProjectIDAndLabelParams struct {
 type ListProfilesByProjectIDAndLabelRow struct {
 	Profile                   Profile                   `json:"profile"`
 	ProfilesWithEntityProfile ProfilesWithEntityProfile `json:"profiles_with_entity_profile"`
+	ProfilesWithSelectors     []ProfileSelector         `json:"profiles_with_selectors"`
 }
 
 func (q *Queries) ListProfilesByProjectIDAndLabel(ctx context.Context, arg ListProfilesByProjectIDAndLabelParams) ([]ListProfilesByProjectIDAndLabelRow, error) {
@@ -469,6 +501,7 @@ func (q *Queries) ListProfilesByProjectIDAndLabel(ctx context.Context, arg ListP
 			&i.ProfilesWithEntityProfile.CreatedAt,
 			&i.ProfilesWithEntityProfile.UpdatedAt,
 			&i.ProfilesWithEntityProfile.Profid,
+			pq.Array(&i.ProfilesWithSelectors),
 		); err != nil {
 			return nil, err
 		}

--- a/internal/db/profiles.sql.go
+++ b/internal/db/profiles.sql.go
@@ -360,9 +360,9 @@ func (q *Queries) GetProfileForEntity(ctx context.Context, arg GetProfileForEnti
 const listProfilesByProjectID = `-- name: ListProfilesByProjectID :many
 WITH helper AS(
      SELECT pr.id as profid,
-            ARRAY_AGG(ROW(ps.id, ps.profile_id, ps.entity, ps.selector, ps.comment)::profile_selector) FILTER (WHERE ps.id IS NOT NULL) AS selectors
+            ARRAY_AGG(ROW(ps.id, ps.profile_id, ps.entity, ps.selector, ps.comment)::profile_selector) AS selectors
        FROM profiles pr
-       LEFT JOIN profile_selectors ps
+       JOIN profile_selectors ps
          ON pr.id = ps.profile_id
       WHERE pr.project_id = $1
       GROUP BY pr.id
@@ -373,7 +373,7 @@ SELECT
     helper.selectors::profile_selector[] AS profiles_with_selectors
 FROM profiles
 JOIN profiles_with_entity_profiles ON profiles.id = profiles_with_entity_profiles.profid
-JOIN helper ON profiles.id = helper.profid
+LEFT JOIN helper ON profiles.id = helper.profid
 WHERE profiles.project_id = $1
 `
 
@@ -430,9 +430,9 @@ func (q *Queries) ListProfilesByProjectID(ctx context.Context, projectID uuid.UU
 const listProfilesByProjectIDAndLabel = `-- name: ListProfilesByProjectIDAndLabel :many
 WITH helper AS(
      SELECT pr.id as profid,
-     ARRAY_AGG(ROW(ps.id, ps.profile_id, ps.entity, ps.selector, ps.comment)::profile_selector) FILTER (WHERE ps.id IS NOT NULL) AS selectors
+     ARRAY_AGG(ROW(ps.id, ps.profile_id, ps.entity, ps.selector, ps.comment)::profile_selector) AS selectors
        FROM profiles pr
-       LEFT JOIN profile_selectors ps
+       JOIN profile_selectors ps
          ON pr.id = ps.profile_id
       WHERE pr.project_id = $1
       GROUP BY pr.id
@@ -442,7 +442,7 @@ SELECT profiles.id, profiles.name, profiles.provider, profiles.project_id, profi
        helper.selectors::profile_selector[] AS profiles_with_selectors
 FROM profiles
 JOIN profiles_with_entity_profiles ON profiles.id = profiles_with_entity_profiles.profid
-JOIN helper ON profiles.id = helper.profid
+LEFT JOIN helper ON profiles.id = helper.profid
 WHERE profiles.project_id = $1
 AND (
     -- the most common case first, if the include_labels is empty, we list profiles with no labels

--- a/sqlc.yaml
+++ b/sqlc.yaml
@@ -25,3 +25,7 @@ packages:
     emit_interface: true
     emit_exact_table_names: false
     emit_empty_slices: true
+    overrides:
+      - db_type: profile_selector
+        go_type:
+          type: "ProfileSelector"


### PR DESCRIPTION
# Summary

Extend the Profile List database calls to include selectors

Since the profile selectors need to be included when listing profiles, we need to extend the two profile list calls to list selectors as well.

Because the selectors are stored in a different table, but we still need to retrieve them in the same Go struct defined in models, we define a new SQL type in a migration that represents the selectors and tell sqlc to use it in sqlc.yaml.

This new Go struct needs a Scan method as well to convert raw SQL rows into structs as well.

Co-authored-by: Michelangelo Mori <mmori@stacklok.com>

Fixes: #3721

## Change Type

- [ ] Bug fix (resolves an issue without affecting existing features)
- [x] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [ ] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

There are unit tests and I tested the code as part of a larger branch, too.

# Review Checklist:

- [X] Reviewed my own code for quality and clarity.
- [ ] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [X] Included tests that validate the fix or feature.
- [ ] Checked that related changes are merged.
