### PR TITLE
Don't URL escape the package name when getting versions

### DIFF
--- a/internal/providers/github/common.go
+++ b/internal/providers/github/common.go
@@ -790,9 +790,10 @@ func (gv *GitHub) GetArtifactVersions(
 	ctx context.Context, artifact *minderv1.Artifact,
 	filter provifv1.GetArtifactVersionsFilter,
 ) ([]*minderv1.ArtifactVersion, error) {
-	artifactName := url.QueryEscape(artifact.GetName())
+	// We don't need to URL-encode the artifact name
+	// since this already happens in go-github
 	upstreamVersions, err := gv.getPackageVersions(
-		ctx, artifact.GetOwner(), artifact.GetTypeLower(), artifactName,
+		ctx, artifact.GetOwner(), artifact.GetTypeLower(), artifact.GetName(),
 	)
 	if err != nil {
 		return nil, fmt.Errorf("error retrieving artifact versions: %w", err)


### PR DESCRIPTION
# Summary

URL-escaping is already happening within the go-github library, so we
don't need to do it twice. Doing it twice causes minder to not be able
to retrieve the package versions since indeed that resource is non-existent.

Fixes #3914

## Change Type

***Mark the type of change your PR introduces:***

- [x] Bug fix (resolves an issue without affecting existing features)
- [ ] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [ ] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

***Outline how the changes were tested, including steps to reproduce and any relevant configurations.
Attach screenshots if helpful.***

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [x] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [ ] Included tests that validate the fix or feature.
- [ ] Checked that related changes are merged.
