### PR TITLE
Introduce DB view for rule_instances table

### DIFF
--- a/database/migrations/000076_rule_instances_view.down.sql
+++ b/database/migrations/000076_rule_instances_view.down.sql
@@ -1,0 +1,15 @@
+-- Copyright 2024 Stacklok, Inc
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--      http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+DROP VIEW profiles_with_rule_instances;

--- a/database/migrations/000076_rule_instances_view.up.sql
+++ b/database/migrations/000076_rule_instances_view.up.sql
@@ -1,0 +1,17 @@
+-- Copyright 2024 Stacklok, Inc
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--      http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+CREATE VIEW profiles_with_rule_instances WITH (security_invoker = true) AS (
+    SELECT rule_instances.*, profiles.id as profid FROM profiles LEFT JOIN rule_instances ON profiles.id = rule_instances.profile_id
+);

--- a/internal/db/models.go
+++ b/internal/db/models.go
@@ -567,6 +567,20 @@ type ProfilesWithEntityProfile struct {
 	Profid          uuid.UUID             `json:"profid"`
 }
 
+type ProfilesWithRuleInstance struct {
+	ID         uuid.NullUUID         `json:"id"`
+	ProfileID  uuid.NullUUID         `json:"profile_id"`
+	RuleTypeID uuid.NullUUID         `json:"rule_type_id"`
+	Name       sql.NullString        `json:"name"`
+	EntityType NullEntities          `json:"entity_type"`
+	Def        pqtype.NullRawMessage `json:"def"`
+	Params     pqtype.NullRawMessage `json:"params"`
+	CreatedAt  sql.NullTime          `json:"created_at"`
+	UpdatedAt  sql.NullTime          `json:"updated_at"`
+	ProjectID  uuid.NullUUID         `json:"project_id"`
+	Profid     uuid.UUID             `json:"profid"`
+}
+
 type Project struct {
 	ID             uuid.UUID       `json:"id"`
 	Name           string          `json:"name"`


### PR DESCRIPTION
This mirrors the view which was added in migration 48 for entity_profiles. This should make it more straightforward to change the of the remaining queries which use the entity_profiles table to use rule_instances instead.

# Summary

***Provide a brief overview of the changes and the issue being addressed. 
Explain the rationale and any background necessary for understanding the changes. 
List dependencies required by this change, if any.***

Fixes #(related issue)

## Change Type

***Mark the type of change your PR introduces:***

- [ ] Bug fix (resolves an issue without affecting existing features)
- [x] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [ ] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

***Outline how the changes were tested, including steps to reproduce and any relevant configurations. 
Attach screenshots if helpful.***

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [ ] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [ ] Included tests that validate the fix or feature.
- [ ] Checked that related changes are merged.
