### PR TITLE
Fix project display name when listing invitations

### DIFF
--- a/internal/controlplane/handlers_user.go
+++ b/internal/controlplane/handlers_user.go
@@ -341,12 +341,19 @@ func (s *Server) ListInvitations(ctx context.Context, _ *pb.ListInvitationsReque
 		if err != nil {
 			return nil, status.Errorf(codes.Internal, "failed to get project: %s", err)
 		}
+
+		// Parse the project metadata, so we can get the display name set by project owner
+		meta, err := projects.ParseMetadata(&targetProject)
+		if err != nil {
+			return nil, status.Errorf(codes.Internal, "error parsing project metadata: %v", err)
+		}
+
 		invitations = append(invitations, &pb.Invitation{
 			Code:           i.Code,
 			Role:           i.Role,
 			Email:          i.Email,
 			Project:        i.Project.String(),
-			ProjectDisplay: targetProject.Name,
+			ProjectDisplay: meta.Public.DisplayName,
 			CreatedAt:      timestamppb.New(i.CreatedAt),
 			ExpiresAt:      invite.GetExpireIn7Days(i.UpdatedAt),
 			Expired:        invite.IsExpired(i.UpdatedAt),


### PR DESCRIPTION
# Summary

This ensures the project display name is the one the user set during onboarding.

Similar to [#3750](https://github.com/stacklok/minder/issues/3750)

## Change Type

***Mark the type of change your PR introduces:***

- [x] Bug fix (resolves an issue without affecting existing features)
- [ ] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [ ] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

***Outline how the changes were tested, including steps to reproduce and any relevant configurations. 
Attach screenshots if helpful.***

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [ ] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [ ] Included tests that validate the fix or feature.
- [ ] Checked that related changes are merged.
