### PR TITLE
Add a DB function to delete all selectors for a profile

### DIFF
--- a/database/mock/store.go
+++ b/database/mock/store.go
@@ -554,6 +554,20 @@ func (mr *MockStoreMockRecorder) DeleteSelector(arg0, arg1 any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteSelector", reflect.TypeOf((*MockStore)(nil).DeleteSelector), arg0, arg1)
 }
 
+// DeleteSelectorsByProfileID mocks base method.
+func (m *MockStore) DeleteSelectorsByProfileID(arg0 context.Context, arg1 uuid.UUID) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteSelectorsByProfileID", arg0, arg1)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DeleteSelectorsByProfileID indicates an expected call of DeleteSelectorsByProfileID.
+func (mr *MockStoreMockRecorder) DeleteSelectorsByProfileID(arg0, arg1 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteSelectorsByProfileID", reflect.TypeOf((*MockStore)(nil).DeleteSelectorsByProfileID), arg0, arg1)
+}
+
 // DeleteSessionStateByProjectID mocks base method.
 func (m *MockStore) DeleteSessionStateByProjectID(arg0 context.Context, arg1 db.DeleteSessionStateByProjectIDParams) error {
 	m.ctrl.T.Helper()

--- a/database/query/selectors.sql
+++ b/database/query/selectors.sql
@@ -22,3 +22,7 @@ WHERE id = $1;
 SELECT id, profile_id, entity, selector, comment
 FROM profile_selectors
 WHERE id = $1;
+
+-- name: DeleteSelectorsByProfileID :exec
+DELETE FROM profile_selectors
+WHERE profile_id = $1;

--- a/internal/db/querier.go
+++ b/internal/db/querier.go
@@ -56,6 +56,7 @@ type Querier interface {
 	DeleteRuleStatusesForProfileAndRuleType(ctx context.Context, arg DeleteRuleStatusesForProfileAndRuleTypeParams) error
 	DeleteRuleType(ctx context.Context, id uuid.UUID) error
 	DeleteSelector(ctx context.Context, id uuid.UUID) error
+	DeleteSelectorsByProfileID(ctx context.Context, profileID uuid.UUID) error
 	DeleteSessionStateByProjectID(ctx context.Context, arg DeleteSessionStateByProjectIDParams) error
 	DeleteUser(ctx context.Context, id int32) error
 	EnqueueFlush(ctx context.Context, arg EnqueueFlushParams) (FlushCache, error)

--- a/internal/db/selectors.sql.go
+++ b/internal/db/selectors.sql.go
@@ -52,6 +52,16 @@ func (q *Queries) DeleteSelector(ctx context.Context, id uuid.UUID) error {
 	return err
 }
 
+const deleteSelectorsByProfileID = `-- name: DeleteSelectorsByProfileID :exec
+DELETE FROM profile_selectors
+WHERE profile_id = $1
+`
+
+func (q *Queries) DeleteSelectorsByProfileID(ctx context.Context, profileID uuid.UUID) error {
+	_, err := q.db.ExecContext(ctx, deleteSelectorsByProfileID, profileID)
+	return err
+}
+
 const getSelectorByID = `-- name: GetSelectorByID :one
 SELECT id, profile_id, entity, selector, comment
 FROM profile_selectors


### PR DESCRIPTION
# Summary

We'll do a dumb but easy way of updating selectors - we'll drop all
current for the profile being updated and re-add them.

Relates: #3723

## Change Type

- [ ] Bug fix (resolves an issue without affecting existing features)
- [x] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [ ] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

there is a test + I cherry-picked the patch out of a larger branch

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [ ] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [x] Included tests that validate the fix or feature.
- [ ] Checked that related changes are merged.
