### PR TITLE
Backfill new columns in `rule_evaluations`

### DIFF
--- a/database/migrations/000083_rule_evaluations_ere_id_backfill.down.sql
+++ b/database/migrations/000083_rule_evaluations_ere_id_backfill.down.sql
@@ -1,0 +1,15 @@
+-- Copyright 2024 Stacklok, Inc
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--      http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+ALTER TABLE rule_evaluations ALTER COLUMN rule_instance_id DROP NOT NULL;

--- a/database/migrations/000083_rule_evaluations_ere_id_backfill.up.sql
+++ b/database/migrations/000083_rule_evaluations_ere_id_backfill.up.sql
@@ -1,0 +1,64 @@
+-- Copyright 2024 Stacklok, Inc
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--      http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+BEGIN;
+
+-- backfill rows which don't have an rule instance ID
+UPDATE rule_evaluations
+SET rule_instance_id = ri.id
+FROM rule_instances AS ri
+WHERE rule_evaluations.rule_instance_id IS NULL
+    AND rule_evaluations.rule_name = ri.name
+    AND rule_evaluations.rule_type_id = ri.rule_type_id;
+
+-- backfill rows which don't have an rule entity ID
+-- This process only matches up rule_evaluations which have a corresponding
+-- evaluation_rule_entities entry. Entities which were last evaluated before
+-- the introduction of the evaluation history tables will not have entries
+-- in evaluation_rule_entities - this will be addressed in a future PR.
+
+-- In principle, we could write a single query which matches the three types of
+-- entity we care about. Unfortunately, the rule_evaluations table may contain
+-- the repository ID for non-repo entities. In order to work around this, backfill
+-- each type of entity separately.
+UPDATE rule_evaluations
+SET rule_entity_id = ere.id
+FROM evaluation_rule_entities AS ere
+WHERE rule_evaluations.rule_entity_id IS NULL
+    AND rule_evaluations.entity = 'artifact'::entities
+    AND rule_evaluations.rule_instance_id = ere.rule_id
+    AND rule_evaluations.artifact_id = ere.artifact_id;
+
+UPDATE rule_evaluations
+SET rule_entity_id = ere.id
+FROM evaluation_rule_entities AS ere
+WHERE rule_evaluations.rule_entity_id IS NULL
+  AND rule_evaluations.entity = 'pull_request'::entities
+  AND rule_evaluations.rule_instance_id = ere.rule_id
+  AND rule_evaluations.pull_request_id = ere.pull_request_id;
+
+UPDATE rule_evaluations
+SET rule_entity_id = ere.id
+FROM evaluation_rule_entities AS ere
+WHERE rule_evaluations.rule_entity_id IS NULL
+  AND rule_evaluations.entity = 'repository'::entities
+  AND rule_evaluations.rule_instance_id = ere.rule_id
+  AND rule_evaluations.repository_id = ere.repository_id;
+
+-- make field mandatory
+ALTER TABLE rule_evaluations ALTER COLUMN rule_instance_id SET NOT NULL;
+-- note that rule_entity_id is still expected to contain nulls until we backfill
+-- evaluation state which predates the evaluation history tables.
+
+COMMIT;

--- a/database/mock/store.go
+++ b/database/mock/store.go
@@ -528,20 +528,6 @@ func (mr *MockStoreMockRecorder) DeleteRepository(arg0, arg1 any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteRepository", reflect.TypeOf((*MockStore)(nil).DeleteRepository), arg0, arg1)
 }
 
