### PR TITLE
Use nil evaluation state if there is no previous evaluation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,3 +67,6 @@ examples/rules-and-profiles
 
 # Ignore generated sigstore artifacts while running this locally
 tuf-repo-cdn.sigstore.dev.json
+
+# Offline tokens from minder CLI
+offline.token

--- a/database/mock/store.go
+++ b/database/mock/store.go
@@ -1376,10 +1376,10 @@ func (mr *MockStoreMockRecorder) GetRepositoryByRepoName(arg0, arg1 any) *gomock
 }
 
 // GetRuleEvaluationByProfileIdAndRuleType mocks base method.
-func (m *MockStore) GetRuleEvaluationByProfileIdAndRuleType(arg0 context.Context, arg1 uuid.UUID, arg2 db.NullEntities, arg3 sql.NullString, arg4 uuid.NullUUID, arg5 sql.NullString) (db.ListRuleEvaluationsByProfileIdRow, error) {
+func (m *MockStore) GetRuleEvaluationByProfileIdAndRuleType(arg0 context.Context, arg1 uuid.UUID, arg2 db.NullEntities, arg3 sql.NullString, arg4 uuid.NullUUID, arg5 sql.NullString) (*db.ListRuleEvaluationsByProfileIdRow, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetRuleEvaluationByProfileIdAndRuleType", arg0, arg1, arg2, arg3, arg4, arg5)
-	ret0, _ := ret[0].(db.ListRuleEvaluationsByProfileIdRow)
+	ret0, _ := ret[0].(*db.ListRuleEvaluationsByProfileIdRow)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }

--- a/internal/db/store.go
+++ b/internal/db/store.go
@@ -27,7 +27,7 @@ import (
 type ExtendQuerier interface {
 	Querier
 	GetRuleEvaluationByProfileIdAndRuleType(ctx context.Context, profileID uuid.UUID, entityType NullEntities,
-		ruleName sql.NullString, entityID uuid.NullUUID, ruleTypeName sql.NullString) (ListRuleEvaluationsByProfileIdRow, error)
+		ruleName sql.NullString, entityID uuid.NullUUID, ruleTypeName sql.NullString) (*ListRuleEvaluationsByProfileIdRow, error)
 }
 
 // Store provides all functions to execute db queries and transactions
@@ -110,7 +110,7 @@ func (q *Queries) GetRuleEvaluationByProfileIdAndRuleType(
 	ruleName sql.NullString,
 	entityID uuid.NullUUID,
 	ruleTypeName sql.NullString,
-) (ListRuleEvaluationsByProfileIdRow, error) {
+) (*ListRuleEvaluationsByProfileIdRow, error) {
 	params := ListRuleEvaluationsByProfileIdParams{
 		ProfileID:    profileID,
 		EntityType:   entityType,
@@ -120,17 +120,17 @@ func (q *Queries) GetRuleEvaluationByProfileIdAndRuleType(
 	}
 	res, err := q.ListRuleEvaluationsByProfileId(ctx, params)
 	if err != nil {
-		return ListRuleEvaluationsByProfileIdRow{}, err
+		return nil, err
 	}
 
 	// Single or no row expected
 	switch len(res) {
 	case 0:
-		return ListRuleEvaluationsByProfileIdRow{}, nil
+		return nil, nil
 	case 1:
-		return res[0], nil
+		return &res[0], nil
 	}
-	return ListRuleEvaluationsByProfileIdRow{},
+	return nil,
 		fmt.Errorf("GetRuleEvaluationByProfileIdAndRuleType - expected 1 row, got %d", len(res))
 }
 

--- a/internal/engine/actions/actions.go
+++ b/internal/engine/actions/actions.go
@@ -25,7 +25,6 @@ import (
 	"runtime/debug"
 
 	"github.com/rs/zerolog"
-	"github.com/sqlc-dev/pqtype"
 	"google.golang.org/protobuf/reflect/protoreflect"
 
 	"github.com/stacklok/minder/internal/db"
@@ -121,7 +120,7 @@ func (rae *RuleActionsEngine) DoActions(
 		cmd := shouldRemediate(params.GetEvalStatusFromDb(), params.GetEvalErr())
 		// Run remediation
 		result.RemediateMeta, result.RemediateErr = rae.processAction(ctx, remediate.ActionType, cmd, ent, params,
-			getMeta(params.GetEvalStatusFromDb().RemMetadata))
+			getRemediationMeta(params.GetEvalStatusFromDb()))
 	}
 
 	// Try alerting
@@ -130,7 +129,7 @@ func (rae *RuleActionsEngine) DoActions(
 		cmd := shouldAlert(params.GetEvalStatusFromDb(), params.GetEvalErr(), result.RemediateErr, remediateEngine.Type())
 		// Run alerting
 		result.AlertMeta, result.AlertErr = rae.processAction(ctx, alert.ActionType, cmd, ent, params,
-			getMeta(params.GetEvalStatusFromDb().AlertMetadata))
+			getAlertMeta(params.GetEvalStatusFromDb()))
 	}
 	return result
 }
