### PR TITLE
Remove use of `entity_profile_rules` table

### DIFF
--- a/database/mock/store.go
+++ b/database/mock/store.go
@@ -513,20 +513,6 @@ func (mr *MockStoreMockRecorder) DeleteRepository(arg0, arg1 any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteRepository", reflect.TypeOf((*MockStore)(nil).DeleteRepository), arg0, arg1)
 }
 
-// DeleteRuleInstantiation mocks base method.
-func (m *MockStore) DeleteRuleInstantiation(arg0 context.Context, arg1 db.DeleteRuleInstantiationParams) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DeleteRuleInstantiation", arg0, arg1)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// DeleteRuleInstantiation indicates an expected call of DeleteRuleInstantiation.
-func (mr *MockStoreMockRecorder) DeleteRuleInstantiation(arg0, arg1 any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteRuleInstantiation", reflect.TypeOf((*MockStore)(nil).DeleteRuleInstantiation), arg0, arg1)
-}
-
 // DeleteRuleStatusesForProfileAndRuleType mocks base method.
 func (m *MockStore) DeleteRuleStatusesForProfileAndRuleType(arg0 context.Context, arg1 db.DeleteRuleStatusesForProfileAndRuleTypeParams) error {
 	m.ctrl.T.Helper()
@@ -999,21 +985,6 @@ func (m *MockStore) GetProfileByProjectAndID(arg0 context.Context, arg1 db.GetPr
 func (mr *MockStoreMockRecorder) GetProfileByProjectAndID(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetProfileByProjectAndID", reflect.TypeOf((*MockStore)(nil).GetProfileByProjectAndID), arg0, arg1)
-}
-
-// GetProfileForEntity mocks base method.
-func (m *MockStore) GetProfileForEntity(arg0 context.Context, arg1 db.GetProfileForEntityParams) (db.EntityProfile, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetProfileForEntity", arg0, arg1)
-	ret0, _ := ret[0].(db.EntityProfile)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetProfileForEntity indicates an expected call of GetProfileForEntity.
-func (mr *MockStoreMockRecorder) GetProfileForEntity(arg0, arg1 any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetProfileForEntity", reflect.TypeOf((*MockStore)(nil).GetProfileForEntity), arg0, arg1)
 }
 
 // GetProfileStatusByIdAndProject mocks base method.
@@ -2232,19 +2203,4 @@ func (m *MockStore) UpsertRuleInstance(arg0 context.Context, arg1 db.UpsertRuleI
 func (mr *MockStoreMockRecorder) UpsertRuleInstance(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpsertRuleInstance", reflect.TypeOf((*MockStore)(nil).UpsertRuleInstance), arg0, arg1)
-}
-
-// UpsertRuleInstantiation mocks base method.
-func (m *MockStore) UpsertRuleInstantiation(arg0 context.Context, arg1 db.UpsertRuleInstantiationParams) (db.EntityProfileRule, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UpsertRuleInstantiation", arg0, arg1)
-	ret0, _ := ret[0].(db.EntityProfileRule)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// UpsertRuleInstantiation indicates an expected call of UpsertRuleInstantiation.
-func (mr *MockStoreMockRecorder) UpsertRuleInstantiation(arg0, arg1 any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpsertRuleInstantiation", reflect.TypeOf((*MockStore)(nil).UpsertRuleInstantiation), arg0, arg1)
 }

--- a/database/query/profiles.sql
+++ b/database/query/profiles.sql
@@ -46,9 +46,6 @@ RETURNING *;
 -- name: DeleteProfileForEntity :exec
 DELETE FROM entity_profiles WHERE profile_id = $1 AND entity = $2;
 
--- name: GetProfileForEntity :one
-SELECT * FROM entity_profiles WHERE profile_id = $1 AND entity = $2;
-
 -- name: GetProfileByProjectAndID :many
 WITH helper AS(
     SELECT pr.id as profid,
@@ -112,14 +109,6 @@ AND (
 -- name: DeleteProfile :exec
 DELETE FROM profiles
 WHERE id = $1 AND project_id = $2;
-
--- name: UpsertRuleInstantiation :one
-INSERT INTO entity_profile_rules (entity_profile_id, rule_type_id)
-VALUES ($1, $2)
-ON CONFLICT (entity_profile_id, rule_type_id) DO NOTHING RETURNING *;
-
--- name: DeleteRuleInstantiation :exec
-DELETE FROM entity_profile_rules WHERE entity_profile_id = $1 AND rule_type_id = $2;
 
 -- name: ListProfilesInstantiatingRuleType :many
 SELECT DISTINCT(p.name)

--- a/internal/db/querier.go
+++ b/internal/db/querier.go
@@ -51,7 +51,6 @@ type Querier interface {
 	DeleteProvider(ctx context.Context, arg DeleteProviderParams) error
 	DeletePullRequest(ctx context.Context, arg DeletePullRequestParams) error
 	DeleteRepository(ctx context.Context, id uuid.UUID) error
-	DeleteRuleInstantiation(ctx context.Context, arg DeleteRuleInstantiationParams) error
 	// DeleteRuleStatusesForProfileAndRuleType deletes a rule evaluation
 	// but locks the table before doing so.
 	DeleteRuleStatusesForProfileAndRuleType(ctx context.Context, arg DeleteRuleStatusesForProfileAndRuleTypeParams) error
@@ -117,7 +116,6 @@ type Querier interface {
 	GetProfileByIDAndLock(ctx context.Context, arg GetProfileByIDAndLockParams) (Profile, error)
 	GetProfileByNameAndLock(ctx context.Context, arg GetProfileByNameAndLockParams) (Profile, error)
 	GetProfileByProjectAndID(ctx context.Context, arg GetProfileByProjectAndIDParams) ([]GetProfileByProjectAndIDRow, error)
-	GetProfileForEntity(ctx context.Context, arg GetProfileForEntityParams) (EntityProfile, error)
 	GetProfileStatusByIdAndProject(ctx context.Context, arg GetProfileStatusByIdAndProjectParams) (GetProfileStatusByIdAndProjectRow, error)
 	GetProfileStatusByNameAndProject(ctx context.Context, arg GetProfileStatusByNameAndProjectParams) (GetProfileStatusByNameAndProjectRow, error)
 	GetProfileStatusByProject(ctx context.Context, projectID uuid.UUID) ([]GetProfileStatusByProjectRow, error)
@@ -271,7 +269,6 @@ type Querier interface {
 	// See the License for the specific language governing permissions and
 	// limitations under the License.
 	UpsertRuleInstance(ctx context.Context, arg UpsertRuleInstanceParams) (uuid.UUID, error)
-	UpsertRuleInstantiation(ctx context.Context, arg UpsertRuleInstantiationParams) (EntityProfileRule, error)
 }
 
 var _ Querier = (*Queries)(nil)

--- a/internal/engine/actions/alert/security_advisory/security_advisory.go
+++ b/internal/engine/actions/alert/security_advisory/security_advisory.go
@@ -22,14 +22,13 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/stacklok/minder/internal/profiles/models"
 	htmltemplate "html/template"
 	"strings"
 
-	"github.com/stacklok/minder/internal/db"
-
 	"github.com/google/go-github/v63/github"
 	"github.com/rs/zerolog"
+	"github.com/stacklok/minder/internal/db"
+	"github.com/stacklok/minder/internal/profiles/models"
 	"google.golang.org/protobuf/reflect/protoreflect"
 
 	enginerr "github.com/stacklok/minder/internal/engine/errors"

--- a/internal/profiles/service.go
+++ b/internal/profiles/service.go
@@ -272,7 +272,7 @@ func (p *profileService) UpdateProfile(
 		minderv1.Entity_ENTITY_TASK_RUN:           profile.GetTaskRun(),
 		minderv1.Entity_ENTITY_BUILD:              profile.GetBuild(),
 	} {
-		if err = updateProfileRulesForEntity(ctx, ent, &updatedProfile, qtx, entRules, rules); err != nil {
+		if err = updateProfileRulesForEntity(ctx, ent, &updatedProfile, qtx, entRules); err != nil {
 			return nil, err
 		}
 
@@ -302,11 +302,6 @@ func (p *profileService) UpdateProfile(
 	}
 
 	unusedRuleStatuses := getUnusedOldRuleStatuses(rules, oldRules)
-	unusedRuleTypes := getUnusedOldRuleTypes(rules, oldRules)
-
-	if err := deleteUnusedRulesFromProfile(ctx, &updatedProfile, unusedRuleTypes, qtx); err != nil {
-		return nil, status.Errorf(codes.Internal, "error updating profile: %v", err)
-	}
 
 	if err := deleteRuleStatusesForProfile(ctx, &updatedProfile, unusedRuleStatuses, qtx); err != nil {
 		return nil, status.Errorf(codes.Internal, "error updating profile: %v", err)
@@ -379,7 +374,7 @@ func copyFieldValue(dstReflect, srcReflect protoreflect.Message, fieldDesc proto
 		dstList.Truncate(0)
 
 		// append all elements from the source list to the destination list
-		// effectivelly replacing the destination list with the source list
+		// effectively replacing the destination list with the source list
 		for i := 0; i < srcList.Len(); i++ {
 			dstList.Append(srcList.Get(i))
 		}
@@ -418,7 +413,7 @@ func createProfileRulesForEntity(
 		log.Printf("error marshalling %s rules: %v", entity, err)
 		return status.Errorf(codes.Internal, "error creating profile")
 	}
-	entProf, err := qtx.CreateProfileForEntity(ctx, db.CreateProfileForEntityParams{
+	_, err = qtx.CreateProfileForEntity(ctx, db.CreateProfileForEntityParams{
 		ProfileID:       profile.ID,
 		Entity:          entities.EntityTypeToDB(entity),
 		ContextualRules: marshalled,
@@ -426,27 +421,6 @@ func createProfileRulesForEntity(
 	if err != nil {
 		log.Printf("error creating profile for entity %s: %v", entity, err)
 		return status.Errorf(codes.Internal, "error creating profile")
-	}
-
-	for idx := range rulesInProf {
-		ruleRef := rulesInProf[idx]
-
-		if ruleRef.Entity != entity {
-			continue
-		}
-
-		ruleID := ruleRef.RuleID
-
-		_, err := qtx.UpsertRuleInstantiation(ctx, db.UpsertRuleInstantiationParams{
-			EntityProfileID: entProf.ID,
-			RuleTypeID:      ruleID,
-		})
-		if errors.Is(err, sql.ErrNoRows) {
-			log.Printf("the rule instantiation for rule already existed.")
-		} else if err != nil {
-			log.Printf("error creating rule instantiation: %v", err)
-			return status.Errorf(codes.Internal, "error creating profile")
-		}
 	}
 
 	return err
@@ -620,48 +594,12 @@ func (_ *profileService) getRulesFromProfile(
 	return rulesInProf, nil
 }
 
-func deleteUnusedRulesFromProfile(
-	ctx context.Context,
-	profile *db.Profile,
-	unusedRules []EntityAndRuleTuple,
-	querier db.Querier,
-) error {
-	for _, rule := range unusedRules {
-		// get entity profile
-		log.Printf("getting profile for entity %s", rule.Entity)
-		entProf, err := querier.GetProfileForEntity(ctx, db.GetProfileForEntityParams{
-			ProfileID: profile.ID,
-			Entity:    entities.EntityTypeToDB(rule.Entity),
-		})
-		if err != nil {
-			if errors.Is(err, sql.ErrNoRows) {
-				log.Printf("skipping rule deletion for entity %s, profile not found", rule.Entity)
-				continue
-			}
-			log.Printf("error getting profile for entity %s: %v", rule.Entity, err)
-			return fmt.Errorf("error getting profile for entity %s: %w", rule.Entity, err)
-		}
-
-		log.Printf("deleting rule instantiation for rule %s for entity profile %s", rule.RuleID, entProf.ID)
-		if err := querier.DeleteRuleInstantiation(ctx, db.DeleteRuleInstantiationParams{
-			EntityProfileID: entProf.ID,
-			RuleTypeID:      rule.RuleID,
-		}); err != nil {
-			log.Printf("error deleting rule instantiation: %v", err)
-			return fmt.Errorf("error deleting rule instantiation: %w", err)
-		}
-	}
-
-	return nil
-}
-
 func updateProfileRulesForEntity(
 	ctx context.Context,
 	entity minderv1.Entity,
 	profile *db.Profile,
 	qtx db.Querier,
 	rules []*minderv1.Profile_Rule,
-	rulesInProf RuleMapping,
 ) error {
 	if len(rules) == 0 {
 		return qtx.DeleteProfileForEntity(ctx, db.DeleteProfileForEntityParams{
@@ -675,7 +613,7 @@ func updateProfileRulesForEntity(
 		log.Printf("error marshalling %s rules: %v", entity, err)
 		return status.Errorf(codes.Internal, "error creating profile")
 	}
-	entProf, err := qtx.UpsertProfileForEntity(ctx, db.UpsertProfileForEntityParams{
+	_, err = qtx.UpsertProfileForEntity(ctx, db.UpsertProfileForEntityParams{
 		ProfileID:       profile.ID,
 		Entity:          entities.EntityTypeToDB(entity),
 		ContextualRules: marshalled,
@@ -683,25 +621,6 @@ func updateProfileRulesForEntity(
 	if err != nil {
 		log.Printf("error updating profile for entity %s: %v", entity, err)
 		return err
-	}
-
-	for idx := range rulesInProf {
-		ruleRef := rulesInProf[idx]
-
-		if ruleRef.Entity != entity {
-			continue
-		}
-
-		_, err := qtx.UpsertRuleInstantiation(ctx, db.UpsertRuleInstantiationParams{
-			EntityProfileID: entProf.ID,
-			RuleTypeID:      ruleRef.RuleID,
-		})
-		if errors.Is(err, sql.ErrNoRows) {
-			log.Printf("the rule instantiation for rule already existed.")
-		} else if err != nil {
-			log.Printf("error creating rule instantiation: %v", err)
-			return status.Errorf(codes.Internal, "error updating profile")
-		}
 	}
 
 	return err
@@ -719,28 +638,6 @@ func getUnusedOldRuleStatuses(
 	}
 
 	return unusedRuleStatuses
-}
-
-func getUnusedOldRuleTypes(newRules, oldRules RuleMapping) []EntityAndRuleTuple {
-	var unusedRuleTypes []EntityAndRuleTuple
-
-	oldRulesTypeMap := make(map[string]EntityAndRuleTuple)
-	for ruleTypeAndName, rule := range oldRules {
-		oldRulesTypeMap[ruleTypeAndName.RuleType] = rule
-	}
-
-	newRulesTypeMap := make(map[string]EntityAndRuleTuple)
-	for ruleTypeAndName, rule := range newRules {
-		newRulesTypeMap[ruleTypeAndName.RuleType] = rule
-	}
-
-	for ruleType, rule := range oldRulesTypeMap {
-		if _, ok := newRulesTypeMap[ruleType]; !ok {
-			unusedRuleTypes = append(unusedRuleTypes, rule)
-		}
-	}
-
-	return unusedRuleTypes
 }
 
 func deleteRuleStatusesForProfile(


### PR DESCRIPTION
PR #3903 replaced the one part of minder which queried the data in the `entity_profile_rules` table. This PR removes the code which adds and removes entries to this table. A future PR will drop the table outright.

# Summary

***Provide a brief overview of the changes and the issue being addressed. 
Explain the rationale and any background necessary for understanding the changes. 
List dependencies required by this change, if any.***

Fixes #(related issue)

## Change Type

***Mark the type of change your PR introduces:***

- [ ] Bug fix (resolves an issue without affecting existing features)
- [ ] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [x] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

***Outline how the changes were tested, including steps to reproduce and any relevant configurations. 
Attach screenshots if helpful.***

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [x] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [ ] Included tests that validate the fix or feature.
- [ ] Checked that related changes are merged.
