### PR TITLE
Fix migrated column on rule evaluations

### DIFF
--- a/database/migrations/000087_set_migrated_flag_rule_evaluations.down.sql
+++ b/database/migrations/000087_set_migrated_flag_rule_evaluations.down.sql
@@ -1,0 +1,15 @@
+-- Copyright 2024 Stacklok, Inc
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--      http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+-- Nothing to undo

--- a/database/migrations/000087_set_migrated_flag_rule_evaluations.up.sql
+++ b/database/migrations/000087_set_migrated_flag_rule_evaluations.up.sql
@@ -1,0 +1,41 @@
+-- Copyright 2024 Stacklok, Inc
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--      http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+BEGIN;
+
+UPDATE rule_evaluations AS re
+SET migrated = TRUE
+FROM evaluation_rule_entities AS ere
+WHERE re.entity = 'pull_request'::entities
+  AND ere.entity_type = 'pull_request'::entities
+  AND ere.pull_request_id = re.pull_request_id
+  AND re.migrated = FALSE;
+
+UPDATE rule_evaluations AS re
+SET migrated = TRUE
+FROM evaluation_rule_entities AS ere
+WHERE re.entity = 'artifact'::entities
+  AND ere.entity_type = 'artifact'::entities
+  AND ere.artifact_id = re.artifact_id
+  AND re.migrated = FALSE;
+
+UPDATE rule_evaluations AS re
+SET migrated = TRUE
+FROM evaluation_rule_entities AS ere
+WHERE re.entity = 'repository'::entities
+  AND ere.entity_type = 'repository'::entities
+  AND ere.repository_id = re.repository_id
+  AND re.migrated = FALSE;
+
+COMMIT;


### PR DESCRIPTION
After testing in staging, I found that the migration to set the `migrated` column did not work as expected. The intention was that any rows in `rule_evaluations` which have the same combination of rule instance ids and entity ids should be marked as migrated, as they refer to the same evaluations. This migration addresses this problem.

Tested against staging (with a rollback)

# Summary

***Provide a brief overview of the changes and the issue being addressed. 
Explain the rationale and any background necessary for understanding the changes. 
List dependencies required by this change, if any.***

Fixes #(related issue)

## Change Type

***Mark the type of change your PR introduces:***

- [x] Bug fix (resolves an issue without affecting existing features)
- [ ] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [ ] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

***Outline how the changes were tested, including steps to reproduce and any relevant configurations. 
Attach screenshots if helpful.***

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [ ] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [x] Included tests that validate the fix or feature.
- [ ] Checked that related changes are merged.
