### PR TITLE
Add `release_phase` column to `rule_type` table.

### DIFF
--- a/database/migrations/000100_rule_type_add_state_column.down.sql
+++ b/database/migrations/000100_rule_type_add_state_column.down.sql
@@ -1,0 +1,20 @@
+-- Copyright 2024 Stacklok, Inc
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--      http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+BEGIN;
+
+ALTER TABLE rule_type DROP COLUMN release_phase;
+DROP TYPE release_status;
+
+COMMIT;

--- a/database/migrations/000100_rule_type_add_state_column.up.sql
+++ b/database/migrations/000100_rule_type_add_state_column.up.sql
@@ -1,0 +1,24 @@
+-- Copyright 2024 Stacklok, Inc
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--      http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+BEGIN;
+
+CREATE TYPE release_status AS ENUM ('alpha', 'beta', 'ga', 'deprecated');
+ALTER TABLE rule_type ADD COLUMN release_phase release_status;
+UPDATE rule_type SET release_phase = 'alpha' WHERE release_phase IS NULL;
+ALTER TABLE rule_type
+  ALTER COLUMN release_phase SET DEFAULT 'ga',
+  ALTER COLUMN release_phase SET NOT NULL;
+
+COMMIT;

--- a/internal/db/models.go
+++ b/internal/db/models.go
@@ -331,6 +331,50 @@ func (ns NullProviderType) Value() (driver.Value, error) {
 	return string(ns.ProviderType), nil
 }
 
