### PR TITLE
Remove deduplication logic in evaluation history

### DIFF
--- a/database/migrations/000075_evaluation_history_no_dedupe.down.sql
+++ b/database/migrations/000075_evaluation_history_no_dedupe.down.sql
@@ -1,0 +1,20 @@
+-- Copyright 2024 Stacklok, Inc
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--      http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+BEGIN;
+
+ALTER TABLE evaluation_statuses ADD COLUMN evaluation_times TIMESTAMPZ[] NOT NULL DEFAULT ARRAY[NOW()]::TIMESTAMP[];
+ALTER TABLE evaluation_statuses RENAME COLUMN evaluation_time TO most_recent_evaluation;
+
+COMMIT;

--- a/database/migrations/000075_evaluation_history_no_dedupe.up.sql
+++ b/database/migrations/000075_evaluation_history_no_dedupe.up.sql
@@ -1,0 +1,20 @@
+-- Copyright 2024 Stacklok, Inc
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--      http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+BEGIN;
+
+ALTER TABLE evaluation_statuses DROP COLUMN evaluation_times;
+ALTER TABLE evaluation_statuses RENAME COLUMN most_recent_evaluation TO evaluation_time;
+
+COMMIT;

--- a/database/mock/store.go
+++ b/database/mock/store.go
@@ -1895,20 +1895,6 @@ func (mr *MockStoreMockRecorder) UpdateEncryptedSecret(arg0, arg1 any) *gomock.C
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateEncryptedSecret", reflect.TypeOf((*MockStore)(nil).UpdateEncryptedSecret), arg0, arg1)
 }
 
-// UpdateEvaluationTimes mocks base method.
-func (m *MockStore) UpdateEvaluationTimes(arg0 context.Context, arg1 db.UpdateEvaluationTimesParams) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UpdateEvaluationTimes", arg0, arg1)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// UpdateEvaluationTimes indicates an expected call of UpdateEvaluationTimes.
-func (mr *MockStoreMockRecorder) UpdateEvaluationTimes(arg0, arg1 any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateEvaluationTimes", reflect.TypeOf((*MockStore)(nil).UpdateEvaluationTimes), arg0, arg1)
-}
-
 // UpdateInvitationRole mocks base method.
 func (m *MockStore) UpdateInvitationRole(arg0 context.Context, arg1 db.UpdateInvitationRoleParams) (db.UserInvite, error) {
 	m.ctrl.T.Helper()

--- a/internal/db/models.go
+++ b/internal/db/models.go
@@ -494,12 +494,11 @@ type EvaluationRuleEntity struct {
 }
 
 type EvaluationStatus struct {
-	ID                   uuid.UUID       `json:"id"`
-	RuleEntityID         uuid.UUID       `json:"rule_entity_id"`
-	Status               EvalStatusTypes `json:"status"`
-	Details              string          `json:"details"`
-	EvaluationTimes      PgTimeArray     `json:"evaluation_times"`
-	MostRecentEvaluation time.Time       `json:"most_recent_evaluation"`
+	ID             uuid.UUID       `json:"id"`
+	RuleEntityID   uuid.UUID       `json:"rule_entity_id"`
+	Status         EvalStatusTypes `json:"status"`
+	Details        string          `json:"details"`
+	EvaluationTime time.Time       `json:"evaluation_time"`
 }
 
 type Feature struct {

--- a/internal/db/querier.go
+++ b/internal/db/querier.go
@@ -217,7 +217,6 @@ type Querier interface {
 	RepositoryExistsAfterID(ctx context.Context, id uuid.UUID) (bool, error)
 	SetCurrentVersion(ctx context.Context, arg SetCurrentVersionParams) error
 	UpdateEncryptedSecret(ctx context.Context, arg UpdateEncryptedSecretParams) error
-	UpdateEvaluationTimes(ctx context.Context, arg UpdateEvaluationTimesParams) error
 	// UpdateInvitationRole updates an invitation by its code. This is intended to be
 	// called by a user who has issued an invitation and then decided to change the
 	// role of the invitee.


### PR DESCRIPTION
I have run into a number of issues involving pq and sqlc's ability to deal with postgres timestamp arrays. At this point, rather than invest further effort, I have decided to remove the deduplication feature for now. Since this will only be useful at the point where we use reconciliation more extensively, I would prefer to reintroduce this functionality once we have more data to back up its utility.

# Summary

***Provide a brief overview of the changes and the issue being addressed. 
Explain the rationale and any background necessary for understanding the changes. 
List dependencies required by this change, if any.***

Fixes #(related issue)

## Change Type

***Mark the type of change your PR introduces:***

- [x] Bug fix (resolves an issue without affecting existing features)
- [ ] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [ ] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

***Outline how the changes were tested, including steps to reproduce and any relevant configurations. 
Attach screenshots if helpful.***

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [x] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [x] Included tests that validate the fix or feature.
- [ ] Checked that related changes are merged.
