### PR TITLE
Consider that pypi package names may be normalized

### DIFF
--- a/internal/engine/eval/vulncheck/pkgdb.go
+++ b/internal/engine/eval/vulncheck/pkgdb.go
@@ -191,7 +191,7 @@ func (p *PyPiReply) LineHasDependency(line string) bool {
 	}
 
 	name := strings.TrimSpace(line[:nameMatch[0]])
-	return name == p.Info.Name
+	return pyNormalizeName(name) == pyNormalizeName(p.Info.Name)
 }
 
 // HasPatchedVersion returns true if the vulnerable package can be updated to a patched version

--- a/internal/engine/eval/vulncheck/pkgdb_test.go
+++ b/internal/engine/eval/vulncheck/pkgdb_test.go
@@ -286,6 +286,20 @@ func TestPyPiReplyLineHasDependency(t *testing.T) {
 			},
 			expectRetval: false,
 		},
+		{
+			name: "Match, different case and underscores",
+			line: "Some-package==1.1.0",
+			reply: &PyPiReply{
+				Info: struct {
+					Name    string `json:"name"`
+					Version string `json:"version"`
+				}{
+					Name:    "some_package",
+					Version: "1.1.0",
+				},
+			},
+			expectRetval: true,
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/engine/ingester/diff/parse.go
+++ b/internal/engine/ingester/diff/parse.go
@@ -125,16 +125,10 @@ func pyReqNormalizeLine(line string) string {
 func pyReqAddPkgName(depList []*pbinternal.Dependency, pkgName, version string) []*pbinternal.Dependency {
 	dep := &pbinternal.Dependency{
 		Ecosystem: pbinternal.DepEcosystem_DEP_ECOSYSTEM_PYPI,
-		Name:      pyNormalizeName(pkgName),
+		Name:      pkgName,
 		Version:   version,
 	}
 	return append(depList, dep)
-}
-
-func pyNormalizeName(pkgName string) string {
-	regex := regexp.MustCompile(`[-_.]+`)
-	result := regex.ReplaceAllString(pkgName, "-")
-	return strings.ToLower(result)
 }
 
 func goParse(patch string) ([]*pbinternal.Dependency, error) {

--- a/internal/engine/ingester/diff/parse_test.go
+++ b/internal/engine/ingester/diff/parse_test.go
@@ -348,20 +348,6 @@ func TestPyPiParse(t *testing.T) {
 			expectedCount:        0,
 			expectedDependencies: []*pbinternal.Dependency{},
 		},
-		{
-			description: "Single addition, uppercase",
-			content: `
- Flask
-+ Django==3.2.21`,
-			expectedCount: 1,
-			expectedDependencies: []*pbinternal.Dependency{
-				{
-					Ecosystem: pbinternal.DepEcosystem_DEP_ECOSYSTEM_PYPI,
-					Name:      "django",
-					Version:   "3.2.21",
-				},
-			},
-		},
 	}
 	for _, tt := range tests {
 		tt := tt


### PR DESCRIPTION
# Summary
The PyPI specification states that python package names should be normalized https://packaging.python.org/en/latest/specifications/name-normalization/#name-normalization.

The package names in `requirements.txt` do not necessarily adhere to the normalization rules, but the response from OSV does. 
This was causing our PR review handler to fail in some cases, because it could not figure out which line in the diff needed to be changed, since there was no exact match.
This changes the matcher to use normalized names when looking for PyPI dependencies in the PR diff.


Fixes #2605

## Change Type

***Mark the type of change your PR introduces:***

- [x] Bug fix (resolves an issue without affecting existing features)
- [ ] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [ ] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

***Outline how the changes were tested, including steps to reproduce and any relevant configurations. 
Attach screenshots if helpful.***

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [ ] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [x] Included tests that validate the fix or feature.
- [ ] Checked that related changes are merged.
