### PR TITLE
Store repo license again

### DIFF
--- a/internal/providers/github/properties.go
+++ b/internal/providers/github/properties.go
@@ -38,6 +38,8 @@ const (
 	RepoPropertyCloneURL = "github/clone_url"
 	// RepoPropertyDefaultBranch represents the github repository default branch
 	RepoPropertyDefaultBranch = "github/default_branch"
+	// RepoPropertyLicense represents the github repository license
+	RepoPropertyLicense = "github/license"
 )
 
 type propertyWrapper func(ctx context.Context, ghCli *GitHub, name string) (map[string]any, error)
@@ -70,6 +72,7 @@ var repoPropertyDefinitions = []propertyOrigin{
 			RepoPropertyDeployURL,
 			RepoPropertyCloneURL,
 			RepoPropertyDefaultBranch,
+			RepoPropertyLicense,
 		},
 		wrapper: getRepoWrapper,
 	},
@@ -117,6 +120,7 @@ func getRepoWrapper(ctx context.Context, ghCli *GitHub, name string) (map[string
 		RepoPropertyDeployURL:     repo.GetDeploymentsURL(),
 		RepoPropertyCloneURL:      repo.GetCloneURL(),
 		RepoPropertyDefaultBranch: repo.GetDefaultBranch(),
+		RepoPropertyLicense:       repo.GetLicense().GetSPDXID(),
 	}
 
 	return repoProps, nil

--- a/internal/repositories/github/service.go
+++ b/internal/repositories/github/service.go
@@ -402,6 +402,12 @@ func (r *repositoryService) persistRepository(
 			return nil, fmt.Errorf("error creating repository object: %w", err)
 		}
 
+		License := sql.NullString{}
+		if pbRepo.License != "" {
+			License.String = pbRepo.License
+			License.Valid = true
+		}
+
 		// update the database
 		dbRepo, err := t.CreateRepository(ctx, db.CreateRepositoryParams{
 			Provider:   provider.Name,
@@ -423,6 +429,7 @@ func (r *repositoryService) persistRepository(
 				String: pbRepo.DefaultBranch,
 				Valid:  true,
 			},
+			License: License,
 		})
 		if err != nil {
 			return pbRepo, err
@@ -493,6 +500,7 @@ func pbRepoFromProperties(
 		IsPrivate:     isPrivate,
 		IsFork:        isFork,
 		DefaultBranch: repoProperties.GetProperty(ghprov.RepoPropertyDefaultBranch).GetString(),
+		License:       repoProperties.GetProperty(ghprov.RepoPropertyLicense).GetString(),
 	}
 
 	return pbRepo, nil


### PR DESCRIPTION
# Summary

We used to store repo license since
5a78abc38d3608b9e77d11042aaaf6eea04f6763 but then stopping saving the
attribute in d68e8e697dcd36f8c1fd9ec9d8a894903c4f2827. We still have
ruletypes that rely on that attribute, so let's just re-add it.

Side-note: Saving generic attributes will get way easier once we
implement properties fully.

## Change Type

- [x] Bug fix (resolves an issue without affecting existing features)
- [ ] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [ ] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

manually

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [ ] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [ ] Included tests that validate the fix or feature.
- [ ] Checked that related changes are merged.
