### PR TITLE
Add interface for the provider to get a name for an entity

### DIFF
--- a/internal/providers/dockerhub/dockerhub.go
+++ b/internal/providers/dockerhub/dockerhub.go
@@ -189,3 +189,9 @@ func (_ *dockerHubImageLister) FetchProperty(
 	_ context.Context, _ string, _ minderv1.Entity, _ string) (*properties.Property, error) {
 	return nil, nil
 }
+
+// GetEntityName implements the provider interface
+// TODO: Implement this
+func (_ *dockerHubImageLister) GetEntityName(_ minderv1.Entity, _ *properties.Properties) (string, error) {
+	return "", nil
+}

--- a/internal/providers/github/entity_name.go
+++ b/internal/providers/github/entity_name.go
@@ -1,0 +1,78 @@
+//
+// Copyright 2024 Stacklok, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package github
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/stacklok/minder/internal/entities/properties"
+	minderv1 "github.com/stacklok/minder/pkg/api/protobuf/go/minder/v1"
+)
+
+// GetEntityName implements the Provider interface
+func (_ *GitHub) GetEntityName(entType minderv1.Entity, props *properties.Properties) (string, error) {
+	return getEntityName(entType, props)
+}
+
+func getEntityName(entType minderv1.Entity, props *properties.Properties) (string, error) {
+	if props == nil {
+		return "", errors.New("properties are nil")
+	}
+
+	//nolint:exhaustive // we want to fail if we don't support the entity type
+	switch entType {
+	case minderv1.Entity_ENTITY_REPOSITORIES:
+		return getRepoName(props)
+	case minderv1.Entity_ENTITY_ARTIFACTS:
+		return getArtifactName(props)
+	case minderv1.Entity_ENTITY_PULL_REQUESTS:
+		return getPullRequestName(props)
+	default:
+		return "", fmt.Errorf("unsupported entity type: %s", entType)
+	}
+}
+
+func getRepoName(props *properties.Properties) (string, error) {
+	repoNameP := props.GetProperty(RepoPropertyName)
+	repoOwnerP := props.GetProperty(RepoPropertyOwner)
+
+	if repoNameP == nil || repoOwnerP == nil {
+		return "", errors.New("missing required properties")
+	}
+
+	repoName := repoNameP.GetString()
+	if repoName == "" {
+		return "", errors.New("missing required repo-name property value")
+	}
+
+	repoOwner := repoOwnerP.GetString()
+	if repoOwner == "" {
+		return "", errors.New("missing required repo-owner property value")
+	}
+
+	return fmt.Sprintf("%s/%s", repoOwner, repoName), nil
+}
+
+func getArtifactName(_ *properties.Properties) (string, error) {
+	// TODO: implement
+	return "", errors.New("not implemented")
+}
+
+func getPullRequestName(_ *properties.Properties) (string, error) {
+	// TODO: implement
+	return "", errors.New("not implemented")
+}

--- a/internal/providers/github/ghcr/ghcr.go
+++ b/internal/providers/github/ghcr/ghcr.go
@@ -148,3 +148,9 @@ func (_ *ImageLister) FetchAllProperties(_ context.Context, _ string, _ minderv1
 func (_ *ImageLister) FetchProperty(_ context.Context, _ string, _ minderv1.Entity, _ string) (*properties.Property, error) {
 	return nil, nil
 }
+
+// GetEntityName implements the provider interface
+// TODO: Implement this
+func (_ *ImageLister) GetEntityName(_ minderv1.Entity, _ *properties.Properties) (string, error) {
+	return "", nil
+}

--- a/internal/providers/github/mock/github.go
+++ b/internal/providers/github/mock/github.go
@@ -92,6 +92,21 @@ func (mr *MockProviderMockRecorder) FetchProperty(ctx, name, entType, key any) *
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FetchProperty", reflect.TypeOf((*MockProvider)(nil).FetchProperty), ctx, name, entType, key)
 }
 
