### PR TITLE
Add profile ID to `latest_evaluation_statuses`

### DIFF
--- a/database/migrations/000078_latest_status_profile_id.down.sql
+++ b/database/migrations/000078_latest_status_profile_id.down.sql
@@ -1,0 +1,18 @@
+-- Copyright 2024 Stacklok, Inc
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--      http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+-- introduce some denormalization to simplify a common access pattern
+-- namely: retrieving the latest rule statuses for a specific profile
+-- A future PR will backfill this column and make it NOT NULL
+ALTER TABLE latest_evaluation_statuses DROP COLUMN profile_id;

--- a/database/migrations/000078_latest_status_profile_id.up.sql
+++ b/database/migrations/000078_latest_status_profile_id.up.sql
@@ -1,0 +1,19 @@
+-- Copyright 2024 Stacklok, Inc
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--      http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+-- introduce some denormalization to simplify a common access pattern
+-- namely: retrieving the latest rule statuses for a specific profile
+-- A future PR will backfill this column and make it NOT NULL
+ALTER TABLE latest_evaluation_statuses ADD COLUMN profile_id UUID REFERENCES profiles(id);
+CREATE INDEX idx_profile_id ON latest_evaluation_statuses(profile_id);

--- a/database/query/eval_history.sql
+++ b/database/query/eval_history.sql
@@ -55,10 +55,12 @@ RETURNING id;
 -- name: UpsertLatestEvaluationStatus :exec
 INSERT INTO latest_evaluation_statuses(
     rule_entity_id,
-    evaluation_history_id
+    evaluation_history_id,
+    profile_id
 ) VALUES (
     $1,
-    $2
+    $2,
+    $3
 )
 ON CONFLICT (rule_entity_id) DO UPDATE
 SET evaluation_history_id = $2;

