### PR TITLE
Add reference to central entities table in new rule eval history tables

### DIFF
--- a/cmd/server/app/history_purge_test.go
+++ b/cmd/server/app/history_purge_test.go
@@ -47,7 +47,7 @@ func TestRecordSize(t *testing.T) {
 		},
 	)
 
-	require.Equal(t, 80, int(size))
+	require.Equal(t, 96, int(size))
 }
 
 func TestPurgeLoop(t *testing.T) {

--- a/cmd/server/app/migrate_up.go
+++ b/cmd/server/app/migrate_up.go
@@ -127,6 +127,10 @@ var upCmd = &cobra.Command{
 			cmd.Printf("Error while populating entities table with pull requests: %v\n", err)
 		}
 
+		if err := store.TemporaryPopulateEvaluationHistory(ctx); err != nil {
+			cmd.Printf("Error while populating entities table with evaluation history: %v\n", err)
+		}
+
 		return nil
 	},
 }

--- a/database/migrations/000095_eval_central_entities.down.sql
+++ b/database/migrations/000095_eval_central_entities.down.sql
@@ -1,0 +1,21 @@
+-- Copyright 2024 Stacklok, Inc
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--      http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+BEGIN;
+
+-- Drop optional FK towards entity_instances(id) in evaluation_rule_entities
+
+ALTER TABLE evaluation_rule_entities DROP COLUMN entity_instance_id;
+
+COMMIT;

--- a/database/migrations/000095_eval_central_entities.up.sql
+++ b/database/migrations/000095_eval_central_entities.up.sql
@@ -1,0 +1,22 @@
+-- Copyright 2024 Stacklok, Inc
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--      http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+BEGIN;
+
+-- Add optional FK towards entity_instances(id) in evaluation_rule_entities
+
+ALTER TABLE evaluation_rule_entities ADD COLUMN entity_instance_id UUID;
+ALTER TABLE evaluation_rule_entities ADD CONSTRAINT fk_entity_instance_id FOREIGN KEY (entity_instance_id) REFERENCES entity_instances(id) ON DELETE CASCADE;
+
+COMMIT;

--- a/database/mock/store.go
+++ b/database/mock/store.go
@@ -2104,6 +2104,20 @@ func (mr *MockStoreMockRecorder) TemporaryPopulateArtifacts(arg0 any) *gomock.Ca
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TemporaryPopulateArtifacts", reflect.TypeOf((*MockStore)(nil).TemporaryPopulateArtifacts), arg0)
 }
 
+// TemporaryPopulateEvaluationHistory mocks base method.
+func (m *MockStore) TemporaryPopulateEvaluationHistory(arg0 context.Context) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "TemporaryPopulateEvaluationHistory", arg0)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// TemporaryPopulateEvaluationHistory indicates an expected call of TemporaryPopulateEvaluationHistory.
+func (mr *MockStoreMockRecorder) TemporaryPopulateEvaluationHistory(arg0 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TemporaryPopulateEvaluationHistory", reflect.TypeOf((*MockStore)(nil).TemporaryPopulateEvaluationHistory), arg0)
+}
+
 // TemporaryPopulatePullRequests mocks base method.
 func (m *MockStore) TemporaryPopulatePullRequests(arg0 context.Context) error {
 	m.ctrl.T.Helper()

--- a/internal/db/eval_history_test.go
+++ b/internal/db/eval_history_test.go
@@ -719,6 +719,10 @@ func createRandomEvaluationRuleEntity(
 				Valid: true,
 			},
 			EntityType: EntitiesRepository,
+			EntityInstanceID: uuid.NullUUID{
+				UUID:  entityID,
+				Valid: true,
+			},
 		},
 	)
 	require.NoError(t, err)

--- a/internal/db/models.go
+++ b/internal/db/models.go
@@ -491,12 +491,13 @@ type EntityProfile struct {
 }
 
 type EvaluationRuleEntity struct {
-	ID            uuid.UUID     `json:"id"`
-	RuleID        uuid.UUID     `json:"rule_id"`
-	RepositoryID  uuid.NullUUID `json:"repository_id"`
-	PullRequestID uuid.NullUUID `json:"pull_request_id"`
-	ArtifactID    uuid.NullUUID `json:"artifact_id"`
-	EntityType    Entities      `json:"entity_type"`
+	ID               uuid.UUID     `json:"id"`
+	RuleID           uuid.UUID     `json:"rule_id"`
+	RepositoryID     uuid.NullUUID `json:"repository_id"`
+	PullRequestID    uuid.NullUUID `json:"pull_request_id"`
+	ArtifactID       uuid.NullUUID `json:"artifact_id"`
+	EntityType       Entities      `json:"entity_type"`
+	EntityInstanceID uuid.NullUUID `json:"entity_instance_id"`
 }
 
 type EvaluationStatus struct {

--- a/internal/db/profiles_test.go
+++ b/internal/db/profiles_test.go
@@ -165,6 +165,10 @@ func createRuleEntity(
 			PullRequestID: uuid.NullUUID{},
 			ArtifactID:    uuid.NullUUID{},
 			EntityType:    EntitiesRepository,
+			EntityInstanceID: uuid.NullUUID{
+				UUID:  repoID,
+				Valid: true,
+			},
 		},
 	)
 	require.NoError(t, err)

