### PR TITLE
Add from/to filters to `minder history list`.

### DIFF
--- a/cmd/cli/app/history/history_list.go
+++ b/cmd/cli/app/history/history_list.go
@@ -25,6 +25,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	"google.golang.org/grpc"
+	"google.golang.org/protobuf/types/known/timestamppb"
 
 	"github.com/stacklok/minder/cmd/cli/app"
 	"github.com/stacklok/minder/cmd/cli/app/common"
@@ -59,6 +60,10 @@ func listCommand(ctx context.Context, cmd *cobra.Command, _ []string, conn *grpc
 	remediationStatus := viper.GetStringSlice("remediation-status")
 	alertStatus := viper.GetStringSlice("alert-status")
 
+	// time range
+	from := viper.GetTime("from")
+	to := viper.GetTime("to")
+
 	// page options
 	cursorStr := viper.GetString("cursor")
 	size := viper.GetUint64("size")
@@ -88,7 +93,7 @@ func listCommand(ctx context.Context, cmd *cobra.Command, _ []string, conn *grpc
 	}
 
 	// list all the things
-	resp, err := client.ListEvaluationHistory(ctx, &minderv1.ListEvaluationHistoryRequest{
+	req := &minderv1.ListEvaluationHistoryRequest{
 		Context:     &minderv1.Context{Project: &project},
 		EntityType:  entityType,
 		EntityName:  entityName,
@@ -99,7 +104,19 @@ func listCommand(ctx context.Context, cmd *cobra.Command, _ []string, conn *grpc
 		From:        nil,
 		To:          nil,
 		Cursor:      cursorFromOptions(cursorStr, size),
-	})
+	}
+
+	// Viper returns time.Time rather than a pointer to it, so we
+	// have to check whether from and/or to were specified by
+	// other means.
+	if cmd.Flags().Lookup("from").Changed {
+		req.From = timestamppb.New(from)
+	}
+	if cmd.Flags().Lookup("to").Changed {
+		req.To = timestamppb.New(to)
+	}
+
+	resp, err := client.ListEvaluationHistory(ctx, req)
 	if err != nil {
 		return cli.MessageAndError("Error getting profile status", err)
 	}
@@ -217,6 +234,8 @@ func init() {
 	listCmd.Flags().String("eval-status", "", evalFilterMsg)
 	listCmd.Flags().String("remediation-status", "", remediationFilterMsg)
 	listCmd.Flags().String("alert-status", "", alertFilterMsg)
+	listCmd.Flags().String("from", "", "Filter evaluation history list by time")
+	listCmd.Flags().String("to", "", "Filter evaluation history list by time")
 	listCmd.Flags().StringP("cursor", "c", "", "Fetch previous or next page from the list")
 	listCmd.Flags().Uint64P("size", "s", defaultPageSize, "Change the number of items fetched")
 }


### PR DESCRIPTION
# Summary

This change adds `--from` and `--to` optional flags, which let the customer specify a time window for evaluation times. Allowed formats are those supported by the library we're currently using (viper) and are listed [here](https://github.com/spf13/cast/blob/48ddde5701366ade1d3aba346e09bb58430d37c6/cast_test.go#L934-L952).

Fixes #3927


## Change Type

- [ ] Bug fix (resolves an issue without affecting existing features)
- [X] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [ ] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

Manual tests.

# Review Checklist:

- [X] Reviewed my own code for quality and clarity.
- [X] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [ ] Included tests that validate the fix or feature.
- [X] Checked that related changes are merged.
