### PR TITLE
Make `ruletype test` token's viper path unique

### DIFF
--- a/cmd/dev/app/rule_type/rttst.go
+++ b/cmd/dev/app/rule_type/rttst.go
@@ -83,7 +83,7 @@ func CmdTest() *cobra.Command {
 		os.Exit(1)
 	}
 
-	if err := viper.BindPFlag("auth.token", testCmd.Flags().Lookup("token")); err != nil {
+	if err := viper.BindPFlag("test.auth.token", testCmd.Flags().Lookup("token")); err != nil {
 		fmt.Fprintf(os.Stderr, "Error binding flag: %s\n", err)
 		os.Exit(1)
 	}
@@ -99,7 +99,7 @@ func testCmdRun(cmd *cobra.Command, _ []string) error {
 	ppath := cmd.Flag("profile")
 	rstatus := cmd.Flag("remediate-status")
 	rMetaPath := cmd.Flag("remediate-metadata")
-	token := viper.GetString("auth.token")
+	token := viper.GetString("test.auth.token")
 	providerclass := cmd.Flag("provider")
 	providerconfig := cmd.Flag("provider-config")
 


### PR DESCRIPTION
# Summary

This is needed for it to work... as it seems the viper name has clashed
with other subcommands in that binary.

## Change Type

***Mark the type of change your PR introduces:***

- [x] Bug fix (resolves an issue without affecting existing features)
- [ ] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [ ] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

***Outline how the changes were tested, including steps to reproduce and any relevant configurations. 
Attach screenshots if helpful.***

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [ ] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [ ] Included tests that validate the fix or feature.
- [ ] Checked that related changes are merged.
