### PR TITLE
Allow unmanaged attributes in KC for local dev

### DIFF
--- a/identity/config/stacklok.yaml
+++ b/identity/config/stacklok.yaml
@@ -163,6 +163,15 @@ users:
         # add-roles -r stacklok --uusername service-account-minder-server --cclientid realm-management --rolename manage-users
         - manage-users
 
+# Allow unmanaged attributes for gh_id and gh_login
+components:
+  org.keycloak.userprofile.UserProfileProvider:
+    - providerId: "declarative-user-profile"
+      config:
+        kc.user.profile.config:
+        - >-
+          {"attributes":[{"name":"username","displayName":"${username}","validations":{"length":{"min":3,"max":255},"username-prohibited-characters":{},"up-username-not-idn-homograph":{}},"permissions":{"view":["admin","user"],"edit":["admin","user"]},"multivalued":false},{"name":"email","displayName":"${email}","validations":{"email":{},"length":{"max":255}},"required":{"roles":["user"]},"permissions":{"view":["admin","user"],"edit":["admin","user"]},"multivalued":false},{"name":"firstName","displayName":"${firstName}","validations":{"length":{"max":255},"person-name-prohibited-characters":{}},"required":{"roles":["user"]},"permissions":{"view":["admin","user"],"edit":["admin","user"]},"multivalued":false},{"name":"lastName","displayName":"${lastName}","validations":{"length":{"max":255},"person-name-prohibited-characters":{}},"required":{"roles":["user"]},"permissions":{"view":["admin","user"],"edit":["admin","user"]},"multivalued":false}],"groups":[{"name":"user-metadata","displayHeader":"User metadata","displayDescription":"Attributes, which refer to user metadata"}],"unmanagedAttributePolicy":"ENABLED"}
+
 authenticationFlows:
   - alias: "browser"
     description: "browser based authentication"


### PR DESCRIPTION
# Summary

Update Keycloak config in local docker image to allow for unmanaged attributes. Without this the attributes `gh_id` and `gh_login` weren't getting mapped into the token correctly, which was causing problems when looking up the user.

Fixes #4084

note: It is intentional that there's a JSON string in the YAML file. It would be nice if they offered a better configuration option, but this is the way to do it for now.

## Change Type

***Mark the type of change your PR introduces:***

- [x] Bug fix (resolves an issue without affecting existing features)
- [ ] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [ ] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

***Outline how the changes were tested, including steps to reproduce and any relevant configurations. 
Attach screenshots if helpful.***

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [ ] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [ ] Included tests that validate the fix or feature.
- [ ] Checked that related changes are merged.
