### PR TITLE
Require entity-type in profile status get to avoid permafail

### DIFF
--- a/cmd/cli/app/profile/status/status_get.go
+++ b/cmd/cli/app/profile/status/status_get.go
@@ -100,4 +100,9 @@ func init() {
 		os.Exit(1)
 	}
 
+	if err := getCmd.MarkFlagRequired("entity-type"); err != nil {
+		getCmd.Printf("Error marking flag required: %s", err)
+		os.Exit(1)
+	}
+
 }


### PR DESCRIPTION
# Summary

***Provide a brief overview of the changes and the issue being addressed. 

This commit marks `entity-type` as required in
`minder profile status get` to avoide sending
`ENTITY_UNSPECIFIED` to the API (which always fails).

## Change Type

***Mark the type of change your PR introduces:***

- [x] Bug fix (resolves an issue without affecting existing features)
- [ ] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [ ] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

***Outline how the changes were tested, including steps to reproduce and any relevant configurations. 
Attach screenshots if helpful.***

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [ ] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [ ] Included tests that validate the fix or feature.
- [ ] Checked that related changes are merged.
