### PR TITLE
Check for non-empty length of previous metadata

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,3 +67,6 @@ examples/rules-and-profiles
 
 # Ignore generated sigstore artifacts while running this locally
 tuf-repo-cdn.sigstore.dev.json
+
+# Offline tokens from minder CLI
+offline.token

--- a/internal/engine/actions/alert/security_advisory/security_advisory.go
+++ b/internal/engine/actions/alert/security_advisory/security_advisory.go
@@ -336,7 +336,7 @@ func (alert *Alert) getParamsForSecurityAdvisory(
 		},
 	}
 	// Unmarshal the existing alert metadata, if any
-	if metadata != nil {
+	if metadata != nil && len(*metadata) != 0 {
 		meta := &alertMetadata{}
 		err := json.Unmarshal(*metadata, meta)
 		if err != nil {


### PR DESCRIPTION
If there is no prior alert state for a rule/entity pair, an empty db result struct is passed around in the evaluation context. Due to a change from an inner join to a left join, the field's type changed from a pointer to a byte slice to just a byte slice. In the empty case, this means that the alert metadata is represented by an empty byte slice instead of a nil. Change the code to check for empty length in addition to nil-ness.

# Summary

***Provide a brief overview of the changes and the issue being addressed. 
Explain the rationale and any background necessary for understanding the changes. 
List dependencies required by this change, if any.***

Fixes #(related issue)

## Change Type

***Mark the type of change your PR introduces:***

- [x] Bug fix (resolves an issue without affecting existing features)
- [ ] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [ ] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

***Outline how the changes were tested, including steps to reproduce and any relevant configurations. 
Attach screenshots if helpful.***

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [ ] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [x] Included tests that validate the fix or feature.
- [ ] Checked that related changes are merged.