@@ -166,7 +165,7 @@ func shouldRemediate(prevEvalFromDb *db.ListRuleEvaluationsByProfileIdRow, evalE
 
 	// Get previous Remediation status
 	prevRemediation := db.RemediationStatusTypesSkipped
-	if prevEvalFromDb.RemStatus.Valid {
+	if prevEvalFromDb != nil && prevEvalFromDb.RemStatus.Valid {
 		prevRemediation = prevEvalFromDb.RemStatus.RemediationStatusTypes
 	}
 
@@ -215,7 +214,7 @@ func shouldAlert(
 
 	// Get previous Alert status
 	prevAlert := db.AlertStatusTypesSkipped
-	if prevEvalFromDb.AlertStatus.Valid {
+	if prevEvalFromDb != nil && prevEvalFromDb.AlertStatus.Valid {
 		prevAlert = prevEvalFromDb.AlertStatus.AlertStatusTypes
 	}
 
@@ -299,10 +298,18 @@ func (rae *RuleActionsEngine) isSkippable(ctx context.Context, actionType engif.
 	return skipAction
 }
 
-// getMeta returns the json.RawMessage from the database type, empty if not valid
-func getMeta(rawMsg pqtype.NullRawMessage) *json.RawMessage {
-	if rawMsg.Valid {
-		return &rawMsg.RawMessage
+// getRemediationMeta returns the json.RawMessage from the database type, empty if not valid
+func getRemediationMeta(prevEvalFromDb *db.ListRuleEvaluationsByProfileIdRow) *json.RawMessage {
+	if prevEvalFromDb != nil && prevEvalFromDb.RemMetadata.Valid {
+		return &prevEvalFromDb.RemMetadata.RawMessage
+	}
+	return nil
+}
+
+// getAlertMeta returns the json.RawMessage from the database type, empty if not valid
+func getAlertMeta(prevEvalFromDb *db.ListRuleEvaluationsByProfileIdRow) *json.RawMessage {
+	if prevEvalFromDb != nil && prevEvalFromDb.AlertMetadata.Valid {
+		return &prevEvalFromDb.AlertMetadata.RawMessage
 	}
 	return nil
 }

--- a/internal/engine/actions/alert/security_advisory/security_advisory.go
+++ b/internal/engine/actions/alert/security_advisory/security_advisory.go
@@ -404,9 +404,9 @@ func (_ *Alert) runDoNothing(ctx context.Context, params *paramsSA) (json.RawMes
 	logger.Debug().Msg("Running do nothing")
 
 	// Return the previous alert status.
-	err := enginerr.AlertStatusAsError(params.prevStatus.AlertStatus.AlertStatusTypes)
+	err := enginerr.AlertStatusAsError(params.prevStatus)
 	// If there is a valid alert metadata, return it too
-	if params.prevStatus.AlertMetadata.Valid {
+	if params.prevStatus != nil && params.prevStatus.AlertMetadata.Valid {
 		return params.prevStatus.AlertMetadata.RawMessage, err
 	}
 	// If there is no alert metadata, return nil as the metadata and the error

--- a/internal/engine/actions/remediate/pull_request/pull_request.go
+++ b/internal/engine/actions/remediate/pull_request/pull_request.go
@@ -580,9 +580,9 @@ func (_ *Remediator) runDoNothing(ctx context.Context, p *paramsPR) (json.RawMes
 	logger.Debug().Msg("Running do nothing")
 
 	// Return the previous remediation status.
-	err := enginerr.RemediationStatusAsError(p.prevStatus.RemStatus)
+	err := enginerr.RemediationStatusAsError(p.prevStatus)
 	// If there is a valid remediation metadata, return it too
-	if p.prevStatus.RemMetadata.Valid {
+	if p.prevStatus != nil && p.prevStatus.RemMetadata.Valid {
 		return p.prevStatus.RemMetadata.RawMessage, err
 	}
 	// If there is no remediation metadata, return nil as the metadata and the error

--- a/internal/engine/errors/errors.go
+++ b/internal/engine/errors/errors.go
@@ -160,12 +160,12 @@ func ErrorAsRemediationStatus(err error) db.RemediationStatusTypes {
 }
 
 // RemediationStatusAsError returns the remediation status for a given error
-func RemediationStatusAsError(ns db.NullRemediationStatusTypes) error {
-	if !ns.Valid {
+func RemediationStatusAsError(prevStatus *db.ListRuleEvaluationsByProfileIdRow) error {
+	if prevStatus == nil || !prevStatus.RemStatus.Valid {
 		return ErrActionSkipped
 	}
 
-	s := ns.RemediationStatusTypes
+	s := prevStatus.RemStatus.RemediationStatusTypes
 	switch s {
 	case db.RemediationStatusTypesSuccess:
 		return nil
@@ -203,7 +203,13 @@ func ErrorAsAlertStatus(err error) db.AlertStatusTypes {
 }
 
 // AlertStatusAsError returns the error for a given alert status
-func AlertStatusAsError(s db.AlertStatusTypes) error {
+func AlertStatusAsError(prevStatus *db.ListRuleEvaluationsByProfileIdRow) error {
+	if prevStatus == nil || !prevStatus.AlertStatus.Valid {
+		return errors.New("no previous alert state")
+	}
+
+	s := prevStatus.AlertStatus.AlertStatusTypes
+
 	switch s {
 	case db.AlertStatusTypesOn:
 		return nil

--- a/internal/engine/eval_status.go
+++ b/internal/engine/eval_status.go
@@ -99,7 +99,7 @@ func (e *executor) createEvalStatusParams(
 	}
 
 	// Save the current rule evaluation status to the evalParams
-	params.EvalStatusFromDb = &evalStatus
+	params.EvalStatusFromDb = evalStatus
 
 	return params, nil
 }

--- a/internal/engine/executor_test.go
+++ b/internal/engine/executor_test.go
@@ -108,7 +108,7 @@ func TestExecutor_handleEntityEvent(t *testing.T) {
 		gomock.Any(),
 		gomock.Any(),
 		gomock.Any(),
-	).Return(db.ListRuleEvaluationsByProfileIdRow{}, nil)
+	).Return(nil, nil)
 
 	mockStore.EXPECT().
 		GetProviderByID(gomock.Any(), gomock.Eq(providerID)).

--- a/internal/engine/interfaces/interface.go
+++ b/internal/engine/interfaces/interface.go
@@ -188,6 +188,7 @@ func (e *EvalStatusParams) GetRule() *models.RuleInstance {
 }
 
 // GetEvalStatusFromDb returns the evaluation status from the database
+// Returns nil if there is no previous state for this rule/entity
 func (e *EvalStatusParams) GetEvalStatusFromDb() *db.ListRuleEvaluationsByProfileIdRow {
 	return e.EvalStatusFromDb
 }


### PR DESCRIPTION
The rule engine has a copy of the previous evaluation state as part of its context. Prior to this PR, if there is no previous state for a rule/entity pair, an empty struct would be passed around. This requires each part of the code which uses the previous state (particularly remediations and alerts) to test if the fields in the state struct are the default value. This problem was highlighted in PR #4089 when the types of some the fields changed, requiring the code to be changed to have different default checks.

This PR changes the logic so that a nil pointer is returned if there is no existing state. This makes the check for a lack of previous state to be consistent irrespective of the fields needed or their type.
# Summary

***Provide a brief overview of the changes and the issue being addressed. 
Explain the rationale and any background necessary for understanding the changes. 
List dependencies required by this change, if any.***

Fixes #(related issue)

## Change Type

***Mark the type of change your PR introduces:***

- [ ] Bug fix (resolves an issue without affecting existing features)
- [ ] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [x] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

***Outline how the changes were tested, including steps to reproduce and any relevant configurations. 
Attach screenshots if helpful.***

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [ ] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [x] Included tests that validate the fix or feature.
- [ ] Checked that related changes are merged.
