### PR TITLE
Change selectors.New to not return an error

### DIFF
--- a/cmd/dev/app/rule_type/rttst.go
+++ b/cmd/dev/app/rule_type/rttst.go
@@ -201,10 +201,7 @@ func testCmdRun(cmd *cobra.Command, _ []string) error {
 }
 
 func getProfileSelectors(entType minderv1.Entity, profile *minderv1.Profile) (selectors.Selection, error) {
-	selectorEnv, err := selectors.NewEnv()
-	if err != nil {
-		return nil, fmt.Errorf("error creating selector environment: %w", err)
-	}
+	selectorEnv := selectors.NewEnv()
 
 	profSel, err := selectorEnv.NewSelectionFromProfile(entType, profile.Selection)
 	if err != nil {

--- a/internal/engine/selectors/selectors.go
+++ b/internal/engine/selectors/selectors.go
@@ -153,7 +153,7 @@ type entityEnvCache struct {
 
 // NewEnv creates a new Env struct with the default factories for each entity type. The factories
 // are used on first access to create the CEL environments for each entity type.
-func NewEnv() (*Env, error) {
+func NewEnv() *Env {
 	factoryMap := map[minderv1.Entity]celEnvFactory{
 		minderv1.Entity_ENTITY_UNSPECIFIED:  genericEnvFactory,
 		minderv1.Entity_ENTITY_REPOSITORIES: repoEnvFactory,
@@ -169,7 +169,7 @@ func NewEnv() (*Env, error) {
 	return &Env{
 		entityEnvs: entityEnvs,
 		factories:  factoryMap,
-	}, nil
+	}
 }
 
 // NewSelectionFromProfile creates a new Selection (compiled CEL programs for that entity type)

--- a/internal/engine/selectors/selectors_test.go
+++ b/internal/engine/selectors/selectors_test.go
@@ -28,8 +28,7 @@ import (
 func TestNewSelectorEngine(t *testing.T) {
 	t.Parallel()
 
-	env, err := NewEnv()
-	require.NoError(t, err)
+	env := NewEnv()
 	require.NotNil(t, env)
 	require.NotNil(t, env.entityEnvs)
 	require.NotNil(t, env.entityEnvs[minderv1.Entity_ENTITY_REPOSITORIES])
@@ -410,8 +409,7 @@ func TestSelectSelectorEntity(t *testing.T) {
 		t.Run(scenario.name, func(t *testing.T) {
 			t.Parallel()
 
-			env, err := NewEnv()
-			require.NoError(t, err)
+			env := NewEnv()
 
 			se := scenario.selectorEntityBld()
 
@@ -506,8 +504,7 @@ func TestSelectorEntityFillProperties(t *testing.T) {
 	}
 
 	for _, scenario := range scenarios {
-		env, err := NewEnv()
-		require.NoError(t, err)
+		env := NewEnv()
 
 		seBuilder := newTestRepoSelectorEntity()
 		se := seBuilder()


### PR DESCRIPTION

# Summary

This is just a small refactoring that makes future patches easier to apply.

The function was only ever returning nil anyway and it would make using
it in minder easier as well

## Change Type

- [ ] Bug fix (resolves an issue without affecting existing features)
- [ ] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [x] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

just make to be honest

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [ ] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [ ] Included tests that validate the fix or feature.
- [ ] Checked that related changes are merged.
