### PR TITLE
Trim quotes when returning selector comments

### DIFF
--- a/internal/db/profile_selector_scan.go
+++ b/internal/db/profile_selector_scan.go
@@ -63,7 +63,9 @@ func (s *ProfileSelector) Scan(value interface{}) error {
 	selector = strings.TrimSuffix(selector, "\"")
 	s.Selector = selector
 
-	s.Comment = parts[4]
+	comment := strings.TrimPrefix(parts[4], "\"")
+	comment = strings.TrimSuffix(comment, "\"")
+	s.Comment = comment
 
 	return nil
 }

--- a/internal/db/profiles_test.go
+++ b/internal/db/profiles_test.go
@@ -246,7 +246,7 @@ func TestProfileListWithSelectors(t *testing.T) {
 
 	noSelectors := createRandomProfile(t, randomEntities.proj.ID, []string{})
 	oneSelectorProfile := createRandomProfile(t, randomEntities.proj.ID, []string{})
-	oneSel := createRepoSelector(t, oneSelectorProfile.ID, "one_selector1", "one_comment1")
+	oneSel := createRepoSelector(t, oneSelectorProfile.ID, "one_selector1", "multi word comment")
 
 	multiSelectorProfile := createRandomProfile(t, randomEntities.proj.ID, []string{})
 	mulitSel1 := createRepoSelector(t, multiSelectorProfile.ID, "multi_selector1", "multi_comment1")


### PR DESCRIPTION

# Summary

Let's not return the description quoted to the user.

Related: #3723

## Change Type

- [x] Bug fix (resolves an issue without affecting existing features)
- [ ] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [ ] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

manual + there's a unit test

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [ ] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [x] Included tests that validate the fix or feature.
- [ ] Checked that related changes are merged.