+// GetEntityName mocks base method.
+func (m *MockProvider) GetEntityName(entType v10.Entity, props *properties.Properties) (string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetEntityName", entType, props)
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetEntityName indicates an expected call of GetEntityName.
+func (mr *MockProviderMockRecorder) GetEntityName(entType, props any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetEntityName", reflect.TypeOf((*MockProvider)(nil).GetEntityName), entType, props)
+}
+
 // MockGit is a mock of Git interface.
 type MockGit struct {
 	ctrl     *gomock.Controller
@@ -172,6 +187,21 @@ func (m *MockGit) FetchProperty(ctx context.Context, name string, entType v10.En
 func (mr *MockGitMockRecorder) FetchProperty(ctx, name, entType, key any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FetchProperty", reflect.TypeOf((*MockGit)(nil).FetchProperty), ctx, name, entType, key)
+}
+
+// GetEntityName mocks base method.
+func (m *MockGit) GetEntityName(entType v10.Entity, props *properties.Properties) (string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetEntityName", entType, props)
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetEntityName indicates an expected call of GetEntityName.
+func (mr *MockGitMockRecorder) GetEntityName(entType, props any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetEntityName", reflect.TypeOf((*MockGit)(nil).GetEntityName), entType, props)
 }
 
 // MockREST is a mock of REST interface.
@@ -270,6 +300,21 @@ func (mr *MockRESTMockRecorder) GetBaseURL() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetBaseURL", reflect.TypeOf((*MockREST)(nil).GetBaseURL))
 }
 
+// GetEntityName mocks base method.
+func (m *MockREST) GetEntityName(entType v10.Entity, props *properties.Properties) (string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetEntityName", entType, props)
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetEntityName indicates an expected call of GetEntityName.
+func (mr *MockRESTMockRecorder) GetEntityName(entType, props any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetEntityName", reflect.TypeOf((*MockREST)(nil).GetEntityName), entType, props)
+}
+
 // NewRequest mocks base method.
 func (m *MockREST) NewRequest(method, url string, body any) (*http.Request, error) {
 	m.ctrl.T.Helper()
@@ -350,6 +395,21 @@ func (m *MockRepoLister) FetchProperty(ctx context.Context, name string, entType
 func (mr *MockRepoListerMockRecorder) FetchProperty(ctx, name, entType, key any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FetchProperty", reflect.TypeOf((*MockRepoLister)(nil).FetchProperty), ctx, name, entType, key)
+}
+
+// GetEntityName mocks base method.
+func (m *MockRepoLister) GetEntityName(entType v10.Entity, props *properties.Properties) (string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetEntityName", entType, props)
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetEntityName indicates an expected call of GetEntityName.
+func (mr *MockRepoListerMockRecorder) GetEntityName(entType, props any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetEntityName", reflect.TypeOf((*MockRepoLister)(nil).GetEntityName), entType, props)
 }
 
 // ListAllRepositories mocks base method.
@@ -758,6 +818,21 @@ func (m *MockGitHub) GetCredential() v11.GitHubCredential {
 func (mr *MockGitHubMockRecorder) GetCredential() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCredential", reflect.TypeOf((*MockGitHub)(nil).GetCredential))
+}
+
+// GetEntityName mocks base method.
+func (m *MockGitHub) GetEntityName(entType v10.Entity, props *properties.Properties) (string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetEntityName", entType, props)
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetEntityName indicates an expected call of GetEntityName.
+func (mr *MockGitHubMockRecorder) GetEntityName(entType, props any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetEntityName", reflect.TypeOf((*MockGitHub)(nil).GetEntityName), entType, props)
 }
 
 // GetLogin mocks base method.
@@ -1199,6 +1274,21 @@ func (mr *MockImageListerMockRecorder) FetchProperty(ctx, name, entType, key any
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FetchProperty", reflect.TypeOf((*MockImageLister)(nil).FetchProperty), ctx, name, entType, key)
 }
 
+// GetEntityName mocks base method.
+func (m *MockImageLister) GetEntityName(entType v10.Entity, props *properties.Properties) (string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetEntityName", entType, props)
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetEntityName indicates an expected call of GetEntityName.
+func (mr *MockImageListerMockRecorder) GetEntityName(entType, props any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetEntityName", reflect.TypeOf((*MockImageLister)(nil).GetEntityName), entType, props)
+}
+
 // GetNamespaceURL mocks base method.
 func (m *MockImageLister) GetNamespaceURL() string {
 	m.ctrl.T.Helper()
@@ -1338,6 +1428,21 @@ func (m *MockOCI) GetDigest(ctx context.Context, name, tag string) (string, erro
 func (mr *MockOCIMockRecorder) GetDigest(ctx, name, tag any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDigest", reflect.TypeOf((*MockOCI)(nil).GetDigest), ctx, name, tag)
+}
+
+// GetEntityName mocks base method.
+func (m *MockOCI) GetEntityName(entType v10.Entity, props *properties.Properties) (string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetEntityName", entType, props)
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetEntityName indicates an expected call of GetEntityName.
+func (mr *MockOCIMockRecorder) GetEntityName(entType, props any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetEntityName", reflect.TypeOf((*MockOCI)(nil).GetEntityName), entType, props)
 }
 
 // GetManifest mocks base method.

--- a/internal/providers/github/properties.go
+++ b/internal/providers/github/properties.go
@@ -107,7 +107,6 @@ func getRepoWrapper(ctx context.Context, ghCli *GitHub, name string) (map[string
 
 	repoProps := map[string]any{
 		// general entity
-		properties.PropertyName:       fmt.Sprintf("%s/%s", repo.GetOwner().GetLogin(), repo.GetName()),
 		properties.PropertyUpstreamID: fmt.Sprintf("%d", repo.GetID()),
 		// general repo
 		properties.RepoPropertyIsPrivate:  repo.GetPrivate(),
@@ -121,6 +120,11 @@ func getRepoWrapper(ctx context.Context, ghCli *GitHub, name string) (map[string
 		RepoPropertyCloneURL:      repo.GetCloneURL(),
 		RepoPropertyDefaultBranch: repo.GetDefaultBranch(),
 		RepoPropertyLicense:       repo.GetLicense().GetSPDXID(),
+	}
+
+	repoProps[properties.PropertyName], err = getEntityName(minderv1.Entity_ENTITY_REPOSITORIES, properties.NewProperties(repoProps))
+	if err != nil {
+		return nil, err
 	}
 
 	return repoProps, nil

--- a/internal/providers/gitlab/gitlab.go
+++ b/internal/providers/gitlab/gitlab.go
@@ -123,6 +123,13 @@ func (_ *gitlabClient) FetchAllProperties(_ context.Context, _ string, _ minderv
 }
 
 // FetchProperty implements the provider interface
+// TODO: Implement this
 func (_ *gitlabClient) FetchProperty(_ context.Context, _ string, _ minderv1.Entity, _ string) (*properties.Property, error) {
 	return nil, nil
+}
+
+// GetEntityName implements the provider interface
+// TODO: Implement this
+func (_ *gitlabClient) GetEntityName(_ minderv1.Entity, _ *properties.Properties) (string, error) {
+	return "", nil
 }

--- a/internal/providers/selectors/mock/interface.go
+++ b/internal/providers/selectors/mock/interface.go
@@ -86,6 +86,21 @@ func (mr *MockRepoSelectorConverterMockRecorder) FetchProperty(ctx, name, entTyp
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FetchProperty", reflect.TypeOf((*MockRepoSelectorConverter)(nil).FetchProperty), ctx, name, entType, key)
 }
 
+// GetEntityName mocks base method.
+func (m *MockRepoSelectorConverter) GetEntityName(entType v1.Entity, props *properties.Properties) (string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetEntityName", entType, props)
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetEntityName indicates an expected call of GetEntityName.
+func (mr *MockRepoSelectorConverterMockRecorder) GetEntityName(entType, props any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetEntityName", reflect.TypeOf((*MockRepoSelectorConverter)(nil).GetEntityName), entType, props)
+}
+
 // RepoToSelectorEntity mocks base method.
 func (m *MockRepoSelectorConverter) RepoToSelectorEntity(ctx context.Context, repo *v1.Repository) *proto.SelectorEntity {
 	m.ctrl.T.Helper()
@@ -181,6 +196,21 @@ func (mr *MockArtifactSelectorConverterMockRecorder) FetchProperty(ctx, name, en
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FetchProperty", reflect.TypeOf((*MockArtifactSelectorConverter)(nil).FetchProperty), ctx, name, entType, key)
 }
 
+// GetEntityName mocks base method.
+func (m *MockArtifactSelectorConverter) GetEntityName(entType v1.Entity, props *properties.Properties) (string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetEntityName", entType, props)
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetEntityName indicates an expected call of GetEntityName.
+func (mr *MockArtifactSelectorConverterMockRecorder) GetEntityName(entType, props any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetEntityName", reflect.TypeOf((*MockArtifactSelectorConverter)(nil).GetEntityName), entType, props)
+}
+
 // MockPullRequestSelectorConverter is a mock of PullRequestSelectorConverter interface.
 type MockPullRequestSelectorConverter struct {
 	ctrl     *gomock.Controller
@@ -246,6 +276,21 @@ func (m *MockPullRequestSelectorConverter) FetchProperty(ctx context.Context, na
 func (mr *MockPullRequestSelectorConverterMockRecorder) FetchProperty(ctx, name, entType, key any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FetchProperty", reflect.TypeOf((*MockPullRequestSelectorConverter)(nil).FetchProperty), ctx, name, entType, key)
+}
+
+// GetEntityName mocks base method.
+func (m *MockPullRequestSelectorConverter) GetEntityName(entType v1.Entity, props *properties.Properties) (string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetEntityName", entType, props)
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetEntityName indicates an expected call of GetEntityName.
+func (mr *MockPullRequestSelectorConverterMockRecorder) GetEntityName(entType, props any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetEntityName", reflect.TypeOf((*MockPullRequestSelectorConverter)(nil).GetEntityName), entType, props)
 }
 
 // PullRequestToSelectorEntity mocks base method.

--- a/internal/providers/selectors/selector_entity_test.go
+++ b/internal/providers/selectors/selector_entity_test.go
@@ -124,6 +124,10 @@ func (_ *fullProvider) FetchProperty(_ context.Context, _ string, _ minderv1.Ent
 	return nil, nil
 }
 
+func (_ *fullProvider) GetEntityName(_ minderv1.Entity, _ *properties.Properties) (string, error) {
+	return "", nil
+}
+
 func newMockProvider(t *testing.T, name, class string) *fullProvider {
 	t.Helper()
 
@@ -160,6 +164,10 @@ func (_ *repoOnlyProvider) FetchAllProperties(_ context.Context, _ string, _ min
 
 func (_ *repoOnlyProvider) FetchProperty(_ context.Context, _ string, _ minderv1.Entity, _ string) (*properties.Property, error) {
 	return nil, nil
+}
+
+func (_ *repoOnlyProvider) GetEntityName(_ minderv1.Entity, _ *properties.Properties) (string, error) {
+	return "", nil
 }
 
 func (m *repoOnlyProvider) RepoToSelectorEntity(_ context.Context, repo *minderv1.Repository) *internalpb.SelectorEntity {

--- a/internal/providers/testproviders/git.go
+++ b/internal/providers/testproviders/git.go
@@ -55,3 +55,8 @@ func (_ *GitProvider) FetchProperty(
 	_ context.Context, _ string, _ minderv1.Entity, _ string) (*properties.Property, error) {
 	return nil, nil
 }
+
+// GetEntityName implements the Provider interface
+func (_ *GitProvider) GetEntityName(_ minderv1.Entity, _ *properties.Properties) (string, error) {
+	return "", nil
+}

--- a/internal/providers/testproviders/rest.go
+++ b/internal/providers/testproviders/rest.go
@@ -64,3 +64,8 @@ func (_ *RESTProvider) FetchProperty(
 	_ context.Context, _ string, _ minderv1.Entity, _ string) (*properties.Property, error) {
 	return nil, nil
 }
+
+// GetEntityName implements the Provider interface
+func (_ *RESTProvider) GetEntityName(_ minderv1.Entity, _ *properties.Properties) (string, error) {
+	return "", nil
+}

--- a/pkg/providers/v1/providers.go
+++ b/pkg/providers/v1/providers.go
@@ -50,6 +50,10 @@ type Provider interface {
 	FetchAllProperties(ctx context.Context, name string, entType minderv1.Entity) (*properties.Properties, error)
 	// FetchProperty fetches a single property for the given entity
 	FetchProperty(ctx context.Context, name string, entType minderv1.Entity, key string) (*properties.Property, error)
+	// GetEntityName forms an entity name from the given properties
+	// The name is used to identify the entity within minder and is how
+	// it will be stored in the database.
+	GetEntityName(entType minderv1.Entity, props *properties.Properties) (string, error)
 }
 
 // Git is the interface for git providers


### PR DESCRIPTION
# Summary

entity names are provider specific. This makes it so that providers must
have an interface to name an entity so it can be set in the properties
and ultimately stored in Minder.

Closes: #4166

## Change Type

***Mark the type of change your PR introduces:***

- [ ] Bug fix (resolves an issue without affecting existing features)
- [x] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [ ] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [ ] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [ ] Included tests that validate the fix or feature.
- [ ] Checked that related changes are merged.
