### PR TITLE
Add `rule_entity_id` to `rule_evaluations`

### DIFF
--- a/database/migrations/000079_rule_evaluations_evaluation_history.down.sql
+++ b/database/migrations/000079_rule_evaluations_evaluation_history.down.sql
@@ -15,6 +15,7 @@
 BEGIN;
 
 ALTER TABLE public.rule_evaluations DROP COLUMN rule_entity_id;
+ALTER TABLE public.rule_evaluations DROP COLUMN rule_instance_id;
 
 ALTER TABLE latest_evaluation_statuses DROP CONSTRAINT latest_evaluation_statuses_profile_id_fkey;
 ALTER TABLE latest_evaluation_statuses

--- a/database/migrations/000079_rule_evaluations_evaluation_history.down.sql
+++ b/database/migrations/000079_rule_evaluations_evaluation_history.down.sql
@@ -1,0 +1,29 @@
+-- Copyright 2024 Stacklok, Inc
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--      http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+BEGIN;
+
+ALTER TABLE public.rule_evaluations DROP COLUMN rule_entity_id;
+
+ALTER TABLE latest_evaluation_statuses DROP CONSTRAINT latest_evaluation_statuses_profile_id_fkey;
+ALTER TABLE latest_evaluation_statuses
+    ADD CONSTRAINT latest_evaluation_statuses_profile_id_fkey
+    FOREIGN KEY (profile_id)
+    REFERENCES profiles(id);
+
+-- recreate index with default name
+DROP INDEX latest_evaluation_statuses_profile_id_idx;
+CREATE INDEX idx_profile_id ON latest_evaluation_statuses(profile_id);
+
+COMMIT;

--- a/database/migrations/000079_rule_evaluations_evaluation_history.up.sql
+++ b/database/migrations/000079_rule_evaluations_evaluation_history.up.sql
@@ -15,9 +15,10 @@
 BEGIN;
 
 -- link each entry in the rule_evaluations table to the evaluation_rule_entities
--- table. This will simplify migrating statuses from the old status tables over
--- to the new history tables.
-ALTER TABLE public.rule_evaluations ADD COLUMN rule_entity_id UUID REFERENCES evaluation_rule_entities(id) ON DELETE CASCADE;
+-- table, and to the rule_instances table. This will simplify migrating statuses
+-- from the old status tables over to the new history tables.
+ALTER TABLE rule_evaluations ADD COLUMN rule_entity_id UUID REFERENCES evaluation_rule_entities(id) ON DELETE CASCADE;
+ALTER TABLE rule_evaluations ADD COLUMN rule_instance_id UUID REFERENCES rule_instances(id) ON DELETE CASCADE;
 
 -- Fix some omissions from the previous PR
 

--- a/database/migrations/000079_rule_evaluations_evaluation_history.up.sql
+++ b/database/migrations/000079_rule_evaluations_evaluation_history.up.sql
@@ -1,0 +1,36 @@
+-- Copyright 2024 Stacklok, Inc
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--      http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+BEGIN;
+
+-- link each entry in the rule_evaluations table to the evaluation_rule_entities
+-- table. This will simplify migrating statuses from the old status tables over
+-- to the new history tables.
+ALTER TABLE public.rule_evaluations ADD COLUMN rule_entity_id UUID REFERENCES evaluation_rule_entities(id) ON DELETE CASCADE;
+
+-- Fix some omissions from the previous PR
+
+-- First, add an ON DELETE CASCADE to the profile_id FK
+ALTER TABLE latest_evaluation_statuses DROP CONSTRAINT latest_evaluation_statuses_profile_id_fkey;
+ALTER TABLE latest_evaluation_statuses
+    ADD CONSTRAINT latest_evaluation_statuses_profile_id_fkey
+    FOREIGN KEY (profile_id)
+    REFERENCES profiles(id)
+    ON DELETE CASCADE;
+
+-- recreate index with default name
+DROP INDEX IF EXISTS idx_profile_id;
+CREATE INDEX ON latest_evaluation_statuses(profile_id);
+
+COMMIT;

