### PR TITLE
Use central entities table for EEA logic

### DIFF
--- a/database/migrations/000099_eea_entity_instance_idx.down.sql
+++ b/database/migrations/000099_eea_entity_instance_idx.down.sql
@@ -1,0 +1,22 @@
+-- Copyright 2024 Stacklok, Inc
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--      http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+BEGIN;
+
+-- Drop the unique index on entity_instance_id from the entity_execution_lock and flush_cache tables
+
+DROP INDEX entity_execution_lock_entity_instance_idx ON entity_execution_lock;
+DROP INDEX flush_cache_entity_instance_idx ON flush_cache;
+
+COMMIT;

--- a/database/migrations/000099_eea_entity_instance_idx.up.sql
+++ b/database/migrations/000099_eea_entity_instance_idx.up.sql
@@ -1,0 +1,22 @@
+-- Copyright 2024 Stacklok, Inc
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--      http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+BEGIN;
+
+-- Add entity_instance_id as a unique index to the entity_execution_lock and flush_cache tables
+
+CREATE UNIQUE INDEX entity_execution_lock_entity_instance_idx ON entity_execution_lock (entity_instance_id);
+CREATE UNIQUE INDEX flush_cache_entity_instance_idx ON flush_cache (entity_instance_id);
+
+COMMIT;

--- a/database/mock/store.go
+++ b/database/mock/store.go
@@ -702,7 +702,7 @@ func (mr *MockStoreMockRecorder) FindProviders(arg0, arg1 any) *gomock.Call {
 }
 
 // FlushCache mocks base method.
-func (m *MockStore) FlushCache(arg0 context.Context, arg1 db.FlushCacheParams) (db.FlushCache, error) {
+func (m *MockStore) FlushCache(arg0 context.Context, arg1 uuid.UUID) (db.FlushCache, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "FlushCache", arg0, arg1)
 	ret0, _ := ret[0].(db.FlushCache)

--- a/database/query/entity_execution_lock.sql
+++ b/database/query/entity_execution_lock.sql
@@ -23,11 +23,10 @@ INSERT INTO entity_execution_lock(
     sqlc.narg(pull_request_id)::UUID,
     sqlc.arg(project_id)::UUID,
     sqlc.arg(entity_instance_id)::UUID
-) ON CONFLICT(entity, COALESCE(repository_id, '00000000-0000-0000-0000-000000000000'::UUID), COALESCE(artifact_id, '00000000-0000-0000-0000-000000000000'::UUID), COALESCE(pull_request_id, '00000000-0000-0000-0000-000000000000'::UUID))
+) ON CONFLICT(entity_instance_id)
 DO UPDATE SET
     locked_by = gen_random_uuid(),
-    last_lock_time = NOW(),
-    entity_instance_id = sqlc.arg(entity_instance_id)::UUID
+    last_lock_time = NOW()
 WHERE entity_execution_lock.last_lock_time < (NOW() - (@interval::TEXT || ' seconds')::interval)
 RETURNING *;
 
@@ -37,19 +36,11 @@ RETURNING *;
 
 -- name: ReleaseLock :exec
 DELETE FROM entity_execution_lock
-WHERE entity = sqlc.arg(entity)::entities AND
-    COALESCE(repository_id, '00000000-0000-0000-0000-000000000000'::UUID) = COALESCE(sqlc.narg(repository_id)::UUID, '00000000-0000-0000-0000-000000000000'::UUID) AND
-    COALESCE(artifact_id, '00000000-0000-0000-0000-000000000000'::UUID) = COALESCE(sqlc.narg(artifact_id)::UUID, '00000000-0000-0000-0000-000000000000'::UUID) AND
-    COALESCE(pull_request_id, '00000000-0000-0000-0000-000000000000'::UUID) = COALESCE(sqlc.narg(pull_request_id)::UUID, '00000000-0000-0000-0000-000000000000'::UUID) AND
-    locked_by = sqlc.arg(locked_by)::UUID;
+WHERE entity_instance_id = sqlc.arg(entity_instance_id) AND locked_by = sqlc.arg(locked_by)::UUID;
 
 -- name: UpdateLease :exec
 UPDATE entity_execution_lock SET last_lock_time = NOW()
