### PR TITLE
Add owner flag validation during provider enrollment

### DIFF
--- a/config/server-config.yaml.example
+++ b/config/server-config.yaml.example
@@ -110,6 +110,7 @@ authz:
 #    namespace: stacklok
 #    name: healthcheck
 
+# Set key_dir path to /app/.ssh for docker compose and .ssh for running minder outside of docker compose
 crypto:
     keystore:
         type: local

--- a/internal/providers/github/common.go
+++ b/internal/providers/github/common.go
@@ -94,6 +94,7 @@ type ClientService interface {
 	GetUserIdFromToken(ctx context.Context, token *oauth2.Token) (*int64, error)
 	ListUserInstallations(ctx context.Context, token *oauth2.Token) ([]*github.Installation, error)
 	DeleteInstallation(ctx context.Context, id int64, jwt string) (*github.Response, error)
+	GetOrgMembership(ctx context.Context, token *oauth2.Token, org string) (*github.Membership, *github.Response, error)
 }
 
 var _ ClientService = (*ClientServiceImplementation)(nil)
@@ -137,6 +138,14 @@ func (ClientServiceImplementation) ListUserInstallations(
 func (ClientServiceImplementation) DeleteInstallation(ctx context.Context, id int64, jwt string) (*github.Response, error) {
 	ghClient := github.NewClient(nil).WithAuthToken(jwt)
 	return ghClient.Apps.DeleteInstallation(ctx, id)
+}
+
+// GetOrgMembership is a wrapper for the GitHub API to get users' organization membership
+func (ClientServiceImplementation) GetOrgMembership(
+	ctx context.Context, token *oauth2.Token, org string,
+) (*github.Membership, *github.Response, error) {
+	ghClient := github.NewClient(nil).WithAuthToken(token.AccessToken)
+	return ghClient.Organizations.GetOrgMembership(ctx, "", org)
 }
 
 // Delegate is the interface that contains operations that differ between different GitHub actors (user vs app)

--- a/internal/providers/github/mock/common.go
+++ b/internal/providers/github/mock/common.go
@@ -74,6 +74,22 @@ func (mr *MockClientServiceMockRecorder) GetInstallation(ctx, id, jwt any) *gomo
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetInstallation", reflect.TypeOf((*MockClientService)(nil).GetInstallation), ctx, id, jwt)
 }
 
+// GetOrgMembership mocks base method.
+func (m *MockClientService) GetOrgMembership(ctx context.Context, token *oauth2.Token, org string) (*github.Membership, *github.Response, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetOrgMembership", ctx, token, org)
+	ret0, _ := ret[0].(*github.Membership)
+	ret1, _ := ret[1].(*github.Response)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
+}
+
+// GetOrgMembership indicates an expected call of GetOrgMembership.
+func (mr *MockClientServiceMockRecorder) GetOrgMembership(ctx, token, org any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetOrgMembership", reflect.TypeOf((*MockClientService)(nil).GetOrgMembership), ctx, token, org)
+}
+
 // GetUserIdFromToken mocks base method.
 func (m *MockClientService) GetUserIdFromToken(ctx context.Context, token *oauth2.Token) (*int64, error) {
 	m.ctrl.T.Helper()

--- a/internal/providers/github/service/mock/service.go
+++ b/internal/providers/github/service/mock/service.go
@@ -130,6 +130,21 @@ func (mr *MockGitHubProviderServiceMockRecorder) ValidateGitHubInstallationId(ct
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ValidateGitHubInstallationId", reflect.TypeOf((*MockGitHubProviderService)(nil).ValidateGitHubInstallationId), ctx, token, installationID)
 }
 
+// ValidateOrgMembershipForToken mocks base method.
+func (m *MockGitHubProviderService) ValidateOrgMembershipForToken(ctx context.Context, token *oauth2.Token, org string) (bool, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ValidateOrgMembershipForToken", ctx, token, org)
+	ret0, _ := ret[0].(bool)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ValidateOrgMembershipForToken indicates an expected call of ValidateOrgMembershipForToken.
+func (mr *MockGitHubProviderServiceMockRecorder) ValidateOrgMembershipForToken(ctx, token, org any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ValidateOrgMembershipForToken", reflect.TypeOf((*MockGitHubProviderService)(nil).ValidateOrgMembershipForToken), ctx, token, org)
+}
+
 // VerifyProviderTokenIdentity mocks base method.
 func (m *MockGitHubProviderService) VerifyProviderTokenIdentity(ctx context.Context, remoteUser, accessToken string) error {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
# Summary

***Provide a brief overview of the changes and the issue being addressed. 
This PR addresses the issue #2723 . When enrolling a provider, the owner flag is not validated. Incase the owner flag is invalid or the token has no access to the owner/organization during provider enrollment, the repo registration will fail which is a later step in the process. The change includes checking for a valid GH organization (passed as owner flag) that matches the owner flag and ensure the token has access to the GH organization.

Explain the rationale and any background necessary for understanding the changes. 
List dependencies required by this change, if any.***
I created a type struct to make Git API calls prior to actual provider enrollment flow, also created an interface to be able to mock the tests. The intent of the existing types seems to be useful post provider enrollment so decided to create a new type.

Fixes #(related issue)
#2723 
## Change Type

***Mark the type of change your PR introduces:***

- [x] Bug fix (resolves an issue without affecting existing features)
- [ ] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [ ] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

***Outline how the changes were tested, including steps to reproduce and any relevant configurations. 
Attach screenshots if helpful.***
👉 Existing tests will validate the valid owner path.
👉 Added the unit tests to validate the invalid owner flag code path. 
👉  Provide a valid owner flag (a GH org) and provider enrollment is successful
👉  Provide an invalid owner flag and provider enrollment fails during the oauth flow with clear error message about the owner flag.

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [ ] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [x] Included tests that validate the fix or feature.
- [ ] Checked that related changes are merged.
