### PR TITLE
Use project as targeting key, propagate message context through entity evaluation

### DIFF
--- a/internal/engine/handler.go
+++ b/internal/engine/handler.go
@@ -17,12 +17,14 @@ package engine
 import (
 	"context"
 	"fmt"
+	"slices"
 	"sync"
 	"time"
 
 	"github.com/ThreeDotsLabs/watermill/message"
 	"github.com/rs/zerolog"
 
+	"github.com/stacklok/minder/internal/engine/engcontext"
 	"github.com/stacklok/minder/internal/engine/entities"
 	"github.com/stacklok/minder/internal/events"
 	minderlogger "github.com/stacklok/minder/internal/logger"
@@ -48,6 +50,11 @@ type ExecutorEventHandler struct {
 	// when the server is shutting down.
 	terminationcontext context.Context
 	executor           Executor
+	// cancels are a set of cancel functions for current entity events in flight.
+	// This allows us to cancel rule evaluation directly when terminationContext
+	// is cancelled.
+	cancels []*context.CancelFunc
+	lock    sync.Mutex
 }
 
 // NewExecutorEventHandler creates the event handler for the executor
@@ -57,13 +64,24 @@ func NewExecutorEventHandler(
 	handlerMiddleware []message.HandlerMiddleware,
 	executor Executor,
 ) *ExecutorEventHandler {
-	return &ExecutorEventHandler{
+	eh := &ExecutorEventHandler{
 		evt:                    evt,
 		wgEntityEventExecution: &sync.WaitGroup{},
 		terminationcontext:     ctx,
 		handlerMiddleware:      handlerMiddleware,
 		executor:               executor,
 	}
+	go func() {
+		<-ctx.Done()
+		eh.lock.Lock()
+		defer eh.lock.Unlock()
+
+		for _, cancel := range eh.cancels {
+			(*cancel)()
+		}
+	}()
+
+	return eh
 }
 
 // Register implements the Consumer interface.
@@ -79,9 +97,24 @@ func (e *ExecutorEventHandler) Wait() {
 // HandleEntityEvent handles events coming from webhooks/signals
 // as well as the init event.
 func (e *ExecutorEventHandler) HandleEntityEvent(msg *message.Message) error {
-	// Grab the context before making a copy of the message
-	msgCtx := msg.Context()
-	// Let's not share memory with the caller
+
+	// NOTE: we're _deliberately_ "escaping" from the parent context's Cancel/Done
+	// completion, because the default watermill behavior for both Go channels and
+	// SQL is to process messages sequentially, but we need additional parallelism
+	// beyond that.  When we switch to a different message processing system, we
+	// should aim to remove this goroutine altogether and have the messaging system
+	// provide the parallelism.
+	// We _do_ still want to cancel on shutdown, however.
+	// TODO: Make this timeout configurable
+	msgCtx := context.WithoutCancel(msg.Context())
+	msgCtx, shutdownCancel := context.WithCancel(msgCtx)
+	{
+		e.lock.Lock()
+		defer e.lock.Unlock()
+		e.cancels = append(e.cancels, &shutdownCancel)
+	}
+
+	// Let's not share memory with the caller.  Note that this does not copy Context
 	msg = msg.Copy()
 
 	inf, err := entities.ParseEntityEvent(msg)
@@ -95,11 +128,15 @@ func (e *ExecutorEventHandler) HandleEntityEvent(msg *message.Message) error {
 		if inf.Type == pb.Entity_ENTITY_ARTIFACTS {
 			time.Sleep(ArtifactSignatureWaitPeriod)
 		}
-		// TODO: Make this timeout configurable
-		ctx, cancel := context.WithTimeout(e.terminationcontext, DefaultExecutionTimeout)
-		defer cancel()
 
-		ts := minderlogger.BusinessRecord(msgCtx)
+		ctx, cancel := context.WithTimeout(msgCtx, DefaultExecutionTimeout)
+		defer cancel()
+		ctx = engcontext.WithEntityContext(ctx, &engcontext.EntityContext{
+			Project:  engcontext.Project{ID: inf.ProjectID},
+			// TODO: extract Provider name from ProviderID
+		})
+
+		ts := minderlogger.BusinessRecord(ctx)
 		ctx = ts.WithTelemetry(ctx)
 
 		logger := zerolog.Ctx(ctx)
@@ -116,14 +153,14 @@ func (e *ExecutorEventHandler) HandleEntityEvent(msg *message.Message) error {
 		// here even though we also record it in the middleware because the evaluation
 		// is done in a separate goroutine which usually still runs after the middleware
 		// had already recorded the telemetry.
-		logMsg := zerolog.Ctx(ctx).Info()
+		logMsg := logger.Info()
 		if err != nil {
-			logMsg = zerolog.Ctx(ctx).Error()
+			logMsg = logger.Error()
 		}
 		ts.Record(logMsg).Send()
 
 		if err != nil {
-			zerolog.Ctx(ctx).Info().
+			logger.Info().
 				Str("project", inf.ProjectID.String()).
 				Str("provider_id", inf.ProviderID.String()).
 				Str("entity", inf.Type.String()).
@@ -142,6 +179,11 @@ func (e *ExecutorEventHandler) HandleEntityEvent(msg *message.Message) error {
 		if err := e.evt.Publish(events.TopicQueueEntityFlush, msg); err != nil {
 			logger.Err(err).Msg("error publishing flush event")
 		}
+		e.lock.Lock()
+		defer e.lock.Unlock()
+		e.cancels = slices.DeleteFunc(e.cancels, func(cf *context.CancelFunc) bool {
+			return cf == &shutdownCancel
+		})
 	}()
 
 	return nil

--- a/internal/engine/handler.go
+++ b/internal/engine/handler.go
@@ -46,10 +46,7 @@ type ExecutorEventHandler struct {
 	evt                    events.Publisher
 	handlerMiddleware      []message.HandlerMiddleware
 	wgEntityEventExecution *sync.WaitGroup
-	// terminationcontext is used to terminate the executor
-	// when the server is shutting down.
-	terminationcontext context.Context
-	executor           Executor
+	executor               Executor
 	// cancels are a set of cancel functions for current entity events in flight.
 	// This allows us to cancel rule evaluation directly when terminationContext
 	// is cancelled.
@@ -67,7 +64,6 @@ func NewExecutorEventHandler(
 	eh := &ExecutorEventHandler{
 		evt:                    evt,
 		wgEntityEventExecution: &sync.WaitGroup{},
-		terminationcontext:     ctx,
 		handlerMiddleware:      handlerMiddleware,
 		executor:               executor,
 	}
@@ -132,7 +128,7 @@ func (e *ExecutorEventHandler) HandleEntityEvent(msg *message.Message) error {
 		ctx, cancel := context.WithTimeout(msgCtx, DefaultExecutionTimeout)
 		defer cancel()
 		ctx = engcontext.WithEntityContext(ctx, &engcontext.EntityContext{
-			Project:  engcontext.Project{ID: inf.ProjectID},
+			Project: engcontext.Project{ID: inf.ProjectID},
 			// TODO: extract Provider name from ProviderID
 		})
 

--- a/internal/flags/flags.go
+++ b/internal/flags/flags.go
@@ -39,10 +39,12 @@ func fromContext(ctx context.Context) openfeature.EvaluationContext {
 	// Note: engine.EntityFromContext is best-effort, so these values may be zero.
 	ec := engcontext.EntityFromContext(ctx)
 	return openfeature.NewEvaluationContext(
-		jwt.GetUserSubjectFromContext(ctx),
+		ec.Project.ID.String(),
 		map[string]interface{}{
-			"project":  ec.Project.ID.String(),
+			"project": ec.Project.ID.String(),
+			// TODO: is this useful, given how provider names are used?
 			"provider": ec.Provider.Name,
+			"user":     jwt.GetUserSubjectFromContext(ctx),
 		},
 	)
 }


### PR DESCRIPTION
# Summary

Update entity evaluation to propagate message context and include data for flag evaluation in the context.

Update flag evaluation context to store user in the same form as project and provider, and make the project ID the primary targeting key for providers that need it (not GoFeatureFlag).  Since no one is probably using the current fine-grained targeting, this should be okay.

## Change Type

***Mark the type of change your PR introduces:***

- [ ] Bug fix (resolves an issue without affecting existing features)
- [ ] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [x] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

***Outline how the changes were tested, including steps to reproduce and any relevant configurations. 
Attach screenshots if helpful.***

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [x] Added comments to complex or tricky code sections.
- [x] Updated any affected documentation.
- [x] Included tests that validate the fix or feature.
- [x] Checked that related changes are merged.
