### PR TITLE
Fix broken documentation links

### DIFF
--- a/docs/docs/understand/alerts.md
+++ b/docs/docs/understand/alerts.md
@@ -5,7 +5,7 @@ sidebar_position: 50
 
 # Alerts from Minder
 
-Minder issues _alerts_ to notify you when the state of your software supply chain does not meet the criteria that you've defined in your [profile](profiles).
+Minder issues _alerts_ to notify you when the state of your software supply chain does not meet the criteria that you've defined in your [profile](profiles.md).
 
 Alerts are a core feature of Minder providing you with notifications about the status of your registered
 repositories. These alerts automatically open and close based on the evaluation of the rules defined in your profiles.

--- a/docs/docs/understand/profiles.md
+++ b/docs/docs/understand/profiles.md
@@ -5,7 +5,7 @@ sidebar_position: 10
 
 # Profiles in Minder
 
-A _profile_ defines your security policies that you want to apply to your software supply chain. Profiles contain rules that query data in a [provider](providers), and specifies whether Minder will issue [alerts](alerts) or perform automatic [remediations](remediations) when an entity is not in compliance with the policy.
+A _profile_ defines your security policies that you want to apply to your software supply chain. Profiles contain rules that query data in a [provider](providers.md), and specifies whether Minder will issue [alerts](alerts.md) or perform automatic [remediations](remediations.md) when an entity is not in compliance with the policy.
 
 Profiles in Minder allow you to group and manage
 rules for various entity types, such as repositories, pull requests, and artifacts, across your registered GitHub

--- a/docs/docs/understand/providers.md
+++ b/docs/docs/understand/providers.md
@@ -5,7 +5,7 @@ sidebar_position: 20
 
 # Providers in Minder
 
-A _provider_ connects Minder to your software supply chain &mdash; giving Minder information about your source code repositories, and their pull requests, dependencies, and artifacts. Minder will apply your [profiles](profiles) to providers to analyze the security posture of your software supply chain, and then will create [alerts](alerts) and can automatically [remediate](remediations) problems that it finds.
+A _provider_ connects Minder to your software supply chain &mdash; giving Minder information about your source code repositories, and their pull requests, dependencies, and artifacts. Minder will apply your [profiles](profiles.md) to providers to analyze the security posture of your software supply chain, and then will create [alerts](alerts.md) and can automatically [remediate](remediations.md) problems that it finds.
 
 The currently supported providers are:
 * GitHub
@@ -26,4 +26,4 @@ Once a provider is enrolled, public repositories from that provider can be regis
 can then be applied to the registered repositories, giving you an overview of your security posture and providing
 remediations to improve your security posture.
 
-For more information about providers and their configuration, see the [Provider Integrations](../integrations/provider_integrations/github) documentation.
+For more information about providers and their configuration, see the [Provider Integrations](../integrations/provider_integrations/github.md) documentation.

--- a/docs/docs/understand/remediations.md
+++ b/docs/docs/understand/remediations.md
@@ -5,7 +5,7 @@ sidebar_position: 60
 
 # Automatic Remediations in Minder
 
-Minder can perform _automatic remediation_ for many rules in an attempt to resolve problems in your software supply chain, and bring your resources into compliance with your [profile](profiles).
+Minder can perform _automatic remediation_ for many rules in an attempt to resolve problems in your software supply chain, and bring your resources into compliance with your [profile](profiles.md).
 
 The steps to take during automatic remediation are defined within the rule itself and can perform actions like sending a REST call to an endpoint to change configuration, or creating a pull request with a proposed fix.
 

--- a/docs/docs/understand/repository_registration.md
+++ b/docs/docs/understand/repository_registration.md
@@ -3,11 +3,11 @@ title: Repository registration
 sidebar_position: 50
 ---
 
-_Registering a repository_ tells Minder to apply the [profiles](profiles) that you've defined to that repository. Minder will continuously monitor that repository based on the profiles that you've defined, and optionally [alert you](alerts) or [automatically remediate the problem](remediations) when the repository is out of compliance.
+_Registering a repository_ tells Minder to apply the [profiles](profiles.md) that you've defined to that repository. Minder will continuously monitor that repository based on the profiles that you've defined, and optionally [alert you](alerts.md) or [automatically remediate the problem](remediations.md) when the repository is out of compliance.
 
 ## Registering repositories
 
-Once you have [enrolled the GitHub Provider](providers), you can register repositories that you granted Minder access to within GitHub.
+Once you have [enrolled the GitHub Provider](providers.md), you can register repositories that you granted Minder access to within GitHub.
 
 To get a list of repositories, and select them using a menu in Minder's text user interface, run:
 

--- a/docs/docs/user_management/adding_users.md
+++ b/docs/docs/user_management/adding_users.md
@@ -18,7 +18,7 @@ To add a new user to your project, you need to:
 4. Add the user to your project
 
 ## Identify your project ID
-Identify the project that you want to add a new user to. To see all the projects that are available to you, use the [`minder project list`](../ref/cli/minder_project_list) command.
+Identify the project that you want to add a new user to. To see all the projects that are available to you, use the [`minder project list`](../ref/cli/minder_project_list.md) command.
 
 ```
 +--------------------------------------+-------------------+
@@ -33,7 +33,7 @@ In this example, the `my_minder_project` project has Project ID `086df3e2-f1bb-4
 ## Have the new user create a Minder account
 To add a user to your project, that user must first [create their Minder account](https://docs.stacklok.com/minder/getting_started/login#logging-in-to-the-stacklok-hosted-instance), and provide you with their user ID.
 
-The new user must create an account and log in using [`minder auth login`](../ref/cli/minder_auth_login). After login, the user ID will be displayed as the `Subject`. For example:
+The new user must create an account and log in using [`minder auth login`](../ref/cli/minder_auth_login.md). After login, the user ID will be displayed as the `Subject`. For example:
 
 ```
 Here are your details:
@@ -54,7 +54,7 @@ In this example, the new user's User ID is `ef5588e2-802b-47cb-b64a-52167acfea41
 ## Identify their role
 When adding a user into your project, it's crucial to assign them the appropriate role based on their responsibilities and required access levels.
 
-Roles are [documented here](user_roles). To view the available roles in your project, and their descriptions, run:
+Roles are [documented here](user_roles.md). To view the available roles in your project, and their descriptions, run:
 
 ```
 minder project role list


### PR DESCRIPTION

# Summary

The Minder Cloud docs server at https://docs.stacklok.com/minder/ adds a trailing slash to the URL path. This was causing some of our links to be broken.

Ref https://github.com/stacklok/docs/issues/238

## Change Type

***Mark the type of change your PR introduces:***

- [x] Bug fix (resolves an issue without affecting existing features)
- [ ] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [ ] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

***Outline how the changes were tested, including steps to reproduce and any relevant configurations. 
Attach screenshots if helpful.***

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [ ] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [ ] Included tests that validate the fix or feature.
- [ ] Checked that related changes are merged.
