### PR TITLE
Change profile validation to enforce case insensitive unique rule names

### DIFF
--- a/internal/profiles/validator.go
+++ b/internal/profiles/validator.go
@@ -19,6 +19,7 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/google/uuid"
 	"github.com/rs/zerolog/log"
@@ -252,8 +253,10 @@ func validateRuleWithNonEmptyName(
 	ruleNameToType map[string]string, emptyNameTypesSet sets.Set[string],
 ) error {
 	ruleName := rule.GetName()
+	// use the lower case name since we need to validate case-insensitive uniqueness
+	lowercaseName := strings.ToLower(ruleName)
 	ruleType := rule.GetType()
-	if existingType, ok := ruleNameToType[ruleName]; ok {
+	if existingType, ok := ruleNameToType[lowercaseName]; ok {
 		if existingType == ruleType {
 			return &RuleValidationError{
 				Err: fmt.Sprintf("multiple rules of same type with same name '%s' in entity '%s', assign unique names to rules",
@@ -278,7 +281,7 @@ func validateRuleWithNonEmptyName(
 		}
 	}
 
-	ruleNameToType[ruleName] = ruleType
+	ruleNameToType[lowercaseName] = ruleType
 	return nil
 }
 

--- a/internal/profiles/validator_test.go
+++ b/internal/profiles/validator_test.go
@@ -66,6 +66,14 @@ func TestValidatorScenarios(t *testing.T) {
 			ExpectedError: "multiple rules of same type with same name",
 		},
 		{
+			Name: "Validator rejects profile with multiple rules with same name but different cases",
+			Profile: makeProfile(withBasicProfileData, withRules(
+				makeRule(withRuleName("myrule")),
+				makeRule(withRuleName("MYRULE")),
+			)),
+			ExpectedError: "multiple rules of same type with same name",
+		},
+		{
 			Name:          "Validator rejects profile with multiple rules with same name and different types",
 			Profile:       makeProfile(withBasicProfileData, withRules(makeRule(), makeRule(withRuleType("foo")))),
 			ExpectedError: "conflicts with rule name of type",
@@ -123,7 +131,6 @@ func TestValidatorScenarios(t *testing.T) {
 		},
 	}
 
-	// some of this boilerplate can probably be shared across multiple tests
 	for _, testScenario := range validatorTestScenarios {
 		t.Run(testScenario.Name, func(t *testing.T) {
 			t.Parallel()
@@ -235,6 +242,12 @@ func makeRule(opts ...func(rule *minderv1.Profile_Rule)) *minderv1.Profile_Rule 
 
 func withEmptyRuleName(rule *minderv1.Profile_Rule) {
 	rule.Name = ""
+}
+
+func withRuleName(name string) func(rule *minderv1.Profile_Rule) {
+	return func(rule *minderv1.Profile_Rule) {
+		rule.Name = name
+	}
 }
 
 func withRuleType(typeName string) func(rule *minderv1.Profile_Rule) {


### PR DESCRIPTION
Previously, minder required rule names to be unique within an entity type, but did so in a case-sensitive manner. Minder's API expects rule names to be unique in a case-insensitive manner. This changes the validation logic to prevent new rule instances from being created if they are not unique in a case insensitive manner.

# Summary

***Provide a brief overview of the changes and the issue being addressed. 
Explain the rationale and any background necessary for understanding the changes. 
List dependencies required by this change, if any.***

Fixes #(related issue)

## Change Type

***Mark the type of change your PR introduces:***

- [x] Bug fix (resolves an issue without affecting existing features)
- [ ] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [ ] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

***Outline how the changes were tested, including steps to reproduce and any relevant configurations. 
Attach screenshots if helpful.***

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [x] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [x] Included tests that validate the fix or feature.
- [ ] Checked that related changes are merged.
