### PR TITLE
Decouple from/to filtering in history log RPC.

### DIFF
--- a/database/query/eval_history.sql
+++ b/database/query/eval_history.sql
@@ -157,9 +157,8 @@ SELECT s.id::uuid AS evaluation_id,
    AND (sqlc.slice(notAlerts)::alert_status_types[] IS NULL OR ae.status != ANY(sqlc.slice(notAlerts)::alert_status_types[]))
    AND (sqlc.slice(notStatuses)::eval_status_types[] IS NULL OR s.status != ANY(sqlc.slice(notStatuses)::eval_status_types[]))
    -- time range filter
-   AND (sqlc.narg(fromts)::timestamp without time zone IS NULL
-        OR sqlc.narg(tots)::timestamp without time zone IS NULL
-        OR s.evaluation_time BETWEEN sqlc.narg(fromts) AND sqlc.narg(tots))
+   AND (sqlc.narg(fromts)::timestamp without time zone IS NULL OR s.evaluation_time >= sqlc.narg(fromts))
+   AND (sqlc.narg(tots)::timestamp without time zone IS NULL OR  s.evaluation_time < sqlc.narg(tots))
    -- implicit filter by project id
    AND j.id = sqlc.arg(projectId)
  ORDER BY s.evaluation_time DESC

--- a/internal/db/eval_history.sql.go
+++ b/internal/db/eval_history.sql.go
@@ -259,9 +259,8 @@ SELECT s.id::uuid AS evaluation_id,
    AND ($13::alert_status_types[] IS NULL OR ae.status != ANY($13::alert_status_types[]))
    AND ($14::eval_status_types[] IS NULL OR s.status != ANY($14::eval_status_types[]))
    -- time range filter
-   AND ($15::timestamp without time zone IS NULL
-        OR $16::timestamp without time zone IS NULL
-        OR s.evaluation_time BETWEEN $15 AND $16)
+   AND ($15::timestamp without time zone IS NULL OR s.evaluation_time >= $15)
+   AND ($16::timestamp without time zone IS NULL OR  s.evaluation_time < $16)
    -- implicit filter by project id
    AND j.id = $17
  ORDER BY s.evaluation_time DESC

--- a/internal/history/models.go
+++ b/internal/history/models.go
@@ -627,12 +627,6 @@ func NewListEvaluationFilter(opts ...FilterOpt) (ListEvaluationFilter, error) {
 	if filter.projectID == uuid.Nil {
 		return nil, fmt.Errorf("%w: missing", ErrInvalidProjectID)
 	}
-	if filter.to != nil && filter.from == nil {
-		return nil, fmt.Errorf("%w: from is missing", ErrInvalidTimeRange)
-	}
-	if filter.from != nil && filter.to == nil {
-		return nil, fmt.Errorf("%w: to is missing", ErrInvalidTimeRange)
-	}
 	if filter.from != nil && filter.to != nil && filter.from.After(*filter.to) {
 		return nil, fmt.Errorf("%w: from is greated than to", ErrInvalidTimeRange)
 	}

--- a/internal/history/models_test.go
+++ b/internal/history/models_test.go
@@ -226,7 +226,11 @@ func TestListEvaluationFilter(t *testing.T) {
 					WithTo(now),
 				)
 			},
-			err: true,
+			check: func(t *testing.T, filter ListEvaluationFilter) {
+				t.Helper()
+				require.Nil(t, filter.GetFrom())
+				require.Equal(t, now, *filter.GetTo())
+			},
 		},
 		{
 			name: "no to",
@@ -237,7 +241,11 @@ func TestListEvaluationFilter(t *testing.T) {
 					WithFrom(now),
 				)
 			},
-			err: true,
+			check: func(t *testing.T, filter ListEvaluationFilter) {
+				t.Helper()
+				require.Equal(t, now, *filter.GetFrom())
+				require.Nil(t, filter.GetTo())
+			},
 		},
 		{
 			name: "from after to",


### PR DESCRIPTION
# Summary

Currently, ListEvaluationHistory RPC forces the client to either specify both from and to or none of them, but the logic behind the extracted data would allow them to be specified independently.

This change decouples from and to, making the underlying statement a tiny bit more uniform.


## Change Type

- [ ] Bug fix (resolves an issue without affecting existing features)
- [ ] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [X] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

Unit tests and manual tests.

# Review Checklist:

- [X] Reviewed my own code for quality and clarity.
- [ ] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [X] Included tests that validate the fix or feature.
- [X] Checked that related changes are merged.
