### PR TITLE
Fix potential race condition in rule type engine cache

### DIFF
--- a/internal/engine/eval/eval.go
+++ b/internal/engine/eval/eval.go
@@ -55,13 +55,13 @@ func NewRuleEvaluator(
 	case vulncheck.VulncheckEvalType:
 		client, err := provinfv1.As[provinfv1.GitHub](provider)
 		if err != nil {
-			return nil, errors.New("provider does not implement git trait")
+			return nil, errors.New("provider does not implement github trait")
 		}
 		return vulncheck.NewVulncheckEvaluator(client)
 	case trusty.TrustyEvalType:
 		client, err := provinfv1.As[provinfv1.GitHub](provider)
 		if err != nil {
-			return nil, errors.New("provider does not implement git trait")
+			return nil, errors.New("provider does not implement github trait")
 		}
 		return trusty.NewTrustyEvaluator(ctx, client)
 	case application.HomoglyphsEvalType:

--- a/internal/engine/executor.go
+++ b/internal/engine/executor.go
@@ -238,7 +238,7 @@ func (e *executor) getEvaluator(
 
 	params.RuleTypeID = ruleTypeID
 
-	rte, err := ruleEngineCache.GetRuleEngine(ruleTypeID)
+	rte, err := ruleEngineCache.GetRuleEngine(ctx, ruleTypeID)
 	if err != nil {
 		return nil, nil, nil, fmt.Errorf("error creating rule type engine: %w", err)
 	}

--- a/internal/engine/rtengine/cache_test.go
+++ b/internal/engine/rtengine/cache_test.go
@@ -1,0 +1,165 @@
+// Copyright 2024 Stacklok, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package rtengine
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+
+	"github.com/stacklok/minder/internal/db"
+	dbf "github.com/stacklok/minder/internal/db/fixtures"
+	"github.com/stacklok/minder/internal/engine/ingestcache"
+	"github.com/stacklok/minder/internal/providers/git"
+)
+
+func TestGetRuleEngine(t *testing.T) {
+	t.Parallel()
+
+	scenarios := []struct {
+		Name          string
+		Cache         cacheType
+		DBSetup       dbf.DBMockBuilder
+		ExpectedError string
+	}{
+		{
+			Name:  "Retrieves rule engine from cache",
+			Cache: cacheType{ruleTypeID: &RuleTypeEngine{}},
+		},
+		{
+			Name:          "Returns error when rule type does not exist",
+			Cache:         cacheType{},
+			DBSetup:       dbf.NewDBMock(withRuleTypeLookup(nil, sql.ErrNoRows)),
+			ExpectedError: "unknown rule type with ID",
+		},
+		{
+			Name:          "Returns error when rule type lookup fails",
+			Cache:         cacheType{},
+			DBSetup:       dbf.NewDBMock(withRuleTypeLookup(nil, errTest)),
+			ExpectedError: "error creating rule type engine",
+		},
+		{
+			Name:          "Returns error when rule type cannot be parsed",
+			Cache:         cacheType{},
+			DBSetup:       dbf.NewDBMock(withRuleTypeLookup(&db.RuleType{}, nil)),
+			ExpectedError: "error parsing rule type when parsing rule type",
+		},
+		{
+			Name:          "Returns error when rule type engine cannot be instantiated",
+			Cache:         cacheType{},
+			DBSetup:       dbf.NewDBMock(withRuleTypeLookup(&malformedRuleType, nil)),
+			ExpectedError: "error creating rule type engine",
+		},
+		{
+			Name:    "Creates rule type engine for missing rule type and caches it",
+			Cache:   cacheType{},
+			DBSetup: dbf.NewDBMock(withRuleTypeLookup(&ruleType, nil)),
+		},
+	}
+
+	for _, scenario := range scenarios {
+		t.Run(scenario.Name, func(t *testing.T) {
+			t.Parallel()
+
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+			ctx := context.Background()
+
+			var store db.Store
+			if scenario.DBSetup != nil {
+				store = scenario.DBSetup(ctrl)
+			}
+
+			cache := ruleEngineCache{
+				store:       store,
+				provider:    git.NewGit(nil),
+				ingestCache: ingestcache.NewNoopCache(),
+				engines:     scenario.Cache,
+			}
+
+			result, err := cache.GetRuleEngine(ctx, ruleTypeID)
+			if scenario.ExpectedError != "" {
+				require.ErrorContains(t, err, scenario.ExpectedError)
+				require.Nil(t, result)
+				// ensure that the value is present in the cache after testing
+				require.NotContains(t, cache.engines, ruleTypeID)
+			} else {
+				require.NoError(t, err)
+				require.NotNil(t, result)
+				// ensure that the value is present in the cache after testing
+				require.Contains(t, cache.engines, ruleTypeID)
+			}
+		})
+	}
+}
+
+var (
+	ruleTypeID = uuid.New()
+	errTest    = errors.New("error in rule type engine cache test")
+	ruleType   = db.RuleType{
+		ID:         ruleTypeID,
+		Definition: []byte(ruleDefJSON),
+	}
+	malformedRuleType = db.RuleType{
+		ID:         ruleTypeID,
+		Definition: []byte(brokenRuleDef),
+	}
+)
+
+func withRuleTypeLookup(ruleType *db.RuleType, err error) func(dbf.DBMock) {
+	return func(mock dbf.DBMock) {
+		var rt db.RuleType
+		if ruleType != nil {
+			rt = *ruleType
+		}
+		mock.EXPECT().
+			GetRuleTypeByID(gomock.Any(), ruleTypeID).
+			Return(rt, err)
+	}
+}
+
+// just enough of a rule type definition to pass validation
+const ruleDefJSON = `
+{
+	"rule_schema": {},
+	"ingest": {
+		"type": "git",
+        "git": {}
+	},
+	"eval": {
+		"type": "jq",
+		"jq": [{
+			"ingested": {"def": "abc"},
+			"profile": {"def": "xyz"}
+		}]
+	}
+}
+`
+
+// just enough to create an error when instantiating the rule type engine
+const brokenRuleDef = `
+{
+	"rule_schema": {},
+	"ingest": {
+		"type": "git",
+        "git": {}
+	}
+}
+`

--- a/internal/engine/rtengine/cache_test.go
+++ b/internal/engine/rtengine/cache_test.go
@@ -98,7 +98,7 @@ func TestGetRuleEngine(t *testing.T) {
 			if scenario.ExpectedError != "" {
 				require.ErrorContains(t, err, scenario.ExpectedError)
 				require.Nil(t, result)
-				// ensure that the value is present in the cache after testing
+				// ensure that this rule type ID was not cached
 				require.NotContains(t, cache.engines, ruleTypeID)
 			} else {
 				require.NoError(t, err)


### PR DESCRIPTION
This addresses a potential race condition I discovered while working on another task. If a rule instance with a new rule type is added to a profile after the rule type cache is populated, but before the profiles and rule instances are queried, the evaluation will fail because the new rule type will be missing from the cache.

This changes the logic to query for rule types which are not found in the cache, and create a new rule type engine instance and cache it if we get a result.

**Alternatives Considered**

I could simplify this to remove the pre-population and query the database for each rule type when we encounter it first. This would simplify the logic, but at the expense of throwing away the performance gains from loading most of the rules we need in one query.

# Summary

***Provide a brief overview of the changes and the issue being addressed. 
Explain the rationale and any background necessary for understanding the changes. 
List dependencies required by this change, if any.***

Fixes #(related issue)

## Change Type

***Mark the type of change your PR introduces:***

- [x] Bug fix (resolves an issue without affecting existing features)
- [ ] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [ ] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

***Outline how the changes were tested, including steps to reproduce and any relevant configurations. 
Attach screenshots if helpful.***

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [x] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [x] Included tests that validate the fix or feature.
- [ ] Checked that related changes are merged.
