### PR TITLE
Add certificate definition to upload sigstore cert(s) from cosign

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -117,3 +117,6 @@ signs:
       - "--yes" # needed on cosign 2.0.0+
     artifacts: archive
     output: true
+    # It looks like this may default to empty-string, and we need to set it to upload
+    # the sigstore certs
+    certificate: '{{ trimsuffix (trimsuffix .Env.artifact ".zip") ".tar.gz" }}.pem'


### PR DESCRIPTION
# Summary

Ozz noticed that we hadn't included the sigstore certs needed to validate our signatures.  Since we're using keyless signing, we make up public and private keys for the certificate on the spot, so we need to store the public key after the signing, or the signature is useless.  It [appears that we may need the `certificate` field set](https://goreleaser.com/customization/sign/#usage) to upload these certs.

A few grumpy-man-yelling-at-clouds issues:

1. From the [action output](https://github.com/stacklok/minder/actions/runs/10484616388/job/29039268397), it appears that we go and get a new certificate for _each_ artifact, rather than using one cert to sign all the artifacts.
2. Actually verifying the blobs with `cosign verify-blob` is not well documented; I used something like:
   ```
   cosign verify-blob minder_0.0.59_darwin_arm64.tar.gz --certificate sigstore.pub --signature $(cat minder_0.0.59_darwin_arm64.tar.gz.sig) --certificate-identity 'https://github.com/stacklok/minder/.github/workflows/releaser.yml@refs/tags/v0.0.59' --certificate-oidc-issuer https://token.actions.githubusercontent.com
   ```
   Using the _correct_ signature extracted from the workflow above.

## Change Type

***Mark the type of change your PR introduces:***

- [x] Bug fix (resolves an issue without affecting existing features)
- [ ] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [ ] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

***Outline how the changes were tested, including steps to reproduce and any relevant configurations. 
Attach screenshots if helpful.***

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [x] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [ ] Included tests that validate the fix or feature.
- [ ] Checked that related changes are merged.
