### PR TITLE
Change profile/rule status queries to use evaluation history table

### DIFF
--- a/database/query/profile_status.sql
+++ b/database/query/profile_status.sql
@@ -78,39 +78,40 @@ WHERE p.project_id = $1;
 -- cast after MIN is required due to a known bug in sqlc: https://github.com/sqlc-dev/sqlc/issues/1965
 
 -- name: ListOldestRuleEvaluationsByRepositoryId :many
-SELECT re.repository_id::uuid AS repository_id, MIN(rde.last_updated)::timestamp AS oldest_last_updated
-FROM rule_evaluations re
-    INNER JOIN rule_details_eval rde ON re.id = rde.rule_eval_id
-WHERE re.repository_id = ANY (sqlc.arg('repository_ids')::uuid[])
-GROUP BY re.repository_id;
+SELECT ere.repository_id::uuid AS repository_id, MIN(es.evaluation_time)::timestamp AS oldest_last_updated
+FROM evaluation_rule_entities AS ere
+    INNER JOIN latest_evaluation_statuses AS les ON ere.id = les.rule_entity_id
+    INNER JOIN evaluation_statuses AS es ON les.evaluation_history_id = es.id
+WHERE ere.repository_id = ANY (sqlc.arg('repository_ids')::uuid[])
+GROUP BY ere.repository_id;
 
 -- name: ListRuleEvaluationsByProfileId :many
 WITH
    eval_details AS (
    SELECT
-       rule_eval_id,
+       id,
        status AS eval_status,
        details AS eval_details,
-       last_updated AS eval_last_updated
-   FROM rule_details_eval
+       evaluation_time AS eval_last_updated
+   FROM evaluation_statuses
    ),
    remediation_details AS (
        SELECT
-           rule_eval_id,
+           evaluation_id,
            status AS rem_status,
            details AS rem_details,
            metadata AS rem_metadata,
-           last_updated AS rem_last_updated
-       FROM rule_details_remediate
+           created_at AS rem_last_updated
+       FROM remediation_events
    ),
    alert_details AS (
        SELECT
-           rule_eval_id,
+           evaluation_id,
            status AS alert_status,
            details AS alert_details,
            metadata AS alert_metadata,
-           last_updated AS alert_last_updated
-       FROM rule_details_alert
+           created_at AS alert_last_updated
+       FROM alert_events
    )
 
 SELECT
@@ -125,10 +126,10 @@ SELECT
     ad.alert_details,
     ad.alert_metadata,
     ad.alert_last_updated,
-    res.id AS rule_evaluation_id,
-    res.repository_id,
-    res.entity,
-    res.rule_name,
+    ed.id AS rule_evaluation_id,
+    ere.repository_id,
+    ere.entity_type,
+    ri.name AS rule_name,
     repo.repo_name,
     repo.repo_owner,
     repo.provider,
@@ -137,21 +138,23 @@ SELECT
     rt.id AS rule_type_id,
     rt.guidance as rule_type_guidance,
     rt.display_name as rule_type_display_name
-FROM rule_evaluations res
-         LEFT JOIN eval_details ed ON ed.rule_eval_id = res.id
-         LEFT JOIN remediation_details rd ON rd.rule_eval_id = res.id
-         LEFT JOIN alert_details ad ON ad.rule_eval_id = res.id
-         INNER JOIN repositories repo ON repo.id = res.repository_id
-         INNER JOIN rule_type rt ON rt.id = res.rule_type_id
-WHERE res.profile_id = $1 AND
+FROM latest_evaluation_statuses les
+         INNER JOIN evaluation_rule_entities ere ON ere.id = les.rule_entity_id
+         INNER JOIN eval_details ed ON ed.id = les.evaluation_history_id
+         INNER JOIN remediation_details rd ON rd.evaluation_id = les.evaluation_history_id
+         INNER JOIN alert_details ad ON ad.evaluation_id = les.evaluation_history_id
+         INNER JOIN rule_instances AS ri ON ri.id = ere.rule_id
+         INNER JOIN rule_type rt ON rt.id = ri.rule_type_id
+         INNER JOIN repositories repo ON repo.id = ere.repository_id
+WHERE les.profile_id = $1 AND
     (
         CASE
-            WHEN sqlc.narg(entity_type)::entities = 'repository' AND res.repository_id = sqlc.narg(entity_id)::UUID THEN true
-            WHEN sqlc.narg(entity_type)::entities  = 'artifact' AND res.artifact_id = sqlc.narg(entity_id)::UUID THEN true
-            WHEN sqlc.narg(entity_type)::entities  = 'pull_request' AND res.pull_request_id = sqlc.narg(entity_id)::UUID THEN true
+            WHEN sqlc.narg(entity_type)::entities = 'repository' AND ere.repository_id = sqlc.narg(entity_id)::UUID THEN true
+            WHEN sqlc.narg(entity_type)::entities  = 'artifact' AND ere.artifact_id = sqlc.narg(entity_id)::UUID THEN true
+            WHEN sqlc.narg(entity_type)::entities  = 'pull_request' AND ere.pull_request_id = sqlc.narg(entity_id)::UUID THEN true
             WHEN sqlc.narg(entity_id)::UUID IS NULL THEN true
             ELSE false
             END
         ) AND (rt.name = sqlc.narg(rule_type_name) OR sqlc.narg(rule_type_name) IS NULL)
