### PR TITLE
CheckHealth RPC now logs error when failing.

### DIFF
--- a/internal/controlplane/handlers.go
+++ b/internal/controlplane/handlers.go
@@ -19,6 +19,7 @@ package controlplane
 import (
 	"context"
 
+	"github.com/rs/zerolog"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
@@ -29,8 +30,9 @@ import (
 const PaginationLimit = 10
 
 // CheckHealth is a simple health check for monitoring
-func (s *Server) CheckHealth(_ context.Context, _ *pb.CheckHealthRequest) (*pb.CheckHealthResponse, error) {
+func (s *Server) CheckHealth(ctx context.Context, _ *pb.CheckHealthRequest) (*pb.CheckHealthResponse, error) {
 	if err := s.store.CheckHealth(); err != nil {
+		zerolog.Ctx(ctx).Error().Err(err).Msg("health check failed")
 		return nil, status.Errorf(codes.Internal, "failed to check health: %v", err)
 	}
 	return &pb.CheckHealthResponse{Status: "OK"}, nil


### PR DESCRIPTION
# Summary

This change aims to add a little more introspection on why health check might fail. It's meant to help in scenarios like e.g. when Minder goes CLBO because of liveness check failures. Currently, it is hard to tell whether this is because of lack of resources, most likely CPU, or because it fails to connect to the database.

## Change Type

- [ ] Bug fix (resolves an issue without affecting existing features)
- [ ] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [x] Refactoring or test improvements (no bug fixes or new functionality)

# Review Checklist:

- [X] Reviewed my own code for quality and clarity.
- [ ] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [ ] Included tests that validate the fix or feature.
- [X] Checked that related changes are merged.
