### PR TITLE
Return structured errors from the selectors API

### DIFF
--- a/internal/engine/selectors/mock/selectors.go
+++ b/internal/engine/selectors/mock/selectors.go
@@ -56,6 +56,43 @@ func (mr *MockSelectionBuilderMockRecorder) NewSelectionFromProfile(arg0, arg1 a
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewSelectionFromProfile", reflect.TypeOf((*MockSelectionBuilder)(nil).NewSelectionFromProfile), arg0, arg1)
 }
 
+// MockSelectionChecker is a mock of SelectionChecker interface.
+type MockSelectionChecker struct {
+	ctrl     *gomock.Controller
+	recorder *MockSelectionCheckerMockRecorder
+}
+
+// MockSelectionCheckerMockRecorder is the mock recorder for MockSelectionChecker.
+type MockSelectionCheckerMockRecorder struct {
+	mock *MockSelectionChecker
+}
+
+// NewMockSelectionChecker creates a new mock instance.
+func NewMockSelectionChecker(ctrl *gomock.Controller) *MockSelectionChecker {
+	mock := &MockSelectionChecker{ctrl: ctrl}
+	mock.recorder = &MockSelectionCheckerMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MockSelectionChecker) EXPECT() *MockSelectionCheckerMockRecorder {
+	return m.recorder
+}
+
+// CheckSelector mocks base method.
+func (m *MockSelectionChecker) CheckSelector(arg0 *v1.Profile_Selector) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CheckSelector", arg0)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// CheckSelector indicates an expected call of CheckSelector.
+func (mr *MockSelectionCheckerMockRecorder) CheckSelector(arg0 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CheckSelector", reflect.TypeOf((*MockSelectionChecker)(nil).CheckSelector), arg0)
+}
+
 // MockSelection is a mock of Selection interface.
 type MockSelection struct {
 	ctrl     *gomock.Controller

--- a/internal/engine/selectors/selectors.go
+++ b/internal/engine/selectors/selectors.go
@@ -19,6 +19,7 @@
 package selectors
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"strings"
@@ -38,7 +39,109 @@ var (
 	// ErrResultUnknown is returned when the result of a selector expression is unknown
 	// this tells the caller to try again with more information
 	ErrResultUnknown = errors.New("result is unknown")
+	// ErrUnsupported is returned when the entity type is not supported
+	ErrUnsupported = errors.New("unsupported entity type")
 )
+
+// ErrKind is a string for the kind of error that occurred
+type ErrKind string
+
+const (
+	// ErrKindParse is an error kind for parsing errors, e.g. syntax errors
+	ErrKindParse ErrKind = "parse"
+	// ErrKindCheck is an error kind for checking errors, e.g. mismatched types
+	ErrKindCheck ErrKind = "check"
+)
+
+// ErrInstance is one occurrence of an error in a CEL expression
+type ErrInstance struct {
+	Line int    `json:"line,omitempty"`
+	Col  int    `json:"col,omitempty"`
+	Msg  string `json:"msg,omitempty"`
+}
+
+// ErrDetails is a struct that holds the details of an error in a CEL expression
+type ErrDetails struct {
+	Errors []ErrInstance `json:"errors,omitempty"`
+	Source string        `json:"source,omitempty"`
+}
+
+// AsJSON returns the ErrDetails as a JSON string
+func (ed *ErrDetails) AsJSON() string {
+	edBytes, err := json.Marshal(ed)
+	if err != nil {
+		return fmt.Sprintf(`{"error": "failed to marshal JSON: %s"}`, err)
+	}
+	return string(edBytes)
+}
+
+func errDetailsFromCelIssues(source string, issues *cel.Issues) ErrDetails {
+	var ed ErrDetails
+
+	ed.Source = source
+	ed.Errors = make([]ErrInstance, 0, len(issues.Errors()))
+	for _, err := range issues.Errors() {
+		ed.Errors = append(ed.Errors, ErrInstance{
+			Line: err.Location.Line(),
+			Col:  err.Location.Column(),
+			Msg:  err.Message,
+		})
+	}
+
+	return ed
+}
+
+// ErrStructure is a struct that callers can use to deserialize the JSON error
+type ErrStructure struct {
+	Err     ErrKind    `json:"err"`
+	Details ErrDetails `json:"details"`
+}
+
+// ParseError is an error type for syntax errors in CEL expressions
+type ParseError struct {
+	ErrDetails
+}
+
+// Error implements the error interface for ParseError
+func (pe *ParseError) Error() string {
+	return fmt.Sprintf(`{"err": "%s", "details": %s}`, ErrKindParse, pe.AsJSON())
+}
+
+// Is checks if the target error is a ParseError
+func (_ *ParseError) Is(target error) bool {
+	var t *ParseError
+	return errors.As(target, &t)
+}
+
+// CheckError is an error type for type checking errors in CEL expressions, e.g.
+// mismatched types
+type CheckError struct {
+	ErrDetails
+}
+
+// Error implements the error interface for CheckError
+func (ce *CheckError) Error() string {
+	return fmt.Sprintf(`{"err": "%s", "details": %s}`, ErrKindCheck, ce.AsJSON())
+}
+
+// Is checks if the target error is a CheckError
+func (_ *CheckError) Is(target error) bool {
+	var t *CheckError
+	ok := errors.As(target, &t)
+	return ok
+}
+
+func newParseError(source string, issues *cel.Issues) error {
+	return &ParseError{
+		ErrDetails: errDetailsFromCelIssues(source, issues),
+	}
+}
+
+func newCheckError(source string, issues *cel.Issues) error {
+	return &CheckError{
+		ErrDetails: errDetailsFromCelIssues(source, issues),
+	}
+}
 
 // celEnvFactory is an interface for creating CEL environments
 // for an entity. Each entity must implement this interface to be
@@ -112,14 +215,9 @@ type compiledSelector struct {
 
 // compileSelectorForEntity compiles a selector expression for a given entity type into a CEL program
 func compileSelectorForEntity(env *cel.Env, selector string) (*compiledSelector, error) {
-	ast, issues := env.Parse(selector)
-	if issues.Err() != nil {
-		return nil, fmt.Errorf("failed to parse expression %q: %w", selector, issues.Err())
-	}
-
-	checked, issues := env.Check(ast)
-	if issues.Err() != nil {
-		return nil, fmt.Errorf("failed to check expression %q: %w", selector, issues.Err())
+	checked, err := checkSelectorForEntity(env, selector)
+	if err != nil {
+		return nil, fmt.Errorf("failed to check expression %q: %w", selector, err)
 	}
 
 	program, err := env.Program(checked,
@@ -136,11 +234,30 @@ func compileSelectorForEntity(env *cel.Env, selector string) (*compiledSelector,
 	}, nil
 }
 
+func checkSelectorForEntity(env *cel.Env, selector string) (*cel.Ast, error) {
+	parsedAst, issues := env.Parse(selector)
+	if issues.Err() != nil {
+		return nil, newParseError(selector, issues)
+	}
+
+	checkedAst, issues := env.Check(parsedAst)
+	if issues.Err() != nil {
+		return nil, newCheckError(selector, issues)
+	}
+
+	return checkedAst, nil
+}
+
 // SelectionBuilder is an interface for creating Selections (a collection of compiled CEL expressions)
 // for an entity type. This is what the user of this module uses. The interface makes it easier to pass
 // mocks by the user of this module.
 type SelectionBuilder interface {
 	NewSelectionFromProfile(minderv1.Entity, []*minderv1.Profile_Selector) (Selection, error)
+}
+
+// SelectionChecker is an interface for checking if a selector expression is valid for a given entity type
+type SelectionChecker interface {
+	CheckSelector(*minderv1.Profile_Selector) error
 }
 
 // Env is a struct that holds the CEL environments for each entity type and the factories for creating
@@ -213,6 +330,18 @@ func (e *Env) NewSelectionFromProfile(
 		selector: selector,
 		entity:   entityType,
 	}, nil
+}
+
+// CheckSelector checks if a selector expression compiles and is valid for a given entity
+func (e *Env) CheckSelector(sel *minderv1.Profile_Selector) error {
+	ent := minderv1.EntityFromString(sel.GetEntity())
+	env, err := e.envForEntity(ent)
+	if err != nil {
+		return fmt.Errorf("failed to get environment for entity %v: %w", ent, ErrUnsupported)
+	}
+
+	_, err = checkSelectorForEntity(env, sel.Selector)
+	return err
 }
 
 // envForEntity gets the CEL environment for a given entity type. If the environment is not cached,

--- a/internal/engine/selectors/selectors_test.go
+++ b/internal/engine/selectors/selectors_test.go
@@ -16,6 +16,9 @@
 package selectors
 
 import (
+	"encoding/json"
+	"errors"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -131,13 +134,15 @@ func TestSelectSelectorEntity(t *testing.T) {
 	t.Parallel()
 
 	scenarios := []struct {
-		name                    string
-		exprs                   []*minderv1.Profile_Selector
-		selectOptions           []SelectOption
-		selectorEntityBld       testSelectorEntityBuilder
-		expectedNewSelectionErr string
-		expectedSelectErr       error
-		selected                bool
+		name                       string
+		exprs                      []*minderv1.Profile_Selector
+		selectOptions              []SelectOption
+		selectorEntityBld          testSelectorEntityBuilder
+		expectedNewSelectionErrMsg string
+		expectedNewSelectionErr    error
+		expectedStructuredErr      *ErrStructure
+		expectedSelectErr          error
+		selected                   bool
 	}{
 		{
 			name:              "No selectors",
@@ -322,8 +327,20 @@ func TestSelectSelectorEntity(t *testing.T) {
 					Selector: "artifact.name != 'testorg/testrepo'",
 				},
 			},
+			selectorEntityBld:          newTestRepoSelectorEntity(),
+			expectedNewSelectionErrMsg: "undeclared reference to 'artifact'",
+			selected:                   false,
+		},
+		{
+			name: "CEL expression that does not parse",
+			exprs: []*minderv1.Profile_Selector{
+				{
+					Entity:   minderv1.RepositoryEntity.String(),
+					Selector: "repository.name == ",
+				},
+			},
 			selectorEntityBld:       newTestRepoSelectorEntity(),
-			expectedNewSelectionErr: "undeclared reference to 'artifact'",
+			expectedNewSelectionErr: &ParseError{},
 			selected:                false,
 		},
 		{
@@ -334,9 +351,23 @@ func TestSelectSelectorEntity(t *testing.T) {
 					Selector: "repository.iamnothere == 'value'",
 				},
 			},
-			selectorEntityBld:       newTestRepoSelectorEntity(),
-			expectedNewSelectionErr: "undefined field 'iamnothere'",
-			selected:                false,
+			selectorEntityBld:          newTestRepoSelectorEntity(),
+			expectedNewSelectionErrMsg: "undefined field 'iamnothere'",
+			expectedNewSelectionErr:    &CheckError{},
+			expectedStructuredErr: &ErrStructure{
+				Err: ErrKindCheck,
+				Details: ErrDetails{
+					Errors: []ErrInstance{
+						{
+							Line: 1,
+							Col:  10,
+							Msg:  "undefined field 'iamnothere'",
+						},
+					},
+					Source: "repository.iamnothere == 'value'",
+				},
+			},
+			selected: false,
 		},
 		{
 			name: "Use a property that is defined and true result",
@@ -497,9 +528,21 @@ func TestSelectSelectorEntity(t *testing.T) {
 			se := scenario.selectorEntityBld()
 
 			sels, err := env.NewSelectionFromProfile(se.EntityType, scenario.exprs)
-			if scenario.expectedNewSelectionErr != "" {
+			if scenario.expectedNewSelectionErrMsg != "" {
 				require.Error(t, err)
-				require.Contains(t, err.Error(), scenario.expectedNewSelectionErr)
+				require.Contains(t, err.Error(), scenario.expectedNewSelectionErrMsg)
+			}
+			if scenario.expectedNewSelectionErr != nil {
+				require.Error(t, err)
+				require.ErrorIs(t, err, scenario.expectedNewSelectionErr)
+			}
+			if scenario.expectedStructuredErr != nil {
+				testErrUnmarshallableValue(t, err, scenario.expectedStructuredErr)
+			}
+
+			if scenario.expectedNewSelectionErrMsg != "" ||
+				scenario.expectedNewSelectionErr != nil ||
+				scenario.expectedStructuredErr != nil {
 				return
 			}
 
@@ -517,6 +560,29 @@ func TestSelectSelectorEntity(t *testing.T) {
 			require.Equal(t, scenario.selected, selected)
 		})
 	}
+}
+
+func testErrUnmarshallableValue(t *testing.T, err error, expected *ErrStructure) {
+	t.Helper()
+
+	var ce *CheckError
+	var pe *ParseError
+	var jsonString string
+
+	if errors.As(err, &ce) {
+		jsonString = ce.Error()
+	} else if errors.As(err, &pe) {
+		jsonString = pe.Error()
+	} else {
+		t.Fatalf("error is not of type CheckError or ParseError")
+	}
+
+	var structuredErr ErrStructure
+	if err := json.NewDecoder(strings.NewReader(jsonString)).Decode(&structuredErr); err != nil {
+		t.Fatalf("failed to unmarshal error: %v", err)
+	}
+
+	require.Equal(t, expected, &structuredErr)
 }
 
 func TestSelectorEntityFillProperties(t *testing.T) {

--- a/internal/engine/selectors/selectors_test.go
+++ b/internal/engine/selectors/selectors_test.go
@@ -577,6 +577,9 @@ func testErrUnmarshallableValue(t *testing.T, err error, expected *ErrStructure)
 		t.Fatalf("error is not of type CheckError or ParseError")
 	}
 
+	// both errors unwrap to ErrSelectorCheck
+	require.ErrorIs(t, err, ErrSelectorCheck)
+
 	var structuredErr ErrStructure
 	if err := json.NewDecoder(strings.NewReader(jsonString)).Decode(&structuredErr); err != nil {
 		t.Fatalf("failed to unmarshal error: %v", err)


### PR DESCRIPTION
# Summary

In order to tell the user what's wrong with a selector they are about to
take into use, let's introduce a structured way of returning errors to
the selector API.

The errors can be represented as JSON in order for clients to be able to
parse the error without knowing much about the type.

Related: #3725


## Change Type

- [ ] Bug fix (resolves an issue without affecting existing features)
- [x] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [ ] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

with the added unit tests and as part of a larger topic branch

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [ ] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [x] Included tests that validate the fix or feature.
- [ ] Checked that related changes are merged.
