### PR TITLE
Provider properties interface

### DIFF
--- a/internal/entities/properties/constants.go
+++ b/internal/entities/properties/constants.go
@@ -1,0 +1,34 @@
+//
+// Copyright 2024 Stacklok, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package properties
+
+// General entity keys
+const (
+	// PropertyName represents the name of the entity. The name is formatted by the provider
+	PropertyName = "name"
+	// PropertyUpstreamID represents the ID of the entity in the provider
+	PropertyUpstreamID = "upstream_id"
+)
+
+// Repository property keys
+const (
+	// RepoPropertyIsPrivate represents whether the repository is private
+	RepoPropertyIsPrivate = "is_private"
+	// RepoPropertyIsArchived represents whether the repository is archived
+	RepoPropertyIsArchived = "is_archived"
+	// RepoPropertyIsFork represents whether the repository is a fork
+	RepoPropertyIsFork = "is_fork"
+)

--- a/internal/entities/properties/properties.go
+++ b/internal/entities/properties/properties.go
@@ -1,0 +1,126 @@
+//
+// Copyright 2024 Stacklok, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package properties provides a simple way to access properties of an entity
+package properties
+
+import (
+	"fmt"
+
+	"github.com/puzpuzpuz/xsync/v3"
+)
+
+// Property is a struct that holds a value. It's just a wrapper around an interface{}
+// with typed getters and handling of an empty receiver
+type Property struct {
+	value any
+}
+
+// NewProperty creates a new Property with a given value
+func NewProperty(value any) *Property {
+	return &Property{value: value}
+}
+
+func propertyValueAs[T any](value any) (T, error) {
+	var zero T
+	val, ok := value.(T)
+	if !ok {
+		return zero, fmt.Errorf("value is not of type %T", zero)
+	}
+	return val, nil
+}
+
+// AsBool returns the boolean value, or an error if the value is not a boolean
+func (p *Property) AsBool() (bool, error) {
+	if p == nil {
+		return false, fmt.Errorf("property is nil")
+	}
+	return propertyValueAs[bool](p.value)
+}
+
+// GetBool returns the boolean value, or false if the value is not a boolean
+func (p *Property) GetBool() bool {
+	val, err := p.AsBool()
+	if err != nil {
+		return false
+	}
+	return val
+}
+
+// AsString returns the string value, or an error if the value is not a string
+func (p *Property) AsString() (string, error) {
+	if p == nil {
+		return "", fmt.Errorf("property is nil")
+	}
+	return propertyValueAs[string](p.value)
+}
+
+// GetString returns the string value, or an empty string if the value is not a string
+func (p *Property) GetString() string {
+	if p == nil {
+		return ""
+	}
+	val, err := p.AsString()
+	if err != nil {
+		return ""
+	}
+	return val
+}
+
+// AsInt64 returns the int64 value, or an error if the value is not an int64
+func (p *Property) AsInt64() (int64, error) {
+	if p == nil {
+		return 0, fmt.Errorf("property is nil")
+	}
+	return propertyValueAs[int64](p.value)
+}
+
+// GetInt64 returns the int64 value, or 0 if the value is not an int64
+func (p *Property) GetInt64() int64 {
+	if p == nil {
+		return 0
+	}
+	val, err := p.AsInt64()
+	if err != nil {
+		return 0
+	}
+	return val
+}
+
+// Properties struct that holds the properties map and provides access to Property values
+type Properties struct {
+	props *xsync.MapOf[string, Property]
+}
+
+// NewProperties Properties from a map
+func NewProperties(props map[string]any) *Properties {
+	propsMap := xsync.NewMapOf[string, Property](xsync.WithPresize(len(props)))
+
+	for key, value := range props {
+		propsMap.Store(key, Property{value: value})
+	}
+	return &Properties{
+		props: propsMap,
+	}
+}
+
+// GetProperty returns the Property for a given key or an empty one as a fallback
+func (p *Properties) GetProperty(key string) *Property {
+	prop, ok := p.props.Load(key)
+	if !ok {
+		return nil
+	}
+	return &prop
+}

