### PR TITLE
Ensure `ON DELETE` is properly set for the central entities table

### DIFF
--- a/database/migrations/000091_entity_project_fk.down.sql
+++ b/database/migrations/000091_entity_project_fk.down.sql
@@ -1,0 +1,15 @@
+-- Copyright 2024 Stacklok, Inc
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--      http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+-- It doesn't make sense to remove this FK constraint

--- a/database/migrations/000091_entity_project_fk.up.sql
+++ b/database/migrations/000091_entity_project_fk.up.sql
@@ -1,0 +1,27 @@
+-- Copyright 2024 Stacklok, Inc
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--      http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+-- Drop the foreign key constraint and then recreate it with the ON DELETE CASCADE option
+BEGIN;
+
+ALTER TABLE entity_instances DROP CONSTRAINT entity_instances_project_id_fkey;
+
+ALTER TABLE entity_instances ADD CONSTRAINT entity_instances_project_id_fkey FOREIGN KEY (project_id) REFERENCES projects(id) ON DELETE CASCADE;
+
+-- Do the same for the provider ID, since deleting a provider should delete all entities associated with it
+ALTER TABLE entity_instances DROP CONSTRAINT entity_instances_provider_id_fkey;
+
+ALTER TABLE entity_instances ADD CONSTRAINT entity_instances_provider_id_fkey FOREIGN KEY (provider_id) REFERENCES providers(id) ON DELETE CASCADE;
+
+COMMIT;


### PR DESCRIPTION
# Summary

This was missing the `ON DELETE CASCADE` option from the foreign key
constraints for project ID and provider ID references. These are
important since they ensure that project and provider deletion clean up
resources as needed.

## Change Type

***Mark the type of change your PR introduces:***

- [x] Bug fix (resolves an issue without affecting existing features)
- [ ] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [ ] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

***Outline how the changes were tested, including steps to reproduce and any relevant configurations. 
Attach screenshots if helpful.***

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [ ] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [ ] Included tests that validate the fix or feature.
- [ ] Checked that related changes are merged.
