### PR TITLE
Fix project display name when resolving invite

### DIFF
--- a/internal/controlplane/handlers_user.go
+++ b/internal/controlplane/handlers_user.go
@@ -411,10 +411,17 @@ func (s *Server) ResolveInvitation(ctx context.Context, req *pb.ResolveInvitatio
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "failed to get project: %s", err)
 	}
+
+	// Parse the project metadata, so we can get the display name set by project owner
+	meta, err := projects.ParseMetadata(&targetProject)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "error parsing project metadata: %v", err)
+	}
+
 	return &pb.ResolveInvitationResponse{
 		Role:           deletedInvite.Role,
 		Project:        deletedInvite.Project.String(),
-		ProjectDisplay: targetProject.Name,
+		ProjectDisplay: meta.Public.DisplayName,
 		Email:          deletedInvite.Email,
 		IsAccepted:     req.Accept,
 	}, nil


### PR DESCRIPTION
# Summary

This ensures the project display name is the one the user set during onboarding.

Similar to https://github.com/stacklok/minder/issues/3750

## Change Type

***Mark the type of change your PR introduces:***

- [x] Bug fix (resolves an issue without affecting existing features)
- [ ] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [ ] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

***Outline how the changes were tested, including steps to reproduce and any relevant configurations. 
Attach screenshots if helpful.***

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [ ] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [ ] Included tests that validate the fix or feature.
- [ ] Checked that related changes are merged.