--- a/internal/entities/properties/properties_test.go
+++ b/internal/entities/properties/properties_test.go
@@ -1,0 +1,264 @@
+//
+// Copyright 2024 Stacklok, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package properties
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestBoolGetters(t *testing.T) {
+	t.Parallel()
+
+	input := map[string]any{
+		"id":         1,
+		"is_private": true,
+	}
+
+	scenarios := []struct {
+		name      string
+		propName  string
+		errString string
+		expValue  bool
+		callGet   bool
+	}{
+		{
+			name:     "AsBool known property",
+			propName: "is_private",
+			expValue: true,
+		},
+		{
+			name:     "GetBool known property",
+			propName: "is_private",
+			expValue: true,
+			callGet:  true,
+		},
+		{
+			name:      "AsBool unknown property",
+			propName:  "unknown",
+			errString: "property is nil",
+		},
+		{
+			name:     "GetBool unknown property",
+			propName: "unknown",
+			expValue: false,
+			callGet:  true,
+		},
+		{
+			name:      "AsBool non-bool property",
+			propName:  "id",
+			errString: "value is not of type bool",
+		},
+		{
+			name:     "GetBool non-bool property",
+			propName: "id",
+			expValue: false,
+			callGet:  true,
+		},
+	}
+
+	for _, s := range scenarios {
+		t.Run(s.name, func(t *testing.T) {
+			t.Parallel()
+
+			props := NewProperties(input)
+			p := props.GetProperty(s.propName)
+			if s.callGet {
+				got := p.GetBool()
+				require.Equal(t, s.expValue, got)
+			} else {
+				got, err := p.AsBool()
+				if s.errString == "" {
+					require.NoError(t, err)
+					require.Equal(t, s.expValue, got)
+				} else {
+					require.Error(t, err)
+					require.ErrorContains(t, err, s.errString)
+				}
+			}
+		})
+	}
+}
+
+func TestStringGetters(t *testing.T) {
+	t.Parallel()
+
+	input := map[string]any{
+		"id":         1,
+		"is_private": true,
+		"name":       "test",
+	}
+
+	scenarios := []struct {
+		name      string
+		propName  string
+		errString string
+		expValue  string
+		callGet   bool
+	}{
+		{
+			name:     "AsString known property",
+			propName: "name",
+			expValue: "test",
+		},
+		{
+			name:     "GetString known property",
+			propName: "name",
+			expValue: "test",
+			callGet:  true,
+		},
+		{
+			name:      "AsString unknown property",
+			propName:  "unknown",
+			errString: "property is nil",
+		},
+		{
+			name:     "GetString unknown property",
+			propName: "unknown",
+			expValue: "",
+			callGet:  true,
+		},
+		{
+			name:      "AsString non-string property",
+			propName:  "id",
+			errString: "value is not of type string",
+		},
+		{
+			name:     "GetString non-string property",
+			propName: "id",
+			expValue: "",
+			callGet:  true,
+		},
+	}
+
+	for _, s := range scenarios {
+		t.Run(s.name, func(t *testing.T) {
+			t.Parallel()
+
+			props := NewProperties(input)
+			p := props.GetProperty(s.propName)
+			if s.callGet {
+				got := p.GetString()
+				require.Equal(t, s.expValue, got)
+			} else {
+				got, err := p.AsString()
+				if s.errString == "" {
+					require.NoError(t, err)
+					require.Equal(t, s.expValue, got)
+				} else {
+					require.Error(t, err)
+					require.ErrorContains(t, err, s.errString)
+				}
+			}
+		})
+	}
+}
+
+func TestInt64Getters(t *testing.T) {
+	t.Parallel()
+
+	input := map[string]any{
+		"id":         1,
+		"is_private": true,
+		"count":      int64(5),
+	}
+
+	scenarios := []struct {
+		name      string
+		propName  string
+		errString string
+		expValue  int64
+		callGet   bool
+	}{
+		{
+			name:     "AsInt64 known property",
+			propName: "count",
+			expValue: 5,
+		},
+		{
+			name:     "GetInt64 known property",
+			propName: "count",
+			expValue: 5,
+			callGet:  true,
+		},
+		{
+			name:      "AsInt64 unknown property",
+			propName:  "unknown",
+			errString: "property is nil",
+		},
+		{
+			name:     "GetInt64 unknown property",
+			propName: "unknown",
+			expValue: 0,
+			callGet:  true,
+		},
+		{
+			name:      "AsInt64 non-int64 property",
+			propName:  "is_private",
+			errString: "value is not of type int64",
+		},
+		{
+			name:     "GetInt64 non-int64 property",
+			propName: "is_private",
+			expValue: 0,
+			callGet:  true,
+		},
+	}
+
+	for _, s := range scenarios {
+		t.Run(s.name, func(t *testing.T) {
+			t.Parallel()
+
+			props := NewProperties(input)
+			p := props.GetProperty(s.propName)
+			if s.callGet {
+				got := p.GetInt64()
+				require.Equal(t, s.expValue, got)
+			} else {
+				got, err := p.AsInt64()
+				if s.errString == "" {
+					require.NoError(t, err)
+					require.Equal(t, s.expValue, got)
+				} else {
+					require.Error(t, err)
+					require.ErrorContains(t, err, s.errString)
+				}
+			}
+		})
+	}
+}
+
+func TestNewProperty(t *testing.T) {
+	t.Parallel()
+
+	p := NewProperty(true)
+	require.NotNil(t, p)
+	require.Equal(t, true, p.GetBool())
+}
+
+func TestNewProperties(t *testing.T) {
+	t.Parallel()
+
+	t.Run("nil input", func(t *testing.T) {
+		t.Parallel()
+
+		props := NewProperties(nil)
+		require.NotNil(t, props)
+		p := props.GetProperty("test")
+		require.Nil(t, p)
+	})
+}