-          AND (lower(res.rule_name) = lower(sqlc.narg(rule_name)) OR sqlc.narg(rule_name) IS NULL)
+          AND (lower(ri.name) = lower(sqlc.narg(rule_name)) OR sqlc.narg(rule_name) IS NULL)
 ;

--- a/database/query/profile_status.sql
+++ b/database/query/profile_status.sql
@@ -145,7 +145,7 @@ FROM latest_evaluation_statuses les
          INNER JOIN alert_details ad ON ad.evaluation_id = les.evaluation_history_id
          INNER JOIN rule_instances AS ri ON ri.id = ere.rule_id
          INNER JOIN rule_type rt ON rt.id = ri.rule_type_id
-         INNER JOIN repositories repo ON repo.id = ere.repository_id
+         LEFT JOIN repositories repo ON repo.id = ere.repository_id
 WHERE les.profile_id = $1 AND
     (
         CASE

--- a/internal/controlplane/handlers_evalstatus.go
+++ b/internal/controlplane/handlers_evalstatus.go
@@ -556,8 +556,8 @@ func buildRuleEvaluationStatusFromDBEvaluation(
 ) (*minderv1.RuleEvaluationStatus, error) {
 	guidance := ""
 	// Only return the rule type guidance text when there is a problem
-	if eval.EvalStatus.EvalStatusTypes == db.EvalStatusTypesFailure ||
-		eval.EvalStatus.EvalStatusTypes == db.EvalStatusTypesError {
+	if eval.EvalStatus == db.EvalStatusTypesFailure ||
+		eval.EvalStatus == db.EvalStatusTypesError {
 		guidance = eval.RuleTypeGuidance
 	}
 
@@ -574,14 +574,14 @@ func buildRuleEvaluationStatusFromDBEvaluation(
 
 	entityInfo := map[string]string{}
 	remediationURL := ""
-	if eval.Entity == db.EntitiesRepository {
+	if eval.EntityType == db.EntitiesRepository {
 		entityInfo["provider"] = eval.Provider
 		entityInfo["repo_owner"] = eval.RepoOwner
 		entityInfo["repo_name"] = eval.RepoName
 		entityInfo["repository_id"] = eval.RepositoryID.UUID.String()
 
 		remediationURL, err = getRemediationURLFromMetadata(
-			eval.RemMetadata.RawMessage, fmt.Sprintf("%s/%s", eval.RepoOwner, eval.RepoName),
+			eval.RemMetadata, fmt.Sprintf("%s/%s", eval.RepoOwner, eval.RepoName),
 		)
 		if err != nil {
 			return nil, fmt.Errorf("parsing remediation pull request data: %w", err)
@@ -599,15 +599,15 @@ func buildRuleEvaluationStatusFromDBEvaluation(
 		RuleId:                 eval.RuleTypeID.String(),
 		ProfileId:              profile.Profile.ID.String(),
 		RuleName:               eval.RuleName,
-		Entity:                 string(eval.Entity),
-		Status:                 string(eval.EvalStatus.EvalStatusTypes),
-		LastUpdated:            timestamppb.New(eval.EvalLastUpdated.Time),
+		Entity:                 string(eval.EntityType),
+		Status:                 string(eval.EvalStatus),
+		LastUpdated:            timestamppb.New(eval.EvalLastUpdated),
 		EntityInfo:             entityInfo,
-		Details:                eval.EvalDetails.String,
+		Details:                eval.EvalDetails,
 		Guidance:               guidance,
-		RemediationStatus:      string(eval.RemStatus.RemediationStatusTypes),
-		RemediationLastUpdated: timestamppb.New(eval.RemLastUpdated.Time),
-		RemediationDetails:     eval.RemDetails.String,
+		RemediationStatus:      string(eval.RemStatus),
+		RemediationLastUpdated: timestamppb.New(eval.RemLastUpdated),
+		RemediationDetails:     eval.RemDetails,
 		RemediationUrl:         remediationURL,
 		RuleDisplayName:        nString,
 		RuleTypeName:           eval.RuleTypeName,
@@ -618,7 +618,7 @@ func buildRuleEvaluationStatusFromDBEvaluation(
 
 func buildEntityFromEvaluation(eval db.ListRuleEvaluationsByProfileIdRow) *minderv1.EntityTypedId {
 	ent := &minderv1.EntityTypedId{
-		Type: dbEntityToEntity(eval.Entity),
+		Type: dbEntityToEntity(eval.EntityType),
 	}
 
 	if ent.Type == minderv1.Entity_ENTITY_REPOSITORIES && eval.RepoOwner != "" && eval.RepoName != "" {
@@ -655,18 +655,18 @@ func buildProfileStatus(
 // database row.
 func buildEvalResultAlertFromLRERow(eval *db.ListRuleEvaluationsByProfileIdRow) *minderv1.EvalResultAlert {
 	era := &minderv1.EvalResultAlert{
-		Status:      string(eval.AlertStatus.AlertStatusTypes),
-		LastUpdated: timestamppb.New(eval.AlertLastUpdated.Time),
-		Details:     eval.AlertDetails.String,
+		Status:      string(eval.AlertStatus),
+		LastUpdated: timestamppb.New(eval.AlertLastUpdated),
+		Details:     eval.AlertDetails,
 	}
 
-	if eval.AlertMetadata.Valid && eval.AlertStatus.AlertStatusTypes == db.AlertStatusTypesOn {
+	if eval.AlertStatus == db.AlertStatusTypesOn {
 		repoSlug := ""
 		if eval.RepoOwner != "" && eval.RepoName != "" {
 			repoSlug = fmt.Sprintf("%s/%s", eval.RepoOwner, eval.RepoName)
 		}
 		urlString, err := getAlertURLFromMetadata(
-			eval.AlertMetadata.RawMessage, repoSlug,
+			eval.AlertMetadata, repoSlug,
 		)
 		if err == nil {
 			era.Url = urlString

--- a/internal/controlplane/handlers_evalstatus_test.go
+++ b/internal/controlplane/handlers_evalstatus_test.go
@@ -21,7 +21,6 @@ import (
 	"time"
 
 	"github.com/google/uuid"
-	"github.com/sqlc-dev/pqtype"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
@@ -40,21 +39,12 @@ func TestBuildEvalResultAlertFromLRERow(t *testing.T) {
 		{
 			name: "normal",
 			sut: &db.ListRuleEvaluationsByProfileIdRow{
-				AlertStatus: db.NullAlertStatusTypes{
-					AlertStatusTypes: db.AlertStatusTypesOn,
-				},
-				AlertLastUpdated: sql.NullTime{
-					Time: d,
-				},
-				AlertDetails: sql.NullString{
-					String: "details go here",
-				},
-				AlertMetadata: pqtype.NullRawMessage{
-					Valid:      true,
-					RawMessage: []byte(`{"ghsa_id": "GHAS-advisory_ID_here"}`),
-				},
-				RepoOwner: "example",
-				RepoName:  "test",
+				AlertStatus:      db.AlertStatusTypesOn,
+				AlertLastUpdated: d,
+				AlertDetails:     "details go here",
+				AlertMetadata:    []byte(`{"ghsa_id": "GHAS-advisory_ID_here"}`),
+				RepoOwner:        "example",
+				RepoName:         "test",
 			},
 			expect: &minderv1.EvalResultAlert{
 				Status:      string(db.AlertStatusTypesOn),
@@ -66,15 +56,9 @@ func TestBuildEvalResultAlertFromLRERow(t *testing.T) {
 		{
 			name: "no-advisory",
 			sut: &db.ListRuleEvaluationsByProfileIdRow{
-				AlertStatus: db.NullAlertStatusTypes{
-					AlertStatusTypes: db.AlertStatusTypesOn,
-				},
-				AlertLastUpdated: sql.NullTime{
-					Time: d,
-				},
-				AlertDetails: sql.NullString{
-					String: "details go here",
-				},
+				AlertStatus:      db.AlertStatusTypesOn,
+				AlertLastUpdated: d,
+				AlertDetails:     "details go here",
 			},
 			expect: &minderv1.EvalResultAlert{
 				Status:      string(db.AlertStatusTypesOn),
@@ -86,20 +70,12 @@ func TestBuildEvalResultAlertFromLRERow(t *testing.T) {
 		{
 			name: "no-repo-owner",
 			sut: &db.ListRuleEvaluationsByProfileIdRow{
-				AlertStatus: db.NullAlertStatusTypes{
-					AlertStatusTypes: db.AlertStatusTypesOn,
-				},
-				AlertLastUpdated: sql.NullTime{
-					Time: d,
-				},
-				AlertDetails: sql.NullString{
-					String: "details go here",
-				},
-				AlertMetadata: pqtype.NullRawMessage{
-					RawMessage: []byte(`{"ghsa_id": "GHAS-advisory_ID_here"}`),
-				},
-				RepoOwner: "",
-				RepoName:  "test",
+				AlertStatus:      db.AlertStatusTypesOn,
+				AlertLastUpdated: d,
+				AlertDetails:     "details go here",
+				AlertMetadata:    []byte(`{"ghsa_id": "GHAS-advisory_ID_here"}`),
+				RepoOwner:        "",
+				RepoName:         "test",
 			},
 			expect: &minderv1.EvalResultAlert{
 				Status:      string(db.AlertStatusTypesOn),

--- a/internal/controlplane/handlers_evalstatus_test.go
+++ b/internal/controlplane/handlers_evalstatus_test.go
@@ -43,8 +43,14 @@ func TestBuildEvalResultAlertFromLRERow(t *testing.T) {
 				AlertLastUpdated: d,
 				AlertDetails:     "details go here",
 				AlertMetadata:    []byte(`{"ghsa_id": "GHAS-advisory_ID_here"}`),
-				RepoOwner:        "example",
-				RepoName:         "test",
+				RepoOwner: sql.NullString{
+					String: "example",
+					Valid:  true,
+				},
+				RepoName: sql.NullString{
+					String: "test",
+					Valid:  true,
+				},
 			},
 			expect: &minderv1.EvalResultAlert{
 				Status:      string(db.AlertStatusTypesOn),
@@ -74,8 +80,14 @@ func TestBuildEvalResultAlertFromLRERow(t *testing.T) {
 				AlertLastUpdated: d,
 				AlertDetails:     "details go here",
 				AlertMetadata:    []byte(`{"ghsa_id": "GHAS-advisory_ID_here"}`),
-				RepoOwner:        "",
-				RepoName:         "test",
+				RepoOwner: sql.NullString{
+					String: "",
+					Valid:  true,
+				},
+				RepoName: sql.NullString{
+					String: "test",
+					Valid:  true,
+				},
 			},
 			expect: &minderv1.EvalResultAlert{
 				Status:      string(db.AlertStatusTypesOn),

--- a/internal/controlplane/handlers_profile.go
+++ b/internal/controlplane/handlers_profile.go
@@ -424,15 +424,10 @@ func (s *Server) getRuleEvaluationStatuses(
 	ruleEvaluationStatuses := make(
 		[]*minderv1.RuleEvaluationStatus, 0, len(dbRuleEvaluationStatuses),
 	)
-	l := zerolog.Ctx(ctx)
 	// Loop through the rule evaluation statuses and convert them to protobuf
 	for _, dbRuleEvalStat := range dbRuleEvaluationStatuses {
 		// Get the rule evaluation status
-		st, err := getRuleEvalStatus(ctx, s.store, profileId, dbEntity, selector, dbRuleEvalStat, projectID)
-		if err != nil {
-			l.Err(err).Msg("error getting rule evaluation status")
-			continue
-		}
+		st := getRuleEvalStatus(ctx, s.store, profileId, dbEntity, selector, dbRuleEvalStat, projectID)
 		// Append the rule evaluation status to the list
 		ruleEvaluationStatuses = append(ruleEvaluationStatuses, st)
 	}
@@ -450,24 +445,13 @@ func getRuleEvalStatus(
 	selector *uuid.NullUUID,
 	dbRuleEvalStat db.ListRuleEvaluationsByProfileIdRow,
 	projectID uuid.UUID,
-) (*minderv1.RuleEvaluationStatus, error) {
+) *minderv1.RuleEvaluationStatus {
 	l := zerolog.Ctx(ctx)
 	var guidance string
 	var err error
 
-	// make sure all fields are valid
-	if !dbRuleEvalStat.EvalStatus.Valid ||
-		!dbRuleEvalStat.EvalDetails.Valid ||
-		!dbRuleEvalStat.EvalLastUpdated.Valid ||
-		!dbRuleEvalStat.RemStatus.Valid ||
-		!dbRuleEvalStat.RemDetails.Valid ||
-		!dbRuleEvalStat.AlertStatus.Valid ||
-		!dbRuleEvalStat.AlertDetails.Valid {
-		return nil, fmt.Errorf("rule evaluation status not valid")
-	}
-
-	if dbRuleEvalStat.EvalStatus.EvalStatusTypes == db.EvalStatusTypesFailure ||
-		dbRuleEvalStat.EvalStatus.EvalStatusTypes == db.EvalStatusTypesError {
+	if dbRuleEvalStat.EvalStatus == db.EvalStatusTypesFailure ||
+		dbRuleEvalStat.EvalStatus == db.EvalStatusTypesError {
 		ruleTypeInfo, err := store.GetRuleTypeByID(ctx, dbRuleEvalStat.RuleTypeID)
 		if err != nil {
 			l.Err(err).Msg("error getting rule type info from db")
@@ -476,9 +460,9 @@ func getRuleEvalStatus(
 		}
 	}
 	remediationURL := ""
-	if dbRuleEvalStat.Entity == db.EntitiesRepository {
+	if dbRuleEvalStat.EntityType == db.EntitiesRepository {
 		remediationURL, err = getRemediationURLFromMetadata(
-			dbRuleEvalStat.RemMetadata.RawMessage,
+			dbRuleEvalStat.RemMetadata,
 			fmt.Sprintf("%s/%s", dbRuleEvalStat.RepoOwner, dbRuleEvalStat.RepoName),
 		)
 		if err != nil {
@@ -493,33 +477,27 @@ func getRuleEvalStatus(
 		RuleName:            dbRuleEvalStat.RuleTypeName,
 		RuleTypeName:        dbRuleEvalStat.RuleTypeName,
 		RuleDescriptionName: dbRuleEvalStat.RuleName,
-		Entity:              string(dbRuleEvalStat.Entity),
-		Status:              string(dbRuleEvalStat.EvalStatus.EvalStatusTypes),
-		Details:             dbRuleEvalStat.EvalDetails.String,
+		Entity:              string(dbRuleEvalStat.EntityType),
+		Status:              string(dbRuleEvalStat.EvalStatus),
+		Details:             dbRuleEvalStat.EvalDetails,
 		EntityInfo:          getRuleEvalEntityInfo(ctx, store, dbEntity, selector, dbRuleEvalStat, projectID),
 		Guidance:            guidance,
-		LastUpdated:         timestamppb.New(dbRuleEvalStat.EvalLastUpdated.Time),
-		RemediationStatus:   string(dbRuleEvalStat.RemStatus.RemediationStatusTypes),
-		RemediationDetails:  dbRuleEvalStat.RemDetails.String,
+		LastUpdated:         timestamppb.New(dbRuleEvalStat.EvalLastUpdated),
+		RemediationStatus:   string(dbRuleEvalStat.RemStatus),
+		RemediationDetails:  dbRuleEvalStat.RemDetails,
 		RemediationUrl:      remediationURL,
 		Alert: &minderv1.EvalResultAlert{
-			Status:  string(dbRuleEvalStat.AlertStatus.AlertStatusTypes),
-			Details: dbRuleEvalStat.AlertDetails.String,
+			Status:      string(dbRuleEvalStat.AlertStatus),
+			Details:     dbRuleEvalStat.AlertDetails,
+			LastUpdated: timestamppb.New(dbRuleEvalStat.AlertLastUpdated),
 		},
-	}
-
-	if dbRuleEvalStat.RemLastUpdated.Valid {
-		st.RemediationLastUpdated = timestamppb.New(dbRuleEvalStat.RemLastUpdated.Time)
-	}
-
-	if dbRuleEvalStat.AlertLastUpdated.Valid {
-		st.Alert.LastUpdated = timestamppb.New(dbRuleEvalStat.AlertLastUpdated.Time)
+		RemediationLastUpdated: timestamppb.New(dbRuleEvalStat.RemLastUpdated),
 	}
 
 	// If the alert is on and its metadata is valid, parse it and set the URL
-	if dbRuleEvalStat.AlertMetadata.Valid && st.Alert.Status == string(db.AlertStatusTypesOn) {
+	if st.Alert.Status == string(db.AlertStatusTypesOn) {
 		alertURL, err := getAlertURLFromMetadata(
-			dbRuleEvalStat.AlertMetadata.RawMessage,
+			dbRuleEvalStat.AlertMetadata,
 			fmt.Sprintf("%s/%s", st.EntityInfo["repo_owner"], st.EntityInfo["repo_name"]),
 		)
 		if err != nil {
@@ -528,7 +506,7 @@ func getRuleEvalStatus(
 			st.Alert.Url = alertURL
 		}
 	}
-	return st, nil
+	return st
 }
 
 // GetProfileStatusByProject is a method to get profile status for a project

--- a/internal/controlplane/handlers_profile.go
+++ b/internal/controlplane/handlers_profile.go
@@ -285,9 +285,9 @@ func getRuleEvalEntityInfo(
 
 	if rs.RepositoryID.Valid {
 		// this is always true now but might not be when we support entities not tied to a repo
-		entityInfo["repo_name"] = rs.RepoName
-		entityInfo["repo_owner"] = rs.RepoOwner
-		entityInfo["provider"] = rs.Provider
+		entityInfo["repo_name"] = rs.RepoName.String
+		entityInfo["repo_owner"] = rs.RepoOwner.String
+		entityInfo["provider"] = rs.Provider.String
 		entityInfo["repository_id"] = rs.RepositoryID.UUID.String()
 	}
 
@@ -463,7 +463,7 @@ func getRuleEvalStatus(
 	if dbRuleEvalStat.EntityType == db.EntitiesRepository {
 		remediationURL, err = getRemediationURLFromMetadata(
 			dbRuleEvalStat.RemMetadata,
-			fmt.Sprintf("%s/%s", dbRuleEvalStat.RepoOwner, dbRuleEvalStat.RepoName),
+			fmt.Sprintf("%s/%s", dbRuleEvalStat.RepoOwner.String, dbRuleEvalStat.RepoName.String),
 		)
 		if err != nil {
 			// A failure parsing the alert metadata points to a corrupt record. Log but don't err.

--- a/internal/db/profile_status.sql.go
+++ b/internal/db/profile_status.sql.go
@@ -216,7 +216,7 @@ FROM latest_evaluation_statuses les
          INNER JOIN alert_details ad ON ad.evaluation_id = les.evaluation_history_id
          INNER JOIN rule_instances AS ri ON ri.id = ere.rule_id
          INNER JOIN rule_type rt ON rt.id = ri.rule_type_id
-         INNER JOIN repositories repo ON repo.id = ere.repository_id
+         LEFT JOIN repositories repo ON repo.id = ere.repository_id
 WHERE les.profile_id = $1 AND
     (
         CASE
@@ -254,9 +254,9 @@ type ListRuleEvaluationsByProfileIdRow struct {
 	RepositoryID          uuid.NullUUID          `json:"repository_id"`
 	EntityType            Entities               `json:"entity_type"`
 	RuleName              string                 `json:"rule_name"`
-	RepoName              string                 `json:"repo_name"`
-	RepoOwner             string                 `json:"repo_owner"`
-	Provider              string                 `json:"provider"`
+	RepoName              sql.NullString         `json:"repo_name"`
+	RepoOwner             sql.NullString         `json:"repo_owner"`
+	Provider              sql.NullString         `json:"provider"`
 	RuleTypeName          string                 `json:"rule_type_name"`
 	RuleTypeSeverityValue Severity               `json:"rule_type_severity_value"`
 	RuleTypeID            uuid.UUID              `json:"rule_type_id"`

--- a/internal/db/profile_status.sql.go
+++ b/internal/db/profile_status.sql.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/lib/pq"
-	"github.com/sqlc-dev/pqtype"
 )
 
 const getProfileStatusByIdAndProject = `-- name: GetProfileStatusByIdAndProject :one
@@ -119,11 +118,12 @@ func (q *Queries) GetProfileStatusByProject(ctx context.Context, projectID uuid.
 
 const listOldestRuleEvaluationsByRepositoryId = `-- name: ListOldestRuleEvaluationsByRepositoryId :many
 
-SELECT re.repository_id::uuid AS repository_id, MIN(rde.last_updated)::timestamp AS oldest_last_updated
-FROM rule_evaluations re
-    INNER JOIN rule_details_eval rde ON re.id = rde.rule_eval_id
-WHERE re.repository_id = ANY ($1::uuid[])
-GROUP BY re.repository_id
+SELECT ere.repository_id::uuid AS repository_id, MIN(es.evaluation_time)::timestamp AS oldest_last_updated
+FROM evaluation_rule_entities AS ere
+    INNER JOIN latest_evaluation_statuses AS les ON ere.id = les.rule_entity_id
+    INNER JOIN evaluation_statuses AS es ON les.evaluation_history_id = es.id
+WHERE ere.repository_id = ANY ($1::uuid[])
+GROUP BY ere.repository_id
 `
 
 type ListOldestRuleEvaluationsByRepositoryIdRow struct {
@@ -160,29 +160,29 @@ const listRuleEvaluationsByProfileId = `-- name: ListRuleEvaluationsByProfileId 
 WITH
    eval_details AS (
    SELECT
-       rule_eval_id,
+       id,
        status AS eval_status,
        details AS eval_details,
-       last_updated AS eval_last_updated
-   FROM rule_details_eval
+       evaluation_time AS eval_last_updated
+   FROM evaluation_statuses
    ),
    remediation_details AS (
        SELECT
-           rule_eval_id,
+           evaluation_id,
            status AS rem_status,
            details AS rem_details,
            metadata AS rem_metadata,
-           last_updated AS rem_last_updated
-       FROM rule_details_remediate
+           created_at AS rem_last_updated
+       FROM remediation_events
    ),
    alert_details AS (
        SELECT
-           rule_eval_id,
+           evaluation_id,
            status AS alert_status,
            details AS alert_details,
            metadata AS alert_metadata,
-           last_updated AS alert_last_updated
-       FROM rule_details_alert
+           created_at AS alert_last_updated
+       FROM alert_events
    )
 
 SELECT
@@ -197,10 +197,10 @@ SELECT
     ad.alert_details,
     ad.alert_metadata,
     ad.alert_last_updated,
-    res.id AS rule_evaluation_id,
-    res.repository_id,
-    res.entity,
-    res.rule_name,
+    ed.id AS rule_evaluation_id,
+    ere.repository_id,
+    ere.entity_type,
+    ri.name AS rule_name,
     repo.repo_name,
     repo.repo_owner,
     repo.provider,
@@ -209,23 +209,25 @@ SELECT
     rt.id AS rule_type_id,
     rt.guidance as rule_type_guidance,
     rt.display_name as rule_type_display_name
-FROM rule_evaluations res
-         LEFT JOIN eval_details ed ON ed.rule_eval_id = res.id
-         LEFT JOIN remediation_details rd ON rd.rule_eval_id = res.id
-         LEFT JOIN alert_details ad ON ad.rule_eval_id = res.id
-         INNER JOIN repositories repo ON repo.id = res.repository_id
-         INNER JOIN rule_type rt ON rt.id = res.rule_type_id
-WHERE res.profile_id = $1 AND
+FROM latest_evaluation_statuses les
+         INNER JOIN evaluation_rule_entities ere ON ere.id = les.rule_entity_id
+         INNER JOIN eval_details ed ON ed.id = les.evaluation_history_id
+         INNER JOIN remediation_details rd ON rd.evaluation_id = les.evaluation_history_id
+         INNER JOIN alert_details ad ON ad.evaluation_id = les.evaluation_history_id
+         INNER JOIN rule_instances AS ri ON ri.id = ere.rule_id
+         INNER JOIN rule_type rt ON rt.id = ri.rule_type_id
+         INNER JOIN repositories repo ON repo.id = ere.repository_id
+WHERE les.profile_id = $1 AND
     (
         CASE
-            WHEN $2::entities = 'repository' AND res.repository_id = $3::UUID THEN true
-            WHEN $2::entities  = 'artifact' AND res.artifact_id = $3::UUID THEN true
-            WHEN $2::entities  = 'pull_request' AND res.pull_request_id = $3::UUID THEN true
+            WHEN $2::entities = 'repository' AND ere.repository_id = $3::UUID THEN true
+            WHEN $2::entities  = 'artifact' AND ere.artifact_id = $3::UUID THEN true
+            WHEN $2::entities  = 'pull_request' AND ere.pull_request_id = $3::UUID THEN true
             WHEN $3::UUID IS NULL THEN true
             ELSE false
             END
         ) AND (rt.name = $4 OR $4 IS NULL)
-          AND (lower(res.rule_name) = lower($5) OR $5 IS NULL)
+          AND (lower(ri.name) = lower($5) OR $5 IS NULL)
 `
 
 type ListRuleEvaluationsByProfileIdParams struct {
@@ -237,29 +239,29 @@ type ListRuleEvaluationsByProfileIdParams struct {
 }
 
 type ListRuleEvaluationsByProfileIdRow struct {
-	EvalStatus            NullEvalStatusTypes        `json:"eval_status"`
-	EvalLastUpdated       sql.NullTime               `json:"eval_last_updated"`
-	EvalDetails           sql.NullString             `json:"eval_details"`
-	RemStatus             NullRemediationStatusTypes `json:"rem_status"`
-	RemDetails            sql.NullString             `json:"rem_details"`
-	RemMetadata           pqtype.NullRawMessage      `json:"rem_metadata"`
-	RemLastUpdated        sql.NullTime               `json:"rem_last_updated"`
-	AlertStatus           NullAlertStatusTypes       `json:"alert_status"`
-	AlertDetails          sql.NullString             `json:"alert_details"`
-	AlertMetadata         pqtype.NullRawMessage      `json:"alert_metadata"`
-	AlertLastUpdated      sql.NullTime               `json:"alert_last_updated"`
-	RuleEvaluationID      uuid.UUID                  `json:"rule_evaluation_id"`
-	RepositoryID          uuid.NullUUID              `json:"repository_id"`
-	Entity                Entities                   `json:"entity"`
-	RuleName              string                     `json:"rule_name"`
-	RepoName              string                     `json:"repo_name"`
-	RepoOwner             string                     `json:"repo_owner"`
-	Provider              string                     `json:"provider"`
-	RuleTypeName          string                     `json:"rule_type_name"`
-	RuleTypeSeverityValue Severity                   `json:"rule_type_severity_value"`
-	RuleTypeID            uuid.UUID                  `json:"rule_type_id"`
-	RuleTypeGuidance      string                     `json:"rule_type_guidance"`
-	RuleTypeDisplayName   string                     `json:"rule_type_display_name"`
+	EvalStatus            EvalStatusTypes        `json:"eval_status"`
+	EvalLastUpdated       time.Time              `json:"eval_last_updated"`
+	EvalDetails           string                 `json:"eval_details"`
+	RemStatus             RemediationStatusTypes `json:"rem_status"`
+	RemDetails            string                 `json:"rem_details"`
+	RemMetadata           json.RawMessage        `json:"rem_metadata"`
+	RemLastUpdated        time.Time              `json:"rem_last_updated"`
+	AlertStatus           AlertStatusTypes       `json:"alert_status"`
+	AlertDetails          string                 `json:"alert_details"`
+	AlertMetadata         json.RawMessage        `json:"alert_metadata"`
+	AlertLastUpdated      time.Time              `json:"alert_last_updated"`
+	RuleEvaluationID      uuid.UUID              `json:"rule_evaluation_id"`
+	RepositoryID          uuid.NullUUID          `json:"repository_id"`
+	EntityType            Entities               `json:"entity_type"`
+	RuleName              string                 `json:"rule_name"`
+	RepoName              string                 `json:"repo_name"`
+	RepoOwner             string                 `json:"repo_owner"`
+	Provider              string                 `json:"provider"`
+	RuleTypeName          string                 `json:"rule_type_name"`
+	RuleTypeSeverityValue Severity               `json:"rule_type_severity_value"`
+	RuleTypeID            uuid.UUID              `json:"rule_type_id"`
+	RuleTypeGuidance      string                 `json:"rule_type_guidance"`
+	RuleTypeDisplayName   string                 `json:"rule_type_display_name"`
 }
 
 func (q *Queries) ListRuleEvaluationsByProfileId(ctx context.Context, arg ListRuleEvaluationsByProfileIdParams) ([]ListRuleEvaluationsByProfileIdRow, error) {
@@ -291,7 +293,7 @@ func (q *Queries) ListRuleEvaluationsByProfileId(ctx context.Context, arg ListRu
 			&i.AlertLastUpdated,
 			&i.RuleEvaluationID,
 			&i.RepositoryID,
-			&i.Entity,
+			&i.EntityType,
 			&i.RuleName,
 			&i.RepoName,
 			&i.RepoOwner,

--- a/internal/db/profiles_test.go
+++ b/internal/db/profiles_test.go
@@ -3651,10 +3651,10 @@ func verifyRow(
 	require.Equal(t, rt.ID, row.RuleTypeID)
 	require.Equal(t, rt.Name, row.RuleTypeName)
 
-	require.Equal(t, randomEntities.repo.RepoName, row.RepoName)
-	require.Equal(t, randomEntities.repo.RepoOwner, row.RepoOwner)
+	require.Equal(t, randomEntities.repo.RepoName, row.RepoName.String)
+	require.Equal(t, randomEntities.repo.RepoOwner, row.RepoOwner.String)
 
-	require.Equal(t, randomEntities.prov.Name, row.Provider)
+	require.Equal(t, randomEntities.prov.Name, row.Provider.String)
 }
 
 func TestListRuleEvaluations(t *testing.T) {

--- a/internal/engine/actions/alert/security_advisory/security_advisory.go
+++ b/internal/engine/actions/alert/security_advisory/security_advisory.go
@@ -404,11 +404,6 @@ func (_ *Alert) runDoNothing(ctx context.Context, params *paramsSA) (json.RawMes
 	logger.Debug().Msg("Running do nothing")
 
 	// Return the previous alert status.
-	err := enginerr.AlertStatusAsError(params.prevStatus.AlertStatus.AlertStatusTypes)
-	// If there is a valid alert metadata, return it too
-	if params.prevStatus.AlertMetadata.Valid {
-		return params.prevStatus.AlertMetadata.RawMessage, err
-	}
-	// If there is no alert metadata, return nil as the metadata and the error
-	return nil, err
+	err := enginerr.AlertStatusAsError(params.prevStatus.AlertStatus)
+	return params.prevStatus.AlertMetadata, err
 }

--- a/internal/engine/actions/remediate/pull_request/pull_request.go
+++ b/internal/engine/actions/remediate/pull_request/pull_request.go
@@ -581,10 +581,5 @@ func (_ *Remediator) runDoNothing(ctx context.Context, p *paramsPR) (json.RawMes
 
 	// Return the previous remediation status.
 	err := enginerr.RemediationStatusAsError(p.prevStatus.RemStatus)
-	// If there is a valid remediation metadata, return it too
-	if p.prevStatus.RemMetadata.Valid {
-		return p.prevStatus.RemMetadata.RawMessage, err
-	}
-	// If there is no remediation metadata, return nil as the metadata and the error
-	return nil, err
+	return p.prevStatus.RemMetadata, err
 }

--- a/internal/engine/errors/errors.go
+++ b/internal/engine/errors/errors.go
@@ -160,13 +160,8 @@ func ErrorAsRemediationStatus(err error) db.RemediationStatusTypes {
 }
 
 // RemediationStatusAsError returns the remediation status for a given error
-func RemediationStatusAsError(ns db.NullRemediationStatusTypes) error {
-	if !ns.Valid {
-		return ErrActionSkipped
-	}
-
-	s := ns.RemediationStatusTypes
-	switch s {
+func RemediationStatusAsError(ns db.RemediationStatusTypes) error {
+	switch ns {
 	case db.RemediationStatusTypesSuccess:
 		return nil
 	case db.RemediationStatusTypesFailure:
@@ -178,9 +173,9 @@ func RemediationStatusAsError(ns db.NullRemediationStatusTypes) error {
 	case db.RemediationStatusTypesPending:
 		return ErrActionPending
 	case db.RemediationStatusTypesError:
-		return fmt.Errorf("generic remediation error status: %s", s)
+		return fmt.Errorf("generic remediation error status: %s", ns)
 	}
-	return fmt.Errorf("generic remediation error status: %s", s)
+	return fmt.Errorf("generic remediation error status: %s", ns)
 }
 
 // ErrorAsAlertStatus returns the alert status for a given error

--- a/internal/util/cli/table/simple/simple.go
+++ b/internal/util/cli/table/simple/simple.go
@@ -117,7 +117,7 @@ func profileStatusLayout(table *tablewriter.Table) {
 func ruleEvaluationsLayout(table *tablewriter.Table) {
 	defaultLayout(table)
 	table.SetHeader([]string{
-		"Rule ID", "Rule Name", "Entity", "Status", "Remediation", "Entity Info"})
+		"Rule Type ID", "Rule Name", "Entity", "Status", "Remediation", "Entity Info"})
 	table.SetAutoMergeCellsByColumnIndex([]int{0})
 	// This is needed for the rule definition and rule parameters
 	table.SetAutoWrapText(true)


### PR DESCRIPTION
Depends on: #4065 

This change allows most of the functionality which previously used the `rule_evaluations` (and related) tables to use the new evaluation history tables instead.

Change in API behaviour: `GetProfileStatusByName` previously returned repo information when querying Github pull requests and artifacts. This behaviour relied on a quirk of the old rule evaluation tables, and is no longer carried forward in the new implementation.

# Summary

***Provide a brief overview of the changes and the issue being addressed. 
Explain the rationale and any background necessary for understanding the changes. 
List dependencies required by this change, if any.***

Fixes #(related issue)

## Change Type

***Mark the type of change your PR introduces:***

- [ ] Bug fix (resolves an issue without affecting existing features)
- [x] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [ ] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

***Outline how the changes were tested, including steps to reproduce and any relevant configurations. 
Attach screenshots if helpful.***

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [x] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [x] Included tests that validate the fix or feature.
- [ ] Checked that related changes are merged.
