### PR TITLE
Add Execution ID in the executor's evaluation param logs

### DIFF
--- a/internal/engine/eval_status.go
+++ b/internal/engine/eval_status.go
@@ -55,6 +55,7 @@ func (e *executor) createEvalStatusParams(
 		ArtifactID:    artID,
 		PullRequestID: prID,
 		ProjectID:     inf.ProjectID,
+		ExecutionID:   *inf.ExecutionID, // Execution ID is required in the executor.
 	}
 
 	// Prepare params for fetching the current rule evaluation from the database

--- a/internal/engine/interfaces/interface.go
+++ b/internal/engine/interfaces/interface.go
@@ -147,6 +147,7 @@ type EvalStatusParams struct {
 	evalErr          error
 	actionsOnOff     map[ActionType]ActionOpt
 	actionsErr       evalerrors.ActionsError
+	ExecutionID      uuid.UUID
 }
 
 // Ensure EvalStatusParams implements the necessary interfaces
@@ -250,6 +251,7 @@ func (e *EvalStatusParams) DecorateLogger(l zerolog.Logger) zerolog.Logger {
 		Str("rule_type", e.GetRule().GetType()).
 		Str("rule_name", e.GetRule().GetName()).
 		Str("rule_type_id", e.GetRuleTypeID().String()).
+		Str("execution_id", e.ExecutionID.String()).
 		Logger()
 	if e.RepoID.Valid {
 		outl = outl.With().Str("repository_id", e.RepoID.UUID.String()).Logger()


### PR DESCRIPTION
# Summary

The execution ID is very handy to link together a single run when
debugging Minder. Unfortunately, it's not set everywhere... so let's do
that! This way, we'll be able to better debug minder throughout the
execution of policy for an entity.

## Change Type

***Mark the type of change your PR introduces:***

- [ ] Bug fix (resolves an issue without affecting existing features)
- [ ] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [x] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

***Outline how the changes were tested, including steps to reproduce and any relevant configurations. 
Attach screenshots if helpful.***

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [ ] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [ ] Included tests that validate the fix or feature.
- [ ] Checked that related changes are merged.