-WHERE entity = $1 AND
-COALESCE(repository_id, '00000000-0000-0000-0000-000000000000'::UUID) = COALESCE(sqlc.narg(repository_id), '00000000-0000-0000-0000-000000000000'::UUID) AND
-COALESCE(artifact_id, '00000000-0000-0000-0000-000000000000'::UUID) = COALESCE(sqlc.narg(artifact_id)::UUID, '00000000-0000-0000-0000-000000000000'::UUID) AND
-COALESCE(pull_request_id, '00000000-0000-0000-0000-000000000000'::UUID) = COALESCE(sqlc.narg(pull_request_id)::UUID, '00000000-0000-0000-0000-000000000000'::UUID) AND
-locked_by = sqlc.arg(locked_by)::UUID;
+WHERE entity_instance_id = $1 AND locked_by = sqlc.arg(locked_by)::UUID;
 
 -- name: EnqueueFlush :one
 INSERT INTO flush_cache(
@@ -66,16 +57,13 @@ INSERT INTO flush_cache(
     sqlc.narg(pull_request_id)::UUID,
     sqlc.arg(project_id)::UUID,
     sqlc.arg(entity_instance_id)::UUID
-) ON CONFLICT(entity, COALESCE(repository_id, '00000000-0000-0000-0000-000000000000'::UUID), COALESCE(artifact_id, '00000000-0000-0000-0000-000000000000'::UUID), COALESCE(pull_request_id, '00000000-0000-0000-0000-000000000000'::UUID))
+) ON CONFLICT(entity_instance_id)
 DO NOTHING
 RETURNING *;
 
 -- name: FlushCache :one
 DELETE FROM flush_cache
-WHERE entity = $1 AND
-    COALESCE(repository_id, '00000000-0000-0000-0000-000000000000'::UUID) = COALESCE(sqlc.narg(repository_id)::UUID, '00000000-0000-0000-0000-000000000000'::UUID) AND
-    COALESCE(artifact_id, '00000000-0000-0000-0000-000000000000'::UUID) = COALESCE(sqlc.narg(artifact_id)::UUID, '00000000-0000-0000-0000-000000000000'::UUID) AND
-    COALESCE(pull_request_id, '00000000-0000-0000-0000-000000000000'::UUID) = COALESCE(sqlc.narg(pull_request_id)::UUID, '00000000-0000-0000-0000-000000000000'::UUID)
+WHERE entity_instance_id= $1
 RETURNING *;
 
 -- name: ListFlushCache :many

