### PR TITLE
Do a noop update when updating the entities table

### DIFF
--- a/database/query/entities.sql
+++ b/database/query/entities.sql
@@ -35,7 +35,9 @@ INSERT INTO entity_instances (
     provider_id,
     originated_from
 ) VALUES ($1, $2, $3, sqlc.arg(project_id), sqlc.arg(provider_id), sqlc.narg(originated_from))
-ON CONFLICT (id) DO NOTHING
+ON CONFLICT (id) DO UPDATE
+SET
+    id = entity_instances.id  -- This is a "noop" update to ensure the RETURNING clause works
 RETURNING *;
 
 -- DeleteEntity removes an entity from the entity_instances table for a project.

--- a/internal/db/entities.sql.go
+++ b/internal/db/entities.sql.go
@@ -109,7 +109,9 @@ INSERT INTO entity_instances (
     provider_id,
     originated_from
 ) VALUES ($1, $2, $3, $4, $5, $6)
-ON CONFLICT (id) DO NOTHING
+ON CONFLICT (id) DO UPDATE
+SET
+    id = entity_instances.id  -- This is a "noop" update to ensure the RETURNING clause works
 RETURNING id, entity_type, name, project_id, provider_id, created_at, originated_from
 `
 


### PR DESCRIPTION
# Summary

The `ON CONFLICT DO NOTHING` clause we used previously would have caused
the SQL query to return "No rows in result set". Let's pretend we do an
update by setting an ID to its own value to trigger the `RETURN` clause.

## Change Type

- [x] Bug fix (resolves an issue without affecting existing features)
- [ ] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [ ] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

smoke tests

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [ ] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [ ] Included tests that validate the fix or feature.
- [ ] Checked that related changes are merged.
