### PR TITLE
Respect the action overrides

### DIFF
--- a/cmd/dev/app/rule_type/rttst.go
+++ b/cmd/dev/app/rule_type/rttst.go
@@ -177,8 +177,8 @@ func testCmdRun(cmd *cobra.Command, _ []string) error {
 	}
 
 	actionConfig := models.ActionConfiguration{
-		Remediate: models.ActionOptFromString(profile.Remediate, models.ActionOptOff),
-		Alert:     models.ActionOptFromString(profile.Alert, models.ActionOptOff),
+		Remediate: actionOptFromString(profile.Remediate, models.ActionOptOff),
+		Alert:     actionOptFromString(profile.Alert, models.ActionOptOff),
 	}
 
 	// TODO: use cobra context here
@@ -428,4 +428,22 @@ func readProviderConfig(fpath string) ([]byte, error) {
 	}
 
 	return w.Bytes(), nil
+}
+
+func actionOptFromString(s *string, defAction models.ActionOpt) models.ActionOpt {
+	var actionOptMap = map[string]models.ActionOpt{
+		"on":      models.ActionOptOn,
+		"off":     models.ActionOptOff,
+		"dry_run": models.ActionOptDryRun,
+	}
+
+	if s == nil {
+		return defAction
+	}
+
+	if v, ok := actionOptMap[*s]; ok {
+		return v
+	}
+
+	return models.ActionOptUnknown
 }

--- a/internal/engine/actions/actions.go
+++ b/internal/engine/actions/actions.go
@@ -72,8 +72,8 @@ func NewRuleActions(
 		// The on/off state of the actions is an integral part of the action engine
 		// and should be set upon creation.
 		actionsOnOff: map[engif.ActionType]models.ActionOpt{
-			remEngine.Class():   actionConfig.Remediate,
-			alertEngine.Class(): actionConfig.Alert,
+			remEngine.Class():   remEngine.GetOnOffState(actionConfig.Remediate),
+			alertEngine.Class(): alertEngine.GetOnOffState(actionConfig.Alert),
 		},
 	}, nil
 }

--- a/internal/engine/actions/alert/noop/noop.go
+++ b/internal/engine/actions/alert/noop/noop.go
@@ -26,7 +26,6 @@ import (
 	enginerr "github.com/stacklok/minder/internal/engine/errors"
 	"github.com/stacklok/minder/internal/engine/interfaces"
 	"github.com/stacklok/minder/internal/profiles/models"
-	pb "github.com/stacklok/minder/pkg/api/protobuf/go/minder/v1"
 )
 
 // Alert is the structure backing the noop alert
@@ -50,7 +49,7 @@ func (_ *Alert) Type() string {
 }
 
 // GetOnOffState returns the off state of the noop engine
