### PR TITLE
Fix issue with Alert URLs for pull requests and artifacts

### DIFF
--- a/database/mock/store.go
+++ b/database/mock/store.go
@@ -1315,6 +1315,36 @@ func (mr *MockStoreMockRecorder) GetQuerierWithTransaction(arg0 any) *gomock.Cal
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetQuerierWithTransaction", reflect.TypeOf((*MockStore)(nil).GetQuerierWithTransaction), arg0)
 }
 
+// GetRepoPathFromArtifactID mocks base method.
+func (m *MockStore) GetRepoPathFromArtifactID(arg0 context.Context, arg1 uuid.UUID) (db.GetRepoPathFromArtifactIDRow, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetRepoPathFromArtifactID", arg0, arg1)
+	ret0, _ := ret[0].(db.GetRepoPathFromArtifactIDRow)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetRepoPathFromArtifactID indicates an expected call of GetRepoPathFromArtifactID.
+func (mr *MockStoreMockRecorder) GetRepoPathFromArtifactID(arg0, arg1 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRepoPathFromArtifactID", reflect.TypeOf((*MockStore)(nil).GetRepoPathFromArtifactID), arg0, arg1)
+}
+
+// GetRepoPathFromPullRequestID mocks base method.
+func (m *MockStore) GetRepoPathFromPullRequestID(arg0 context.Context, arg1 uuid.UUID) (db.GetRepoPathFromPullRequestIDRow, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetRepoPathFromPullRequestID", arg0, arg1)
+	ret0, _ := ret[0].(db.GetRepoPathFromPullRequestIDRow)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetRepoPathFromPullRequestID indicates an expected call of GetRepoPathFromPullRequestID.
+func (mr *MockStoreMockRecorder) GetRepoPathFromPullRequestID(arg0, arg1 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRepoPathFromPullRequestID", reflect.TypeOf((*MockStore)(nil).GetRepoPathFromPullRequestID), arg0, arg1)
+}
+
 // GetRepositoryByID mocks base method.
 func (m *MockStore) GetRepositoryByID(arg0 context.Context, arg1 uuid.UUID) (db.Repository, error) {
 	m.ctrl.T.Helper()

--- a/database/query/profile_status.sql
+++ b/database/query/profile_status.sql
@@ -137,7 +137,13 @@ SELECT
     rt.severity_value as rule_type_severity_value,
     rt.id AS rule_type_id,
     rt.guidance as rule_type_guidance,
-    rt.display_name as rule_type_display_name
+    rt.display_name as rule_type_display_name,
+    -- TODO: store entity ID directly in evaluation_rule_entities
+    CASE
+        WHEN ere.entity_type = 'artifact'::entities THEN ere.artifact_id
+        WHEN ere.entity_type = 'repository'::entities THEN ere.repository_id
+        WHEN ere.entity_type = 'pull_request'::entities THEN ere.pull_request_id
+    END::uuid as entity_id
 FROM latest_evaluation_statuses les
          INNER JOIN evaluation_rule_entities ere ON ere.id = les.rule_entity_id
          INNER JOIN eval_details ed ON ed.id = les.evaluation_history_id

--- a/database/query/repositories.sql
+++ b/database/query/repositories.sql
@@ -76,3 +76,13 @@ SELECT COUNT(*) FROM repositories;
 -- name: GetProviderWebhooks :many
 SELECT repo_owner, repo_name, webhook_id FROM repositories
 WHERE webhook_id IS NOT NULL AND provider_id = $1;
+
+-- name: GetRepoPathFromArtifactID :one
+SELECT r.repo_owner AS owner , r.repo_name AS name FROM repositories AS r
+JOIN artifacts AS a ON a.repository_id = r.id
+WHERE a.id = $1;
+
+-- name: GetRepoPathFromPullRequestID :one
+SELECT r.repo_owner AS owner , r.repo_name AS name FROM repositories AS r
+JOIN pull_requests AS p ON p.repository_id = r.id
+WHERE p.id = $1;

--- a/internal/db/profile_status.sql.go
+++ b/internal/db/profile_status.sql.go
@@ -208,7 +208,13 @@ SELECT
     rt.severity_value as rule_type_severity_value,
     rt.id AS rule_type_id,
     rt.guidance as rule_type_guidance,
-    rt.display_name as rule_type_display_name
+    rt.display_name as rule_type_display_name,
+    -- TODO: store entity ID directly in evaluation_rule_entities
+    CASE
+        WHEN ere.entity_type = 'artifact'::entities THEN ere.artifact_id
+        WHEN ere.entity_type = 'repository'::entities THEN ere.repository_id
+        WHEN ere.entity_type = 'pull_request'::entities THEN ere.pull_request_id
+    END::uuid as entity_id
 FROM latest_evaluation_statuses les
          INNER JOIN evaluation_rule_entities ere ON ere.id = les.rule_entity_id
          INNER JOIN eval_details ed ON ed.id = les.evaluation_history_id
@@ -262,6 +268,7 @@ type ListRuleEvaluationsByProfileIdRow struct {
 	RuleTypeID            uuid.UUID              `json:"rule_type_id"`
 	RuleTypeGuidance      string                 `json:"rule_type_guidance"`
 	RuleTypeDisplayName   string                 `json:"rule_type_display_name"`
+	EntityID              uuid.UUID              `json:"entity_id"`
 }
 
 func (q *Queries) ListRuleEvaluationsByProfileId(ctx context.Context, arg ListRuleEvaluationsByProfileIdParams) ([]ListRuleEvaluationsByProfileIdRow, error) {
@@ -303,6 +310,7 @@ func (q *Queries) ListRuleEvaluationsByProfileId(ctx context.Context, arg ListRu
 			&i.RuleTypeID,
 			&i.RuleTypeGuidance,
 			&i.RuleTypeDisplayName,
+			&i.EntityID,
 		); err != nil {
 			return nil, err
 		}

--- a/internal/db/querier.go
+++ b/internal/db/querier.go
@@ -149,6 +149,8 @@ type Querier interface {
 	GetProviderWebhooks(ctx context.Context, providerID uuid.UUID) ([]GetProviderWebhooksRow, error)
 	GetPullRequest(ctx context.Context, arg GetPullRequestParams) (PullRequest, error)
 	GetPullRequestByID(ctx context.Context, id uuid.UUID) (PullRequest, error)
+	GetRepoPathFromArtifactID(ctx context.Context, id uuid.UUID) (GetRepoPathFromArtifactIDRow, error)
+	GetRepoPathFromPullRequestID(ctx context.Context, id uuid.UUID) (GetRepoPathFromPullRequestIDRow, error)
 	// avoid using this, where possible use GetRepositoryByIDAndProject instead
 	GetRepositoryByID(ctx context.Context, id uuid.UUID) (Repository, error)
 	GetRepositoryByIDAndProject(ctx context.Context, arg GetRepositoryByIDAndProjectParams) (Repository, error)

--- a/internal/db/repositories.sql.go
+++ b/internal/db/repositories.sql.go
@@ -146,6 +146,42 @@ func (q *Queries) GetProviderWebhooks(ctx context.Context, providerID uuid.UUID)
 	return items, nil
 }
 
+const getRepoPathFromArtifactID = `-- name: GetRepoPathFromArtifactID :one
+SELECT r.repo_owner AS owner , r.repo_name AS name FROM repositories AS r
+JOIN artifacts AS a ON a.repository_id = r.id
+WHERE a.id = $1
+`
+
+type GetRepoPathFromArtifactIDRow struct {
+	Owner string `json:"owner"`
+	Name  string `json:"name"`
+}
+
+func (q *Queries) GetRepoPathFromArtifactID(ctx context.Context, id uuid.UUID) (GetRepoPathFromArtifactIDRow, error) {
+	row := q.db.QueryRowContext(ctx, getRepoPathFromArtifactID, id)
+	var i GetRepoPathFromArtifactIDRow
+	err := row.Scan(&i.Owner, &i.Name)
+	return i, err
+}
+
+const getRepoPathFromPullRequestID = `-- name: GetRepoPathFromPullRequestID :one
+SELECT r.repo_owner AS owner , r.repo_name AS name FROM repositories AS r
+JOIN pull_requests AS p ON p.repository_id = r.id
+WHERE p.id = $1
+`
+
+type GetRepoPathFromPullRequestIDRow struct {
+	Owner string `json:"owner"`
+	Name  string `json:"name"`
+}
+
+func (q *Queries) GetRepoPathFromPullRequestID(ctx context.Context, id uuid.UUID) (GetRepoPathFromPullRequestIDRow, error) {
+	row := q.db.QueryRowContext(ctx, getRepoPathFromPullRequestID, id)
+	var i GetRepoPathFromPullRequestIDRow
+	err := row.Scan(&i.Owner, &i.Name)
+	return i, err
+}
+
 const getRepositoryByID = `-- name: GetRepositoryByID :one
 SELECT id, provider, project_id, repo_owner, repo_name, repo_id, is_private, is_fork, webhook_id, webhook_url, deploy_url, clone_url, created_at, updated_at, default_branch, license, provider_id, reminder_last_sent FROM repositories WHERE id = $1
 `


### PR DESCRIPTION
The `GetProfileStatusByName` URL returns a bunch of information about profiles, including the URL of GHSA alerts if one was created. Minder does not store this URL in the DB, and instead creates it on the fly in the handler code. This assumed that the repo name and owner was returned from the `ListRuleEvaluationsByProfileId` SQL query for all entities, not just repositories.

Since my recent changes removed the link between evaluation history and repositories for artifacts and pull requests, this logic stopped working. This works around the problem by querying the DB explicitly.

Ideally, the URL would be stored in the database as part of the alert metadata. This handles, for example, self-hosted Github, or indeed, alerts other than GHSAs. I consider that a longer term change which requires additional changes. This fixes the immediate problem.

Validated locally that this fixes the issue with the smoke tests.

# Summary

***Provide a brief overview of the changes and the issue being addressed. 
Explain the rationale and any background necessary for understanding the changes. 
List dependencies required by this change, if any.***

Fixes #(related issue)

## Change Type

***Mark the type of change your PR introduces:***

- [x] Bug fix (resolves an issue without affecting existing features)
- [ ] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [ ] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

***Outline how the changes were tested, including steps to reproduce and any relevant configurations. 
Attach screenshots if helpful.***

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [ ] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [x] Included tests that validate the fix or feature.
- [ ] Checked that related changes are merged.