--- a/internal/db/querier.go
+++ b/internal/db/querier.go
@@ -72,7 +72,7 @@ type Querier interface {
 	// providers by it. It also optionally takes a name, in case we want to
 	// filter by name as well.
 	FindProviders(ctx context.Context, arg FindProvidersParams) ([]Provider, error)
-	FlushCache(ctx context.Context, arg FlushCacheParams) (FlushCache, error)
+	FlushCache(ctx context.Context, entityInstanceID uuid.UUID) (FlushCache, error)
 	GetAccessTokenByEnrollmentNonce(ctx context.Context, arg GetAccessTokenByEnrollmentNonceParams) (ProviderAccessToken, error)
 	GetAccessTokenByProjectID(ctx context.Context, arg GetAccessTokenByProjectIDParams) (ProviderAccessToken, error)
 	GetAccessTokenByProvider(ctx context.Context, provider string) ([]ProviderAccessToken, error)

--- a/internal/eea/eea.go
+++ b/internal/eea/eea.go
@@ -199,7 +199,10 @@ func (e *EEA) FlushMessageHandler(msg *message.Message) error {
 		return fmt.Errorf("error unmarshalling payload: %w", err)
 	}
 
-	repoID, artifactID, pullRequestID := inf.GetEntityDBIDs()
+	eID, err := inf.GetID()
+	if err != nil {
+		return fmt.Errorf("error getting entity ID: %w", err)
+	}
 
 	logger := zerolog.Ctx(ctx).With().
 		Str("component", "EEA").
@@ -211,12 +214,7 @@ func (e *EEA) FlushMessageHandler(msg *message.Message) error {
 
 	logger.Debug().Msg("flushing event")
 
-	_, err = e.querier.FlushCache(ctx, db.FlushCacheParams{
-		Entity:        entities.EntityTypeToDB(inf.Type),
-		RepositoryID:  repoID,
-		ArtifactID:    artifactID,
-		PullRequestID: pullRequestID,
-	})
+	_, err = e.querier.FlushCache(ctx, eID)
 	// Nothing to do here. If we can't flush the cache, it means
 	// that the event has already been executed.
 	if err != nil && errors.Is(err, sql.ErrNoRows) {

--- a/internal/engine/eval_status.go
+++ b/internal/engine/eval_status.go
@@ -39,11 +39,16 @@ func (e *executor) createEvalStatusParams(
 	rule *models.RuleInstance,
 ) (*engif.EvalStatusParams, error) {
 	repoID, artID, prID := inf.GetEntityDBIDs()
+	eID, err := inf.GetID()
+	if err != nil {
+		return nil, fmt.Errorf("Error getting ID from entity info wrapper")
+	}
 
 	params := &engif.EvalStatusParams{
 		Rule:          rule,
 		Profile:       profile,
 		EntityType:    entities.EntityTypeToDB(inf.Type),
+		EntityID:      eID,
 		RepoID:        repoID,
 		ArtifactID:    artID,
 		PullRequestID: prID,

--- a/internal/engine/executor_test.go
+++ b/internal/engine/executor_test.go
@@ -256,24 +256,15 @@ default allow = true`,
 	// Mock update lease for lock
 	mockStore.EXPECT().
 		UpdateLease(gomock.Any(), db.UpdateLeaseParams{
-			Entity: db.EntitiesRepository,
-			RepositoryID: uuid.NullUUID{
-				UUID:  repositoryID,
-				Valid: true,
-			},
-			ArtifactID:    uuid.NullUUID{},
-			PullRequestID: uuid.NullUUID{},
-			LockedBy:      executionID,
+			EntityInstanceID: repositoryID,
+			LockedBy:         executionID,
 		}).Return(nil)
 
 	// Mock release lock
 	mockStore.EXPECT().
 		ReleaseLock(gomock.Any(), db.ReleaseLockParams{
-			Entity:        db.EntitiesRepository,
-			RepositoryID:  uuid.NullUUID{UUID: repositoryID, Valid: true},
-			ArtifactID:    uuid.NullUUID{},
-			PullRequestID: uuid.NullUUID{},
-			LockedBy:      executionID,
+			EntityInstanceID: repositoryID,
+			LockedBy:         executionID,
 		}).Return(nil)
 
 	// -- end expectations

--- a/internal/engine/interfaces/interface.go
+++ b/internal/engine/interfaces/interface.go
@@ -117,6 +117,7 @@ type EvalStatusParams struct {
 	TaskRunID        uuid.UUID
 	BuildID          uuid.UUID
 	EntityType       db.Entities
+	EntityID         uuid.UUID
 	EvalStatusFromDb *db.ListRuleEvaluationsByProfileIdRow
 	evalErr          error
 	actionsOnOff     map[ActionType]models.ActionOpt


### PR DESCRIPTION
# Summary

This replaces the logic from the EEA from the convoluted per-entity
column to use a single reference from the central entitites table.

Closes: https://github.com/stacklok/minder/issues/4168

## Change Type

***Mark the type of change your PR introduces:***

- [ ] Bug fix (resolves an issue without affecting existing features)
- [x] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [ ] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

***Outline how the changes were tested, including steps to reproduce and any relevant configurations. 
Attach screenshots if helpful.***

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [ ] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [ ] Included tests that validate the fix or feature.
- [ ] Checked that related changes are merged.