--- a/database/query/profile_status.sql
+++ b/database/query/profile_status.sql
@@ -1,8 +1,8 @@
 
 -- name: UpsertRuleEvaluations :one
 INSERT INTO rule_evaluations (
-    profile_id, repository_id, artifact_id, pull_request_id, rule_type_id, entity, rule_name, rule_entity_id
-) VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+    profile_id, repository_id, artifact_id, pull_request_id, rule_type_id, entity, rule_name, rule_entity_id, rule_instance_id
+) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
 ON CONFLICT (profile_id, repository_id, COALESCE(artifact_id, '00000000-0000-0000-0000-000000000000'::UUID), COALESCE(pull_request_id, '00000000-0000-0000-0000-000000000000'::UUID), entity, rule_type_id, lower(rule_name))
   DO UPDATE SET profile_id = $1
 RETURNING id;

--- a/database/query/profile_status.sql
+++ b/database/query/profile_status.sql
@@ -1,8 +1,8 @@
 
 -- name: UpsertRuleEvaluations :one
 INSERT INTO rule_evaluations (
-    profile_id, repository_id, artifact_id, pull_request_id, rule_type_id, entity, rule_name
-) VALUES ($1, $2, $3, $4, $5, $6, $7)
+    profile_id, repository_id, artifact_id, pull_request_id, rule_type_id, entity, rule_name, rule_entity_id
+) VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
 ON CONFLICT (profile_id, repository_id, COALESCE(artifact_id, '00000000-0000-0000-0000-000000000000'::UUID), COALESCE(pull_request_id, '00000000-0000-0000-0000-000000000000'::UUID), entity, rule_type_id, lower(rule_name))
   DO UPDATE SET profile_id = $1
 RETURNING id;

