### PR TITLE
Accept filters multiple times in `history list`.

### DIFF
--- a/cmd/cli/app/history/history_list.go
+++ b/cmd/cli/app/history/history_list.go
@@ -228,12 +228,12 @@ func init() {
 	entityTypesMsg := fmt.Sprintf(basicMsg, "entity type", strings.Join(entityTypes, ", "))
 
 	// Flags
-	listCmd.Flags().String("profile-name", "", "Filter evaluation history list by profile name")
-	listCmd.Flags().String("entity-name", "", "Filter evaluation history list by entity name")
-	listCmd.Flags().String("entity-type", "", entityTypesMsg)
-	listCmd.Flags().String("eval-status", "", evalFilterMsg)
-	listCmd.Flags().String("remediation-status", "", remediationFilterMsg)
-	listCmd.Flags().String("alert-status", "", alertFilterMsg)
+	listCmd.Flags().StringSlice("profile-name", nil, "Filter evaluation history list by profile name")
+	listCmd.Flags().StringSlice("entity-name", nil, "Filter evaluation history list by entity name")
+	listCmd.Flags().StringSlice("entity-type", nil, entityTypesMsg)
+	listCmd.Flags().StringSlice("eval-status", nil, evalFilterMsg)
+	listCmd.Flags().StringSlice("remediation-status", nil, remediationFilterMsg)
+	listCmd.Flags().StringSlice("alert-status", nil, alertFilterMsg)
 	listCmd.Flags().String("from", "", "Filter evaluation history list by time")
 	listCmd.Flags().String("to", "", "Filter evaluation history list by time")
 	listCmd.Flags().StringP("cursor", "c", "", "Fetch previous or next page from the list")


### PR DESCRIPTION
# Summary

ListEvaluationHistory RPC accepts multiple entries for string-like filters, e.g. evaluation statuses, profile names, etc. While minder CLI internally manages those filters as slices, viper is not configured to accept repeated options.

This change makes it possible to provide `--profile-name`, `--entity-name`, `--entity-type`, `--eval-status`, `--remediation-status`, and `--alert-status` options multiple times with different values, all of which will eventually be passed to the backend as filters.

Fixes #3978

## Change Type

- [X] Bug fix (resolves an issue without affecting existing features)
- [ ] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [ ] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

Manually tested against local and staging environment.

# Review Checklist:

- [X] Reviewed my own code for quality and clarity.
- [ ] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [ ] Included tests that validate the fix or feature.
- [X] Checked that related changes are merged.
