### PR TITLE
Define own type around struct{} to work around linter warning

### DIFF
--- a/internal/auth/jwt/jwtauth.go
+++ b/internal/auth/jwt/jwtauth.go
@@ -114,7 +114,9 @@ func NewJwtValidator(ctx context.Context, jwksUrl string, issUrl string, aud str
 	}, nil
 }
 
-var userTokenContextKey struct{}
+type userTokenContextKeyType struct{}
+
+var userTokenContextKey userTokenContextKeyType
 
 // GetUserSubjectFromContext returns the user subject from the context, or nil
 func GetUserSubjectFromContext(ctx context.Context) string {


### PR DESCRIPTION

# Summary

Fixes:
```
internal/auth/jwt/jwtauth.go:146:32: SA1029: should not use empty
anonymous struct as key for value; define your own type to avoid
collisions (staticcheck)
        return context.WithValue(ctx, userTokenContextKey, token)
                                              ^
```

## Change Type

- [x] Bug fix (resolves an issue without affecting existing features)
- [ ] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [ ] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

make lint and auth

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [ ] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [ ] Included tests that validate the fix or feature.
- [ ] Checked that related changes are merged.