-func (_ *Alert) GetOnOffState(_ *pb.Profile) models.ActionOpt {
+func (_ *Alert) GetOnOffState(_ models.ActionOpt) models.ActionOpt {
 	return models.ActionOptOff
 }
 

--- a/internal/engine/actions/alert/security_advisory/security_advisory.go
+++ b/internal/engine/actions/alert/security_advisory/security_advisory.go
@@ -181,8 +181,8 @@ func (_ *Alert) Type() string {
 }
 
 // GetOnOffState returns the alert action state read from the profile
-func (_ *Alert) GetOnOffState(p *pb.Profile) models.ActionOpt {
-	return models.ActionOptFromString(p.Alert, models.ActionOptOn)
+func (_ *Alert) GetOnOffState(actionOpt models.ActionOpt) models.ActionOpt {
+	return models.ActionOptOrDefault(actionOpt, models.ActionOptOn)
 }
 
 // Do alerts through security advisory

--- a/internal/engine/actions/remediate/gh_branch_protect/gh_branch_protect.go
+++ b/internal/engine/actions/remediate/gh_branch_protect/gh_branch_protect.go
@@ -98,8 +98,8 @@ func (_ *GhBranchProtectRemediator) Type() string {
 }
 
 // GetOnOffState returns the alert action state read from the profile
-func (_ *GhBranchProtectRemediator) GetOnOffState(p *pb.Profile) models.ActionOpt {
-	return models.ActionOptFromString(p.Remediate, models.ActionOptOff)
+func (_ *GhBranchProtectRemediator) GetOnOffState(actionOpt models.ActionOpt) models.ActionOpt {
+	return models.ActionOptOrDefault(actionOpt, models.ActionOptOff)
 }
 
 // Do perform the remediation

--- a/internal/engine/actions/remediate/noop/noop.go
+++ b/internal/engine/actions/remediate/noop/noop.go
@@ -26,7 +26,6 @@ import (
 	enginerr "github.com/stacklok/minder/internal/engine/errors"
 	"github.com/stacklok/minder/internal/engine/interfaces"
 	"github.com/stacklok/minder/internal/profiles/models"
-	pb "github.com/stacklok/minder/pkg/api/protobuf/go/minder/v1"
 )
 
 // Remediator is the structure backing the noop remediator
@@ -50,7 +49,7 @@ func (_ *Remediator) Type() string {
 }
 
 // GetOnOffState returns the off state of the noop engine
-func (_ *Remediator) GetOnOffState(_ *pb.Profile) models.ActionOpt {
+func (_ *Remediator) GetOnOffState(_ models.ActionOpt) models.ActionOpt {
 	return models.ActionOptOff
 }
 

--- a/internal/engine/actions/remediate/pull_request/pull_request.go
+++ b/internal/engine/actions/remediate/pull_request/pull_request.go
@@ -150,8 +150,8 @@ func (_ *Remediator) Type() string {
 }
 
 // GetOnOffState returns the alert action state read from the profile
-func (_ *Remediator) GetOnOffState(p *pb.Profile) models.ActionOpt {
-	return models.ActionOptFromString(p.Remediate, models.ActionOptOff)
+func (_ *Remediator) GetOnOffState(actionOpt models.ActionOpt) models.ActionOpt {
+	return models.ActionOptOrDefault(actionOpt, models.ActionOptOff)
 }
 
 // Do perform the remediation

--- a/internal/engine/actions/remediate/rest/rest.go
+++ b/internal/engine/actions/remediate/rest/rest.go
@@ -107,8 +107,8 @@ func (_ *Remediator) Type() string {
 }
 
 // GetOnOffState returns the alert action state read from the profile
-func (_ *Remediator) GetOnOffState(p *pb.Profile) models.ActionOpt {
-	return models.ActionOptFromString(p.Remediate, models.ActionOptOff)
+func (_ *Remediator) GetOnOffState(actionOpt models.ActionOpt) models.ActionOpt {
+	return models.ActionOptOrDefault(actionOpt, models.ActionOptOff)
 }
 
 // Do perform the remediation

--- a/internal/engine/interfaces/interface.go
+++ b/internal/engine/interfaces/interface.go
@@ -30,7 +30,6 @@ import (
 	"github.com/stacklok/minder/internal/db"
 	evalerrors "github.com/stacklok/minder/internal/engine/errors"
 	"github.com/stacklok/minder/internal/profiles/models"
-	pb "github.com/stacklok/minder/pkg/api/protobuf/go/minder/v1"
 )
 
 // Ingester is the interface for a rule type ingester
@@ -70,7 +69,7 @@ type ActionType string
 type Action interface {
 	Class() ActionType
 	Type() string
-	GetOnOffState(*pb.Profile) models.ActionOpt
+	GetOnOffState(models.ActionOpt) models.ActionOpt
 	Do(ctx context.Context, cmd ActionCmd, setting models.ActionOpt, entity protoreflect.ProtoMessage,
 		params ActionsParams, metadata *json.RawMessage) (json.RawMessage, error)
 }

--- a/internal/profiles/models/models.go
+++ b/internal/profiles/models/models.go
@@ -138,3 +138,12 @@ func ActionOptFromDB(dbState db.NullActionType) ActionOpt {
 		return ActionOptUnknown
 	}
 }
+
+// ActionOptOrDefault returns defaultVal if the ActionOpt is
+// ActionOptUnknown, or returns actionOpt otherwise
+func ActionOptOrDefault(actionOpt ActionOpt, defaultVal ActionOpt) ActionOpt {
+	if actionOpt == ActionOptUnknown {
+		return defaultVal
+	}
+	return actionOpt
+}

--- a/internal/profiles/models/models.go
+++ b/internal/profiles/models/models.go
@@ -102,25 +102,6 @@ func (a ActionOpt) String() string {
 	return [...]string{"on", "off", "dry_run", "unknown"}[a]
 }
 
-// ActionOptFromString returns the ActionOpt from a string representation
-func ActionOptFromString(s *string, defAction ActionOpt) ActionOpt {
-	var actionOptMap = map[string]ActionOpt{
-		"on":      ActionOptOn,
-		"off":     ActionOptOff,
-		"dry_run": ActionOptDryRun,
-	}
-
-	if s == nil {
-		return defAction
-	}
-
-	if v, ok := actionOptMap[*s]; ok {
-		return v
-	}
-
-	return ActionOptUnknown
-}
-
 // ActionOptFromDB converts the db representation of action type to ActionOpt
 func ActionOptFromDB(dbState db.NullActionType) ActionOpt {
 	if !dbState.Valid {


### PR DESCRIPTION
PR #3899 accidentally removed a call to GetOnOffState, which allows individual actions to override the remediation and alerting status in the profile. This leads to some unusual behaviour, such as attempting to run the noop alerts and remediations instead of skipping them. This PR reinstates the calls to GetOnOffState, but changes the function to accept the ActionOpt status for that action type instead of taking a pointer to the entire profile.

# Summary

***Provide a brief overview of the changes and the issue being addressed. 
Explain the rationale and any background necessary for understanding the changes. 
List dependencies required by this change, if any.***

Fixes #(related issue)

## Change Type

***Mark the type of change your PR introduces:***

- [x] Bug fix (resolves an issue without affecting existing features)
- [ ] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [ ] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

***Outline how the changes were tested, including steps to reproduce and any relevant configurations. 
Attach screenshots if helpful.***

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [ ] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [ ] Included tests that validate the fix or feature.
- [ ] Checked that related changes are merged.
