### PR TITLE
Add an Iterator over Properties

### DIFF
--- a/internal/entities/properties/properties.go
+++ b/internal/entities/properties/properties.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/puzpuzpuz/xsync/v3"
 	"google.golang.org/protobuf/types/known/structpb"
+	"iter"
 )
 
 // Property is a struct that holds a value. It's just a wrapper around structpb.Value
@@ -232,4 +233,13 @@ func (p *Properties) GetProperty(key string) *Property {
 		return nil
 	}
 	return &prop
+}
+
+// Iterate implements the seq2 iterator so that the caller can call for key, prop := range Iterate()
+func (p *Properties) Iterate() iter.Seq2[string, *Property] {
+	return func(yield func(string, *Property) bool) {
+		p.props.Range(func(key string, v Property) bool {
+			return yield(key, &v)
+		})
+	}
 }

--- a/internal/entities/properties/properties_test.go
+++ b/internal/entities/properties/properties_test.go
@@ -450,3 +450,25 @@ func TestUnwrapTypeErrors(t *testing.T) {
 		})
 	}
 }
+
+func TestIterator(t *testing.T) {
+	t.Parallel()
+
+	input := map[string]any{
+		"name":       "test",
+		"is_private": true,
+	}
+
+	output := make(map[string]any)
+
+	props, err := NewProperties(input)
+	require.NoError(t, err)
+
+	count := 0
+	for key, p := range props.Iterate() {
+		count++
+		output[key] = p.RawValue()
+	}
+	require.Equal(t, input, output)
+	require.Equal(t, 2, count)
+}


### PR DESCRIPTION
# Summary

Uses the new Go 1.23 feature to implement an iterator over properties.
This will simplify the future code.

Related: #4171

## Change Type

- [ ] Bug fix (resolves an issue without affecting existing features)
- [x] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [ ] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

part of a larger branch

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [ ] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [x] Included tests that validate the fix or feature.
- [ ] Checked that related changes are merged.
