### PR TITLE
Unescape quotes when retrieving selectors

### DIFF
--- a/internal/db/profile_selector_scan.go
+++ b/internal/db/profile_selector_scan.go
@@ -61,6 +61,7 @@ func (s *ProfileSelector) Scan(value interface{}) error {
 
 	selector := strings.TrimPrefix(parts[3], "\"")
 	selector = strings.TrimSuffix(selector, "\"")
+	selector = strings.ReplaceAll(selector, `""`, `"`)
 	s.Selector = selector
 
 	comment := strings.TrimPrefix(parts[4], "\"")

--- a/internal/db/profile_selector_scan_test.go
+++ b/internal/db/profile_selector_scan_test.go
@@ -1,0 +1,67 @@
+// Copyright 2024 Stacklok, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package db
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestScan(t *testing.T) {
+	t.Parallel()
+
+	selectorId := uuid.New()
+	profileId := uuid.New()
+
+	tc := []struct {
+		name     string
+		input    interface{}
+		expected ProfileSelector
+	}{
+		{
+			name:  "Valid input with all fields",
+			input: []byte(fmt.Sprintf("(%s,%s,repository,\"entity.name == \"\"test/test\"\" && repository.is_fork != true\",\"comment1\")", selectorId, profileId)),
+			expected: ProfileSelector{
+				ID:        selectorId,
+				ProfileID: profileId,
+				Entity: NullEntities{
+					Valid:    true,
+					Entities: EntitiesRepository,
+				},
+				Selector: "entity.name == \"test/test\" && repository.is_fork != true",
+				Comment:  "comment1",
+			},
+		},
+	}
+
+	for _, tc := range tc {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			var ps ProfileSelector
+			err := ps.Scan(tc.input)
+
+			assert.NoError(t, err, "Expected no error")
+			assert.Equal(t, tc.expected.ID, ps.ID)
+			assert.Equal(t, tc.expected.ProfileID, ps.ProfileID)
+			assert.Equal(t, tc.expected.Entity, ps.Entity)
+			assert.Equal(t, tc.expected.Selector, ps.Selector)
+			assert.Equal(t, tc.expected.Comment, ps.Comment)
+		})
+	}
+}


### PR DESCRIPTION
Fix #4122

# Summary

Since we're writing a custom `Scan`, we need to unescape the double quotes when retrieving the selectors string from the DB.

Fixes #4122

## Change Type

***Mark the type of change your PR introduces:***

- [x] Bug fix (resolves an issue without affecting existing features)
- [ ] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [ ] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

***Outline how the changes were tested, including steps to reproduce and any relevant configurations. 
Attach screenshots if helpful.***

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [ ] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [x] Included tests that validate the fix or feature.
- [ ] Checked that related changes are merged.