-// DeleteRuleStatusesForProfileAndRuleType mocks base method.
-func (m *MockStore) DeleteRuleStatusesForProfileAndRuleType(arg0 context.Context, arg1 db.DeleteRuleStatusesForProfileAndRuleTypeParams) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DeleteRuleStatusesForProfileAndRuleType", arg0, arg1)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// DeleteRuleStatusesForProfileAndRuleType indicates an expected call of DeleteRuleStatusesForProfileAndRuleType.
-func (mr *MockStoreMockRecorder) DeleteRuleStatusesForProfileAndRuleType(arg0, arg1 any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteRuleStatusesForProfileAndRuleType", reflect.TypeOf((*MockStore)(nil).DeleteRuleStatusesForProfileAndRuleType), arg0, arg1)
-}
-
 // DeleteRuleType mocks base method.
 func (m *MockStore) DeleteRuleType(arg0 context.Context, arg1 uuid.UUID) error {
 	m.ctrl.T.Helper()

--- a/database/query/profile_status.sql
+++ b/database/query/profile_status.sql
@@ -84,15 +84,6 @@ FROM rule_evaluations re
 WHERE re.repository_id = ANY (sqlc.arg('repository_ids')::uuid[])
 GROUP BY re.repository_id;
 
--- DeleteRuleStatusesForProfileAndRuleType deletes a rule evaluation
--- but locks the table before doing so.
-
--- name: DeleteRuleStatusesForProfileAndRuleType :exec
-DELETE FROM rule_evaluations
-WHERE id IN (
-    SELECT id FROM rule_evaluations as re
-    WHERE re.profile_id = $1 AND re.rule_type_id = $2 AND re.rule_name = $3 FOR UPDATE);
-
 -- name: ListRuleEvaluationsByProfileId :many
 WITH
    eval_details AS (

--- a/internal/db/models.go
+++ b/internal/db/models.go
@@ -680,7 +680,7 @@ type RuleEvaluation struct {
 	PullRequestID  uuid.NullUUID `json:"pull_request_id"`
 	RuleName       string        `json:"rule_name"`
 	RuleEntityID   uuid.NullUUID `json:"rule_entity_id"`
-	RuleInstanceID uuid.NullUUID `json:"rule_instance_id"`
+	RuleInstanceID uuid.UUID     `json:"rule_instance_id"`
 }
 
 type RuleInstance struct {

--- a/internal/db/profile_status.sql.go
+++ b/internal/db/profile_status.sql.go
@@ -16,27 +16,6 @@ import (
 	"github.com/sqlc-dev/pqtype"
 )
 
-const deleteRuleStatusesForProfileAndRuleType = `-- name: DeleteRuleStatusesForProfileAndRuleType :exec
-
-DELETE FROM rule_evaluations
-WHERE id IN (
-    SELECT id FROM rule_evaluations as re
-    WHERE re.profile_id = $1 AND re.rule_type_id = $2 AND re.rule_name = $3 FOR UPDATE)
-`
-
-type DeleteRuleStatusesForProfileAndRuleTypeParams struct {
-	ProfileID  uuid.UUID `json:"profile_id"`
-	RuleTypeID uuid.UUID `json:"rule_type_id"`
-	RuleName   string    `json:"rule_name"`
-}
-
-// DeleteRuleStatusesForProfileAndRuleType deletes a rule evaluation
-// but locks the table before doing so.
-func (q *Queries) DeleteRuleStatusesForProfileAndRuleType(ctx context.Context, arg DeleteRuleStatusesForProfileAndRuleTypeParams) error {
-	_, err := q.db.ExecContext(ctx, deleteRuleStatusesForProfileAndRuleType, arg.ProfileID, arg.RuleTypeID, arg.RuleName)
-	return err
-}
-
 const getProfileStatusByIdAndProject = `-- name: GetProfileStatusByIdAndProject :one
 SELECT p.id, p.name, ps.profile_status, ps.last_updated FROM profile_status ps
 INNER JOIN profiles p ON p.id = ps.profile_id
@@ -460,7 +439,7 @@ type UpsertRuleEvaluationsParams struct {
 	Entity         Entities      `json:"entity"`
 	RuleName       string        `json:"rule_name"`
 	RuleEntityID   uuid.NullUUID `json:"rule_entity_id"`
-	RuleInstanceID uuid.NullUUID `json:"rule_instance_id"`
+	RuleInstanceID uuid.UUID     `json:"rule_instance_id"`
 }
 
 func (q *Queries) UpsertRuleEvaluations(ctx context.Context, arg UpsertRuleEvaluationsParams) (uuid.UUID, error) {

--- a/internal/db/querier.go
+++ b/internal/db/querier.go
@@ -52,9 +52,6 @@ type Querier interface {
 	DeleteProvider(ctx context.Context, arg DeleteProviderParams) error
 	DeletePullRequest(ctx context.Context, arg DeletePullRequestParams) error
 	DeleteRepository(ctx context.Context, id uuid.UUID) error
-	// DeleteRuleStatusesForProfileAndRuleType deletes a rule evaluation
-	// but locks the table before doing so.
-	DeleteRuleStatusesForProfileAndRuleType(ctx context.Context, arg DeleteRuleStatusesForProfileAndRuleTypeParams) error
 	DeleteRuleType(ctx context.Context, id uuid.UUID) error
 	DeleteSelector(ctx context.Context, id uuid.UUID) error
 	DeleteSelectorsByProfileID(ctx context.Context, profileID uuid.UUID) error

--- a/internal/engine/eval_status.go
+++ b/internal/engine/eval_status.go
@@ -184,17 +184,14 @@ func (e *executor) createOrUpdateEvalStatus(
 		// Upsert evaluation
 		// TODO: replace these tables with the evaluation statuses table after migration
 		legacyEvalID, err := qtx.UpsertRuleEvaluations(ctx, db.UpsertRuleEvaluationsParams{
-			ProfileID:     params.Profile.ID,
-			RepositoryID:  params.RepoID,
-			ArtifactID:    params.ArtifactID,
-			Entity:        params.EntityType,
-			RuleTypeID:    params.Rule.RuleTypeID,
-			PullRequestID: params.PullRequestID,
-			RuleName:      params.Rule.Name,
-			RuleInstanceID: uuid.NullUUID{
-				UUID:  params.Rule.ID,
-				Valid: true,
-			},
+			ProfileID:      params.Profile.ID,
+			RepositoryID:   params.RepoID,
+			ArtifactID:     params.ArtifactID,
+			Entity:         params.EntityType,
+			RuleTypeID:     params.Rule.RuleTypeID,
+			PullRequestID:  params.PullRequestID,
+			RuleName:       params.Rule.Name,
+			RuleInstanceID: params.Rule.ID,
 			RuleEntityID: uuid.NullUUID{
 				UUID:  ruleEntityID,
 				Valid: true,

--- a/internal/engine/executor_test.go
+++ b/internal/engine/executor_test.go
@@ -261,10 +261,7 @@ default allow = true`,
 				UUID:  ruleEntityID,
 				Valid: true,
 			},
-			RuleInstanceID: uuid.NullUUID{
-				UUID:  ruleInstanceID,
-				Valid: true,
-			},
+			RuleInstanceID: ruleInstanceID,
 		}).Return(ruleEvalId, nil)
 
 	// Mock upserting eval details status


### PR DESCRIPTION
# Summary

Backfill the `rule_instance_id` and `rule_entity_id` columns and make them non
nullable. Note that the backfilling of `rule_entity_id` should not change any
rows in production - any `rule_evaluation` rows with corresponding entries in
`evaluation_rule_entities` should already have a non null `rule_entity_id`
column.

As a side effect of setting up the `rule_instance_id` foreign key association
it is no longer necessary to explicitly delete old rule statuses when updating
profiles - instead they are deleted by the FK association. This simplifies the
profile update code significantly.

Fixes #(related issue)

## Change Type

***Mark the type of change your PR introduces:***

- [ ] Bug fix (resolves an issue without affecting existing features)
- [x] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [ ] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

***Outline how the changes were tested, including steps to reproduce and any relevant configurations. 
Attach screenshots if helpful.***

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [ ] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [x] Included tests that validate the fix or feature.
- [x] Checked that related changes are merged.