--- a/internal/db/eval_history.sql.go
+++ b/internal/db/eval_history.sql.go
@@ -379,21 +379,24 @@ func (q *Queries) ListEvaluationHistory(ctx context.Context, arg ListEvaluationH
 const upsertLatestEvaluationStatus = `-- name: UpsertLatestEvaluationStatus :exec
 INSERT INTO latest_evaluation_statuses(
     rule_entity_id,
-    evaluation_history_id
+    evaluation_history_id,
+    profile_id
 ) VALUES (
     $1,
-    $2
+    $2,
+    $3
 )
 ON CONFLICT (rule_entity_id) DO UPDATE
 SET evaluation_history_id = $2
 `
 
 type UpsertLatestEvaluationStatusParams struct {
-	RuleEntityID        uuid.UUID `json:"rule_entity_id"`
-	EvaluationHistoryID uuid.UUID `json:"evaluation_history_id"`
+	RuleEntityID        uuid.UUID     `json:"rule_entity_id"`
+	EvaluationHistoryID uuid.UUID     `json:"evaluation_history_id"`
+	ProfileID           uuid.NullUUID `json:"profile_id"`
 }
 
 func (q *Queries) UpsertLatestEvaluationStatus(ctx context.Context, arg UpsertLatestEvaluationStatusParams) error {
-	_, err := q.db.ExecContext(ctx, upsertLatestEvaluationStatus, arg.RuleEntityID, arg.EvaluationHistoryID)
+	_, err := q.db.ExecContext(ctx, upsertLatestEvaluationStatus, arg.RuleEntityID, arg.EvaluationHistoryID, arg.ProfileID)
 	return err
 }

--- a/internal/db/models.go
+++ b/internal/db/models.go
@@ -520,8 +520,9 @@ type FlushCache struct {
 }
 
 type LatestEvaluationStatus struct {
-	RuleEntityID        uuid.UUID `json:"rule_entity_id"`
-	EvaluationHistoryID uuid.UUID `json:"evaluation_history_id"`
+	RuleEntityID        uuid.UUID     `json:"rule_entity_id"`
+	EvaluationHistoryID uuid.UUID     `json:"evaluation_history_id"`
+	ProfileID           uuid.NullUUID `json:"profile_id"`
 }
 
 type Profile struct {

--- a/internal/engine/eval_status.go
+++ b/internal/engine/eval_status.go
@@ -197,6 +197,7 @@ func (e *executor) createOrUpdateEvalStatus(
 			ctx,
 			qtx,
 			params.Rule.ID,
+			params.Profile.ID,
 			params.EntityType,
 			entityID,
 			params.GetEvalErr(),

--- a/internal/engine/executor_test.go
+++ b/internal/engine/executor_test.go
@@ -325,7 +325,7 @@ default allow = true`,
 
 	historyService := mockhistory.NewMockEvaluationHistoryService(ctrl)
 	historyService.EXPECT().
-		StoreEvaluationStatus(gomock.Any(), gomock.Any(), ruleInstanceID, db.EntitiesRepository, repositoryID, gomock.Any()).
+		StoreEvaluationStatus(gomock.Any(), gomock.Any(), ruleInstanceID, profileID, db.EntitiesRepository, repositoryID, gomock.Any()).
 		Return(uuid.New(), nil)
 
 	mockStore.EXPECT().

--- a/internal/history/mock/service.go
+++ b/internal/history/mock/service.go
@@ -58,16 +58,16 @@ func (mr *MockEvaluationHistoryServiceMockRecorder) ListEvaluationHistory(ctx, q
 }
 
 // StoreEvaluationStatus mocks base method.
-func (m *MockEvaluationHistoryService) StoreEvaluationStatus(ctx context.Context, qtx db.Querier, ruleID uuid.UUID, entityType db.Entities, entityID uuid.UUID, evalError error) (uuid.UUID, error) {
+func (m *MockEvaluationHistoryService) StoreEvaluationStatus(ctx context.Context, qtx db.Querier, ruleID, profileID uuid.UUID, entityType db.Entities, entityID uuid.UUID, evalError error) (uuid.UUID, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "StoreEvaluationStatus", ctx, qtx, ruleID, entityType, entityID, evalError)
+	ret := m.ctrl.Call(m, "StoreEvaluationStatus", ctx, qtx, ruleID, profileID, entityType, entityID, evalError)
 	ret0, _ := ret[0].(uuid.UUID)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // StoreEvaluationStatus indicates an expected call of StoreEvaluationStatus.
-func (mr *MockEvaluationHistoryServiceMockRecorder) StoreEvaluationStatus(ctx, qtx, ruleID, entityType, entityID, evalError any) *gomock.Call {
+func (mr *MockEvaluationHistoryServiceMockRecorder) StoreEvaluationStatus(ctx, qtx, ruleID, profileID, entityType, entityID, evalError any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StoreEvaluationStatus", reflect.TypeOf((*MockEvaluationHistoryService)(nil).StoreEvaluationStatus), ctx, qtx, ruleID, entityType, entityID, evalError)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StoreEvaluationStatus", reflect.TypeOf((*MockEvaluationHistoryService)(nil).StoreEvaluationStatus), ctx, qtx, ruleID, profileID, entityType, entityID, evalError)
 }

--- a/internal/history/service.go
+++ b/internal/history/service.go
@@ -38,6 +38,7 @@ type EvaluationHistoryService interface {
 		ctx context.Context,
 		qtx db.Querier,
 		ruleID uuid.UUID,
+		profileID uuid.UUID,
 		entityType db.Entities,
 		entityID uuid.UUID,
 		evalError error,
@@ -64,6 +65,7 @@ func (e *evaluationHistoryService) StoreEvaluationStatus(
 	ctx context.Context,
 	qtx db.Querier,
 	ruleID uuid.UUID,
+	profileID uuid.UUID,
 	entityType db.Entities,
 	entityID uuid.UUID,
 	evalError error,
@@ -111,7 +113,7 @@ func (e *evaluationHistoryService) StoreEvaluationStatus(
 		ruleEntityID = latestRecord.RuleEntityID
 	}
 
-	evaluationID, err := e.createNewStatus(ctx, qtx, ruleEntityID, status, details)
+	evaluationID, err := e.createNewStatus(ctx, qtx, ruleEntityID, profileID, status, details)
 	if err != nil {
 		return uuid.Nil, fmt.Errorf("error while creating new evaluation status for rule/entity %s: %w", ruleEntityID, err)
 	}
@@ -123,6 +125,7 @@ func (_ *evaluationHistoryService) createNewStatus(
 	ctx context.Context,
 	qtx db.Querier,
 	ruleEntityID uuid.UUID,
+	profileID uuid.UUID,
 	status db.EvalStatusTypes,
 	details string,
 ) (uuid.UUID, error) {
@@ -142,6 +145,10 @@ func (_ *evaluationHistoryService) createNewStatus(
 		db.UpsertLatestEvaluationStatusParams{
 			RuleEntityID:        ruleEntityID,
 			EvaluationHistoryID: newEvaluationID,
+			ProfileID: uuid.NullUUID{
+				UUID:  profileID,
+				Valid: true,
+			},
 		},
 	)
 	if err != nil {

--- a/internal/history/service_test.go
+++ b/internal/history/service_test.go
@@ -114,7 +114,7 @@ func TestStoreEvaluationStatus(t *testing.T) {
 			}
 
 			service := NewEvaluationHistoryService()
-			id, err := service.StoreEvaluationStatus(ctx, store, ruleID, scenario.EntityType, entityID, errTest)
+			id, err := service.StoreEvaluationStatus(ctx, store, ruleID, profileID, scenario.EntityType, entityID, errTest)
 			if scenario.ExpectedError == "" {
 				require.Equal(t, evaluationID, id)
 				require.NoError(t, err)
@@ -795,6 +795,7 @@ func makeHistoryRow(
 
 var (
 	ruleID       = uuid.New()
+	profileID    = uuid.New()
 	entityID     = uuid.New()
 	ruleEntityID = uuid.New()
 	evaluationID = uuid.New()


### PR DESCRIPTION
Adding this information to the `latest_evaluation_statuses` table simplifies the process of changing the profile status queries to use the evaluation history tables instead of the old tables I am trying to replace.

# Summary

***Provide a brief overview of the changes and the issue being addressed. 
Explain the rationale and any background necessary for understanding the changes. 
List dependencies required by this change, if any.***

Fixes #(related issue)

## Change Type

***Mark the type of change your PR introduces:***

- [ ] Bug fix (resolves an issue without affecting existing features)
- [x] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [ ] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

***Outline how the changes were tested, including steps to reproduce and any relevant configurations. 
Attach screenshots if helpful.***

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [x] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [ ] Included tests that validate the fix or feature.
- [ ] Checked that related changes are merged.
