### PR TITLE
Add support for cursors to `minder history list`.

### DIFF
--- a/internal/util/cli/styles.go
+++ b/internal/util/cli/styles.go
@@ -36,7 +36,12 @@ var (
 	BlackColor = lipgloss.Color("#000000")
 )
 
-// Styles
+// Common styles
+var (
+	CursorStyle = lipgloss.NewStyle().Foreground(SecondaryColor)
+)
+
+// Banner styles
 var (
 	// DefaultBannerWidth is the default width for a banner
 	DefaultBannerWidth = 80


### PR DESCRIPTION
# Summary

This change adds two flags to `minder history list` command, namely `--cursor`, which lets the user specify the cursor to a specific page of the list, and `--size`, which lets the user specify the number of items to retrieve. The two flags can be used independently from one another.

For obvious reasons, code was also added to print the cursors. I picked an arbitrary position, but reviewed the style with James to ensure some degree of uniformity with the rest of the product.

Fixes #3913


## Change Type

- [ ] Bug fix (resolves an issue without affecting existing features)
- [X] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [ ] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

Manual tests.

# Review Checklist:

- [X] Reviewed my own code for quality and clarity.
- [X] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [ ] Included tests that validate the fix or feature.
- [X] Checked that related changes are merged.