+type ReleaseStatus string
+
+const (
+	ReleaseStatusAlpha      ReleaseStatus = "alpha"
+	ReleaseStatusBeta       ReleaseStatus = "beta"
+	ReleaseStatusGa         ReleaseStatus = "ga"
+	ReleaseStatusDeprecated ReleaseStatus = "deprecated"
+)
+
+func (e *ReleaseStatus) Scan(src interface{}) error {
+	switch s := src.(type) {
+	case []byte:
+		*e = ReleaseStatus(s)
+	case string:
+		*e = ReleaseStatus(s)
+	default:
+		return fmt.Errorf("unsupported scan type for ReleaseStatus: %T", src)
+	}
+	return nil
+}
+
+type NullReleaseStatus struct {
+	ReleaseStatus ReleaseStatus `json:"release_status"`
+	Valid         bool          `json:"valid"` // Valid is true if ReleaseStatus is not NULL
+}
+
+// Scan implements the Scanner interface.
+func (ns *NullReleaseStatus) Scan(value interface{}) error {
+	if value == nil {
+		ns.ReleaseStatus, ns.Valid = "", false
+		return nil
+	}
+	ns.Valid = true
+	return ns.ReleaseStatus.Scan(value)
+}
+
+// Value implements the driver Valuer interface.
+func (ns NullReleaseStatus) Value() (driver.Value, error) {
+	if !ns.Valid {
+		return nil, nil
+	}
+	return string(ns.ReleaseStatus), nil
+}
+
 type RemediationStatusTypes string
 
 const (
@@ -694,6 +738,7 @@ type RuleType struct {
 	ProviderID     uuid.NullUUID   `json:"provider_id"`
 	SubscriptionID uuid.NullUUID   `json:"subscription_id"`
 	DisplayName    string          `json:"display_name"`
+	ReleasePhase   ReleaseStatus   `json:"release_phase"`
 }
 
 type SessionStore struct {

--- a/internal/db/rule_types.sql.go
+++ b/internal/db/rule_types.sql.go
@@ -32,7 +32,7 @@ INSERT INTO rule_type (
     $6,
     $7,
     $8
-) RETURNING id, name, provider, project_id, description, guidance, definition, created_at, updated_at, severity_value, provider_id, subscription_id, display_name
+) RETURNING id, name, provider, project_id, description, guidance, definition, created_at, updated_at, severity_value, provider_id, subscription_id, display_name, release_phase
 `
 
 type CreateRuleTypeParams struct {
@@ -72,6 +72,7 @@ func (q *Queries) CreateRuleType(ctx context.Context, arg CreateRuleTypeParams) 
 		&i.ProviderID,
 		&i.SubscriptionID,
 		&i.DisplayName,
+		&i.ReleasePhase,
 	)
 	return i, err
 }
@@ -86,7 +87,7 @@ func (q *Queries) DeleteRuleType(ctx context.Context, id uuid.UUID) error {
 }
 
 const getRuleTypeByID = `-- name: GetRuleTypeByID :one
-SELECT id, name, provider, project_id, description, guidance, definition, created_at, updated_at, severity_value, provider_id, subscription_id, display_name FROM rule_type WHERE id = $1
+SELECT id, name, provider, project_id, description, guidance, definition, created_at, updated_at, severity_value, provider_id, subscription_id, display_name, release_phase FROM rule_type WHERE id = $1
 `
 
 func (q *Queries) GetRuleTypeByID(ctx context.Context, id uuid.UUID) (RuleType, error) {
@@ -106,12 +107,13 @@ func (q *Queries) GetRuleTypeByID(ctx context.Context, id uuid.UUID) (RuleType, 
 		&i.ProviderID,
 		&i.SubscriptionID,
 		&i.DisplayName,
+		&i.ReleasePhase,
 	)
 	return i, err
 }
 
 const getRuleTypeByName = `-- name: GetRuleTypeByName :one
-SELECT id, name, provider, project_id, description, guidance, definition, created_at, updated_at, severity_value, provider_id, subscription_id, display_name FROM rule_type WHERE  project_id = ANY($1::uuid[]) AND lower(name) = lower($2)
+SELECT id, name, provider, project_id, description, guidance, definition, created_at, updated_at, severity_value, provider_id, subscription_id, display_name, release_phase FROM rule_type WHERE  project_id = ANY($1::uuid[]) AND lower(name) = lower($2)
 `
 
 type GetRuleTypeByNameParams struct {
@@ -136,6 +138,7 @@ func (q *Queries) GetRuleTypeByName(ctx context.Context, arg GetRuleTypeByNamePa
 		&i.ProviderID,
 		&i.SubscriptionID,
 		&i.DisplayName,
+		&i.ReleasePhase,
 	)
 	return i, err
 }
@@ -155,7 +158,7 @@ func (q *Queries) GetRuleTypeNameByID(ctx context.Context, id uuid.UUID) (string
 }
 
 const getRuleTypesByEntityInHierarchy = `-- name: GetRuleTypesByEntityInHierarchy :many
-SELECT rt.id, rt.name, rt.provider, rt.project_id, rt.description, rt.guidance, rt.definition, rt.created_at, rt.updated_at, rt.severity_value, rt.provider_id, rt.subscription_id, rt.display_name FROM rule_type AS rt
+SELECT rt.id, rt.name, rt.provider, rt.project_id, rt.description, rt.guidance, rt.definition, rt.created_at, rt.updated_at, rt.severity_value, rt.provider_id, rt.subscription_id, rt.display_name, rt.release_phase FROM rule_type AS rt
 JOIN rule_instances AS ri ON ri.rule_type_id = rt.id
 WHERE ri.entity_type = $1
 AND ri.project_id = ANY($2::uuid[])
@@ -189,6 +192,7 @@ func (q *Queries) GetRuleTypesByEntityInHierarchy(ctx context.Context, arg GetRu
 			&i.ProviderID,
 			&i.SubscriptionID,
 			&i.DisplayName,
+			&i.ReleasePhase,
 		); err != nil {
 			return nil, err
 		}
@@ -204,7 +208,7 @@ func (q *Queries) GetRuleTypesByEntityInHierarchy(ctx context.Context, arg GetRu
 }
 
 const listRuleTypesByProject = `-- name: ListRuleTypesByProject :many
-SELECT id, name, provider, project_id, description, guidance, definition, created_at, updated_at, severity_value, provider_id, subscription_id, display_name FROM rule_type WHERE project_id = $1
+SELECT id, name, provider, project_id, description, guidance, definition, created_at, updated_at, severity_value, provider_id, subscription_id, display_name, release_phase FROM rule_type WHERE project_id = $1
 `
 
 func (q *Queries) ListRuleTypesByProject(ctx context.Context, projectID uuid.UUID) ([]RuleType, error) {
@@ -230,6 +234,7 @@ func (q *Queries) ListRuleTypesByProject(ctx context.Context, projectID uuid.UUI
 			&i.ProviderID,
 			&i.SubscriptionID,
 			&i.DisplayName,
+			&i.ReleasePhase,
 		); err != nil {
 			return nil, err
 		}
@@ -248,7 +253,7 @@ const updateRuleType = `-- name: UpdateRuleType :one
 UPDATE rule_type
     SET description = $2, definition = $3::jsonb, severity_value = $4, display_name = $5
     WHERE id = $1
-    RETURNING id, name, provider, project_id, description, guidance, definition, created_at, updated_at, severity_value, provider_id, subscription_id, display_name
+    RETURNING id, name, provider, project_id, description, guidance, definition, created_at, updated_at, severity_value, provider_id, subscription_id, display_name, release_phase
 `
 
 type UpdateRuleTypeParams struct {
@@ -282,6 +287,7 @@ func (q *Queries) UpdateRuleType(ctx context.Context, arg UpdateRuleTypeParams) 
 		&i.ProviderID,
 		&i.SubscriptionID,
 		&i.DisplayName,
+		&i.ReleasePhase,
 	)
 	return i, err
 }


### PR DESCRIPTION
# Summary

The new `release_phase` column of `rule_type` table contains release phase information about the rule type, being one of `alpha`, `beta`, `ga`, or `deprecated`. The available states are defined as an enumerated type.

Fixes #4242
Fixes #4243

## Change Type

- [ ] Bug fix (resolves an issue without affecting existing features)
- [X] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [ ] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

Manually tested up and down migration.

# Review Checklist:

- [X] Reviewed my own code for quality and clarity.
- [ ] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [ ] Included tests that validate the fix or feature.
- [X] Checked that related changes are merged.
