### PR TITLE
Make go mock an explicit dependency in tools

### DIFF
--- a/tools/go.mod
+++ b/tools/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/openfga/cli v0.5.1
 	github.com/pseudomuto/protoc-gen-doc v1.5.1
 	github.com/sqlc-dev/sqlc v1.27.0
+	go.uber.org/mock v0.4.0
 	golang.org/x/lint v0.0.0-20210508222113-6edffad5e616
 	golang.org/x/tools v0.24.0
 	google.golang.org/grpc/cmd/protoc-gen-go-grpc v1.5.1
@@ -314,7 +315,6 @@ require (
 	go.opentelemetry.io/proto/otlp v1.3.1 // indirect
 	go.uber.org/atomic v1.11.0 // indirect
 	go.uber.org/automaxprocs v1.5.3 // indirect
-	go.uber.org/mock v0.4.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	go.uber.org/zap v1.27.0 // indirect
 	golang.org/x/crypto v0.26.0 // indirect

--- a/tools/tools.go
+++ b/tools/tools.go
@@ -47,6 +47,7 @@ import (
 	_ "github.com/openfga/cli/cmd/fga"
 	_ "github.com/pseudomuto/protoc-gen-doc/cmd/protoc-gen-doc"
 	_ "github.com/sqlc-dev/sqlc/cmd/sqlc"
+	_ "go.uber.org/mock/mockgen"
 	_ "golang.org/x/lint/golint"
 	_ "golang.org/x/tools/cmd/goimports"
 	_ "google.golang.org/grpc/cmd/protoc-gen-go-grpc"


### PR DESCRIPTION
# Summary

Prior to this commit, the go mock dependency was implicitly added by the openFGA dependency.
The latest openFGA update removed the implicit dependency and caused our CI to fail (see https://github.com/stacklok/minder/actions/runs/10347230154/job/28637107802?pr=4112)

## Change Type

***Mark the type of change your PR introduces:***

- [ ] Bug fix (resolves an issue without affecting existing features)
- [ ] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [x] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

***Outline how the changes were tested, including steps to reproduce and any relevant configurations. 
Attach screenshots if helpful.***

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [ ] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [ ] Included tests that validate the fix or feature.
- [ ] Checked that related changes are merged.