--- a/internal/db/querier.go
+++ b/internal/db/querier.go
@@ -239,6 +239,14 @@ type Querier interface {
 	RepositoryExistsAfterID(ctx context.Context, id uuid.UUID) (bool, error)
 	SetCurrentVersion(ctx context.Context, arg SetCurrentVersionParams) error
 	TemporaryPopulateArtifacts(ctx context.Context) error
+	// TemporaryPopulateEvaluationHistory sets the entity_instance_id column for
+	// all existing evaluation_rule_entities records to the id of the entity
+	// instance that the rule entity is associated with. We derive this from the entity_type
+	// and the corresponding entity id (repository_id, pull_request_id, or artifact_id).
+	// Note that there are cases where repository_id and pull_request_id will both be set,
+	// so we need to rely on the entity_type to determine which one to use. The same
+	// applies to repository_id and artifact_id.
+	TemporaryPopulateEvaluationHistory(ctx context.Context) error
 	TemporaryPopulatePullRequests(ctx context.Context) error
 	TemporaryPopulateRepositories(ctx context.Context) error
 	UpdateEncryptedSecret(ctx context.Context, arg UpdateEncryptedSecretParams) error

--- a/internal/db/repositories_test.go
+++ b/internal/db/repositories_test.go
@@ -67,6 +67,16 @@ func createRandomRepository(t *testing.T, project uuid.UUID, prov Provider, opts
 	require.NoError(t, err)
 	require.NotEmpty(t, repo)
 
+	ei, err := testQueries.CreateEntityWithID(context.Background(), CreateEntityWithIDParams{
+		ID:         repo.ID,
+		Name:       arg.RepoName,
+		ProjectID:  project,
+		ProviderID: prov.ID,
+		EntityType: EntitiesRepository,
+	})
+	require.NoError(t, err)
+	require.NotEmpty(t, ei)
+
 	require.Equal(t, arg.Provider, repo.Provider)
 	require.Equal(t, arg.ProjectID, repo.ProjectID)
 	require.Equal(t, arg.RepoOwner, repo.RepoOwner)

--- a/internal/history/service.go
+++ b/internal/history/service.go
@@ -95,11 +95,12 @@ func (e *evaluationHistoryService) StoreEvaluationStatus(
 		if errors.Is(err, sql.ErrNoRows) {
 			ruleEntityID, err = qtx.InsertEvaluationRuleEntity(ctx,
 				db.InsertEvaluationRuleEntityParams{
-					RuleID:        params.RuleID,
-					RepositoryID:  params.RepositoryID,
-					PullRequestID: params.PullRequestID,
-					ArtifactID:    params.ArtifactID,
-					EntityType:    entityType,
+					RuleID:           params.RuleID,
+					RepositoryID:     params.RepositoryID,
+					PullRequestID:    params.PullRequestID,
+					ArtifactID:       params.ArtifactID,
+					EntityType:       entityType,
+					EntityInstanceID: params.EntityID,
 				},
 			)
 			if err != nil {
@@ -168,6 +169,8 @@ func paramsFromEntity(
 		Valid: true,
 	}
 
+	params.EntityID = nullableEntityID
+
 	switch entityType {
 	case db.EntitiesRepository:
 		params.RepositoryID = nullableEntityID
@@ -188,6 +191,9 @@ type ruleEntityParams struct {
 	RepositoryID  uuid.NullUUID
 	ArtifactID    uuid.NullUUID
 	PullRequestID uuid.NullUUID
+	// Is the target entity ID. We'll be replacing the single-entity IDs
+	// with this one.
+	EntityID uuid.NullUUID
 }
 
 func (_ *evaluationHistoryService) ListEvaluationHistory(


### PR DESCRIPTION
# Summary

This starts populating the relevant data so we can migrate to using the
central table in a further increment. Note that this is merely adding data
and not changing any logic as of yet. The idea is to start populating
and get us to a point where we can remove the NULL constraint.

Fixes https://github.com/stacklok/minder/issues/4170

## Change Type

***Mark the type of change your PR introduces:***

- [ ] Bug fix (resolves an issue without affecting existing features)
- [x] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [ ] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

***Outline how the changes were tested, including steps to reproduce and any relevant configurations. 
Attach screenshots if helpful.***

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [ ] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [ ] Included tests that validate the fix or feature.
- [ ] Checked that related changes are merged.
