### PR TITLE
Give metric attributes unique names

### DIFF
--- a/internal/engine/metrics.go
+++ b/internal/engine/metrics.go
@@ -89,8 +89,8 @@ func (e *ExecutorMetrics) CountEvalStatus(
 	entityType db.Entities,
 ) {
 	e.evalCounter.Add(ctx, 1, metric.WithAttributes(
-		attribute.String("entity_type", string(entityType)),
-		attribute.String("status", string(status)),
+		attribute.String("eval_entity_type", string(entityType)),
+		attribute.String("eval_status_type", string(status)),
 	))
 }
 
@@ -100,7 +100,7 @@ func (e *ExecutorMetrics) CountRemediationStatus(
 	status db.RemediationStatusTypes,
 ) {
 	e.evalCounter.Add(ctx, 1, metric.WithAttributes(
-		attribute.String("status", string(status)),
+		attribute.String("remediation_status_type", string(status)),
 	))
 }
 
@@ -110,7 +110,7 @@ func (e *ExecutorMetrics) CountAlertStatus(
 	status db.AlertStatusTypes,
 ) {
 	e.evalCounter.Add(ctx, 1, metric.WithAttributes(
-		attribute.String("status", string(status)),
+		attribute.String("alert_status_type", string(status)),
 	))
 }
 


### PR DESCRIPTION
# Summary

From experimentation, it seems that attributes of the same name in
different metrics are shared. This leads to, for example, alert status
types showing up in the remediation graph.

## Change Type

***Mark the type of change your PR introduces:***

- [x] Bug fix (resolves an issue without affecting existing features)
- [ ] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [ ] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

***Outline how the changes were tested, including steps to reproduce and any relevant configurations. 
Attach screenshots if helpful.***

# Review Checklist:

- [ ] Reviewed my own code for quality and clarity.
- [ ] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [ ] Included tests that validate the fix or feature.
- [ ] Checked that related changes are merged.
