### PR TITLE
Add history purge command to minder server cli.

### DIFF
--- a/cmd/server/app/history.go
+++ b/cmd/server/app/history.go
@@ -1,0 +1,34 @@
+//
+// Copyright 2023 Stacklok, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package app
+
+import (
+	"github.com/spf13/cobra"
+)
+
+// historyCmd represents the history command
+var historyCmd = &cobra.Command{
+	Use:   "history",
+	Short: "Evaluation history",
+	Long:  `Manage evaluation history log with subcommands.`,
+	RunE: func(cmd *cobra.Command, _ []string) error {
+		return cmd.Usage()
+	},
+}
+
+func init() {
+	RootCmd.AddCommand(historyCmd)
+}

--- a/cmd/server/app/history_purge.go
+++ b/cmd/server/app/history_purge.go
@@ -1,0 +1,233 @@
+// Copyright 2024 Stacklok, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package app
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	_ "github.com/golang-migrate/migrate/v4/database/postgres" // nolint
+	_ "github.com/golang-migrate/migrate/v4/source/file"       // nolint
+	"github.com/google/uuid"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+
+	"github.com/stacklok/minder/internal/config"
+	serverconfig "github.com/stacklok/minder/internal/config/server"
+	"github.com/stacklok/minder/internal/db"
+	"github.com/stacklok/minder/internal/logger"
+)
+
+// historyPurgeCmd represents the `history purge` command
+var historyPurgeCmd = &cobra.Command{
+	Use:   "purge",
+	Short: "Removes evaluation history entries",
+	Long:  `deletes all evaluation history entries older than 30 days, maintaining the latest one per rule/entity pair`,
+	RunE:  historyPurgeCommand,
+}
+
+func historyPurgeCommand(cmd *cobra.Command, _ []string) error {
+	batchSize := viper.GetUint("batch-size")
+	dryRun := viper.GetBool("dry-run")
+
+	cfg, err := config.ReadConfigFromViper[serverconfig.Config](viper.GetViper())
+	if err != nil {
+		cliErrorf(cmd, "unable to read config: %s", err)
+	}
+
+	ctx := logger.FromFlags(cfg.LoggingConfig).WithContext(context.Background())
+
+	// instantiate `db.Store` so we can run queries
+	store, closer, err := wireUpDB(ctx, cfg)
+	if err != nil {
+		cliErrorf(cmd, "unable to connect to database: %s", err)
+	}
+	defer closer()
+
+	threshold := time.Now().UTC().AddDate(-30, 0, 0)
+	fmt.Printf("Calculated threshold is %s", threshold)
+
+	if err := purgeLoop(ctx, store, threshold, batchSize, dryRun, cmd.Printf); err != nil {
+		cliErrorf(cmd, "failed purging evaluation log: %s", err)
+	}
+
+	return nil
+}
+
+// purgeLoop routine cleans up the evaluation history log by deleting
+// all records older than a fixed threshold.
+//
+// As of the time of this writing, the size of the row structs is 80
+// bytes, specifically
+//
+// * go time is 24 bytes
+// * rule id, entity id and evaluation id are 16 bytes UUIDs, adding
+// 48 bytes
+// * entity type, which is necessary because there's no guarantee that
+// the entity id is unique across entity types, is mapped to an
+// integer and adds another 16 bytes
+//
+// Given their size, 4 million records would allocate around 300MB of
+// RAM, adding some overhead for the used data structures we estimate
+// 500MB total RAM consumption in the worst case.
+//
+// From the execution time perspective, this is not necessarily the
+// best approach, and the time to first byte might become significant
+// as usage increases.
+func purgeLoop(
+	ctx context.Context,
+	store db.Store,
+	threshold time.Time,
+	batchSize uint,
+	dryRun bool,
+	printf func(format string, a ...any),
+) error {
+	total := 0
+	deleted := 0
+
+	records, err := store.ListEvaluationHistoryOlderThan(
+		ctx,
+		db.ListEvaluationHistoryOlderThanParams{
+			Threshold: threshold,
+			Size:      int32(4000000),
+		},
+	)
+	if err != nil {
+		return fmt.Errorf("error purging evaluation history: %w", err)
+	}
+
+	if len(records) == 0 {
+		printf("No records to delete\n")
+		return nil
+	}
+
+	total = len(records)
+	deletes := filterRecords(records)
+
+	if len(deletes) == 0 {
+		printf("No records to delete after filtering\n")
+		return nil
+	}
+
+	// Skip deletion if --dry-run was passed.
+	if !dryRun {
+		deleted, err = deleteEvaluationHistory(
+			ctx,
+			store,
+			deletes,
+			batchSize,
+		)
+		if err != nil {
+			return err
+		}
+	}
+
+	printf("Done purging history, deleted %d out of %d total records\n",
+		deleted,
+		total,
+	)
+
+	return nil
+}
+
+// filterRecords sift through the records separating the latest for
+// any given entity/rule combination from older ones that can be
+// safely deleted.
+func filterRecords(
+	records []db.ListEvaluationHistoryOlderThanRow,
+) []db.ListEvaluationHistoryOlderThanRow {
+	toDelete := make([]db.ListEvaluationHistoryOlderThanRow, 0)
+	toKeep := make(map[string]db.ListEvaluationHistoryOlderThanRow)
+
+	for _, record := range records {
+		// Record key is the combination of entity type,
+		// entity id and rule id.
+		key := fmt.Sprintf("%d/%s/%s",
+			record.EntityType,
+			record.EntityID,
+			record.RuleID,
+		)
+		latest, found := toKeep[key]
+
+		if !found {
+			// Tracking record as new latest for the same
+			// entity/rule.
+			toKeep[key] = record
+			continue
+		}
+
+		if record.EvaluationTime.After(latest.EvaluationTime) {
+			// Swap records because one was found that was
+			// more recent record for entity/rule.
+			toDelete = append(toDelete, latest)
+			toKeep[key] = record
+			continue
+		}
+
+		// If execution gets this far, we delete the record.
+		toDelete = append(toDelete, record)
+	}
+
+	return toDelete
+}
+
+func deleteEvaluationHistory(
+	ctx context.Context,
+	store db.Store,
+	records []db.ListEvaluationHistoryOlderThanRow,
+	batchSize uint,
+) (int, error) {
+	deleted := 0
+	for {
+		// Skip deletion if --dry-run was passed.
+		if len(records) == 0 {
+			break
+		}
+
+		// This only happens at the last iteration if the
+		// number of records to delete is not a multiple of
+		// the batch size.
+		if batchSize > uint(len(records)) {
+			batchSize = uint(len(records))
+		}
+
+		// Deletion is done by evaluation id.
+		batch := make([]uuid.UUID, 0, batchSize)
+		for _, record := range records[:batchSize] {
+			batch = append(batch, record.ID)
+		}
+
+		partial, err := db.WithTransaction[int64](store,
+			func(qtx db.ExtendQuerier) (int64, error) {
+				return qtx.DeleteEvaluationHistoryByIDs(ctx, batch)
+			},
+		)
+		if err != nil {
+			return 0, fmt.Errorf("error while deleting old evaluations: %w", err)
+		}
+
+		records = records[batchSize:]
+		deleted = deleted + int(partial)
+	}
+
+	return int(deleted), nil
+}
+
+func init() {
+	historyCmd.AddCommand(historyPurgeCmd)
+	historyPurgeCmd.Flags().UintP("batch-size", "s", 1000, "Size of the deletion batch")
+	historyPurgeCmd.Flags().Bool("dry-run", false, "Avoids deleting, printing out details about the operation")
+}

