### PR TITLE
Take selectors into use in executor

### DIFF
--- a/cmd/dev/app/rule_type/rttst.go
+++ b/cmd/dev/app/rule_type/rttst.go
@@ -203,12 +203,25 @@ func testCmdRun(cmd *cobra.Command, _ []string) error {
 func getProfileSelectors(entType minderv1.Entity, profile *minderv1.Profile) (selectors.Selection, error) {
 	selectorEnv := selectors.NewEnv()
 
-	profSel, err := selectorEnv.NewSelectionFromProfile(entType, profile.Selection)
+	profSel, err := selectorEnv.NewSelectionFromProfile(entType, modelSelectionFromProfileSelector(profile.Selection))
 	if err != nil {
 		return nil, fmt.Errorf("error creating selectors: %w", err)
 	}
 
 	return profSel, nil
+}
+
+func modelSelectionFromProfileSelector(sel []*minderv1.Profile_Selector) []models.ProfileSelector {
+	modSel := make([]models.ProfileSelector, 0, len(sel))
+	for _, s := range sel {
+		ms := models.ProfileSelector{
+			Entity:   minderv1.EntityFromString(s.Entity),
+			Selector: s.Selector,
+		}
+		modSel = append(modSel, ms)
+	}
+
+	return modSel
 }
 
 func getEiwFromFile(ruletype *minderv1.RuleType, epath string) (*entities.EntityInfoWrapper, error) {

--- a/cmd/dev/app/rule_type/rttst.go
+++ b/cmd/dev/app/rule_type/rttst.go
@@ -314,7 +314,7 @@ func selectAndEval(
 		return fmt.Errorf("error converting entity to selector entity")
 	}
 
-	selected, err := profileSelectors.Select(selEnt)
+	selected, matchedSelector, err := profileSelectors.Select(selEnt)
 	if err != nil {
 		return fmt.Errorf("error selecting entity: %w", err)
 	}
@@ -323,7 +323,7 @@ func selectAndEval(
 	if selected {
 		evalErr = eng.Eval(ctx, inf, evalStatus)
 	} else {
-		evalErr = errors.NewErrEvaluationSkipped("entity not selected by selectors")
+		evalErr = errors.NewErrEvaluationSkipped("entity not selected by selector %s", matchedSelector)
 	}
 
 	return evalErr

--- a/database/mock/store.go
+++ b/database/mock/store.go
@@ -59,10 +59,10 @@ func (mr *MockStoreMockRecorder) BeginTransaction() *gomock.Call {
 }
 
 // BulkGetProfilesByID mocks base method.
-func (m *MockStore) BulkGetProfilesByID(arg0 context.Context, arg1 []uuid.UUID) ([]db.Profile, error) {
+func (m *MockStore) BulkGetProfilesByID(arg0 context.Context, arg1 []uuid.UUID) ([]db.BulkGetProfilesByIDRow, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "BulkGetProfilesByID", arg0, arg1)
-	ret0, _ := ret[0].([]db.Profile)
+	ret0, _ := ret[0].([]db.BulkGetProfilesByIDRow)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }

--- a/database/query/profiles.sql
+++ b/database/query/profiles.sql
@@ -126,6 +126,6 @@ GROUP BY r.entity_type;
 SELECT COUNT(*) AS num_named_profiles FROM profiles WHERE lower(name) = lower(sqlc.arg(name));
 
 -- name: BulkGetProfilesByID :many
-SELECT *
+SELECT sqlc.embed(profiles)
 FROM profiles
 WHERE id = ANY(sqlc.arg(profile_ids)::UUID[]);

--- a/database/query/profiles.sql
+++ b/database/query/profiles.sql
@@ -126,6 +126,17 @@ GROUP BY r.entity_type;
 SELECT COUNT(*) AS num_named_profiles FROM profiles WHERE lower(name) = lower(sqlc.arg(name));
 
 -- name: BulkGetProfilesByID :many
-SELECT sqlc.embed(profiles)
+WITH helper AS(
+    SELECT pr.id as profid,
+           ARRAY_AGG(ROW(ps.id, ps.profile_id, ps.entity, ps.selector, ps.comment)::profile_selector) AS selectors
+    FROM profiles pr
+             JOIN profile_selectors ps
+                  ON pr.id = ps.profile_id
+    WHERE pr.id = ANY(sqlc.arg(profile_ids)::UUID[])
+    GROUP BY pr.id
+)
+SELECT sqlc.embed(profiles),
+       helper.selectors::profile_selector[] AS profiles_with_selectors
 FROM profiles
+LEFT JOIN helper ON profiles.id = helper.profid
 WHERE id = ANY(sqlc.arg(profile_ids)::UUID[]);

--- a/internal/db/profiles.sql.go
+++ b/internal/db/profiles.sql.go
@@ -14,33 +14,37 @@ import (
 )
 
 const bulkGetProfilesByID = `-- name: BulkGetProfilesByID :many
-SELECT id, name, provider, project_id, remediate, alert, created_at, updated_at, provider_id, subscription_id, display_name, labels
+SELECT profiles.id, profiles.name, profiles.provider, profiles.project_id, profiles.remediate, profiles.alert, profiles.created_at, profiles.updated_at, profiles.provider_id, profiles.subscription_id, profiles.display_name, profiles.labels
 FROM profiles
 WHERE id = ANY($1::UUID[])
 `
 
-func (q *Queries) BulkGetProfilesByID(ctx context.Context, profileIds []uuid.UUID) ([]Profile, error) {
+type BulkGetProfilesByIDRow struct {
+	Profile Profile `json:"profile"`
+}
+
+func (q *Queries) BulkGetProfilesByID(ctx context.Context, profileIds []uuid.UUID) ([]BulkGetProfilesByIDRow, error) {
 	rows, err := q.db.QueryContext(ctx, bulkGetProfilesByID, pq.Array(profileIds))
 	if err != nil {
 		return nil, err
 	}
 	defer rows.Close()
-	items := []Profile{}
+	items := []BulkGetProfilesByIDRow{}
 	for rows.Next() {
-		var i Profile
+		var i BulkGetProfilesByIDRow
 		if err := rows.Scan(
-			&i.ID,
-			&i.Name,
-			&i.Provider,
-			&i.ProjectID,
-			&i.Remediate,
-			&i.Alert,
-			&i.CreatedAt,
-			&i.UpdatedAt,
-			&i.ProviderID,
-			&i.SubscriptionID,
-			&i.DisplayName,
-			pq.Array(&i.Labels),
+			&i.Profile.ID,
+			&i.Profile.Name,
+			&i.Profile.Provider,
+			&i.Profile.ProjectID,
+			&i.Profile.Remediate,
+			&i.Profile.Alert,
+			&i.Profile.CreatedAt,
+			&i.Profile.UpdatedAt,
+			&i.Profile.ProviderID,
+			&i.Profile.SubscriptionID,
+			&i.Profile.DisplayName,
+			pq.Array(&i.Profile.Labels),
 		); err != nil {
 			return nil, err
 		}

--- a/internal/db/querier.go
+++ b/internal/db/querier.go
@@ -13,7 +13,7 @@ import (
 )
 
 type Querier interface {
-	BulkGetProfilesByID(ctx context.Context, profileIds []uuid.UUID) ([]Profile, error)
+	BulkGetProfilesByID(ctx context.Context, profileIds []uuid.UUID) ([]BulkGetProfilesByIDRow, error)
 	CountProfilesByEntityType(ctx context.Context) ([]CountProfilesByEntityTypeRow, error)
 	CountProfilesByName(ctx context.Context, name string) (int64, error)
 	CountRepositories(ctx context.Context) (int64, error)

--- a/internal/engine/executor.go
+++ b/internal/engine/executor.go
@@ -136,8 +136,9 @@ func (e *executor) EvalEntityEvent(ctx context.Context, inf *entities.EntityInfo
 		return fmt.Errorf("error while retrieving profiles and rule instances: %w", err)
 	}
 
-	// For each profile, get the profile-override status. Then, if there is no profile-override status,
-	// evaluate each rule and store the outcome in the database or store the override status for all rules
+	// For each profile, get the profileEvalStatus first. Then, if the profileEvalStatus is nil
+	// evaluate each rule and store the outcome in the database. If profileEvalStatus is non-nil,
+	// just store it for all rules without evaluation.
 	for _, profile := range profileAggregates {
 
 		profileEvalStatus := e.profileEvalStatus(ctx, provider, inf, profile)

--- a/internal/engine/executor.go
+++ b/internal/engine/executor.go
@@ -224,13 +224,13 @@ func (e *executor) profileEvalStatus(
 		return fmt.Errorf("error converting entity to selector entity")
 	}
 
-	selected, err := selection.Select(selEnt)
+	selected, matchedSelector, err := selection.Select(selEnt)
 	if err != nil {
 		return fmt.Errorf("error selecting entity: %w", err)
 	}
 
 	if !selected {
-		return evalerrors.NewErrEvaluationSkipped("entity not applicable due to profile selector")
+		return evalerrors.NewErrEvaluationSkipped("entity not applicable due to profile selector %s", matchedSelector)
 	}
 
 	return nil

--- a/internal/engine/executor.go
+++ b/internal/engine/executor.go
@@ -32,11 +32,13 @@ import (
 	"github.com/stacklok/minder/internal/engine/ingestcache"
 	engif "github.com/stacklok/minder/internal/engine/interfaces"
 	"github.com/stacklok/minder/internal/engine/rtengine"
+	"github.com/stacklok/minder/internal/engine/selectors"
 	"github.com/stacklok/minder/internal/history"
 	minderlogger "github.com/stacklok/minder/internal/logger"
 	"github.com/stacklok/minder/internal/profiles"
 	"github.com/stacklok/minder/internal/profiles/models"
 	"github.com/stacklok/minder/internal/providers/manager"
+	provsel "github.com/stacklok/minder/internal/providers/selectors"
 	pb "github.com/stacklok/minder/pkg/api/protobuf/go/minder/v1"
 	provinfv1 "github.com/stacklok/minder/pkg/providers/v1"
 )
@@ -55,6 +57,7 @@ type executor struct {
 	historyService  history.EvaluationHistoryService
 	featureFlags    openfeature.IClient
 	profileStore    profiles.ProfileStore
+	selBuilder      selectors.SelectionBuilder
 }
 
 // NewExecutor creates a new executor
@@ -65,6 +68,7 @@ func NewExecutor(
 	historyService history.EvaluationHistoryService,
 	featureFlags openfeature.IClient,
 	profileStore profiles.ProfileStore,
+	selBuilder selectors.SelectionBuilder,
 ) Executor {
 	return &executor{
 		querier:         querier,
@@ -73,6 +77,7 @@ func NewExecutor(
 		historyService:  historyService,
 		featureFlags:    featureFlags,
 		profileStore:    profileStore,
+		selBuilder:      selBuilder,
 	}
 }
 
@@ -131,10 +136,14 @@ func (e *executor) EvalEntityEvent(ctx context.Context, inf *entities.EntityInfo
 		return fmt.Errorf("error while retrieving profiles and rule instances: %w", err)
 	}
 
-	// For each profile, evaluate each rule and store the outcome in the database
+	// For each profile, get the profile-override status. Then, if there is no profile-override status,
+	// evaluate each rule and store the outcome in the database or store the override status for all rules
 	for _, profile := range profileAggregates {
+
+		profileEvalStatus := e.profileEvalStatus(ctx, provider, inf, profile)
+
 		for _, rule := range profile.Rules {
-			if err := e.evaluateRule(ctx, inf, provider, &profile, &rule, ruleEngineCache); err != nil {
+			if err := e.evaluateRule(ctx, inf, provider, &profile, &rule, ruleEngineCache, profileEvalStatus); err != nil {
 				return fmt.Errorf("error evaluating entity event: %w", err)
 			}
 		}
@@ -150,6 +159,7 @@ func (e *executor) evaluateRule(
 	profile *models.ProfileAggregate,
 	rule *models.RuleInstance,
 	ruleEngineCache rtengine.Cache,
+	profileEvalStatus error,
 ) error {
 	// Create eval status params
 	evalParams, err := e.createEvalStatusParams(ctx, inf, profile, rule)
@@ -176,7 +186,12 @@ func (e *executor) evaluateRule(
 	defer e.updateLockLease(ctx, *inf.ExecutionID, evalParams)
 
 	// Evaluate the rule
-	evalErr := ruleEngine.Eval(ctx, inf, evalParams)
+	var evalErr error
+	if profileEvalStatus != nil {
+		evalErr = profileEvalStatus
+	} else {
+		evalErr = ruleEngine.Eval(ctx, inf, evalParams)
+	}
 	evalParams.SetEvalErr(evalErr)
 
 	// Perform actionEngine, if any
@@ -188,6 +203,37 @@ func (e *executor) evaluateRule(
 
 	// Create or update the evaluation status
 	return e.createOrUpdateEvalStatus(ctx, evalParams)
+}
+
+func (e *executor) profileEvalStatus(
+	ctx context.Context,
+	provider provinfv1.Provider,
+	eiw *entities.EntityInfoWrapper,
+	aggregate models.ProfileAggregate,
+) error {
+	// so far this function only handles selectors. In the future we can extend it to handle other
+	// profile-global evaluations
+
+	selection, err := e.selBuilder.NewSelectionFromProfile(eiw.Type, aggregate.Selectors)
+	if err != nil {
+		return fmt.Errorf("error creating selection from profile: %w", err)
+	}
+
+	selEnt := provsel.EntityToSelectorEntity(ctx, provider, eiw.Type, eiw.Entity)
+	if selEnt == nil {
+		return fmt.Errorf("error converting entity to selector entity")
+	}
+
+	selected, err := selection.Select(selEnt)
+	if err != nil {
+		return fmt.Errorf("error selecting entity: %w", err)
+	}
+
+	if !selected {
+		return evalerrors.NewErrEvaluationSkipped("entity not applicable due to profile selector")
+	}
+
+	return nil
 }
 
 func (e *executor) updateLockLease(

--- a/internal/engine/executor_test.go
+++ b/internal/engine/executor_test.go
@@ -187,15 +187,17 @@ func TestExecutor_handleEntityEvent(t *testing.T) {
 	// list one profile
 	mockStore.EXPECT().
 		BulkGetProfilesByID(gomock.Any(), []uuid.UUID{profileID}).
-		Return([]db.Profile{
+		Return([]db.BulkGetProfilesByIDRow{
 			{
-				ID:        profileID,
-				Name:      "test-profile",
-				ProjectID: projectID,
-				CreatedAt: time.Now(),
-				UpdatedAt: time.Now(),
-				Alert:     db.NullActionType{Valid: true, ActionType: db.ActionTypeOff},
-				Remediate: db.NullActionType{Valid: true, ActionType: db.ActionTypeOff},
+				Profile: db.Profile{
+					ID:        profileID,
+					Name:      "test-profile",
+					ProjectID: projectID,
+					CreatedAt: time.Now(),
+					UpdatedAt: time.Now(),
+					Alert:     db.NullActionType{Valid: true, ActionType: db.ActionTypeOff},
+					Remediate: db.NullActionType{Valid: true, ActionType: db.ActionTypeOff},
+				},
 			},
 		}, nil)
 

--- a/internal/engine/executor_test.go
+++ b/internal/engine/executor_test.go
@@ -40,6 +40,7 @@ import (
 	"github.com/stacklok/minder/internal/engine/actions/alert"
 	"github.com/stacklok/minder/internal/engine/actions/remediate"
 	"github.com/stacklok/minder/internal/engine/entities"
+	mock_selectors "github.com/stacklok/minder/internal/engine/selectors/mock"
 	"github.com/stacklok/minder/internal/flags"
 	mockhistory "github.com/stacklok/minder/internal/history/mock"
 	"github.com/stacklok/minder/internal/logger"
@@ -357,6 +358,18 @@ default allow = true`,
 			return fn(mockStore)
 		})
 
+	mockSelection := mock_selectors.NewMockSelection(ctrl)
+	mockSelection.EXPECT().
+		Select(gomock.Any(), gomock.Any()).
+		Return(true, nil).
+		AnyTimes()
+
+	mockSelectionBuilder := mock_selectors.NewMockSelectionBuilder(ctrl)
+	mockSelectionBuilder.EXPECT().
+		NewSelectionFromProfile(gomock.Any(), gomock.Any()).
+		Return(mockSelection, nil).
+		AnyTimes()
+
 	executor := engine.NewExecutor(
 		mockStore,
 		providerManager,
@@ -364,6 +377,7 @@ default allow = true`,
 		historyService,
 		&flags.FakeClient{},
 		profiles.NewProfileStore(mockStore),
+		mockSelectionBuilder,
 	)
 
 	eiw := entities.NewEntityInfoWrapper().

--- a/internal/engine/executor_test.go
+++ b/internal/engine/executor_test.go
@@ -361,7 +361,7 @@ default allow = true`,
 	mockSelection := mock_selectors.NewMockSelection(ctrl)
 	mockSelection.EXPECT().
 		Select(gomock.Any(), gomock.Any()).
-		Return(true, nil).
+		Return(true, "", nil).
 		AnyTimes()
 
 	mockSelectionBuilder := mock_selectors.NewMockSelectionBuilder(ctrl)

--- a/internal/engine/selectors/mock/selectors.go
+++ b/internal/engine/selectors/mock/selectors.go
@@ -118,7 +118,7 @@ func (m *MockSelection) EXPECT() *MockSelectionMockRecorder {
 }
 
 // Select mocks base method.
-func (m *MockSelection) Select(arg0 *proto.SelectorEntity, arg1 ...selectors.SelectOption) (bool, error) {
+func (m *MockSelection) Select(arg0 *proto.SelectorEntity, arg1 ...selectors.SelectOption) (bool, string, error) {
 	m.ctrl.T.Helper()
 	varargs := []any{arg0}
 	for _, a := range arg1 {
@@ -126,8 +126,9 @@ func (m *MockSelection) Select(arg0 *proto.SelectorEntity, arg1 ...selectors.Sel
 	}
 	ret := m.ctrl.Call(m, "Select", varargs...)
 	ret0, _ := ret[0].(bool)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
+	ret1, _ := ret[1].(string)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
 }
 
 // Select indicates an expected call of Select.

--- a/internal/engine/selectors/mock/selectors.go
+++ b/internal/engine/selectors/mock/selectors.go
@@ -13,6 +13,7 @@ import (
 	reflect "reflect"
 
 	selectors "github.com/stacklok/minder/internal/engine/selectors"
+	models "github.com/stacklok/minder/internal/profiles/models"
 	proto "github.com/stacklok/minder/internal/proto"
 	v1 "github.com/stacklok/minder/pkg/api/protobuf/go/minder/v1"
 	gomock "go.uber.org/mock/gomock"
@@ -42,7 +43,7 @@ func (m *MockSelectionBuilder) EXPECT() *MockSelectionBuilderMockRecorder {
 }
 
 // NewSelectionFromProfile mocks base method.
-func (m *MockSelectionBuilder) NewSelectionFromProfile(arg0 v1.Entity, arg1 []*v1.Profile_Selector) (selectors.Selection, error) {
+func (m *MockSelectionBuilder) NewSelectionFromProfile(arg0 v1.Entity, arg1 []models.ProfileSelector) (selectors.Selection, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "NewSelectionFromProfile", arg0, arg1)
 	ret0, _ := ret[0].(selectors.Selection)

--- a/internal/engine/selectors/selectors.go
+++ b/internal/engine/selectors/selectors.go
@@ -223,6 +223,7 @@ func newEnvForEntity(varName string, typ any, typName string) (*cel.Env, error) 
 }
 
 type compiledSelector struct {
+	orig    string
 	ast     *cel.Ast
 	program cel.Program
 }
@@ -244,6 +245,7 @@ func compileSelectorForEntity(env *cel.Env, selector string) (*compiledSelector,
 
 	return &compiledSelector{
 		ast:     checked,
+		orig:    selector,
 		program: program,
 	}, nil
 }
@@ -388,7 +390,7 @@ func WithUnknownPaths(paths ...string) SelectOption {
 
 // Selection is an interface for selecting entities based on a profile
 type Selection interface {
-	Select(*internalpb.SelectorEntity, ...SelectOption) (bool, error)
+	Select(*internalpb.SelectorEntity, ...SelectOption) (bool, string, error)
 }
 
 // EntitySelection is a struct that holds the compiled CEL expressions for a given entity type
@@ -400,9 +402,9 @@ type EntitySelection struct {
 }
 
 // Select return true if the entity matches all the compiled expressions and false otherwise
-func (s *EntitySelection) Select(se *internalpb.SelectorEntity, userOpts ...SelectOption) (bool, error) {
+func (s *EntitySelection) Select(se *internalpb.SelectorEntity, userOpts ...SelectOption) (bool, string, error) {
 	if se == nil {
-		return false, fmt.Errorf("input entity is nil")
+		return false, "", fmt.Errorf("input entity is nil")
 	}
 
 	var opts selectionOptions
@@ -413,34 +415,34 @@ func (s *EntitySelection) Select(se *internalpb.SelectorEntity, userOpts ...Sele
 	for _, sel := range s.selector {
 		entityMap, err := inputAsMap(se)
 		if err != nil {
-			return false, fmt.Errorf("failed to convert input to map: %w", err)
+			return false, "", fmt.Errorf("failed to convert input to map: %w", err)
 		}
 
 		out, details, err := s.evalWithOpts(&opts, sel, entityMap)
 		// check unknowns /before/ an error. Maybe we should try to special-case the one
 		// error we get from the CEL library in this case and check for the rest?
 		if s.detailHasUnknowns(sel, details) {
-			return false, ErrResultUnknown
+			return false, "", ErrResultUnknown
 		}
 
 		if err != nil {
-			return false, fmt.Errorf("failed to evaluate Expression: %w", err)
+			return false, "", fmt.Errorf("failed to evaluate Expression: %w", err)
 		}
 
 		if types.IsUnknown(out) {
-			return false, ErrResultUnknown
+			return false, "", ErrResultUnknown
 		}
 
 		if out.Type() != cel.BoolType {
-			return false, fmt.Errorf("expression did not evaluate to a boolean: %v", out)
+			return false, "", fmt.Errorf("expression did not evaluate to a boolean: %v", out)
 		}
 
 		if !out.Value().(bool) {
-			return false, nil
+			return false, sel.orig, nil
 		}
 	}
 
-	return true, nil
+	return true, "", nil
 }
 
 func unknownAttributesFromOpts(unknownPaths []string) []*interpreter.AttributePattern {

--- a/internal/engine/selectors/selectors.go
+++ b/internal/engine/selectors/selectors.go
@@ -31,6 +31,7 @@ import (
 	"github.com/google/cel-go/common/types/ref"
 	"github.com/google/cel-go/interpreter"
 
+	"github.com/stacklok/minder/internal/profiles/models"
 	internalpb "github.com/stacklok/minder/internal/proto"
 	minderv1 "github.com/stacklok/minder/pkg/api/protobuf/go/minder/v1"
 )
@@ -265,7 +266,7 @@ func checkSelectorForEntity(env *cel.Env, selector string) (*cel.Ast, error) {
 // for an entity type. This is what the user of this module uses. The interface makes it easier to pass
 // mocks by the user of this module.
 type SelectionBuilder interface {
-	NewSelectionFromProfile(minderv1.Entity, []*minderv1.Profile_Selector) (Selection, error)
+	NewSelectionFromProfile(minderv1.Entity, []models.ProfileSelector) (Selection, error)
 }
 
 // SelectionChecker is an interface for checking if a selector expression is valid for a given entity type
@@ -315,7 +316,7 @@ func NewEnv() *Env {
 // from a profile
 func (e *Env) NewSelectionFromProfile(
 	entityType minderv1.Entity,
-	profileSelection []*minderv1.Profile_Selector,
+	profileSelection []models.ProfileSelector,
 ) (Selection, error) {
 	selector := make([]*compiledSelector, 0, len(profileSelection))
 
@@ -325,8 +326,7 @@ func (e *Env) NewSelectionFromProfile(
 	}
 
 	for _, sel := range profileSelection {
-		ent := minderv1.EntityFromString(sel.GetEntity())
-		if ent != entityType && ent != minderv1.Entity_ENTITY_UNSPECIFIED {
+		if sel.Entity != entityType && sel.Entity != minderv1.Entity_ENTITY_UNSPECIFIED {
 			continue
 		}
 

--- a/internal/engine/selectors/selectors_test.go
+++ b/internal/engine/selectors/selectors_test.go
@@ -550,7 +550,7 @@ func TestSelectSelectorEntity(t *testing.T) {
 			require.NoError(t, err)
 			require.NotNil(t, sels)
 
-			selected, err := sels.Select(se, scenario.selectOptions...)
+			selected, matchedSelector, err := sels.Select(se, scenario.selectOptions...)
 			if scenario.expectedSelectErr != nil {
 				require.Error(t, err)
 				require.Equal(t, scenario.expectedSelectErr, err)
@@ -559,6 +559,11 @@ func TestSelectSelectorEntity(t *testing.T) {
 
 			require.NoError(t, err)
 			require.Equal(t, scenario.selected, selected)
+			if !selected {
+				// TODO(jakub): Add tests with more selectors. If we have more than one selector, we should
+				// also match against an expected index
+				require.Equal(t, scenario.exprs[0].Selector, matchedSelector)
+			}
 		})
 	}
 }
@@ -666,13 +671,13 @@ func TestSelectorEntityFillProperties(t *testing.T) {
 		require.NoError(t, err)
 		require.NotNil(t, sels)
 
-		_, err = sels.Select(se, WithUnknownPaths("repository.properties"))
+		_, _, err = sels.Select(se, WithUnknownPaths("repository.properties"))
 		require.ErrorIs(t, err, ErrResultUnknown)
 
 		// simulate fetching properties
 		scenario.mockFetch(se)
 
-		selected, err := sels.Select(se)
+		selected, _, err := sels.Select(se)
 		if scenario.secondSucceeds {
 			require.NoError(t, err)
 			require.True(t, selected)

--- a/internal/engine/selectors/selectors_test.go
+++ b/internal/engine/selectors/selectors_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/types/known/structpb"
 
+	"github.com/stacklok/minder/internal/profiles/models"
 	internalpb "github.com/stacklok/minder/internal/proto"
 	minderv1 "github.com/stacklok/minder/pkg/api/protobuf/go/minder/v1"
 )
@@ -135,26 +136,26 @@ func TestSelectSelectorEntity(t *testing.T) {
 
 	scenarios := []struct {
 		name                       string
-		exprs                      []*minderv1.Profile_Selector
+		exprs                      []models.ProfileSelector
 		selectOptions              []SelectOption
 		selectorEntityBld          testSelectorEntityBuilder
 		expectedNewSelectionErrMsg string
 		expectedNewSelectionErr    error
-		expectedStructuredErr      *ErrStructure
 		expectedSelectErr          error
+		expectedStructuredErr      *ErrStructure
 		selected                   bool
 	}{
 		{
 			name:              "No selectors",
-			exprs:             []*minderv1.Profile_Selector{},
+			exprs:             []models.ProfileSelector{},
 			selectorEntityBld: newTestRepoSelectorEntity(),
 			selected:          true,
 		},
 		{
 			name: "Simple true repository expression",
-			exprs: []*minderv1.Profile_Selector{
+			exprs: []models.ProfileSelector{
 				{
-					Entity:   minderv1.RepositoryEntity.String(),
+					Entity:   minderv1.Entity_ENTITY_REPOSITORIES,
 					Selector: "repository.name == 'testorg/testrepo'",
 				},
 			},
@@ -163,9 +164,9 @@ func TestSelectSelectorEntity(t *testing.T) {
 		},
 		{
 			name: "Simple true artifact expression",
-			exprs: []*minderv1.Profile_Selector{
+			exprs: []models.ProfileSelector{
 				{
-					Entity:   minderv1.ArtifactEntity.String(),
+					Entity:   minderv1.Entity_ENTITY_ARTIFACTS,
 					Selector: "artifact.type == 'container'",
 				},
 			},
@@ -174,9 +175,9 @@ func TestSelectSelectorEntity(t *testing.T) {
 		},
 		{
 			name: "Simple false artifact expression",
-			exprs: []*minderv1.Profile_Selector{
+			exprs: []models.ProfileSelector{
 				{
-					Entity:   minderv1.ArtifactEntity.String(),
+					Entity:   minderv1.Entity_ENTITY_ARTIFACTS,
 					Selector: "artifact.type != 'container'",
 				},
 			},
@@ -185,9 +186,9 @@ func TestSelectSelectorEntity(t *testing.T) {
 		},
 		{
 			name: "Simple false repository expression",
-			exprs: []*minderv1.Profile_Selector{
+			exprs: []models.ProfileSelector{
 				{
-					Entity:   minderv1.RepositoryEntity.String(),
+					Entity:   minderv1.Entity_ENTITY_REPOSITORIES,
 					Selector: "repository.name != 'testorg/testrepo'",
 				},
 			},
@@ -196,9 +197,9 @@ func TestSelectSelectorEntity(t *testing.T) {
 		},
 		{
 			name: "Simple true pull request expression",
-			exprs: []*minderv1.Profile_Selector{
+			exprs: []models.ProfileSelector{
 				{
-					Entity:   minderv1.PullRequestEntity.String(),
+					Entity:   minderv1.Entity_ENTITY_PULL_REQUESTS,
 					Selector: "pull_request.name == 'testorg/testrepo/123'",
 				},
 			},
@@ -207,9 +208,9 @@ func TestSelectSelectorEntity(t *testing.T) {
 		},
 		{
 			name: "Simple false pull request expression",
-			exprs: []*minderv1.Profile_Selector{
+			exprs: []models.ProfileSelector{
 				{
-					Entity:   minderv1.PullRequestEntity.String(),
+					Entity:   minderv1.Entity_ENTITY_PULL_REQUESTS,
 					Selector: "pull_request.name != 'testorg/testrepo/123'",
 				},
 			},
@@ -218,9 +219,9 @@ func TestSelectSelectorEntity(t *testing.T) {
 		},
 		{
 			name: "Simple true generic entity expression for repo entity type",
-			exprs: []*minderv1.Profile_Selector{
+			exprs: []models.ProfileSelector{
 				{
-					Entity:   minderv1.RepositoryEntity.String(),
+					Entity:   minderv1.Entity_ENTITY_REPOSITORIES,
 					Selector: "entity.name == 'testorg/testrepo'",
 				},
 			},
@@ -229,9 +230,9 @@ func TestSelectSelectorEntity(t *testing.T) {
 		},
 		{
 			name: "Simple false generic entity expression for repo entity type",
-			exprs: []*minderv1.Profile_Selector{
+			exprs: []models.ProfileSelector{
 				{
-					Entity:   minderv1.RepositoryEntity.String(),
+					Entity:   minderv1.Entity_ENTITY_REPOSITORIES,
 					Selector: "entity.name != 'testorg/testrepo'",
 				},
 			},
@@ -240,9 +241,9 @@ func TestSelectSelectorEntity(t *testing.T) {
 		},
 		{
 			name: "Simple true generic entity expression for unspecified entity type",
-			exprs: []*minderv1.Profile_Selector{
+			exprs: []models.ProfileSelector{
 				{
-					Entity:   "",
+					Entity:   minderv1.Entity_ENTITY_UNSPECIFIED,
 					Selector: "entity.name == 'testorg/testrepo'",
 				},
 			},
@@ -251,9 +252,9 @@ func TestSelectSelectorEntity(t *testing.T) {
 		},
 		{
 			name: "Simple false generic entity expression for unspecified entity type",
-			exprs: []*minderv1.Profile_Selector{
+			exprs: []models.ProfileSelector{
 				{
-					Entity:   "",
+					Entity:   minderv1.Entity_ENTITY_UNSPECIFIED,
 					Selector: "entity.name != 'testorg/testrepo'",
 				},
 			},
@@ -262,13 +263,13 @@ func TestSelectSelectorEntity(t *testing.T) {
 		},
 		{
 			name: "Expressions for different types than the entity are skipped",
-			exprs: []*minderv1.Profile_Selector{
+			exprs: []models.ProfileSelector{
 				{
-					Entity:   minderv1.ArtifactEntity.String(),
+					Entity:   minderv1.Entity_ENTITY_ARTIFACTS,
 					Selector: "artifact.name != 'namespace/containername'",
 				},
 				{
-					Entity:   minderv1.PullRequestEntity.String(),
+					Entity:   minderv1.Entity_ENTITY_PULL_REQUESTS,
 					Selector: "pull_request.name != 'namespace/containername'",
 				},
 			},
@@ -277,9 +278,9 @@ func TestSelectSelectorEntity(t *testing.T) {
 		},
 		{
 			name: "Expression on is_fork bool attribute set to true",
-			exprs: []*minderv1.Profile_Selector{
+			exprs: []models.ProfileSelector{
 				{
-					Entity:   minderv1.RepositoryEntity.String(),
+					Entity:   minderv1.Entity_ENTITY_REPOSITORIES,
 					Selector: "repository.is_fork == true",
 				},
 			},
@@ -288,9 +289,9 @@ func TestSelectSelectorEntity(t *testing.T) {
 		},
 		{
 			name: "Expression on is_fork bool attribute set to false",
-			exprs: []*minderv1.Profile_Selector{
+			exprs: []models.ProfileSelector{
 				{
-					Entity:   minderv1.RepositoryEntity.String(),
+					Entity:   minderv1.Entity_ENTITY_REPOSITORIES,
 					Selector: "repository.is_fork == true",
 				},
 			},
@@ -299,9 +300,9 @@ func TestSelectSelectorEntity(t *testing.T) {
 		},
 		{
 			name: "Expression on is_fork bool attribute set to nil and true expression",
-			exprs: []*minderv1.Profile_Selector{
+			exprs: []models.ProfileSelector{
 				{
-					Entity:   minderv1.RepositoryEntity.String(),
+					Entity:   minderv1.Entity_ENTITY_REPOSITORIES,
 					Selector: "repository.is_fork == true",
 				},
 			},
@@ -310,9 +311,9 @@ func TestSelectSelectorEntity(t *testing.T) {
 		},
 		{
 			name: "Expression on is_fork bool attribute set to nil and false expression",
-			exprs: []*minderv1.Profile_Selector{
+			exprs: []models.ProfileSelector{
 				{
-					Entity:   minderv1.RepositoryEntity.String(),
+					Entity:   minderv1.Entity_ENTITY_REPOSITORIES,
 					Selector: "repository.is_fork == false",
 				},
 			},
@@ -321,9 +322,9 @@ func TestSelectSelectorEntity(t *testing.T) {
 		},
 		{
 			name: "Wrong entity type - repo selector uses artifact",
-			exprs: []*minderv1.Profile_Selector{
+			exprs: []models.ProfileSelector{
 				{
-					Entity:   minderv1.RepositoryEntity.String(),
+					Entity:   minderv1.Entity_ENTITY_REPOSITORIES,
 					Selector: "artifact.name != 'testorg/testrepo'",
 				},
 			},
@@ -333,9 +334,9 @@ func TestSelectSelectorEntity(t *testing.T) {
 		},
 		{
 			name: "CEL expression that does not parse",
-			exprs: []*minderv1.Profile_Selector{
+			exprs: []models.ProfileSelector{
 				{
-					Entity:   minderv1.RepositoryEntity.String(),
+					Entity:   minderv1.Entity_ENTITY_REPOSITORIES,
 					Selector: "repository.name == ",
 				},
 			},
@@ -345,9 +346,9 @@ func TestSelectSelectorEntity(t *testing.T) {
 		},
 		{
 			name: "Attempt to use a repo attribute that doesn't exist",
-			exprs: []*minderv1.Profile_Selector{
+			exprs: []models.ProfileSelector{
 				{
-					Entity:   minderv1.RepositoryEntity.String(),
+					Entity:   minderv1.Entity_ENTITY_REPOSITORIES,
 					Selector: "repository.iamnothere == 'value'",
 				},
 			},
@@ -371,9 +372,9 @@ func TestSelectSelectorEntity(t *testing.T) {
 		},
 		{
 			name: "Use a property that is defined and true result",
-			exprs: []*minderv1.Profile_Selector{
+			exprs: []models.ProfileSelector{
 				{
-					Entity:   minderv1.RepositoryEntity.String(),
+					Entity:   minderv1.Entity_ENTITY_REPOSITORIES,
 					Selector: "repository.properties.github['is_fork'] == false",
 				},
 			},
@@ -386,9 +387,9 @@ func TestSelectSelectorEntity(t *testing.T) {
 		},
 		{
 			name: "Use a string property that is defined and true result",
-			exprs: []*minderv1.Profile_Selector{
+			exprs: []models.ProfileSelector{
 				{
-					Entity:   minderv1.RepositoryEntity.String(),
+					Entity:   minderv1.Entity_ENTITY_REPOSITORIES,
 					Selector: "repository.properties.license == 'MIT'",
 				},
 			},
@@ -401,9 +402,9 @@ func TestSelectSelectorEntity(t *testing.T) {
 		},
 		{
 			name: "Use a string property that is defined and false result",
-			exprs: []*minderv1.Profile_Selector{
+			exprs: []models.ProfileSelector{
 				{
-					Entity:   minderv1.RepositoryEntity.String(),
+					Entity:   minderv1.Entity_ENTITY_REPOSITORIES,
 					Selector: "repository.properties.license == 'MIT'",
 				},
 			},
@@ -416,9 +417,9 @@ func TestSelectSelectorEntity(t *testing.T) {
 		},
 		{
 			name: "Use a property that is defined and false result",
-			exprs: []*minderv1.Profile_Selector{
+			exprs: []models.ProfileSelector{
 				{
-					Entity:   minderv1.RepositoryEntity.String(),
+					Entity:   minderv1.Entity_ENTITY_REPOSITORIES,
 					Selector: "repository.properties.github['is_fork'] == false",
 				},
 			},
@@ -431,9 +432,9 @@ func TestSelectSelectorEntity(t *testing.T) {
 		},
 		{
 			name: "Properties are non-nil but we use one that is not defined",
-			exprs: []*minderv1.Profile_Selector{
+			exprs: []models.ProfileSelector{
 				{
-					Entity:   minderv1.RepositoryEntity.String(),
+					Entity:   minderv1.Entity_ENTITY_REPOSITORIES,
 					Selector: "repository.properties.github['is_private'] != true",
 				},
 			},
@@ -447,9 +448,9 @@ func TestSelectSelectorEntity(t *testing.T) {
 		},
 		{
 			name: "Attempt to use a property while having nil properties",
-			exprs: []*minderv1.Profile_Selector{
+			exprs: []models.ProfileSelector{
 				{
-					Entity:   minderv1.RepositoryEntity.String(),
+					Entity:   minderv1.Entity_ENTITY_REPOSITORIES,
 					Selector: "repository.properties.github['is_fork'] != 'true'",
 				},
 			},
@@ -459,9 +460,9 @@ func TestSelectSelectorEntity(t *testing.T) {
 		},
 		{
 			name: "The selector shortcuts if evaluation is not needed for properties",
-			exprs: []*minderv1.Profile_Selector{
+			exprs: []models.ProfileSelector{
 				{
-					Entity:   minderv1.RepositoryEntity.String(),
+					Entity:   minderv1.Entity_ENTITY_REPOSITORIES,
 					Selector: "repository.name == 'testorg/testrepo' || repository.properties.github['is_fork'] != 'true'",
 				},
 			},
@@ -470,9 +471,9 @@ func TestSelectSelectorEntity(t *testing.T) {
 		},
 		{
 			name: "Attempt to use a property but explicitly tell Select that it's not defined",
-			exprs: []*minderv1.Profile_Selector{
+			exprs: []models.ProfileSelector{
 				{
-					Entity:   minderv1.RepositoryEntity.String(),
+					Entity:   minderv1.Entity_ENTITY_REPOSITORIES,
 					Selector: "repository.properties.github['is_fork'] != 'true'",
 				},
 			},
@@ -489,9 +490,9 @@ func TestSelectSelectorEntity(t *testing.T) {
 		},
 		{
 			name: "Use a PR property that is defined and true result",
-			exprs: []*minderv1.Profile_Selector{
+			exprs: []models.ProfileSelector{
 				{
-					Entity:   minderv1.PullRequestEntity.String(),
+					Entity:   minderv1.Entity_ENTITY_PULL_REQUESTS,
 					Selector: "pull_request.properties.github['is_draft'] == false",
 				},
 			},
@@ -504,9 +505,9 @@ func TestSelectSelectorEntity(t *testing.T) {
 		},
 		{
 			name: "Use a PR property that is defined and false result",
-			exprs: []*minderv1.Profile_Selector{
+			exprs: []models.ProfileSelector{
 				{
-					Entity:   minderv1.PullRequestEntity.String(),
+					Entity:   minderv1.Entity_ENTITY_PULL_REQUESTS,
 					Selector: "pull_request.properties.github['is_draft'] == false",
 				},
 			},
@@ -593,15 +594,15 @@ func TestSelectorEntityFillProperties(t *testing.T) {
 
 	scenarios := []struct {
 		name           string
-		exprs          []*minderv1.Profile_Selector
+		exprs          []models.ProfileSelector
 		mockFetch      func(*internalpb.SelectorEntity)
 		secondSucceeds bool
 	}{
 		{
 			name: "Fetch a property that exists",
-			exprs: []*minderv1.Profile_Selector{
+			exprs: []models.ProfileSelector{
 				{
-					Entity:   minderv1.RepositoryEntity.String(),
+					Entity:   minderv1.Entity_ENTITY_REPOSITORIES,
 					Selector: "repository.properties.github['is_fork'] == false",
 				},
 			},
@@ -627,9 +628,9 @@ func TestSelectorEntityFillProperties(t *testing.T) {
 		},
 		{
 			name: "Fail to fetch a property",
-			exprs: []*minderv1.Profile_Selector{
+			exprs: []models.ProfileSelector{
 				{
-					Entity:   minderv1.RepositoryEntity.String(),
+					Entity:   minderv1.Entity_ENTITY_REPOSITORIES,
 					Selector: "repository.properties.github['is_private'] == false",
 				},
 			},

--- a/internal/profiles/store.go
+++ b/internal/profiles/store.go
@@ -101,7 +101,8 @@ func (p *profileStore) GetProfilesForEvaluation(
 				Remediate: models.ActionOptFromDB(profile.Profile.Remediate),
 				Alert:     models.ActionOptFromDB(profile.Profile.Alert),
 			},
-			Rules: profileRules,
+			Rules:     profileRules,
+			Selectors: models.SelectorSliceFromDB(profile.ProfilesWithSelectors),
 		}
 		aggregates = append(aggregates, aggregate)
 	}

--- a/internal/profiles/store.go
+++ b/internal/profiles/store.go
@@ -90,16 +90,16 @@ func (p *profileStore) GetProfilesForEvaluation(
 	// Finally, create the ProfileAggregate instances
 	aggregates := make([]models.ProfileAggregate, len(profiles))
 	for _, profile := range profiles {
-		profileRules, ok := rulesByProfileID[profile.ID]
+		profileRules, ok := rulesByProfileID[profile.Profile.ID]
 		if !ok {
-			return nil, fmt.Errorf("could not find rule instances for profile %s: %w", profile.ID, err)
+			return nil, fmt.Errorf("could not find rule instances for profile %s: %w", profile.Profile.ID, err)
 		}
 		aggregate := models.ProfileAggregate{
-			ID:   profile.ID,
-			Name: profile.Name,
+			ID:   profile.Profile.ID,
+			Name: profile.Profile.Name,
 			ActionConfig: models.ActionConfiguration{
-				Remediate: models.ActionOptFromDB(profile.Remediate),
-				Alert:     models.ActionOptFromDB(profile.Alert),
+				Remediate: models.ActionOptFromDB(profile.Profile.Remediate),
+				Alert:     models.ActionOptFromDB(profile.Profile.Alert),
 			},
 			Rules: profileRules,
 		}

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -36,6 +36,7 @@ import (
 	"github.com/stacklok/minder/internal/email/awsses"
 	"github.com/stacklok/minder/internal/email/noop"
 	"github.com/stacklok/minder/internal/engine"
+	"github.com/stacklok/minder/internal/engine/selectors"
 	"github.com/stacklok/minder/internal/events"
 	"github.com/stacklok/minder/internal/flags"
 	"github.com/stacklok/minder/internal/history"
@@ -190,6 +191,7 @@ func AllInOneServerService(
 	}
 
 	profileStore := profiles.NewProfileStore(store)
+	selEnv := selectors.NewEnv()
 
 	// Register the executor to handle entity evaluations
 	exec := engine.NewExecutor(
@@ -199,6 +201,7 @@ func AllInOneServerService(
 		history.NewEvaluationHistoryService(),
 		featureFlagClient,
 		profileStore,
+		selEnv,
 	)
 
 	handler := engine.NewExecutorEventHandler(


### PR DESCRIPTION
# Summary

- **Change the BulkGetProfilesByID DB query to return an embedded profile** - This will make it easier to extend what the query returns
- **Extend the BulkGetProfilesByID DB query with selectors** - This is to return the selectors at the same time as querying the profiles from the DB and be able to use them in the executor.
- **Extend the ProfileAggregate structure with selectors** - returns the selectors to the engine through the ProfileAggregate struct
- **Change the selector's NewSelectionFromProfile API to accept the structure from the models API** - This will make it easier to use the method in the executor
- **Integrate the selectors into the executor** - When an entity is not selected for a profile, let's save that into a  profile-global status override and use that for all the statuses instead of calling eval
- **Include which selector did unselect the entity** - In addition to returning a bool, let's also return which selector did shortcut the evaluation when returning false

Fixes: #3724
Fixes: #3725 

## Change Type

- [ ] Bug fix (resolves an issue without affecting existing features)
- [x] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [ ] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

manual

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [x] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [x] Included tests that validate the fix or feature.
- [ ] Checked that related changes are merged.