--- a/internal/db/models.go
+++ b/internal/db/models.go
@@ -686,6 +686,7 @@ type RuleEvaluation struct {
 	ArtifactID    uuid.NullUUID `json:"artifact_id"`
 	PullRequestID uuid.NullUUID `json:"pull_request_id"`
 	RuleName      string        `json:"rule_name"`
+	RuleEntityID  uuid.NullUUID `json:"rule_entity_id"`
 }
 
 type RuleInstance struct {

--- a/internal/db/models.go
+++ b/internal/db/models.go
@@ -678,15 +678,16 @@ type RuleDetailsRemediate struct {
 }
 
 type RuleEvaluation struct {
-	ID            uuid.UUID     `json:"id"`
-	Entity        Entities      `json:"entity"`
-	ProfileID     uuid.UUID     `json:"profile_id"`
-	RuleTypeID    uuid.UUID     `json:"rule_type_id"`
-	RepositoryID  uuid.NullUUID `json:"repository_id"`
-	ArtifactID    uuid.NullUUID `json:"artifact_id"`
-	PullRequestID uuid.NullUUID `json:"pull_request_id"`
-	RuleName      string        `json:"rule_name"`
-	RuleEntityID  uuid.NullUUID `json:"rule_entity_id"`
+	ID             uuid.UUID     `json:"id"`
+	Entity         Entities      `json:"entity"`
+	ProfileID      uuid.UUID     `json:"profile_id"`
+	RuleTypeID     uuid.UUID     `json:"rule_type_id"`
+	RepositoryID   uuid.NullUUID `json:"repository_id"`
+	ArtifactID     uuid.NullUUID `json:"artifact_id"`
+	PullRequestID  uuid.NullUUID `json:"pull_request_id"`
+	RuleName       string        `json:"rule_name"`
+	RuleEntityID   uuid.NullUUID `json:"rule_entity_id"`
+	RuleInstanceID uuid.NullUUID `json:"rule_instance_id"`
 }
 
 type RuleInstance struct {

--- a/internal/db/profile_status.sql.go
+++ b/internal/db/profile_status.sql.go
@@ -444,22 +444,23 @@ func (q *Queries) UpsertRuleDetailsRemediate(ctx context.Context, arg UpsertRule
 
 const upsertRuleEvaluations = `-- name: UpsertRuleEvaluations :one
 INSERT INTO rule_evaluations (
-    profile_id, repository_id, artifact_id, pull_request_id, rule_type_id, entity, rule_name, rule_entity_id
-) VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+    profile_id, repository_id, artifact_id, pull_request_id, rule_type_id, entity, rule_name, rule_entity_id, rule_instance_id
+) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
 ON CONFLICT (profile_id, repository_id, COALESCE(artifact_id, '00000000-0000-0000-0000-000000000000'::UUID), COALESCE(pull_request_id, '00000000-0000-0000-0000-000000000000'::UUID), entity, rule_type_id, lower(rule_name))
   DO UPDATE SET profile_id = $1
 RETURNING id
 `
 
 type UpsertRuleEvaluationsParams struct {
-	ProfileID     uuid.UUID     `json:"profile_id"`
-	RepositoryID  uuid.NullUUID `json:"repository_id"`
-	ArtifactID    uuid.NullUUID `json:"artifact_id"`
-	PullRequestID uuid.NullUUID `json:"pull_request_id"`
-	RuleTypeID    uuid.UUID     `json:"rule_type_id"`
-	Entity        Entities      `json:"entity"`
-	RuleName      string        `json:"rule_name"`
-	RuleEntityID  uuid.NullUUID `json:"rule_entity_id"`
+	ProfileID      uuid.UUID     `json:"profile_id"`
+	RepositoryID   uuid.NullUUID `json:"repository_id"`
+	ArtifactID     uuid.NullUUID `json:"artifact_id"`
+	PullRequestID  uuid.NullUUID `json:"pull_request_id"`
+	RuleTypeID     uuid.UUID     `json:"rule_type_id"`
+	Entity         Entities      `json:"entity"`
+	RuleName       string        `json:"rule_name"`
+	RuleEntityID   uuid.NullUUID `json:"rule_entity_id"`
+	RuleInstanceID uuid.NullUUID `json:"rule_instance_id"`
 }
 
 func (q *Queries) UpsertRuleEvaluations(ctx context.Context, arg UpsertRuleEvaluationsParams) (uuid.UUID, error) {
@@ -472,6 +473,7 @@ func (q *Queries) UpsertRuleEvaluations(ctx context.Context, arg UpsertRuleEvalu
 		arg.Entity,
 		arg.RuleName,
 		arg.RuleEntityID,
+		arg.RuleInstanceID,
 	)
 	var id uuid.UUID
 	err := row.Scan(&id)

--- a/internal/db/profile_status.sql.go
+++ b/internal/db/profile_status.sql.go
@@ -444,8 +444,8 @@ func (q *Queries) UpsertRuleDetailsRemediate(ctx context.Context, arg UpsertRule
 
 const upsertRuleEvaluations = `-- name: UpsertRuleEvaluations :one
 INSERT INTO rule_evaluations (
-    profile_id, repository_id, artifact_id, pull_request_id, rule_type_id, entity, rule_name
-) VALUES ($1, $2, $3, $4, $5, $6, $7)
+    profile_id, repository_id, artifact_id, pull_request_id, rule_type_id, entity, rule_name, rule_entity_id
+) VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
 ON CONFLICT (profile_id, repository_id, COALESCE(artifact_id, '00000000-0000-0000-0000-000000000000'::UUID), COALESCE(pull_request_id, '00000000-0000-0000-0000-000000000000'::UUID), entity, rule_type_id, lower(rule_name))
   DO UPDATE SET profile_id = $1
 RETURNING id
@@ -459,6 +459,7 @@ type UpsertRuleEvaluationsParams struct {
 	RuleTypeID    uuid.UUID     `json:"rule_type_id"`
 	Entity        Entities      `json:"entity"`
 	RuleName      string        `json:"rule_name"`
+	RuleEntityID  uuid.NullUUID `json:"rule_entity_id"`
 }
 
 func (q *Queries) UpsertRuleEvaluations(ctx context.Context, arg UpsertRuleEvaluationsParams) (uuid.UUID, error) {
@@ -470,6 +471,7 @@ func (q *Queries) UpsertRuleEvaluations(ctx context.Context, arg UpsertRuleEvalu
 		arg.RuleTypeID,
 		arg.Entity,
 		arg.RuleName,
+		arg.RuleEntityID,
 	)
 	var id uuid.UUID
 	err := row.Scan(&id)

--- a/internal/engine/eval_status.go
+++ b/internal/engine/eval_status.go
@@ -191,6 +191,10 @@ func (e *executor) createOrUpdateEvalStatus(
 			RuleTypeID:    params.Rule.RuleTypeID,
 			PullRequestID: params.PullRequestID,
 			RuleName:      params.Rule.Name,
+			RuleInstanceID: uuid.NullUUID{
+				UUID:  params.Rule.ID,
+				Valid: true,
+			},
 			RuleEntityID: uuid.NullUUID{
 				UUID:  ruleEntityID,
 				Valid: true,

--- a/internal/engine/eval_status.go
+++ b/internal/engine/eval_status.go
@@ -129,23 +129,6 @@ func (e *executor) createOrUpdateEvalStatus(
 		return nil
 	}
 
-	// Upsert evaluation
-	// TODO: replace this table with the evaluation statuses table
-	evalID, err := e.querier.UpsertRuleEvaluations(ctx, db.UpsertRuleEvaluationsParams{
-		ProfileID:     params.Profile.ID,
-		RepositoryID:  params.RepoID,
-		ArtifactID:    params.ArtifactID,
-		Entity:        params.EntityType,
-		RuleTypeID:    params.Rule.RuleTypeID,
-		PullRequestID: params.PullRequestID,
-		RuleName:      params.Rule.Name,
-	})
-	if err != nil {
-		logger.Err(err).Msg("error upserting rule evaluation")
-		return err
-	}
-
-	// Upsert evaluation details
 	entityID, entityType, err := ent.EntityFromIDs(params.RepoID.UUID, params.ArtifactID.UUID, params.PullRequestID.UUID)
 	if err != nil {
 		return err
@@ -153,47 +136,15 @@ func (e *executor) createOrUpdateEvalStatus(
 	status := evalerrors.ErrorAsEvalStatus(params.GetEvalErr())
 	e.metrics.CountEvalStatus(ctx, status, entityType)
 
-	_, err = e.querier.UpsertRuleDetailsEval(ctx, db.UpsertRuleDetailsEvalParams{
-		RuleEvalID: evalID,
-		Status:     evalerrors.ErrorAsEvalStatus(params.GetEvalErr()),
-		Details:    evalerrors.ErrorAsEvalDetails(params.GetEvalErr()),
-	})
-	if err != nil {
-		logger.Err(err).Msg("error upserting rule evaluation details")
-		return err
-	}
-
-	// Upsert remediation details
 	remediationStatus := evalerrors.ErrorAsRemediationStatus(params.GetActionsErr().RemediateErr)
 	e.metrics.CountRemediationStatus(ctx, remediationStatus)
 
-	_, err = e.querier.UpsertRuleDetailsRemediate(ctx, db.UpsertRuleDetailsRemediateParams{
-		RuleEvalID: evalID,
-		Status:     remediationStatus,
-		Details:    errorAsActionDetails(params.GetActionsErr().RemediateErr),
-		Metadata:   params.GetActionsErr().RemediateMeta,
-	})
-	if err != nil {
-		logger.Err(err).Msg("error upserting rule remediation details")
-	}
-
-	// Upsert alert details
 	alertStatus := evalerrors.ErrorAsAlertStatus(params.GetActionsErr().AlertErr)
 	e.metrics.CountAlertStatus(ctx, alertStatus)
 
-	_, err = e.querier.UpsertRuleDetailsAlert(ctx, db.UpsertRuleDetailsAlertParams{
-		RuleEvalID: evalID,
-		Status:     alertStatus,
-		Details:    errorAsActionDetails(params.GetActionsErr().AlertErr),
-		Metadata:   params.GetActionsErr().AlertMeta,
-	})
-	if err != nil {
-		logger.Err(err).Msg("error upserting rule alert details")
-	}
-
-	// Log in the evaluation history tables
+	// Log result in the evaluation history tables
 	err = e.querier.WithTransactionErr(func(qtx db.ExtendQuerier) error {
-		evalID, err := e.historyService.StoreEvaluationStatus(
+		evalID, ruleEntityID, err := e.historyService.StoreEvaluationStatus(
 			ctx,
 			qtx,
 			params.Rule.ID,
@@ -228,6 +179,57 @@ func (e *executor) createOrUpdateEvalStatus(
 		})
 		if err != nil {
 			return err
+		}
+
+		// Upsert evaluation
+		// TODO: replace these tables with the evaluation statuses table after migration
+		legacyEvalID, err := qtx.UpsertRuleEvaluations(ctx, db.UpsertRuleEvaluationsParams{
+			ProfileID:     params.Profile.ID,
+			RepositoryID:  params.RepoID,
+			ArtifactID:    params.ArtifactID,
+			Entity:        params.EntityType,
+			RuleTypeID:    params.Rule.RuleTypeID,
+			PullRequestID: params.PullRequestID,
+			RuleName:      params.Rule.Name,
+			RuleEntityID: uuid.NullUUID{
+				UUID:  ruleEntityID,
+				Valid: true,
+			},
+		})
+		if err != nil {
+			logger.Err(err).Msg("error upserting rule evaluation")
+			return err
+		}
+
+		// Upsert evaluation details
+		_, err = qtx.UpsertRuleDetailsEval(ctx, db.UpsertRuleDetailsEvalParams{
+			RuleEvalID: legacyEvalID,
+			Status:     evalerrors.ErrorAsEvalStatus(params.GetEvalErr()),
+			Details:    evalerrors.ErrorAsEvalDetails(params.GetEvalErr()),
+		})
+		if err != nil {
+			logger.Err(err).Msg("error upserting rule evaluation details")
+			return err
+		}
+
+		_, err = qtx.UpsertRuleDetailsRemediate(ctx, db.UpsertRuleDetailsRemediateParams{
+			RuleEvalID: legacyEvalID,
+			Status:     remediationStatus,
+			Details:    errorAsActionDetails(params.GetActionsErr().RemediateErr),
+			Metadata:   params.GetActionsErr().RemediateMeta,
+		})
+		if err != nil {
+			logger.Err(err).Msg("error upserting rule remediation details")
+		}
+
+		_, err = qtx.UpsertRuleDetailsAlert(ctx, db.UpsertRuleDetailsAlertParams{
+			RuleEvalID: legacyEvalID,
+			Status:     alertStatus,
+			Details:    errorAsActionDetails(params.GetActionsErr().AlertErr),
+			Metadata:   params.GetActionsErr().AlertMeta,
+		})
+		if err != nil {
+			logger.Err(err).Msg("error upserting rule alert details")
 		}
 
 		return nil

--- a/internal/engine/executor_test.go
+++ b/internal/engine/executor_test.go
@@ -258,6 +258,10 @@ default allow = true`,
 				UUID:  ruleEntityID,
 				Valid: true,
 			},
+			RuleInstanceID: uuid.NullUUID{
+				UUID:  ruleInstanceID,
+				Valid: true,
+			},
 		}).Return(ruleEvalId, nil)
 
 	// Mock upserting eval details status

--- a/internal/engine/executor_test.go
+++ b/internal/engine/executor_test.go
@@ -99,7 +99,6 @@ func TestExecutor_handleEntityEvent(t *testing.T) {
 
 	authtoken := generateFakeAccessToken(t, cryptoEngine)
 	// -- start expectations
-
 	// not valuable yet, but would have to be updated once actions start using this
 	mockStore.EXPECT().GetRuleEvaluationByProfileIdAndRuleType(gomock.Any(),
 		gomock.Any(),
@@ -153,6 +152,31 @@ func TestExecutor_handleEntityEvent(t *testing.T) {
 				Params:     emptyJSON,
 				ProjectID:  projectID,
 			}}, nil)
+
+	ruleEntityID := uuid.New()
+	evaluationID := uuid.New()
+	historyService := mockhistory.NewMockEvaluationHistoryService(ctrl)
+	historyService.EXPECT().
+		StoreEvaluationStatus(gomock.Any(), gomock.Any(), ruleInstanceID, profileID, db.EntitiesRepository, repositoryID, gomock.Any()).
+		Return(evaluationID, ruleEntityID, nil)
+
+	mockStore.EXPECT().
+		InsertRemediationEvent(gomock.Any(), db.InsertRemediationEventParams{
+			EvaluationID: evaluationID,
+			Status:       db.RemediationStatusTypesSkipped,
+			Details:      "",
+			Metadata:     json.RawMessage("{}"),
+		}).
+		Return(nil)
+
+	mockStore.EXPECT().
+		InsertAlertEvent(gomock.Any(), db.InsertAlertEventParams{
+			EvaluationID: evaluationID,
+			Status:       db.AlertStatusTypesSkipped,
+			Details:      "",
+			Metadata:     json.RawMessage("{}"),
+		}).
+		Return(nil)
 
 	// only one project in the hierarchy
 	mockStore.EXPECT().
@@ -230,6 +254,10 @@ default allow = true`,
 			RuleTypeID: ruleTypeID,
 			Entity:     db.EntitiesRepository,
 			RuleName:   passthroughRuleType,
+			RuleEntityID: uuid.NullUUID{
+				UUID:  ruleEntityID,
+				Valid: true,
+			},
 		}).Return(ruleEvalId, nil)
 
 	// Mock upserting eval details status
@@ -322,19 +350,6 @@ default allow = true`,
 		DoAndReturn(func(fn func(querier db.ExtendQuerier) error) error {
 			return fn(mockStore)
 		})
-
-	historyService := mockhistory.NewMockEvaluationHistoryService(ctrl)
-	historyService.EXPECT().
-		StoreEvaluationStatus(gomock.Any(), gomock.Any(), ruleInstanceID, profileID, db.EntitiesRepository, repositoryID, gomock.Any()).
-		Return(uuid.New(), nil)
-
-	mockStore.EXPECT().
-		InsertRemediationEvent(gomock.Any(), gomock.Any()).
-		Return(nil)
-
-	mockStore.EXPECT().
-		InsertAlertEvent(gomock.Any(), gomock.Any()).
-		Return(nil)
 
 	executor := engine.NewExecutor(
 		mockStore,

--- a/internal/history/mock/service.go
+++ b/internal/history/mock/service.go
@@ -58,12 +58,13 @@ func (mr *MockEvaluationHistoryServiceMockRecorder) ListEvaluationHistory(ctx, q
 }
 
 // StoreEvaluationStatus mocks base method.
-func (m *MockEvaluationHistoryService) StoreEvaluationStatus(ctx context.Context, qtx db.Querier, ruleID, profileID uuid.UUID, entityType db.Entities, entityID uuid.UUID, evalError error) (uuid.UUID, error) {
+func (m *MockEvaluationHistoryService) StoreEvaluationStatus(ctx context.Context, qtx db.Querier, ruleID, profileID uuid.UUID, entityType db.Entities, entityID uuid.UUID, evalError error) (uuid.UUID, uuid.UUID, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "StoreEvaluationStatus", ctx, qtx, ruleID, profileID, entityType, entityID, evalError)
 	ret0, _ := ret[0].(uuid.UUID)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
+	ret1, _ := ret[1].(uuid.UUID)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
 }
 
 // StoreEvaluationStatus indicates an expected call of StoreEvaluationStatus.

--- a/internal/history/service.go
+++ b/internal/history/service.go
@@ -33,7 +33,8 @@ import (
 // EvaluationHistoryService contains methods to add/query data in the history table.
 type EvaluationHistoryService interface {
 	// StoreEvaluationStatus stores the result of this evaluation in the history table.
-	// Returns the UUID of the evaluation status.
+	// Returns the UUID of the evaluation status, and the UUID of the rule-entity
+	// TODO: stop returning rule-entity ID once we get rid of the old tables.
 	StoreEvaluationStatus(
 		ctx context.Context,
 		qtx db.Querier,
@@ -42,7 +43,7 @@ type EvaluationHistoryService interface {
 		entityType db.Entities,
 		entityID uuid.UUID,
 		evalError error,
-	) (uuid.UUID, error)
+	) (uuid.UUID, uuid.UUID, error)
 	// ListEvaluationHistory returns a list of evaluations stored
 	// in the history table.
 	ListEvaluationHistory(
@@ -69,14 +70,14 @@ func (e *evaluationHistoryService) StoreEvaluationStatus(
 	entityType db.Entities,
 	entityID uuid.UUID,
 	evalError error,
-) (uuid.UUID, error) {
+) (uuid.UUID, uuid.UUID, error) {
 	var ruleEntityID uuid.UUID
 	status := evalerrors.ErrorAsEvalStatus(evalError)
 	details := evalerrors.ErrorAsEvalDetails(evalError)
 
 	params, err := paramsFromEntity(ruleID, entityID, entityType)
 	if err != nil {
-		return uuid.Nil, err
+		return uuid.Nil, uuid.Nil, err
 	}
 
 	// find the latest record for this rule/entity pair
@@ -104,10 +105,10 @@ func (e *evaluationHistoryService) StoreEvaluationStatus(
 				},
 			)
 			if err != nil {
-				return uuid.Nil, fmt.Errorf("error while creating new rule/entity in database: %w", err)
+				return uuid.Nil, uuid.Nil, fmt.Errorf("error while creating new rule/entity in database: %w", err)
 			}
 		} else {
-			return uuid.Nil, fmt.Errorf("error while querying DB: %w", err)
+			return uuid.Nil, uuid.Nil, fmt.Errorf("error while querying DB: %w", err)
 		}
 	} else {
 		ruleEntityID = latestRecord.RuleEntityID
@@ -115,10 +116,10 @@ func (e *evaluationHistoryService) StoreEvaluationStatus(
 
 	evaluationID, err := e.createNewStatus(ctx, qtx, ruleEntityID, profileID, status, details)
 	if err != nil {
-		return uuid.Nil, fmt.Errorf("error while creating new evaluation status for rule/entity %s: %w", ruleEntityID, err)
+		return uuid.Nil, uuid.Nil, fmt.Errorf("error while creating new evaluation status for rule/entity %s: %w", ruleEntityID, err)
 	}
 
-	return evaluationID, nil
+	return evaluationID, ruleEntityID, nil
 }
 
 func (_ *evaluationHistoryService) createNewStatus(

--- a/internal/history/service_test.go
+++ b/internal/history/service_test.go
@@ -114,12 +114,14 @@ func TestStoreEvaluationStatus(t *testing.T) {
 			}
 
 			service := NewEvaluationHistoryService()
-			id, err := service.StoreEvaluationStatus(ctx, store, ruleID, profileID, scenario.EntityType, entityID, errTest)
+			id, ruleEntity, err := service.StoreEvaluationStatus(ctx, store, ruleID, profileID, scenario.EntityType, entityID, errTest)
 			if scenario.ExpectedError == "" {
 				require.Equal(t, evaluationID, id)
+				require.Equal(t, ruleEntityID, ruleEntity)
 				require.NoError(t, err)
 			} else {
 				require.Equal(t, uuid.Nil, id)
+				require.Equal(t, uuid.Nil, ruleEntity)
 				require.ErrorContains(t, err, scenario.ExpectedError)
 			}
 		})


### PR DESCRIPTION
In order to replace the old evaluation status tables, we need to migrate any evaluation statuses to the new tables which predate the introduction of the new evaluation history tables. In order to simplify this migration, create a foreign key link from `rule_evaluations` to `evaluation_rule_entities` (the latter is essentially the new equivalent of the former). A foreign key reference to `rule_instances` is also added, this is also to simplify the migration.

This PR also fixes some issues with the migration introduced in this previous PR.

Tested locally.

# Summary

***Provide a brief overview of the changes and the issue being addressed. 
Explain the rationale and any background necessary for understanding the changes. 
List dependencies required by this change, if any.***

Fixes #(related issue)

## Change Type

***Mark the type of change your PR introduces:***

- [x] Bug fix (resolves an issue without affecting existing features)
- [x] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [ ] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

***Outline how the changes were tested, including steps to reproduce and any relevant configurations. 
Attach screenshots if helpful.***

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [ ] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [x] Included tests that validate the fix or feature.
- [ ] Checked that related changes are merged.
