### PR TITLE
Artifact tag matcher: Curb complexity when parsing regexps from user input

### DIFF
--- a/internal/providers/artifact/versionsfilter.go
+++ b/internal/providers/artifact/versionsfilter.go
@@ -47,6 +47,9 @@ func BuildFilter(tags []string, tagRegex string) (*filter, error) {
 
 	// no tags specified, but a regex was, compile it
 	if tagRegex != "" {
+		if len(tagRegex) > 512 {
+			return nil, fmt.Errorf("tag regular expressions are limited to 512 characters")
+		}
 		re, err := regexp.Compile(tagRegex)
 		if err != nil {
 			return nil, fmt.Errorf("error compiling tag regex: %w", err)


### PR DESCRIPTION
# Summary

This PR adds a length limit to the regular expressions we parse from user input to curve the complexity Minder
handles when compiling them to build a tag matcher.

## Change Type

***Mark the type of change your PR introduces:***

- [x] Bug fix (resolves an issue without affecting existing features)
- [ ] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [ ] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

***Outline how the changes were tested, including steps to reproduce and any relevant configurations. 
Attach screenshots if helpful.***

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [ ] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [x] Included tests that validate the fix or feature.
- [ ] Checked that related changes are merged.
