### PR TITLE
Change `Bool` feature flag function to accept an explicit target value

### DIFF
--- a/internal/controlplane/handlers_authz.go
+++ b/internal/controlplane/handlers_authz.go
@@ -267,7 +267,7 @@ func (s *Server) ListRoleAssignments(
 		}
 	}
 
-	if flags.Bool(ctx, s.featureFlags, flags.UserManagement) {
+	if flags.BoolFromContext(ctx, s.featureFlags, flags.UserManagement) {
 		// Add invitations, which are only stored in the Minder DB
 		invites, err := s.store.ListInvitationsForProject(ctx, targetProject)
 		if err != nil {
@@ -330,14 +330,14 @@ func (s *Server) AssignRole(ctx context.Context, req *minder.AssignRoleRequest) 
 
 	// Decide if it's an invitation or a role assignment
 	if sub == "" && inviteeEmail != "" {
-		if flags.Bool(ctx, s.featureFlags, flags.UserManagement) {
+		if flags.BoolFromContext(ctx, s.featureFlags, flags.UserManagement) {
 			return s.inviteUser(ctx, targetProject, authzRole, inviteeEmail)
 		}
 		return nil, util.UserVisibleError(codes.Unimplemented, "user management is not enabled")
 	} else if sub != "" && inviteeEmail == "" {
 		// Enable one or the other.
 		// This is temporary until we deprecate it completely in favor of email-based role assignments
-		if !flags.Bool(ctx, s.featureFlags, flags.UserManagement) {
+		if !flags.BoolFromContext(ctx, s.featureFlags, flags.UserManagement) {
 			return s.assignRole(ctx, targetProject, authzRole, sub)
 		}
 		return nil, util.UserVisibleError(codes.Unimplemented, "user management is enabled, use invites instead")
@@ -549,7 +549,7 @@ func (s *Server) RemoveRole(ctx context.Context, req *minder.RemoveRoleRequest) 
 
 	// Validate the subject and email - decide if it's about removing an invitation or a role assignment
 	if sub == "" && inviteeEmail != "" {
-		if flags.Bool(ctx, s.featureFlags, flags.UserManagement) {
+		if flags.BoolFromContext(ctx, s.featureFlags, flags.UserManagement) {
 			return s.removeInvite(ctx, targetProject, authzRole, inviteeEmail)
 		}
 		return nil, util.UserVisibleError(codes.Unimplemented, "user management is not enabled")
@@ -720,7 +720,7 @@ func (s *Server) UpdateRole(ctx context.Context, req *minder.UpdateRoleRequest) 
 
 	// Validate the subject and email - decide if it's about updating an invitation or a role assignment
 	if sub == "" && inviteeEmail != "" {
-		if flags.Bool(ctx, s.featureFlags, flags.UserManagement) {
+		if flags.BoolFromContext(ctx, s.featureFlags, flags.UserManagement) {
 			return s.updateInvite(ctx, targetProject, authzRole, inviteeEmail)
 		}
 		return nil, util.UserVisibleError(codes.Unimplemented, "user management is not enabled")

--- a/internal/controlplane/handlers_evalstatus.go
+++ b/internal/controlplane/handlers_evalstatus.go
@@ -37,7 +37,7 @@ func (s *Server) ListEvaluationHistory(
 	ctx context.Context,
 	in *minderv1.ListEvaluationHistoryRequest,
 ) (*minderv1.ListEvaluationHistoryResponse, error) {
-	if flags.Bool(ctx, s.featureFlags, flags.EvalHistory) {
+	if flags.BoolFromContext(ctx, s.featureFlags, flags.EvalHistory) {
 		cursor := in.GetCursor()
 		zerolog.Ctx(ctx).Debug().
 			Strs("entity_type", in.GetEntityType()).

--- a/internal/controlplane/handlers_user.go
+++ b/internal/controlplane/handlers_user.go
@@ -310,7 +310,7 @@ func (s *Server) GetUser(ctx context.Context, _ *pb.GetUserRequest) (*pb.GetUser
 // ListInvitations is a service for listing invitations.
 func (s *Server) ListInvitations(ctx context.Context, _ *pb.ListInvitationsRequest) (*pb.ListInvitationsResponse, error) {
 	// Check if the UserManagement feature is enabled
-	if !flags.Bool(ctx, s.featureFlags, flags.UserManagement) {
+	if !flags.BoolFromContext(ctx, s.featureFlags, flags.UserManagement) {
 		return nil, status.Error(codes.Unimplemented, "feature not enabled")
 	}
 	invitations := make([]*pb.Invitation, 0)
@@ -370,7 +370,7 @@ func (s *Server) ListInvitations(ctx context.Context, _ *pb.ListInvitationsReque
 // ResolveInvitation is a service for resolving an invitation.
 func (s *Server) ResolveInvitation(ctx context.Context, req *pb.ResolveInvitationRequest) (*pb.ResolveInvitationResponse, error) {
 	// Check if the UserManagement feature is enabled
-	if !flags.Bool(ctx, s.featureFlags, flags.UserManagement) {
+	if !flags.BoolFromContext(ctx, s.featureFlags, flags.UserManagement) {
 		return nil, status.Error(codes.Unimplemented, "feature not enabled")
 	}
 

--- a/internal/engine/eval_status.go
+++ b/internal/engine/eval_status.go
@@ -201,7 +201,7 @@ func (e *executor) createOrUpdateEvalStatus(
 		logger.Err(err).Msg("error upserting rule alert details")
 	}
 
-	if flags.Bool(ctx, e.featureFlags, flags.EvalHistory) {
+	if flags.BoolFromProjectID(ctx, e.featureFlags, flags.EvalHistory, params.ProjectID) {
 		// Log in the evaluation history tables
 		_, err = db.WithTransaction(e.querier, func(qtx db.ExtendQuerier) (uuid.UUID, error) {
 			evalID, err := e.historyService.StoreEvaluationStatus(

--- a/internal/engine/eval_status.go
+++ b/internal/engine/eval_status.go
@@ -201,7 +201,7 @@ func (e *executor) createOrUpdateEvalStatus(
 		logger.Err(err).Msg("error upserting rule alert details")
 	}
 
-	if flags.BoolFromProjectID(ctx, e.featureFlags, flags.EvalHistory, params.ProjectID) {
+	if flags.Bool(ctx, e.featureFlags, flags.EvalHistory, params.ProjectID.String()) {
 		// Log in the evaluation history tables
 		_, err = db.WithTransaction(e.querier, func(qtx db.ExtendQuerier) (uuid.UUID, error) {
 			evalID, err := e.historyService.StoreEvaluationStatus(

--- a/internal/flags/flags.go
+++ b/internal/flags/flags.go
@@ -19,7 +19,6 @@ package flags
 import (
 	"context"
 
-	"github.com/google/uuid"
 	ofprovider "github.com/open-feature/go-sdk-contrib/providers/go-feature-flag/pkg"
 	"github.com/open-feature/go-sdk/openfeature"
 	"github.com/rs/zerolog"
@@ -54,14 +53,11 @@ func BoolFromContext(ctx context.Context, client openfeature.IClient, feature Ex
 	return getBool(ctx, client, feature, fromContext(ctx))
 }
 
-// BoolFromProjectID evaluates the feature flag with respect to the specified project ID.
-// This is useful when evaluating feature flags outside a request context.
-func BoolFromProjectID(ctx context.Context, client openfeature.IClient, feature Experiment, projectID uuid.UUID) bool {
+// Bool evaluates the feature flag with respect to the specified target value.
+func Bool(ctx context.Context, client openfeature.IClient, feature Experiment, target string) bool {
 	ectx := openfeature.NewEvaluationContext(
-		projectID.String(),
-		map[string]interface{}{
-			"project": projectID.String(),
-		},
+		target,
+		map[string]any{},
 	)
 	return getBool(ctx, client, feature, ectx)
 }

--- a/internal/flags/flags_test.go
+++ b/internal/flags/flags_test.go
@@ -99,7 +99,7 @@ test_flag:
 				Provider: engcontext.Provider{Name: "testing"},
 			})
 
-			flagResult := Bool(ctx, client, testFlag)
+			flagResult := BoolFromContext(ctx, client, testFlag)
 			if flagResult != tt.expectedFlag {
 				t.Errorf("expected %v, got %v", tt.expectedFlag, flagResult)
 			}


### PR DESCRIPTION
The `Bool` function for feature flag checks assumes that the context argument contains all the information needed to do a feature flag lookup. This is not the case when checking feature flags outside of an API request context (e.g. in the engine code). This manifests itself as a `openfeature: TARGETING_KEY_MISSING: no targetingKey provided in the evaluation context` error. Furthermore, the code also uses a User ID as the targeting key, and it is not clear what the user ID should be when running asynchronous code.

This PR renames the old `Bool` function to `BoolFromContext` to make its purpose more explicit, and adds a new function which takes an explicit target value as an argument. This is used as the targeting key in the openfeature evaluation context.

Fixes: #3775 

# Summary

***Provide a brief overview of the changes and the issue being addressed. 
Explain the rationale and any background necessary for understanding the changes. 
List dependencies required by this change, if any.***

Fixes #(related issue)

## Change Type

***Mark the type of change your PR introduces:***

- [x] Bug fix (resolves an issue without affecting existing features)
- [ ] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [ ] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

***Outline how the changes were tested, including steps to reproduce and any relevant configurations. 
Attach screenshots if helpful.***

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [x] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [ ] Included tests that validate the fix or feature.
- [ ] Checked that related changes are merged.