--- a/internal/providers/github/mock/github.go
+++ b/internal/providers/github/mock/github.go
@@ -19,6 +19,7 @@ import (
 	authn "github.com/google/go-containerregistry/pkg/authn"
 	v1 "github.com/google/go-containerregistry/pkg/v1"
 	github "github.com/google/go-github/v63/github"
+	properties "github.com/stacklok/minder/internal/entities/properties"
 	v10 "github.com/stacklok/minder/pkg/api/protobuf/go/minder/v1"
 	v11 "github.com/stacklok/minder/pkg/providers/v1"
 	gomock "go.uber.org/mock/gomock"
@@ -1186,4 +1187,71 @@ func (m *MockOCI) ListTags(ctx context.Context, name string) ([]string, error) {
 func (mr *MockOCIMockRecorder) ListTags(ctx, name any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListTags", reflect.TypeOf((*MockOCI)(nil).ListTags), ctx, name)
+}
+
+// MockPropertiesFetcher is a mock of PropertiesFetcher interface.
+type MockPropertiesFetcher struct {
+	ctrl     *gomock.Controller
+	recorder *MockPropertiesFetcherMockRecorder
+}
+
+// MockPropertiesFetcherMockRecorder is the mock recorder for MockPropertiesFetcher.
+type MockPropertiesFetcherMockRecorder struct {
+	mock *MockPropertiesFetcher
+}
+
+// NewMockPropertiesFetcher creates a new mock instance.
+func NewMockPropertiesFetcher(ctrl *gomock.Controller) *MockPropertiesFetcher {
+	mock := &MockPropertiesFetcher{ctrl: ctrl}
+	mock.recorder = &MockPropertiesFetcherMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MockPropertiesFetcher) EXPECT() *MockPropertiesFetcherMockRecorder {
+	return m.recorder
+}
+
+// CanImplement mocks base method.
+func (m *MockPropertiesFetcher) CanImplement(trait v10.ProviderType) bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CanImplement", trait)
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// CanImplement indicates an expected call of CanImplement.
+func (mr *MockPropertiesFetcherMockRecorder) CanImplement(trait any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CanImplement", reflect.TypeOf((*MockPropertiesFetcher)(nil).CanImplement), trait)
+}
+
+// FetchAllProperties mocks base method.
+func (m *MockPropertiesFetcher) FetchAllProperties(ctx context.Context, name string, entType v10.Entity) (*properties.Properties, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "FetchAllProperties", ctx, name, entType)
+	ret0, _ := ret[0].(*properties.Properties)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// FetchAllProperties indicates an expected call of FetchAllProperties.
+func (mr *MockPropertiesFetcherMockRecorder) FetchAllProperties(ctx, name, entType any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FetchAllProperties", reflect.TypeOf((*MockPropertiesFetcher)(nil).FetchAllProperties), ctx, name, entType)
+}
+
+// FetchProperty mocks base method.
+func (m *MockPropertiesFetcher) FetchProperty(ctx context.Context, name string, entType v10.Entity, key string) (*properties.Property, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "FetchProperty", ctx, name, entType, key)
+	ret0, _ := ret[0].(*properties.Property)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// FetchProperty indicates an expected call of FetchProperty.
+func (mr *MockPropertiesFetcherMockRecorder) FetchProperty(ctx, name, entType, key any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FetchProperty", reflect.TypeOf((*MockPropertiesFetcher)(nil).FetchProperty), ctx, name, entType, key)
 }

--- a/internal/providers/github/properties.go
+++ b/internal/providers/github/properties.go
@@ -1,0 +1,171 @@
+//
+// Copyright 2024 Stacklok, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package github
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/stacklok/minder/internal/entities/properties"
+	minderv1 "github.com/stacklok/minder/pkg/api/protobuf/go/minder/v1"
+)
+
+const (
+	// RepoPropertyId represents the github repository ID (numerical)
+	RepoPropertyId = "github/repo_id"
+	// RepoPropertyName represents the github repository name
+	RepoPropertyName = "github/repo_name"
+	// RepoPropertyOwner represents the github repository owner
+	RepoPropertyOwner = "github/repo_owner"
+	// RepoPropertyDeployURL represents the github repository deployment URL
+	RepoPropertyDeployURL = "github/deploy_url"
+	// RepoPropertyCloneURL represents the github repository clone URL
+	RepoPropertyCloneURL = "github/clone_url"
+	// RepoPropertyDefaultBranch represents the github repository default branch
+	RepoPropertyDefaultBranch = "github/default_branch"
+)
+
+type propertyWrapper func(ctx context.Context, ghCli *GitHub, name string) (map[string]any, error)
+
+type propertyOrigin struct {
+	keys    []string
+	wrapper propertyWrapper
+}
+
+type propertyFetcher struct {
+	ghCli *GitHub
+
+	propertyOrigins []propertyOrigin
+}
+
+var repoPropertyDefinitions = []propertyOrigin{
+	{
+		keys: []string{
+			// general entity
+			properties.PropertyName,
+			properties.PropertyUpstreamID,
+			// general repo
+			properties.RepoPropertyIsPrivate,
+			properties.RepoPropertyIsArchived,
+			properties.RepoPropertyIsFork,
+			// github-specific
+			RepoPropertyId,
+			RepoPropertyName,
+			RepoPropertyOwner,
+			RepoPropertyDeployURL,
+			RepoPropertyCloneURL,
+			RepoPropertyDefaultBranch,
+		},
+		wrapper: getRepoWrapper,
+	},
+}
+
+func newRepoPropertyFetcher(ghCli *GitHub) *propertyFetcher {
+	return &propertyFetcher{
+		ghCli:           ghCli,
+		propertyOrigins: repoPropertyDefinitions,
+	}
+}
+
+func newPropertyFetcher(ghCli *GitHub, entType minderv1.Entity) *propertyFetcher {
+	if entType != minderv1.Entity_ENTITY_REPOSITORIES {
+		return nil
+	}
+
+	return newRepoPropertyFetcher(ghCli)
+}
+
+func getRepoWrapper(ctx context.Context, ghCli *GitHub, name string) (map[string]any, error) {
+	// TODO: this should be a provider interface, even if private
+	slice := strings.Split(name, "/")
+	if len(slice) != 2 {
+		return nil, errors.New("invalid name")
+	}
+
+	repo, err := ghCli.GetRepository(ctx, slice[0], slice[1])
+	if err != nil {
+		return nil, err
+	}
+
+	repoProps := map[string]any{
+		// general entity
+		properties.PropertyName:       fmt.Sprintf("%s/%s", repo.GetOwner().GetLogin(), repo.GetName()),
+		properties.PropertyUpstreamID: fmt.Sprintf("%d", repo.GetID()),
+		// general repo
+		properties.RepoPropertyIsPrivate:  repo.GetPrivate(),
+		properties.RepoPropertyIsArchived: repo.GetArchived(),
+		properties.RepoPropertyIsFork:     repo.GetFork(),
+		// github-specific
+		RepoPropertyId:            repo.GetID(),
+		RepoPropertyName:          repo.GetName(),
+		RepoPropertyOwner:         repo.GetOwner().GetLogin(),
+		RepoPropertyDeployURL:     repo.GetDeploymentsURL(),
+		RepoPropertyCloneURL:      repo.GetCloneURL(),
+		RepoPropertyDefaultBranch: repo.GetDefaultBranch(),
+	}
+
+	return repoProps, nil
+}
+
+// FetchProperty fetches a single property for the given entity
+func (c *GitHub) FetchProperty(
+	ctx context.Context, name string, entType minderv1.Entity, key string,
+) (*properties.Property, error) {
+	pf := newPropertyFetcher(c, entType)
+
+	for _, po := range pf.propertyOrigins {
+		for _, k := range po.keys {
+			if k == key {
+				props, err := po.wrapper(ctx, pf.ghCli, name)
+				if err != nil {
+					return nil, err
+				}
+
+				value, ok := props[key]
+				if !ok {
+					return nil, errors.New("requested property not found in result")
+				}
+				return properties.NewProperty(value), nil
+			}
+		}
+	}
+
+	return nil, errors.New("property not found")
+}
+
+// FetchAllProperties fetches all properties for the given entity
+func (c *GitHub) FetchAllProperties(
+	ctx context.Context, name string, entType minderv1.Entity,
+) (*properties.Properties, error) {
+	pf := newPropertyFetcher(c, entType)
+
+	result := make(map[string]any)
+
+	for _, po := range pf.propertyOrigins {
+		props, err := po.wrapper(ctx, pf.ghCli, name)
+		if err != nil {
+			return nil, err
+		}
+
+		for k, v := range props {
+			result[k] = v
+		}
+	}
+
+	return properties.NewProperties(result), nil
+}

--- a/internal/repositories/github/service.go
+++ b/internal/repositories/github/service.go
@@ -26,9 +26,11 @@ import (
 	"github.com/rs/zerolog/log"
 
 	"github.com/stacklok/minder/internal/db"
+	"github.com/stacklok/minder/internal/entities/properties"
 	"github.com/stacklok/minder/internal/events"
 	"github.com/stacklok/minder/internal/logger"
 	"github.com/stacklok/minder/internal/projects/features"
+	ghprov "github.com/stacklok/minder/internal/providers/github"
 	"github.com/stacklok/minder/internal/providers/manager"
 	reconcilers "github.com/stacklok/minder/internal/reconcilers/messages"
 	ghclient "github.com/stacklok/minder/internal/repositories/github/clients"
@@ -143,19 +145,36 @@ func (r *repositoryService) CreateRepository(
 		return nil, fmt.Errorf("error instantiating github client: %w", err)
 	}
 
-	// get information about the repo from GitHub, and ensure it exists
-	githubRepo, err := client.GetRepository(ctx, repoOwner, repoName)
+	propClient, err := provifv1.As[provifv1.PropertiesFetcher](p)
 	if err != nil {
-		return nil, fmt.Errorf("error retrieving repo from github: %w", err)
+		return nil, fmt.Errorf("error instantiating properties client: %w", err)
+	}
+
+	repoProperties, err := propClient.FetchAllProperties(
+		ctx,
+		fmt.Sprintf("%s/%s", repoOwner, repoName),
+		pb.Entity_ENTITY_REPOSITORIES)
+	if err != nil {
+		return nil, fmt.Errorf("error fetching properties for repository: %w", err)
+	}
+
+	isArchived, err := repoProperties.GetProperty(properties.RepoPropertyIsArchived).AsBool()
+	if err != nil {
+		return nil, fmt.Errorf("error fetching is_archived property: %w", err)
 	}
 
 	// skip if this is an archived repo
-	if githubRepo.GetArchived() {
+	if isArchived {
 		return nil, ErrArchivedRepoForbidden
 	}
 
+	isPrivate, err := repoProperties.GetProperty(properties.RepoPropertyIsPrivate).AsBool()
+	if err != nil {
+		return nil, fmt.Errorf("error fetching is_archived property: %w", err)
+	}
+
 	// skip if this is a private repo, and private repos are not enabled
-	if githubRepo.GetPrivate() && !features.ProjectAllowsPrivateRepos(ctx, r.store, projectID) {
+	if isPrivate && !features.ProjectAllowsPrivateRepos(ctx, r.store, projectID) {
 		return nil, ErrPrivateRepoForbidden
 	}
 
@@ -168,7 +187,7 @@ func (r *repositoryService) CreateRepository(
 	// insert the repository into the DB
 	dbID, pbRepo, err := r.persistRepository(
 		ctx,
-		githubRepo,
+		repoProperties,
 		githubHook,
 		hookUUID,
 		projectID,
@@ -369,7 +388,7 @@ func (r *repositoryService) pushReconcilerEvent(pbRepo *pb.Repository, projectID
 // returns DB PK along with protobuf representation of a repo
 func (r *repositoryService) persistRepository(
 	ctx context.Context,
-	githubRepo *github.Repository,
+	repoProperties *properties.Properties,
 	githubHook *github.Hook,
 	hookUUID string,
 	projectID uuid.UUID,
@@ -378,20 +397,9 @@ func (r *repositoryService) persistRepository(
 	var outid uuid.UUID
 	pbr, err := db.WithTransaction(r.store, func(t db.ExtendQuerier) (*pb.Repository, error) {
 		// instantiate the response object
-		pbRepo := &pb.Repository{
-			Name:          githubRepo.GetName(),
-			Owner:         githubRepo.GetOwner().GetLogin(),
-			RepoId:        githubRepo.GetID(),
-			HookId:        githubHook.GetID(),
-			HookUrl:       githubHook.GetURL(),
-			DeployUrl:     githubRepo.GetDeploymentsURL(),
-			CloneUrl:      githubRepo.GetCloneURL(),
-			HookType:      githubHook.GetType(),
-			HookName:      githubHook.GetName(),
-			HookUuid:      hookUUID,
-			IsPrivate:     githubRepo.GetPrivate(),
-			IsFork:        githubRepo.GetFork(),
-			DefaultBranch: githubRepo.GetDefaultBranch(),
+		pbRepo, err := pbRepoFromProperties(repoProperties, githubHook, hookUUID)
+		if err != nil {
+			return nil, fmt.Errorf("error creating repository object: %w", err)
 		}
 
 		// update the database
@@ -439,4 +447,53 @@ func (r *repositoryService) persistRepository(
 	}
 
 	return outid, pbr, nil
+}
+
+func pbRepoFromProperties(
+	repoProperties *properties.Properties,
+	githubHook *github.Hook,
+	hookUUID string,
+) (*pb.Repository, error) {
+	name, err := repoProperties.GetProperty(ghprov.RepoPropertyName).AsString()
+	if err != nil {
+		return nil, fmt.Errorf("error fetching name property: %w", err)
+	}
+
+	owner, err := repoProperties.GetProperty(ghprov.RepoPropertyOwner).AsString()
+	if err != nil {
+		return nil, fmt.Errorf("error fetching owner property: %w", err)
+	}
+
+	repoId, err := repoProperties.GetProperty(ghprov.RepoPropertyId).AsInt64()
+	if err != nil {
+		return nil, fmt.Errorf("error fetching repo_id property: %w", err)
+	}
+
+	isPrivate, err := repoProperties.GetProperty(properties.RepoPropertyIsPrivate).AsBool()
+	if err != nil {
+		return nil, fmt.Errorf("error fetching is_archived property: %w", err)
+	}
+
+	isFork, err := repoProperties.GetProperty(properties.RepoPropertyIsFork).AsBool()
+	if err != nil {
+		return nil, fmt.Errorf("error fetching is_archived property: %w", err)
+	}
+
+	pbRepo := &pb.Repository{
+		Name:          name,
+		Owner:         owner,
+		RepoId:        repoId,
+		HookId:        githubHook.GetID(),
+		HookUrl:       githubHook.GetURL(),
+		DeployUrl:     repoProperties.GetProperty(ghprov.RepoPropertyDeployURL).GetString(),
+		CloneUrl:      repoProperties.GetProperty(ghprov.RepoPropertyCloneURL).GetString(),
+		HookType:      githubHook.GetType(),
+		HookName:      githubHook.GetName(),
+		HookUuid:      hookUUID,
+		IsPrivate:     isPrivate,
+		IsFork:        isFork,
+		DefaultBranch: repoProperties.GetProperty(ghprov.RepoPropertyDefaultBranch).GetString(),
+	}
+
+	return pbRepo, nil
 }

--- a/internal/repositories/github/service_test.go
+++ b/internal/repositories/github/service_test.go
@@ -19,6 +19,7 @@ import (
 	"database/sql"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"testing"
 
 	gh "github.com/google/go-github/v63/github"
@@ -28,7 +29,9 @@ import (
 
 	mockdb "github.com/stacklok/minder/database/mock"
 	"github.com/stacklok/minder/internal/db"
+	"github.com/stacklok/minder/internal/entities/properties"
 	mockevents "github.com/stacklok/minder/internal/events/mock"
+	ghprov "github.com/stacklok/minder/internal/providers/github"
 	mockgithub "github.com/stacklok/minder/internal/providers/github/mock"
 	"github.com/stacklok/minder/internal/providers/manager"
 	pf "github.com/stacklok/minder/internal/providers/manager/mock/fixtures"
@@ -40,6 +43,25 @@ import (
 	pb "github.com/stacklok/minder/pkg/api/protobuf/go/minder/v1"
 	provinfv1 "github.com/stacklok/minder/pkg/providers/v1"
 )
+
+// the mockGhProp struct is a wrapper around the mockgithub.MockGitHub struct
+// that implements both the GitHub and PropertiesFetcher interfaces. This is
+// needed because the service converts the Provider interface to both GitHub
+// and PropertiesFetcher interfaces. The GitHub interface is used only to be
+// passed to the webhook manager, which is mocked but still requires the right
+// type
+type mockGhProp struct {
+	*mockgithub.MockGitHub
+	prop *mockgithub.MockPropertiesFetcher
+}
+
+func (mgp *mockGhProp) FetchAllProperties(ctx context.Context, name string, entType pb.Entity) (*properties.Properties, error) {
+	return mgp.prop.FetchAllProperties(ctx, name, entType)
+}
+
+func (mgp *mockGhProp) FetchProperty(ctx context.Context, name string, entType pb.Entity, key string) (*properties.Property, error) {
+	return mgp.prop.FetchProperty(ctx, name, entType, key)
+}
 
 func TestRepositoryService_CreateRepository(t *testing.T) {
 	t.Parallel()
@@ -58,51 +80,51 @@ func TestRepositoryService_CreateRepository(t *testing.T) {
 			ExpectedError: "error instantiating provider",
 		},
 		{
-			Name:          "CreateRepository fails when repo cannot be found in GitHub",
+			Name:          "CreateRepository fails when repo properties cannot be found in GitHub",
 			ProviderSetup: withFailingGet,
-			ExpectedError: "error retrieving repo from github",
+			ExpectedError: "error fetching properties for repository",
 		},
 		{
 			Name:          "CreateRepository fails for private repo in project which disallows private repos",
-			ProviderSetup: withSuccessfulGet(privateRepo),
+			ProviderSetup: withSuccessfulPropFetch(privateProps),
 			DBSetup:       newDBMock(withPrivateReposDisabled),
 			ExpectedError: "private repos cannot be registered in this project",
 		},
 		{
 			Name:          "CreateRepository fails when webhook creation fails",
-			ProviderSetup: withSuccessfulGet(publicRepo),
+			ProviderSetup: withSuccessfulPropFetch(publicProps),
 			WebhookSetup:  newWebhookMock(withFailedWebhookCreate),
 			ExpectedError: "error creating webhook in repo",
 		},
 		{
 			Name:          "CreateRepository fails when repo cannot be inserted into database",
-			ProviderSetup: withSuccessfulGet(publicRepo),
+			ProviderSetup: withSuccessfulPropFetch(publicProps),
 			DBSetup:       newDBMock(withFailedCreate),
 			WebhookSetup:  newWebhookMock(withSuccessfulWebhookCreate, withSuccessfulWebhookDelete),
 			ExpectedError: "error creating repository",
 		},
 		{
 			Name:          "CreateRepository fails when repo cannot be inserted into database (cleanup fails)",
-			ProviderSetup: withSuccessfulGet(publicRepo),
+			ProviderSetup: withSuccessfulPropFetch(publicProps),
 			DBSetup:       newDBMock(withFailedCreate),
 			WebhookSetup:  newWebhookMock(withSuccessfulWebhookCreate, withFailedWebhookDelete),
 			ExpectedError: "error creating repository",
 		},
 		{
 			Name:          "CreateRepository succeeds",
-			ProviderSetup: withSuccessfulGet(publicRepo),
+			ProviderSetup: withSuccessfulPropFetch(publicProps),
 			DBSetup:       newDBMock(withSuccessfulCreate),
 			WebhookSetup:  newWebhookMock(withSuccessfulWebhookCreate),
 		},
 		{
 			Name:          "CreateRepository succeeds (private repos enabled)",
-			ProviderSetup: withSuccessfulGet(privateRepo),
+			ProviderSetup: withSuccessfulPropFetch(privateProps),
 			DBSetup:       newDBMock(withPrivateReposEnabled, withSuccessfulCreate),
 			WebhookSetup:  newWebhookMock(withSuccessfulWebhookCreate),
 		},
 		{
 			Name:           "CreateRepository succeeds (skips failed event send)",
-			ProviderSetup:  withSuccessfulGet(publicRepo),
+			ProviderSetup:  withSuccessfulPropFetch(publicProps),
 			DBSetup:        newDBMock(withSuccessfulCreate),
 			WebhookSetup:   newWebhookMock(withSuccessfulWebhookCreate),
 			EventSendFails: true,
@@ -400,9 +422,10 @@ var (
 	webhook = &gh.Hook{
 		ID: ptr.Ptr[int64](cf.HookID),
 	}
-	publicRepo  = newGithubRepo(false)
-	privateRepo = newGithubRepo(true)
-	provider    = db.Provider{
+	publicRepo   = newGithubRepo(false)
+	publicProps  = newGithubRepoProperties(false)
+	privateProps = newGithubRepoProperties(true)
+	provider     = db.Provider{
 		ID:         uuid.UUID{},
 		Name:       providerName,
 		Implements: []db.ProviderType{db.ProviderTypeGithub},
@@ -559,6 +582,24 @@ func newGithubRepo(isPrivate bool) *gh.Repository {
 	}
 }
 
+func newGithubRepoProperties(isPrivate bool) *properties.Properties {
+	repoProps := map[string]any{
+		properties.PropertyName:           fmt.Sprintf("%s/%s", repoOwner, repoName),
+		properties.PropertyUpstreamID:     fmt.Sprintf("%d", *ghRepoID),
+		properties.RepoPropertyIsPrivate:  isPrivate,
+		properties.RepoPropertyIsArchived: false,
+		properties.RepoPropertyIsFork:     false,
+		ghprov.RepoPropertyId:             *ghRepoID,
+		ghprov.RepoPropertyName:           repoName,
+		ghprov.RepoPropertyOwner:          repoOwner,
+		ghprov.RepoPropertyDeployURL:      "https://foo.com",
+		ghprov.RepoPropertyCloneURL:       "http://cloneurl.com",
+		ghprov.RepoPropertyDefaultBranch:  "main",
+	}
+
+	return properties.NewProperties(repoProps)
+}
+
 func newExpectation(isPrivate bool) *pb.Repository {
 	return &pb.Repository{
 		Id:            ptr.Ptr(dbRepo.ID.String()),
@@ -579,19 +620,27 @@ func newExpectation(isPrivate bool) *pb.Repository {
 }
 
 func withFailingGet(ctrl *gomock.Controller) provinfv1.Provider {
-	provider := mockgithub.NewMockGitHub(ctrl)
-	provider.EXPECT().
-		GetRepository(gomock.Any(), gomock.Any(), gomock.Any()).
+	propMock := mockgithub.NewMockPropertiesFetcher(ctrl)
+	propMock.EXPECT().
+		FetchAllProperties(gomock.Any(), gomock.Any(), gomock.Any()).
 		Return(nil, errDefault)
-	return provider
+
+	return &mockGhProp{
+		MockGitHub: mockgithub.NewMockGitHub(ctrl),
+		prop:       propMock,
+	}
 }
 
-func withSuccessfulGet(repo *gh.Repository) func(*gomock.Controller) provinfv1.Provider {
+func withSuccessfulPropFetch(prop *properties.Properties) func(*gomock.Controller) provinfv1.Provider {
 	return func(ctrl *gomock.Controller) provinfv1.Provider {
-		provider := mockgithub.NewMockGitHub(ctrl)
-		provider.EXPECT().
-			GetRepository(gomock.Any(), gomock.Any(), gomock.Any()).
-			Return(repo, nil)
-		return provider
+		propMock := mockgithub.NewMockPropertiesFetcher(ctrl)
+		propMock.EXPECT().
+			FetchAllProperties(gomock.Any(), gomock.Any(), gomock.Any()).
+			Return(prop, nil)
+
+		return &mockGhProp{
+			MockGitHub: mockgithub.NewMockGitHub(ctrl),
+			prop:       propMock,
+		}
 	}
 }

--- a/pkg/providers/v1/providers.go
+++ b/pkg/providers/v1/providers.go
@@ -31,6 +31,7 @@ import (
 	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-github/v63/github"
 
+	"github.com/stacklok/minder/internal/entities/properties"
 	minderv1 "github.com/stacklok/minder/pkg/api/protobuf/go/minder/v1"
 )
 
@@ -184,6 +185,14 @@ type OCI interface {
 
 	// GetAuthenticator returns the authenticator for the OCI provider
 	GetAuthenticator() (authn.Authenticator, error)
+}
+
+// PropertiesFetcher is the interface for fetching entity properties
+type PropertiesFetcher interface {
+	Provider
+
+	FetchAllProperties(ctx context.Context, name string, entType minderv1.Entity) (*properties.Properties, error)
+	FetchProperty(ctx context.Context, name string, entType minderv1.Entity, key string) (*properties.Property, error)
 }
 
 // ParseAndValidate parses the given provider configuration and validates it.


### PR DESCRIPTION
# Summary

This PR adds a new provider interface for fetching properties as well as its implementation for the github provider. The interface returns new Property types which are convenience types to allow returning Go types from the unstructured properties returned by the providers. Lastly, the PR adds constants for the currently used properties, either generic entity properties, generic repo properties or github-specific repo properties.

Closes: https://github.com/stacklok/minder/issues/4165

## Change Type

***Mark the type of change your PR introduces:***

- [ ] Bug fix (resolves an issue without affecting existing features)
- [x] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [ ] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

***Outline how the changes were tested, including steps to reproduce and any relevant configurations. 
Attach screenshots if helpful.***

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [ ] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [x] Included tests that validate the fix or feature.
- [ ] Checked that related changes are merged.
