### PR TITLE
Disambiguate entity type in history log query.

### DIFF
--- a/database/query/eval_history.sql
+++ b/database/query/eval_history.sql
@@ -141,7 +141,7 @@ SELECT s.id::uuid AS evaluation_id,
  WHERE (sqlc.narg(next)::timestamp without time zone IS NULL OR sqlc.narg(next) > s.evaluation_time)
    AND (sqlc.narg(prev)::timestamp without time zone IS NULL OR sqlc.narg(prev) < s.evaluation_time)
    -- inclusion filters
-   AND (sqlc.slice(entityTypes)::entities[] IS NULL OR entity_type::entities = ANY(sqlc.slice(entityTypes)::entities[]))
+   AND (sqlc.slice(entityTypes)::entities[] IS NULL OR ri.entity_type = ANY(sqlc.slice(entityTypes)::entities[]))
    AND (sqlc.slice(entityNames)::text[] IS NULL OR ere.repository_id IS NULL OR CONCAT(r.repo_owner, '/', r.repo_name) = ANY(sqlc.slice(entityNames)::text[]))
    AND (sqlc.slice(entityNames)::text[] IS NULL OR ere.pull_request_id IS NULL OR pr.pr_number::text = ANY(sqlc.slice(entityNames)::text[]))
    AND (sqlc.slice(entityNames)::text[] IS NULL OR ere.artifact_id IS NULL OR a.artifact_name = ANY(sqlc.slice(entityNames)::text[]))
@@ -150,7 +150,7 @@ SELECT s.id::uuid AS evaluation_id,
    AND (sqlc.slice(alerts)::alert_status_types[] IS NULL OR ae.status = ANY(sqlc.slice(alerts)::alert_status_types[]))
    AND (sqlc.slice(statuses)::eval_status_types[] IS NULL OR s.status = ANY(sqlc.slice(statuses)::eval_status_types[]))
    -- exclusion filters
-   AND (sqlc.slice(notEntityTypes)::entities[] IS NULL OR entity_type::entities != ANY(sqlc.slice(notEntityTypes)::entities[]))
+   AND (sqlc.slice(notEntityTypes)::entities[] IS NULL OR ri.entity_type != ANY(sqlc.slice(notEntityTypes)::entities[]))
    AND (sqlc.slice(notEntityNames)::text[] IS NULL OR ere.repository_id IS NULL OR CONCAT(r.repo_owner, '/', r.repo_name) != ANY(sqlc.slice(notEntityNames)::text[]))
    AND (sqlc.slice(notEntityNames)::text[] IS NULL OR ere.pull_request_id IS NULL OR pr.pr_number::text != ANY(sqlc.slice(notEntityNames)::text[]))
    AND (sqlc.slice(notEntityNames)::text[] IS NULL OR ere.artifact_id IS NULL OR a.artifact_name != ANY(sqlc.slice(notEntityNames)::text[]))

--- a/internal/db/eval_history.sql.go
+++ b/internal/db/eval_history.sql.go
@@ -245,7 +245,7 @@ SELECT s.id::uuid AS evaluation_id,
  WHERE ($1::timestamp without time zone IS NULL OR $1 > s.evaluation_time)
    AND ($2::timestamp without time zone IS NULL OR $2 < s.evaluation_time)
    -- inclusion filters
-   AND ($3::entities[] IS NULL OR entity_type::entities = ANY($3::entities[]))
+   AND ($3::entities[] IS NULL OR ri.entity_type = ANY($3::entities[]))
    AND ($4::text[] IS NULL OR ere.repository_id IS NULL OR CONCAT(r.repo_owner, '/', r.repo_name) = ANY($4::text[]))
    AND ($4::text[] IS NULL OR ere.pull_request_id IS NULL OR pr.pr_number::text = ANY($4::text[]))
    AND ($4::text[] IS NULL OR ere.artifact_id IS NULL OR a.artifact_name = ANY($4::text[]))
@@ -254,7 +254,7 @@ SELECT s.id::uuid AS evaluation_id,
    AND ($7::alert_status_types[] IS NULL OR ae.status = ANY($7::alert_status_types[]))
    AND ($8::eval_status_types[] IS NULL OR s.status = ANY($8::eval_status_types[]))
    -- exclusion filters
-   AND ($9::entities[] IS NULL OR entity_type::entities != ANY($9::entities[]))
+   AND ($9::entities[] IS NULL OR ri.entity_type != ANY($9::entities[]))
    AND ($10::text[] IS NULL OR ere.repository_id IS NULL OR CONCAT(r.repo_owner, '/', r.repo_name) != ANY($10::text[]))
    AND ($10::text[] IS NULL OR ere.pull_request_id IS NULL OR pr.pr_number::text != ANY($10::text[]))
    AND ($10::text[] IS NULL OR ere.artifact_id IS NULL OR a.artifact_name != ANY($10::text[]))


### PR DESCRIPTION
# Summary

Entity type was added to `evaluation_rule_entities` table by commit 1ceab64. This introduced an ambiguity in the evaluation log query that was previously implicitly using entity type from `rule_instances` table. The newly introduced column is not yet filled, so we're just making the statement unambiguous by explicitly adding a reference to the table previously used.

## Change Type

***Mark the type of change your PR introduces:***

- [X] Bug fix (resolves an issue without affecting existing features)
- [ ] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [ ] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

Manual tests.

# Review Checklist:

- [X] Reviewed my own code for quality and clarity.
- [ ] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [ ] Included tests that validate the fix or feature.
- [X] Checked that related changes are merged.
