### PR TITLE
Increase CLI context timeout to 20s

### DIFF
--- a/internal/util/cli/cli.go
+++ b/internal/util/cli/cli.go
@@ -96,7 +96,7 @@ func GrpcForCommand(v *viper.Viper) (*grpc.ClientConn, error) {
 
 // GetAppContext is a helper for getting the cmd app context
 func GetAppContext(ctx context.Context, v *viper.Viper) (context.Context, context.CancelFunc) {
-	return GetAppContextWithTimeoutDuration(ctx, v, 10)
+	return GetAppContextWithTimeoutDuration(ctx, v, 20)
 }
 
 // GetAppContextWithTimeoutDuration is a helper for getting the cmd app context with a custom timeout


### PR DESCRIPTION
# Summary

Users in Spain (and possibly other regions) are experience continuous context timeouts, because requests to the gRPC endpoints on the server are taking longer than 10 seconds.

This increases the timeout, under the assumption that it's better for the CLI to be slow than to error.

## Change Type

***Mark the type of change your PR introduces:***

- [x] Bug fix (resolves an issue without affecting existing features)
- [ ] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [ ] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

***Outline how the changes were tested, including steps to reproduce and any relevant configurations. 
Attach screenshots if helpful.***

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [ ] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [ ] Included tests that validate the fix or feature.
- [ ] Checked that related changes are merged.
