### PR TITLE
Remove unnecessary type conversion causing errors.

### DIFF
--- a/internal/controlplane/handlers_evalstatus.go
+++ b/internal/controlplane/handlers_evalstatus.go
@@ -144,12 +144,8 @@ func fromEvaluationHistoryRow(
 	res := []*minderv1.EvaluationHistory{}
 
 	for _, row := range rows {
-		var dbEntityType db.Entities
-		if err := dbEntityType.Scan(row.EntityType); err != nil {
-			return nil, errors.New("internal error")
-		}
-		entityType := dbEntityToEntity(dbEntityType)
-		entityName, err := getEntityName(dbEntityType, row)
+		entityType := dbEntityToEntity(row.EntityType)
+		entityName, err := getEntityName(row.EntityType, row)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
# Summary

The removed lines cause an error when trying to convert a correctly typed variable into the same itself. Previously, `row.EntityType` was a string and could be converted correctly.

I introduced the bug a couple commits before.

## Change Type

- [X] Bug fix (resolves an issue without affecting existing features)
- [ ] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [ ] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

Manual tests.

# Review Checklist:

- [X] Reviewed my own code for quality and clarity.
- [ ] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [ ] Included tests that validate the fix or feature.
- [X] Checked that related changes are merged.
