### PR TITLE
Surface selector check errors to handlers

### DIFF
--- a/internal/controlplane/handlers_profile_test.go
+++ b/internal/controlplane/handlers_profile_test.go
@@ -201,7 +201,7 @@ func TestCreateProfile(t *testing.T) {
 					Selection: []*minderv1.Profile_Selector{
 						{
 							Entity:      "repository",
-							Selector:    "repository.name != stacklok/demo-repo-go",
+							Selector:    "repository.name != 'stacklok/demo-repo-go'",
 							Description: "Exclude stacklok/demo-repo-go",
 						},
 					},
@@ -220,7 +220,7 @@ func TestCreateProfile(t *testing.T) {
 					Selection: []*minderv1.Profile_Selector{
 						{
 							Entity:      "repository",
-							Selector:    "repository.name != stacklok/demo-repo-go",
+							Selector:    "repository.name != 'stacklok/demo-repo-go'",
 							Description: "Exclude stacklok/demo-repo-go",
 						},
 					},
@@ -241,7 +241,7 @@ func TestCreateProfile(t *testing.T) {
 					Selection: []*minderv1.Profile_Selector{
 						{
 							Entity:      "no_such_entity",
-							Selector:    "repository.name != stacklok/demo-repo-go",
+							Selector:    "repository.name != 'stacklok/demo-repo-go'",
 							Description: "Exclude stacklok/demo-repo-go",
 						},
 					},
@@ -265,7 +265,7 @@ func TestCreateProfile(t *testing.T) {
 							// this entity is valid in the sense that it converts to an entity type but
 							// the current selelectors implementation does not support it
 							Entity:      "build_environment",
-							Selector:    "repository.name != stacklok/demo-repo-go",
+							Selector:    "repository.name != 'stacklok/demo-repo-go'",
 							Description: "Exclude stacklok/demo-repo-go",
 						},
 					},
@@ -820,7 +820,7 @@ func TestPatchProfile(t *testing.T) {
 					Selection: []*minderv1.Profile_Selector{
 						{
 							Entity:      "repository",
-							Selector:    "repository.name != stacklok/demo-repo-go",
+							Selector:    "repository.name != 'stacklok/demo-repo-go'",
 							Description: "Exclude stacklok/demo-repo-go",
 						},
 					},
@@ -842,7 +842,7 @@ func TestPatchProfile(t *testing.T) {
 					Selection: []*minderv1.Profile_Selector{
 						{
 							Entity:      "repository",
-							Selector:    "repository.name != stacklok/demo-repo-go",
+							Selector:    "repository.name != 'stacklok/demo-repo-go'",
 							Description: "Exclude stacklok/demo-repo-go",
 						},
 					},
@@ -863,7 +863,7 @@ func TestPatchProfile(t *testing.T) {
 					Selection: []*minderv1.Profile_Selector{
 						{
 							Entity:      "repository",
-							Selector:    "repository.name != stacklok/demo-repo-go",
+							Selector:    "repository.name != 'stacklok/demo-repo-go'",
 							Description: "Exclude stacklok/demo-repo-go",
 						},
 						{
@@ -880,7 +880,7 @@ func TestPatchProfile(t *testing.T) {
 					Selection: []*minderv1.Profile_Selector{
 						{
 							Entity:      "repository",
-							Selector:    "repository.name != stacklok/demo-repo-go",
+							Selector:    "repository.name != 'stacklok/demo-repo-go'",
 							Description: "Exclude stacklok/demo-repo-go",
 						},
 						{
@@ -907,7 +907,7 @@ func TestPatchProfile(t *testing.T) {
 					Selection: []*minderv1.Profile_Selector{
 						{
 							Entity:      "repository",
-							Selector:    "repository.name != stacklok/demo-repo-go",
+							Selector:    "repository.name != 'stacklok/demo-repo-go'",
 							Description: "Exclude stacklok/demo-repo-go",
 						},
 						{
@@ -933,7 +933,7 @@ func TestPatchProfile(t *testing.T) {
 					Selection: []*minderv1.Profile_Selector{
 						{
 							Entity:      "repository",
-							Selector:    "repository.name != stacklok/demo-repo-go",
+							Selector:    "repository.name != 'stacklok/demo-repo-go'",
 							Description: "Exclude stacklok/demo-repo-go",
 						},
 					},

--- a/internal/engine/selectors/selectors.go
+++ b/internal/engine/selectors/selectors.go
@@ -350,9 +350,12 @@ func (e *Env) NewSelectionFromProfile(
 // CheckSelector checks if a selector expression compiles and is valid for a given entity
 func (e *Env) CheckSelector(sel *minderv1.Profile_Selector) error {
 	ent := minderv1.EntityFromString(sel.GetEntity())
+	if ent == minderv1.Entity_ENTITY_UNSPECIFIED && sel.GetEntity() != "" {
+		return fmt.Errorf("invalid entity type %s: %w", sel.GetEntity(), ErrUnsupported)
+	}
 	env, err := e.envForEntity(ent)
 	if err != nil {
-		return fmt.Errorf("failed to get environment for entity %v: %w", ent, ErrUnsupported)
+		return fmt.Errorf("no environment for entity %v: %w", ent, ErrUnsupported)
 	}
 
 	_, err = checkSelectorForEntity(env, sel.Selector)

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -96,7 +96,8 @@ func AllInOneServerService(
 
 	historySvc := history.NewEvaluationHistoryService()
 	inviteSvc := invites.NewInviteService()
-	profileSvc := profiles.NewProfileService(evt)
+	selChecker := selectors.NewEnv()
+	profileSvc := profiles.NewProfileService(evt, selChecker)
 	ruleSvc := ruletypes.NewRuleTypeService()
 	roleScv := roles.NewRoleService()
 	marketplace, err := marketplaces.NewMarketplaceFromServiceConfig(cfg.Marketplace, profileSvc, ruleSvc)


### PR DESCRIPTION
# Summary

This is a minimal patch to surface selector errors through profile
handlers to clients. It does not expose the structured data (e.g. which
line and which column did the error occur at). I started working on
that, but realized that that's a bigger endevor that ought to be
implemented separately.

Fixes: #3987

## Change Type

- [ ] Bug fix (resolves an issue without affecting existing features)
- [x] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [ ] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

by calling the profile handlers, both grpc through the minder client and HTTP through curl:
```
curl -vv -H "Authorization: Bearer $MINDER_BEARER_TOKEN" 'http://localhost:8080/api/v1/profile' --data-binary @/Users/jakub/devel/playground/ghas-selectors-check-error.json
```

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [x] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [x] Included tests that validate the fix or feature.
- [ ] Checked that related changes are merged.
