### PR TITLE
Fix integer overflow lint errors

### DIFF
--- a/cmd/cli/app/provider/provider_enroll.go
+++ b/cmd/cli/app/provider/provider_enroll.go
@@ -215,7 +215,7 @@ func enrollUsingOAuth2Flow(
 	resp, err := oauthClient.GetAuthorizationURL(ctx, &minderv1.GetAuthorizationURLRequest{
 		Context:       &minderv1.Context{Provider: &providerName, Project: &project},
 		Cli:           true,
-		Port:          int32(port),
+		Port:          port,
 		Owner:         &owner,
 		Config:        providerConfig,
 		ProviderClass: providerClass,
@@ -240,7 +240,7 @@ func enrollUsingOAuth2Flow(
 
 	done := make(chan bool)
 
-	go callBackServer(oAuthCallbackCtx, cmd, project, port, done, oauthClient, openTime, resp.GetState())
+	go callBackServer(oAuthCallbackCtx, cmd, project, int(port), done, oauthClient, openTime, resp.GetState())
 
 	success := <-done
 

--- a/cmd/server/app/history_purge_test.go
+++ b/cmd/server/app/history_purge_test.go
@@ -47,7 +47,7 @@ func TestRecordSize(t *testing.T) {
 		},
 	)
 
-	require.Equal(t, 96, int(size))
+	require.Equal(t, uintptr(96), size)
 }
 
 func TestPurgeLoop(t *testing.T) {

--- a/database/query/eval_history.sql
+++ b/database/query/eval_history.sql
@@ -213,7 +213,7 @@ SELECT s.id::uuid AS evaluation_id,
  ORDER BY
  CASE WHEN sqlc.narg(next)::timestamp without time zone IS NULL THEN s.evaluation_time END ASC,
  CASE WHEN sqlc.narg(prev)::timestamp without time zone IS NULL THEN s.evaluation_time END DESC
- LIMIT sqlc.arg(size)::integer;
+ LIMIT sqlc.arg(size)::bigint;
 
 -- name: ListEvaluationHistoryStaleRecords :many
 SELECT s.evaluation_time,

--- a/internal/db/embedded/testdb.go
+++ b/internal/db/embedded/testdb.go
@@ -81,11 +81,13 @@ func GetFakeStore() (db.Store, CancelFunc, error) {
 	return db.NewStore(sqlDB), cancel, nil
 }
 
-func pickUnusedPort() (int, error) {
+func pickUnusedPort() (int32, error) {
 	l, err := net.Listen("tcp", "localhost:0")
 	if err != nil {
 		return 0, err
 	}
 	defer l.Close()
-	return l.Addr().(*net.TCPAddr).Port, nil
+	// largest TCP port is 2^16, overflow should not happen
+	// nolint: gosec
+	return int32(l.Addr().(*net.TCPAddr).Port), nil
 }

--- a/internal/db/entity_execution_lock.sql_test.go
+++ b/internal/db/entity_execution_lock.sql_test.go
@@ -81,8 +81,8 @@ func TestQueries_LockIfThresholdNotExceeded(t *testing.T) {
 
 	wg.Wait()
 
-	assert.Equal(t, int32(concurrentCalls-1), queueCount.Load(), "expected all but one to be queued")
-	assert.Equal(t, int32(1), effectiveFlush.Load(), "expected only one flush to be queued")
+	assert.Equal(t, concurrentCalls-1, int(queueCount.Load()), "expected all but one to be queued")
+	assert.Equal(t, 1, int(effectiveFlush.Load()), "expected only one flush to be queued")
 
 	t.Log("sleeping for threshold")
 	time.Sleep(time.Duration(threshold) * time.Second)

--- a/internal/db/eval_history.sql.go
+++ b/internal/db/eval_history.sql.go
@@ -405,7 +405,7 @@ SELECT s.id::uuid AS evaluation_id,
  ORDER BY
  CASE WHEN $1::timestamp without time zone IS NULL THEN s.evaluation_time END ASC,
  CASE WHEN $2::timestamp without time zone IS NULL THEN s.evaluation_time END DESC
- LIMIT $18::integer
+ LIMIT $18::bigint
 `
 
 type ListEvaluationHistoryParams struct {
@@ -426,7 +426,7 @@ type ListEvaluationHistoryParams struct {
 	Fromts          sql.NullTime             `json:"fromts"`
 	Tots            sql.NullTime             `json:"tots"`
 	Projectid       uuid.UUID                `json:"projectid"`
-	Size            int32                    `json:"size"`
+	Size            int64                    `json:"size"`
 }
 
 type ListEvaluationHistoryRow struct {

--- a/internal/engine/ingester/diff/diff.go
+++ b/internal/engine/ingester/diff/diff.go
@@ -218,6 +218,7 @@ func ingestFileForFullDiff(filename, patch, patchUrl string) (*pbinternal.PrCont
 			result = append(result, &pbinternal.PrContents_File_Line{
 				Content: line[1:],
 				// see the use of strconv.ParseInt above: this is a safe downcast
+				// nolint: gosec
 				LineNumber: int32(currentLineNumber),
 			})
 

--- a/internal/history/service.go
+++ b/internal/history/service.go
@@ -204,7 +204,7 @@ func (_ *evaluationHistoryService) ListEvaluationHistory(
 	filter ListEvaluationFilter,
 ) (*ListEvaluationHistoryResult, error) {
 	params := db.ListEvaluationHistoryParams{
-		Size: int32(size),
+		Size: int64(size),
 	}
 
 	if err := toSQLCursor(cursor, &params); err != nil {

--- a/internal/util/cli/styles.go
+++ b/internal/util/cli/styles.go
@@ -16,6 +16,7 @@
 package cli
 
 import (
+	"math"
 	"os"
 
 	"github.com/charmbracelet/lipgloss"
@@ -78,7 +79,13 @@ var (
 
 func init() {
 	// Get the terminal width, if available, and set widths based on terminal width
-	w, _, err := term.GetSize(int(os.Stdout.Fd()))
+	fd := os.Stdout.Fd()
+	if fd > math.MaxInt32 {
+		return
+	}
+	// checked for overflow explicitly
+	// nolint: gosec
+	w, _, err := term.GetSize(int(fd))
 	if err == nil {
 		DefaultBannerWidth = w
 	}

--- a/internal/util/helpers.go
+++ b/internal/util/helpers.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 	"io"
 	"io/fs"
+	"math"
 	"net/http"
 	"net/url"
 	"os"
@@ -469,6 +470,11 @@ func Int32FromString(v string) (int32, error) {
 	if err != nil {
 		return 0, fmt.Errorf("error converting string to int: %w", err)
 	}
+	if asInt32 > math.MaxInt32 || asInt32 < math.MinInt32 {
+		return 0, fmt.Errorf("integer %d cannot fit into int32", asInt32)
+	}
+	// already validated overflow
+	// nolint:gosec
 	return int32(asInt32), nil
 }
 

--- a/internal/util/rand/random.go
+++ b/internal/util/rand/random.go
@@ -72,7 +72,7 @@ func RandomFrom[T any](choices []T, seed int64) T {
 // Marking a nosec here because we want this to listen on all addresses to
 // ensure a reliable connection chance for the client. This is based on lessons
 // learned from the sigstore CLI.
-func GetRandomPort() (int, error) {
+func GetRandomPort() (int32, error) {
 	listener, err := net.Listen("tcp", ":0") // #nosec
 	if err != nil {
 		return 0, err
@@ -80,5 +80,7 @@ func GetRandomPort() (int, error) {
 	defer listener.Close()
 
 	port := listener.Addr().(*net.TCPAddr).Port
-	return port, nil
+	// largest TCP port is 2^16, overflow should not happen
+	// nolint: gosec
+	return int32(port), nil
 }


### PR DESCRIPTION
The new version of golangci introduces integer overflow checks. A number of such issues were reported in Minder upon update.

Fixed through a mixture of type changes, explicit checks, and ignoring the linter in places where I was confident that we would never hit an overflow in practice.

# Summary

***Provide a brief overview of the changes and the issue being addressed. 
Explain the rationale and any background necessary for understanding the changes. 
List dependencies required by this change, if any.***

Fixes #(related issue)

## Change Type

***Mark the type of change your PR introduces:***

- [x] Bug fix (resolves an issue without affecting existing features)
- [ ] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [ ] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

***Outline how the changes were tested, including steps to reproduce and any relevant configurations. 
Attach screenshots if helpful.***

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [ ] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [ ] Included tests that validate the fix or feature.
- [ ] Checked that related changes are merged.
