### PR TITLE
Use structpb.Value as internal storage of Property

### DIFF
--- a/internal/entities/properties/properties_test.go
+++ b/internal/entities/properties/properties_test.go
@@ -75,7 +75,9 @@ func TestBoolGetters(t *testing.T) {
 		t.Run(s.name, func(t *testing.T) {
 			t.Parallel()
 
-			props := NewProperties(input)
+			props, err := NewProperties(input)
+			require.NoError(t, err)
+
 			p := props.GetProperty(s.propName)
 			if s.callGet {
 				got := p.GetBool()
@@ -149,7 +151,9 @@ func TestStringGetters(t *testing.T) {
 		t.Run(s.name, func(t *testing.T) {
 			t.Parallel()
 
-			props := NewProperties(input)
+			props, err := NewProperties(input)
+			require.NoError(t, err)
+
 			p := props.GetProperty(s.propName)
 			if s.callGet {
 				got := p.GetString()
@@ -223,7 +227,9 @@ func TestInt64Getters(t *testing.T) {
 		t.Run(s.name, func(t *testing.T) {
 			t.Parallel()
 
-			props := NewProperties(input)
+			props, err := NewProperties(input)
+			require.NoError(t, err)
+
 			p := props.GetProperty(s.propName)
 			if s.callGet {
 				got := p.GetInt64()
@@ -245,7 +251,8 @@ func TestInt64Getters(t *testing.T) {
 func TestNewProperty(t *testing.T) {
 	t.Parallel()
 
-	p := NewProperty(true)
+	p, err := NewProperty(true)
+	require.NoError(t, err)
 	require.NotNil(t, p)
 	require.Equal(t, true, p.GetBool())
 }
@@ -256,7 +263,8 @@ func TestNewProperties(t *testing.T) {
 	t.Run("nil input", func(t *testing.T) {
 		t.Parallel()
 
-		props := NewProperties(nil)
+		props, err := NewProperties(nil)
+		require.NoError(t, err)
 		require.NotNil(t, props)
 		p := props.GetProperty("test")
 		require.Nil(t, p)

--- a/internal/providers/github/properties.go
+++ b/internal/providers/github/properties.go
@@ -122,7 +122,12 @@ func getRepoWrapper(ctx context.Context, ghCli *GitHub, name string) (map[string
 		RepoPropertyLicense:       repo.GetLicense().GetSPDXID(),
 	}
 
-	repoProps[properties.PropertyName], err = getEntityName(minderv1.Entity_ENTITY_REPOSITORIES, properties.NewProperties(repoProps))
+	props, err := properties.NewProperties(repoProps)
+	if err != nil {
+		return nil, err
+	}
+
+	repoProps[properties.PropertyName], err = getEntityName(minderv1.Entity_ENTITY_REPOSITORIES, props)
 	if err != nil {
 		return nil, err
 	}
@@ -148,7 +153,7 @@ func (c *GitHub) FetchProperty(
 				if !ok {
 					return nil, errors.New("requested property not found in result")
 				}
-				return properties.NewProperty(value), nil
+				return properties.NewProperty(value)
 			}
 		}
 	}
@@ -175,5 +180,5 @@ func (c *GitHub) FetchAllProperties(
 		}
 	}
 
-	return properties.NewProperties(result), nil
+	return properties.NewProperties(result)
 }

--- a/internal/repositories/github/service_test.go
+++ b/internal/repositories/github/service_test.go
@@ -578,7 +578,11 @@ func newGithubRepoProperties(isPrivate bool) *properties.Properties {
 		ghprov.RepoPropertyDefaultBranch:  "main",
 	}
 
-	return properties.NewProperties(repoProps)
+	props, err := properties.NewProperties(repoProps)
+	if err != nil {
+		panic(err)
+	}
+	return props
 }
 
 func newExpectation(isPrivate bool) *pb.Repository {


### PR DESCRIPTION
# Summary

There are several reasons to use structpb.Value over `any`:
- NewValue contains pretty nice code that can e.g. serialize a []byte slice base64 encoded
- Returning the value as any actually does checks, for example for over/underflow for numerical values and returns a NaN in that case
- there is another draft PR that proposes to use structpb.Struct in the general entity protobuf message which would make the value easily usable should we need to

Related: #4171

## Change Type

- [ ] Bug fix (resolves an issue without affecting existing features)
- [ ] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [x] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

unit tests

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [ ] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [x] Included tests that validate the fix or feature.
- [ ] Checked that related changes are merged.