--- a/cmd/server/app/history_purge_test.go
+++ b/cmd/server/app/history_purge_test.go
@@ -1,0 +1,414 @@
+// Copyright 2024 Stacklok, Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package app
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+	"unsafe"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+
+	"github.com/stacklok/minder/internal/db"
+	dbf "github.com/stacklok/minder/internal/db/fixtures"
+)
+
+// This test ensures that the size of these records is kept upder
+// control, as the current deletion logic loads all history records
+// beyond a fixed time interval in memory. It is not mandatory to keep
+// the record as low as possible, but allocated resources must be
+// modified accordingly.
+func TestRecordSize(t *testing.T) {
+	t.Parallel()
+	size := unsafe.Sizeof(
+		db.ListEvaluationHistoryOlderThanRow{
+			ID:             uuid.Nil,
+			EvaluationTime: time.Now(),
+			EntityType:     int32(1),
+			EntityID:       uuid.Nil,
+			RuleID:         uuid.Nil,
+		},
+	)
+
+	require.Equal(t, 80, int(size))
+}
+
+func TestFilterRecords(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		records  []db.ListEvaluationHistoryOlderThanRow
+		expected []db.ListEvaluationHistoryOlderThanRow
+	}{
+		{
+			name: "older removed",
+			records: []db.ListEvaluationHistoryOlderThanRow{
+				makeHistoryRow(
+					uuid1,
+					evaluatedAt1,
+					entityType,
+					entityID1,
+					ruleID1,
+				),
+				makeHistoryRow(
+					uuid2,
+					evaluatedAt2,
+					entityType,
+					entityID1,
+					ruleID1,
+				),
+			},
+			expected: []db.ListEvaluationHistoryOlderThanRow{
+				makeHistoryRow(
+					uuid2,
+					evaluatedAt2,
+					entityType,
+					entityID1,
+					ruleID1,
+				),
+			},
+		},
+		{
+			name: "older removed bis",
+			records: []db.ListEvaluationHistoryOlderThanRow{
+				makeHistoryRow(
+					uuid2,
+					evaluatedAt2,
+					entityType,
+					entityID1,
+					ruleID1,
+				),
+				makeHistoryRow(
+					uuid1,
+					evaluatedAt1,
+					entityType,
+					entityID1,
+					ruleID1,
+				),
+			},
+			expected: []db.ListEvaluationHistoryOlderThanRow{
+				makeHistoryRow(
+					uuid2,
+					evaluatedAt2,
+					entityType,
+					entityID1,
+					ruleID1,
+				),
+			},
+		},
+		{
+			name: "all new",
+			records: []db.ListEvaluationHistoryOlderThanRow{
+				makeHistoryRow(
+					uuid1,
+					evaluatedAt1,
+					entityType,
+					entityID1,
+					ruleID1,
+				),
+				makeHistoryRow(
+					uuid2,
+					evaluatedAt2,
+					entityType,
+					entityID2,
+					ruleID2,
+				),
+			},
+			expected: []db.ListEvaluationHistoryOlderThanRow{},
+		},
+		{
+			name: "entity type",
+			records: []db.ListEvaluationHistoryOlderThanRow{
+				makeHistoryRow(
+					uuid1,
+					evaluatedAt1,
+					entityType, // different entity type
+					entityID1,
+					ruleID1,
+				),
+				makeHistoryRow(
+					uuid1,
+					evaluatedAt1,
+					int32(2), // different entity type
+					entityID1,
+					ruleID1,
+				),
+			},
+			expected: []db.ListEvaluationHistoryOlderThanRow{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			res := filterRecords(tt.records)
+			require.Len(t, res, len(tt.expected))
+			for i := 0; i < len(tt.expected); i++ {
+				require.Equal(t, tt.expected[i], res[i])
+			}
+		})
+	}
+}
+
+func TestDeleteEvaluationHistory(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		dbSetup dbf.DBMockBuilder
+		records []db.ListEvaluationHistoryOlderThanRow
+		size    uint
+		err     bool
+	}{
+		{
+			name: "more records",
+			dbSetup: dbf.NewDBMock(
+				withTransactionStuff(),
+				withDeleteEvaluationHistoryByIDs(
+					nil,
+					[]uuid.UUID{
+						uuid1,
+						uuid2,
+						uuid.Nil,
+						uuid.Nil,
+						uuid.Nil,
+					},
+					[]uuid.UUID{
+						uuid.Nil,
+						uuid.Nil,
+						uuid.Nil,
+					},
+				),
+			),
+			records: []db.ListEvaluationHistoryOlderThanRow{
+				makeHistoryRow(
+					uuid1,
+					evaluatedAt1,
+					entityType,
+					entityID1,
+					ruleID1,
+				),
+				makeHistoryRow(
+					uuid2,
+					evaluatedAt1,
+					entityType,
+					entityID1,
+					ruleID1,
+				),
+				makeHistoryRow(
+					uuid.Nil,
+					evaluatedAt1,
+					entityType,
+					entityID1,
+					ruleID1,
+				),
+				makeHistoryRow(
+					uuid.Nil,
+					evaluatedAt1,
+					entityType,
+					entityID1,
+					ruleID1,
+				),
+				makeHistoryRow(
+					uuid.Nil,
+					evaluatedAt1,
+					entityType,
+					entityID1,
+					ruleID1,
+				),
+				makeHistoryRow(
+					uuid.Nil,
+					evaluatedAt1,
+					entityType,
+					entityID1,
+					ruleID1,
+				),
+				makeHistoryRow(
+					uuid.Nil,
+					evaluatedAt1,
+					entityType,
+					entityID1,
+					ruleID1,
+				),
+				makeHistoryRow(
+					uuid.Nil,
+					evaluatedAt1,
+					entityType,
+					entityID1,
+					ruleID1,
+				),
+			},
+			size: 5,
+		},
+		{
+			name: "fewer records",
+			dbSetup: dbf.NewDBMock(
+				withTransactionStuff(),
+				withDeleteEvaluationHistoryByIDs(
+					nil,
+					[]uuid.UUID{
+						uuid1,
+						uuid2,
+					},
+				),
+			),
+			records: []db.ListEvaluationHistoryOlderThanRow{
+				makeHistoryRow(
+					uuid1,
+					evaluatedAt1,
+					entityType,
+					entityID1,
+					ruleID1,
+				),
+				makeHistoryRow(
+					uuid2,
+					evaluatedAt1,
+					entityType,
+					entityID1,
+					ruleID1,
+				),
+			},
+			size: 5,
+		},
+		{
+			name: "transaction stops",
+			dbSetup: dbf.NewDBMock(
+				withTransactionStuff(),
+				withDeleteEvaluationHistoryByIDs(
+					errors.New("boom"),
+					[]uuid.UUID{
+						uuid1,
+						uuid2,
+					},
+				),
+			),
+			records: []db.ListEvaluationHistoryOlderThanRow{
+				makeHistoryRow(
+					uuid1,
+					evaluatedAt1,
+					entityType,
+					entityID1,
+					ruleID1,
+				),
+				makeHistoryRow(
+					uuid2,
+					evaluatedAt1,
+					entityType,
+					entityID1,
+					ruleID1,
+				),
+			},
+			size: 5,
+			err:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+			ctx := context.Background()
+
+			var store db.Store
+			if tt.dbSetup != nil {
+				store = tt.dbSetup(ctrl)
+			}
+
+			_, err := deleteEvaluationHistory(ctx, store, tt.records, tt.size)
+			if tt.err {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
+}
+
+var (
+	uuid1        = uuid.MustParse("00000000-0000-0000-0000-000000000001")
+	uuid2        = uuid.MustParse("00000000-0000-0000-0000-000000000002")
+	entityID1    = uuid.MustParse("00000000-0000-0000-0000-000000000011")
+	entityID2    = uuid.MustParse("00000000-0000-0000-0000-000000000022")
+	ruleID1      = uuid.MustParse("00000000-0000-0000-0000-000000000111")
+	ruleID2      = uuid.MustParse("00000000-0000-0000-0000-000000000222")
+	evaluatedAt1 = time.Now()
+	evaluatedAt2 = evaluatedAt1.Add(-1 * time.Hour)
+	entityType   = int32(1)
+)
+
+//nolint:unparam
+func makeHistoryRow(
+	id uuid.UUID,
+	evaluatedAt time.Time,
+	entityType int32,
+	entityID uuid.UUID,
+	ruleID uuid.UUID,
+) db.ListEvaluationHistoryOlderThanRow {
+	return db.ListEvaluationHistoryOlderThanRow{
+		ID:             id,
+		EvaluationTime: evaluatedAt,
+		EntityType:     entityType,
+		EntityID:       entityID,
+		RuleID:         ruleID,
+	}
+}
+
+func withTransactionStuff() func(dbf.DBMock) {
+	return func(mock dbf.DBMock) {
+		mock.EXPECT().
+			BeginTransaction().
+			AnyTimes()
+		mock.EXPECT().
+			GetQuerierWithTransaction(gomock.Any()).
+			Return(mock).
+			AnyTimes()
+		mock.EXPECT().
+			Commit(gomock.Any()).
+			AnyTimes()
+		mock.EXPECT().
+			Rollback(gomock.Any()).
+			AnyTimes()
+	}
+}
+
+func withDeleteEvaluationHistoryByIDs(
+	err error,
+	params ...[]uuid.UUID,
+) func(dbf.DBMock) {
+	return func(mock dbf.DBMock) {
+		if params != nil {
+			calls := []any{}
+			for _, ps := range params {
+				call := mock.EXPECT().
+					DeleteEvaluationHistoryByIDs(gomock.Any(), ps).
+					Return(int64(len(ps)), err)
+				calls = append(calls, call)
+			}
+			gomock.InOrder(calls...)
+			return
+		}
+		mock.EXPECT().
+			DeleteEvaluationHistoryByIDs(gomock.Any(), gomock.Any()).
+			Return(int64(0), err)
+	}
+}

--- a/database/mock/store.go
+++ b/database/mock/store.go
@@ -370,6 +370,21 @@ func (mr *MockStoreMockRecorder) DeleteArtifact(arg0, arg1 any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteArtifact", reflect.TypeOf((*MockStore)(nil).DeleteArtifact), arg0, arg1)
 }
 
+// DeleteEvaluationHistoryByIDs mocks base method.
+func (m *MockStore) DeleteEvaluationHistoryByIDs(arg0 context.Context, arg1 []uuid.UUID) (int64, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteEvaluationHistoryByIDs", arg0, arg1)
+	ret0, _ := ret[0].(int64)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// DeleteEvaluationHistoryByIDs indicates an expected call of DeleteEvaluationHistoryByIDs.
+func (mr *MockStoreMockRecorder) DeleteEvaluationHistoryByIDs(arg0, arg1 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteEvaluationHistoryByIDs", reflect.TypeOf((*MockStore)(nil).DeleteEvaluationHistoryByIDs), arg0, arg1)
+}
+
 // DeleteExpiredSessionStates mocks base method.
 func (m *MockStore) DeleteExpiredSessionStates(arg0 context.Context) (int64, error) {
 	m.ctrl.T.Helper()
@@ -1567,6 +1582,21 @@ func (m *MockStore) ListEvaluationHistory(arg0 context.Context, arg1 db.ListEval
 func (mr *MockStoreMockRecorder) ListEvaluationHistory(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListEvaluationHistory", reflect.TypeOf((*MockStore)(nil).ListEvaluationHistory), arg0, arg1)
+}
+
+// ListEvaluationHistoryOlderThan mocks base method.
+func (m *MockStore) ListEvaluationHistoryOlderThan(arg0 context.Context, arg1 db.ListEvaluationHistoryOlderThanParams) ([]db.ListEvaluationHistoryOlderThanRow, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListEvaluationHistoryOlderThan", arg0, arg1)
+	ret0, _ := ret[0].([]db.ListEvaluationHistoryOlderThanRow)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListEvaluationHistoryOlderThan indicates an expected call of ListEvaluationHistoryOlderThan.
+func (mr *MockStoreMockRecorder) ListEvaluationHistoryOlderThan(arg0, arg1 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListEvaluationHistoryOlderThan", reflect.TypeOf((*MockStore)(nil).ListEvaluationHistoryOlderThan), arg0, arg1)
 }
 
 // ListFlushCache mocks base method.

--- a/database/mock/store.go
+++ b/database/mock/store.go
@@ -1584,19 +1584,19 @@ func (mr *MockStoreMockRecorder) ListEvaluationHistory(arg0, arg1 any) *gomock.C
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListEvaluationHistory", reflect.TypeOf((*MockStore)(nil).ListEvaluationHistory), arg0, arg1)
 }
 
-// ListEvaluationHistoryOlderThan mocks base method.
-func (m *MockStore) ListEvaluationHistoryOlderThan(arg0 context.Context, arg1 db.ListEvaluationHistoryOlderThanParams) ([]db.ListEvaluationHistoryOlderThanRow, error) {
+// ListEvaluationHistoryStaleRecords mocks base method.
+func (m *MockStore) ListEvaluationHistoryStaleRecords(arg0 context.Context, arg1 db.ListEvaluationHistoryStaleRecordsParams) ([]db.ListEvaluationHistoryStaleRecordsRow, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListEvaluationHistoryOlderThan", arg0, arg1)
-	ret0, _ := ret[0].([]db.ListEvaluationHistoryOlderThanRow)
+	ret := m.ctrl.Call(m, "ListEvaluationHistoryStaleRecords", arg0, arg1)
+	ret0, _ := ret[0].([]db.ListEvaluationHistoryStaleRecordsRow)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// ListEvaluationHistoryOlderThan indicates an expected call of ListEvaluationHistoryOlderThan.
-func (mr *MockStoreMockRecorder) ListEvaluationHistoryOlderThan(arg0, arg1 any) *gomock.Call {
+// ListEvaluationHistoryStaleRecords indicates an expected call of ListEvaluationHistoryStaleRecords.
+func (mr *MockStoreMockRecorder) ListEvaluationHistoryStaleRecords(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListEvaluationHistoryOlderThan", reflect.TypeOf((*MockStore)(nil).ListEvaluationHistoryOlderThan), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListEvaluationHistoryStaleRecords", reflect.TypeOf((*MockStore)(nil).ListEvaluationHistoryStaleRecords), arg0, arg1)
 }
 
 // ListFlushCache mocks base method.

--- a/database/query/eval_history.sql
+++ b/database/query/eval_history.sql
@@ -169,3 +169,34 @@ SELECT s.id::uuid AS evaluation_id,
  CASE WHEN sqlc.narg(next)::timestamp without time zone IS NULL THEN s.evaluation_time END ASC,
  CASE WHEN sqlc.narg(prev)::timestamp without time zone IS NULL THEN s.evaluation_time END DESC
  LIMIT sqlc.arg(size)::integer;
+
+-- name: ListEvaluationHistoryOlderThan :many
+SELECT s.evaluation_time,
+       s.id,
+       ere.rule_id,
+       -- entity type
+       CAST(
+	 CASE
+	 WHEN ere.repository_id IS NOT NULL THEN 1
+	 WHEN ere.pull_request_id IS NOT NULL THEN 2
+	 WHEN ere.artifact_id IS NOT NULL THEN 3
+	 END AS integer
+       ) AS entity_type,
+       -- entity id
+       CAST(
+         CASE
+         WHEN ere.repository_id IS NOT NULL THEN ere.repository_id
+         WHEN ere.pull_request_id IS NOT NULL THEN ere.pull_request_id
+         WHEN ere.artifact_id IS NOT NULL THEN ere.artifact_id
+         END AS uuid
+       ) AS entity_id
+  FROM evaluation_statuses s
+       JOIN evaluation_rule_entities ere ON s.rule_entity_id = ere.id
+ WHERE s.evaluation_time < sqlc.arg(threshold)
+ -- listing from oldest to newest
+ ORDER BY s.evaluation_time ASC, rule_id ASC, entity_id ASC
+ LIMIT sqlc.arg(size)::integer;
+
+-- name: DeleteEvaluationHistoryByIDs :execrows
+DELETE FROM evaluation_statuses s
+ WHERE s.id = ANY(sqlc.slice(evaluationIds));

--- a/internal/db/querier.go
+++ b/internal/db/querier.go
@@ -38,6 +38,7 @@ type Querier interface {
 	CreateSubscription(ctx context.Context, arg CreateSubscriptionParams) (Subscription, error)
 	CreateUser(ctx context.Context, identitySubject string) (User, error)
 	DeleteArtifact(ctx context.Context, id uuid.UUID) error
+	DeleteEvaluationHistoryByIDs(ctx context.Context, evaluationids []uuid.UUID) (int64, error)
 	DeleteExpiredSessionStates(ctx context.Context) (int64, error)
 	DeleteInstallationIDByAppID(ctx context.Context, appInstallationID int64) error
 	// DeleteInvitation deletes an invitation by its code. This is intended to be
@@ -164,6 +165,7 @@ type Querier interface {
 	InsertRemediationEvent(ctx context.Context, arg InsertRemediationEventParams) error
 	ListArtifactsByRepoID(ctx context.Context, repositoryID uuid.NullUUID) ([]Artifact, error)
 	ListEvaluationHistory(ctx context.Context, arg ListEvaluationHistoryParams) ([]ListEvaluationHistoryRow, error)
+	ListEvaluationHistoryOlderThan(ctx context.Context, arg ListEvaluationHistoryOlderThanParams) ([]ListEvaluationHistoryOlderThanRow, error)
 	ListFlushCache(ctx context.Context) ([]FlushCache, error)
 	// ListInvitationsForProject collects the information visible to project
 	// administrators after an invitation has been issued.  In particular, it

--- a/internal/db/querier.go
+++ b/internal/db/querier.go
@@ -165,7 +165,7 @@ type Querier interface {
 	InsertRemediationEvent(ctx context.Context, arg InsertRemediationEventParams) error
 	ListArtifactsByRepoID(ctx context.Context, repositoryID uuid.NullUUID) ([]Artifact, error)
 	ListEvaluationHistory(ctx context.Context, arg ListEvaluationHistoryParams) ([]ListEvaluationHistoryRow, error)
-	ListEvaluationHistoryOlderThan(ctx context.Context, arg ListEvaluationHistoryOlderThanParams) ([]ListEvaluationHistoryOlderThanRow, error)
+	ListEvaluationHistoryStaleRecords(ctx context.Context, arg ListEvaluationHistoryStaleRecordsParams) ([]ListEvaluationHistoryStaleRecordsRow, error)
 	ListFlushCache(ctx context.Context) ([]FlushCache, error)
 	// ListInvitationsForProject collects the information visible to project
 	// administrators after an invitation has been issued.  In particular, it


### PR DESCRIPTION
# Summary

This command is used to manage the life cycle of the history log. The business requirement is to delete all records older than 30 days maintaining the most recent one for each entity/rule pair even if older than 30 days.

Implementing this requirement mandates the processing of the whole set of records older than 30 days, which cannot be processed in chunks without creating arbitrary holes in the history. As a first approximation, the proposed implementation loads all records in RAM, filters out the ones to keep, and issues a series of deletions of up to 1000 records each. A test was added to keep track of the record size. A future improvement would be to spill records to secondary storage, where we would perform sorting and filtering, but it was overly complex and unjustified at this point in time.

Fixes #3636

## Change Type

- [ ] Bug fix (resolves an issue without affecting existing features)
- [X] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [ ] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

Some unit tests, mostly manual tests.

# Review Checklist:

- [X] Reviewed my own code for quality and clarity.
- [X] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [ ] Included tests that validate the fix or feature.
- [X] Checked that related changes are merged.
