### PR TITLE
Extend the db-to-pb profile code to include selectors

### DIFF
--- a/internal/db/domain.go
+++ b/internal/db/domain.go
@@ -32,6 +32,7 @@ func (p *Provider) CanImplement(impl ProviderType) bool {
 type ProfileRow interface {
 	GetProfile() Profile
 	GetEntityProfile() NullEntities
+	GetSelectors() []ProfileSelector
 	GetContextualRules() pqtype.NullRawMessage
 }
 
@@ -50,6 +51,11 @@ func (r ListProfilesByProjectIDAndLabelRow) GetContextualRules() pqtype.NullRawM
 	return r.ProfilesWithEntityProfile.ContextualRules
 }
 
+// GetSelectors returns the selectors
+func (r ListProfilesByProjectIDAndLabelRow) GetSelectors() []ProfileSelector {
+	return r.ProfilesWithSelectors
+}
+
 // GetProfile returns the profile
 func (r ListProfilesByProjectIDRow) GetProfile() Profile {
 	return r.Profile
@@ -63,6 +69,11 @@ func (r ListProfilesByProjectIDRow) GetEntityProfile() NullEntities {
 // GetContextualRules returns the contextual rules
 func (r ListProfilesByProjectIDRow) GetContextualRules() pqtype.NullRawMessage {
 	return r.ProfilesWithEntityProfile.ContextualRules
+}
+
+// GetSelectors returns the selectors
+func (r ListProfilesByProjectIDRow) GetSelectors() []ProfileSelector {
+	return r.ProfilesWithSelectors
 }
 
 // LabelsFromFilter parses the filter string and populates the IncludeLabels and ExcludeLabels fields

--- a/internal/profiles/util.go
+++ b/internal/profiles/util.go
@@ -268,6 +268,8 @@ func MergeDatabaseGetIntoProfiles(ppl []db.GetProfileByProjectAndIDRow) map[stri
 			} else {
 				profiles[p.Profile.Name].Alert = proto.String(string(db.ActionTypeOn))
 			}
+
+			selectorsToProfile(profiles[p.Profile.Name], p.ProfilesWithSelectors)
 		}
 		if pm := rowInfoToProfileMap(
 			profiles[p.Profile.Name],

--- a/internal/profiles/util.go
+++ b/internal/profiles/util.go
@@ -212,6 +212,8 @@ func MergeDatabaseListIntoProfiles[T db.ProfileRow](ppl []T) map[string]*pb.Prof
 			} else {
 				profiles[p.GetProfile().Name].Alert = proto.String(string(db.ActionTypeOn))
 			}
+
+			selectorsToProfile(profiles[p.GetProfile().Name], p.GetSelectors())
 		}
 		if pm := rowInfoToProfileMap(
 			profiles[p.GetProfile().Name], p.GetEntityProfile(),
@@ -324,4 +326,19 @@ func rowInfoToProfileMap(
 	}
 
 	return profile
+}
+
+func selectorsToProfile(
+	profile *pb.Profile,
+	selectors []db.ProfileSelector,
+) {
+	profile.Selection = make([]*pb.Profile_Selector, 0, len(selectors))
+	for _, s := range selectors {
+		profile.Selection = append(profile.Selection, &pb.Profile_Selector{
+			Id:       s.ID.String(),
+			Entity:   string(s.Entity.Entities),
+			Selector: s.Selector,
+			Comment:  s.Comment,
+		})
+	}
 }


### PR DESCRIPTION
# Summary

Extends the `MergeDatabaseGetIntoProfiles` and `MergeDatabaseListIntoProfiles`
functions to include selectors. These will be useful later when we extend the
profile handlers.

- **Extend the ProfileRow interface for selectors**
- **Add selectors to profile in `MergeDatabaseListIntoProfiles`**
- **`MergeDatabaseGetIntoProfiles` includes selectors**

Related: #3723

## Change Type

***Mark the type of change your PR introduces:***

- [ ] Bug fix (resolves an issue without affecting existing features)
- [x] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [ ] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

as part of a larger branch. We'll be able to add tests when we extend the Profile service
and extend the handlers.

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [ ] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [ ] Included tests that validate the fix or feature.
- [ ] Checked that related changes are merged.
