### PR TITLE
Change rule_evaluations upsert to set `migrated` to true

### DIFF
--- a/database/query/profile_status.sql
+++ b/database/query/profile_status.sql
@@ -4,7 +4,7 @@ INSERT INTO rule_evaluations (
     profile_id, repository_id, artifact_id, pull_request_id, rule_type_id, entity, rule_name, rule_instance_id, migrated
 ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, TRUE)
 ON CONFLICT (profile_id, repository_id, COALESCE(artifact_id, '00000000-0000-0000-0000-000000000000'::UUID), COALESCE(pull_request_id, '00000000-0000-0000-0000-000000000000'::UUID), entity, rule_type_id, lower(rule_name))
-  DO UPDATE SET profile_id = $1
+  DO UPDATE SET profile_id = $1, migrated = TRUE -- if we are doing an update, then the data has effectively been migrated already
 RETURNING id;
 
 -- name: UpsertRuleDetailsEval :one

--- a/internal/db/profile_status.sql.go
+++ b/internal/db/profile_status.sql.go
@@ -426,7 +426,7 @@ INSERT INTO rule_evaluations (
     profile_id, repository_id, artifact_id, pull_request_id, rule_type_id, entity, rule_name, rule_instance_id, migrated
 ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, TRUE)
 ON CONFLICT (profile_id, repository_id, COALESCE(artifact_id, '00000000-0000-0000-0000-000000000000'::UUID), COALESCE(pull_request_id, '00000000-0000-0000-0000-000000000000'::UUID), entity, rule_type_id, lower(rule_name))
-  DO UPDATE SET profile_id = $1
+  DO UPDATE SET profile_id = $1, migrated = TRUE -- if we are doing an update, then the data has effectively been migrated already
 RETURNING id
 `
 


### PR DESCRIPTION
This query is always called after an upsert into the evaluation history table, so migrated should always be set to true. Due to the lack of the update in the `ON CONFLICT DO UPDATE` clause, we ran into a situation where unmigrated rows in rule_evaluations were being implicitly migrated by the policy migration (i.e. the code was creating a corresponding row in evaluation_rule_entities) but the migrated flag was still set to false. The migration script would then attempt to copy the data to the evaluation_rule_entities table, which would error out because the data for that rule/entity pair already existed.

# Summary

***Provide a brief overview of the changes and the issue being addressed. 
Explain the rationale and any background necessary for understanding the changes. 
List dependencies required by this change, if any.***

Fixes #(related issue)

## Change Type

***Mark the type of change your PR introduces:***

- [x] Bug fix (resolves an issue without affecting existing features)
- [ ] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [ ] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

***Outline how the changes were tested, including steps to reproduce and any relevant configurations. 
Attach screenshots if helpful.***

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [ ] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [ ] Included tests that validate the fix or feature.
- [ ] Checked that related changes are merged.
