### PR TITLE
Two fixes for GetEntityByName

### DIFF
--- a/database/mock/store.go
+++ b/database/mock/store.go
@@ -866,6 +866,21 @@ func (mr *MockStoreMockRecorder) GetEntityByID(arg0, arg1 any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetEntityByID", reflect.TypeOf((*MockStore)(nil).GetEntityByID), arg0, arg1)
 }
 
+// GetEntityByName mocks base method.
+func (m *MockStore) GetEntityByName(arg0 context.Context, arg1 db.GetEntityByNameParams) (db.EntityInstance, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetEntityByName", arg0, arg1)
+	ret0, _ := ret[0].(db.EntityInstance)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetEntityByName indicates an expected call of GetEntityByName.
+func (mr *MockStoreMockRecorder) GetEntityByName(arg0, arg1 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetEntityByName", reflect.TypeOf((*MockStore)(nil).GetEntityByName), arg0, arg1)
+}
+
 // GetEvaluationHistory mocks base method.
 func (m *MockStore) GetEvaluationHistory(arg0 context.Context, arg1 db.GetEvaluationHistoryParams) (db.GetEvaluationHistoryRow, error) {
 	m.ctrl.T.Helper()

--- a/database/query/entities.sql
+++ b/database/query/entities.sql
@@ -62,7 +62,7 @@ LIMIT 1;
 -- GetEntityByName retrieves an entity by its name for a project or hierarchy of projects.
 -- name: GetEntityByName :one
 SELECT * FROM entity_instances
-WHERE lower(entity_instances.name) = lower(sqlc.arg(name)) AND entity_instances.project_id = $1
+WHERE entity_instances.name = sqlc.arg(name) AND entity_instances.project_id = $1
 LIMIT 1;
 
 -- GetEntitiesByType retrieves all entities of a given type for a project or hierarchy of projects.

--- a/database/query/entities.sql
+++ b/database/query/entities.sql
@@ -60,6 +60,7 @@ WHERE entity_instances.id = $1 AND entity_instances.project_id = ANY(sqlc.arg(pr
 LIMIT 1;
 
 -- GetEntityByName retrieves an entity by its name for a project or hierarchy of projects.
+-- name: GetEntityByName :one
 SELECT * FROM entity_instances
 WHERE lower(entity_instances.name) = lower(sqlc.arg(name)) AND entity_instances.project_id = $1
 LIMIT 1;

--- a/internal/db/entities.sql.go
+++ b/internal/db/entities.sql.go
@@ -253,6 +253,33 @@ func (q *Queries) GetEntityByID(ctx context.Context, arg GetEntityByIDParams) (E
 	return i, err
 }
 
+const getEntityByName = `-- name: GetEntityByName :one
+SELECT id, entity_type, name, project_id, provider_id, created_at, originated_from FROM entity_instances
+WHERE lower(entity_instances.name) = lower($2) AND entity_instances.project_id = $1
+LIMIT 1
+`
+
+type GetEntityByNameParams struct {
+	ProjectID uuid.UUID `json:"project_id"`
+	Name      string    `json:"name"`
+}
+
+// GetEntityByName retrieves an entity by its name for a project or hierarchy of projects.
+func (q *Queries) GetEntityByName(ctx context.Context, arg GetEntityByNameParams) (EntityInstance, error) {
+	row := q.db.QueryRowContext(ctx, getEntityByName, arg.ProjectID, arg.Name)
+	var i EntityInstance
+	err := row.Scan(
+		&i.ID,
+		&i.EntityType,
+		&i.Name,
+		&i.ProjectID,
+		&i.ProviderID,
+		&i.CreatedAt,
+		&i.OriginatedFrom,
+	)
+	return i, err
+}
+
 const temporaryPopulateArtifacts = `-- name: TemporaryPopulateArtifacts :exec
 INSERT INTO entity_instances (id, entity_type, name, project_id, provider_id, created_at, originated_from)
 SELECT artifacts.id, 'artifact', LOWER(repositories.repo_owner) || '/' || artifacts.artifact_name, repositories.project_id, repositories.provider_id, artifacts.created_at, artifacts.repository_id FROM artifacts

--- a/internal/db/entities.sql.go
+++ b/internal/db/entities.sql.go
@@ -255,7 +255,7 @@ func (q *Queries) GetEntityByID(ctx context.Context, arg GetEntityByIDParams) (E
 
 const getEntityByName = `-- name: GetEntityByName :one
 SELECT id, entity_type, name, project_id, provider_id, created_at, originated_from FROM entity_instances
-WHERE lower(entity_instances.name) = lower($2) AND entity_instances.project_id = $1
+WHERE entity_instances.name = $2 AND entity_instances.project_id = $1
 LIMIT 1
 `
 

--- a/internal/db/querier.go
+++ b/internal/db/querier.go
@@ -86,6 +86,8 @@ type Querier interface {
 	GetEntitiesByType(ctx context.Context, arg GetEntitiesByTypeParams) ([]EntityInstance, error)
 	// GetEntityByID retrieves an entity by its ID for a project or hierarchy of projects.
 	GetEntityByID(ctx context.Context, arg GetEntityByIDParams) (EntityInstance, error)
+	// GetEntityByName retrieves an entity by its name for a project or hierarchy of projects.
+	GetEntityByName(ctx context.Context, arg GetEntityByNameParams) (EntityInstance, error)
 	GetEvaluationHistory(ctx context.Context, arg GetEvaluationHistoryParams) (GetEvaluationHistoryRow, error)
 	// GetFeatureInProject verifies if a feature is available for a specific project.
 	// It returns the settings for the feature if it is available.


### PR DESCRIPTION

# Summary

- **Add the sqlc-generating comment to GetEntityByName** - We forgot the comment that makes sqlc generate the code.
- **Do not lowercase when searching an entity by name** -  I don't think lowercasing is the responsibility of the database layer, it should be the provider who should return the entity information lowercased through the naming interface.

## Change Type

- [x] Bug fix (resolves an issue without affecting existing features)
- [ ] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [ ] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

in follow up code, right now the code is unused

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [ ] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [ ] Included tests that validate the fix or feature.
- [ ] Checked that related changes are merged.
