### PR TITLE
Allow nil receiver on Properties

### DIFF
--- a/internal/entities/properties/properties.go
+++ b/internal/entities/properties/properties.go
@@ -118,6 +118,10 @@ func NewProperties(props map[string]any) *Properties {
 
 // GetProperty returns the Property for a given key or an empty one as a fallback
 func (p *Properties) GetProperty(key string) *Property {
+	if p == nil {
+		return nil
+	}
+
 	prop, ok := p.props.Load(key)
 	if !ok {
 		return nil

--- a/internal/entities/properties/properties_test.go
+++ b/internal/entities/properties/properties_test.go
@@ -262,3 +262,16 @@ func TestNewProperties(t *testing.T) {
 		require.Nil(t, p)
 	})
 }
+
+func TestNilReceiver(t *testing.T) {
+	t.Parallel()
+
+	t.Run("GetProperty", func(t *testing.T) {
+		t.Parallel()
+
+		var ps *Properties
+		p := ps.GetProperty("test")
+		require.Nil(t, p)
+		require.False(t, p.GetBool())
+	})
+}


### PR DESCRIPTION
# Summary

Since all the providers that do not explicitly implement properties
interface return `nil, nil`, it might be a good idea to implement a nil
receiver for Properties.

## Change Type

- [ ] Bug fix (resolves an issue without affecting existing features)
- [x] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [ ] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

make test

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [ ] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [x] Included tests that validate the fix or feature.
- [ ] Checked that related changes are merged.
