### PR TITLE
Change the Provider's FetchProperty/FetchAllProperties interface methods to look up by Properties, not just a name

### DIFF
--- a/internal/providers/dockerhub/dockerhub.go
+++ b/internal/providers/dockerhub/dockerhub.go
@@ -179,14 +179,14 @@ func (d *dockerHubImageLister) ListImages(ctx context.Context) ([]string, error)
 // FetchAllProperties implements the provider interface
 // TODO: Implement this
 func (_ *dockerHubImageLister) FetchAllProperties(
-	_ context.Context, _ string, _ minderv1.Entity) (*properties.Properties, error) {
+	_ context.Context, _ *properties.Properties, _ minderv1.Entity) (*properties.Properties, error) {
 	return nil, nil
 }
 
 // FetchProperty implements the provider interface
 // TODO: Implement this
 func (_ *dockerHubImageLister) FetchProperty(
-	_ context.Context, _ string, _ minderv1.Entity, _ string) (*properties.Property, error) {
+	_ context.Context, _ *properties.Properties, _ minderv1.Entity, _ string) (*properties.Property, error) {
 	return nil, nil
 }
 

--- a/internal/providers/github/ghcr/ghcr.go
+++ b/internal/providers/github/ghcr/ghcr.go
@@ -139,13 +139,15 @@ func (g *ImageLister) ListImages(ctx context.Context) ([]string, error) {
 
 // FetchAllProperties implements the provider interface
 // TODO: Implement this
-func (_ *ImageLister) FetchAllProperties(_ context.Context, _ string, _ minderv1.Entity) (*properties.Properties, error) {
+func (_ *ImageLister) FetchAllProperties(
+	_ context.Context, _ *properties.Properties, _ minderv1.Entity) (*properties.Properties, error) {
 	return nil, nil
 }
 
 // FetchProperty implements the provider interface
 // TODO: Implement this
-func (_ *ImageLister) FetchProperty(_ context.Context, _ string, _ minderv1.Entity, _ string) (*properties.Property, error) {
+func (_ *ImageLister) FetchProperty(
+	_ context.Context, _ *properties.Properties, _ minderv1.Entity, _ string) (*properties.Property, error) {
 	return nil, nil
 }
 

--- a/internal/providers/github/mock/github.go
+++ b/internal/providers/github/mock/github.go
@@ -63,33 +63,33 @@ func (mr *MockProviderMockRecorder) CanImplement(trait any) *gomock.Call {
 }
 
 // FetchAllProperties mocks base method.
-func (m *MockProvider) FetchAllProperties(ctx context.Context, name string, entType v10.Entity) (*properties.Properties, error) {
+func (m *MockProvider) FetchAllProperties(ctx context.Context, getByProps *properties.Properties, entType v10.Entity) (*properties.Properties, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "FetchAllProperties", ctx, name, entType)
+	ret := m.ctrl.Call(m, "FetchAllProperties", ctx, getByProps, entType)
 	ret0, _ := ret[0].(*properties.Properties)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // FetchAllProperties indicates an expected call of FetchAllProperties.
-func (mr *MockProviderMockRecorder) FetchAllProperties(ctx, name, entType any) *gomock.Call {
+func (mr *MockProviderMockRecorder) FetchAllProperties(ctx, getByProps, entType any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FetchAllProperties", reflect.TypeOf((*MockProvider)(nil).FetchAllProperties), ctx, name, entType)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FetchAllProperties", reflect.TypeOf((*MockProvider)(nil).FetchAllProperties), ctx, getByProps, entType)
 }
 
 // FetchProperty mocks base method.
-func (m *MockProvider) FetchProperty(ctx context.Context, name string, entType v10.Entity, key string) (*properties.Property, error) {
+func (m *MockProvider) FetchProperty(ctx context.Context, getByProps *properties.Properties, entType v10.Entity, key string) (*properties.Property, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "FetchProperty", ctx, name, entType, key)
+	ret := m.ctrl.Call(m, "FetchProperty", ctx, getByProps, entType, key)
 	ret0, _ := ret[0].(*properties.Property)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // FetchProperty indicates an expected call of FetchProperty.
-func (mr *MockProviderMockRecorder) FetchProperty(ctx, name, entType, key any) *gomock.Call {
+func (mr *MockProviderMockRecorder) FetchProperty(ctx, getByProps, entType, key any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FetchProperty", reflect.TypeOf((*MockProvider)(nil).FetchProperty), ctx, name, entType, key)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FetchProperty", reflect.TypeOf((*MockProvider)(nil).FetchProperty), ctx, getByProps, entType, key)
 }
 
 // GetEntityName mocks base method.
@@ -160,33 +160,33 @@ func (mr *MockGitMockRecorder) Clone(ctx, url, branch any) *gomock.Call {
 }
 
 // FetchAllProperties mocks base method.
-func (m *MockGit) FetchAllProperties(ctx context.Context, name string, entType v10.Entity) (*properties.Properties, error) {
+func (m *MockGit) FetchAllProperties(ctx context.Context, getByProps *properties.Properties, entType v10.Entity) (*properties.Properties, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "FetchAllProperties", ctx, name, entType)
+	ret := m.ctrl.Call(m, "FetchAllProperties", ctx, getByProps, entType)
 	ret0, _ := ret[0].(*properties.Properties)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // FetchAllProperties indicates an expected call of FetchAllProperties.
-func (mr *MockGitMockRecorder) FetchAllProperties(ctx, name, entType any) *gomock.Call {
+func (mr *MockGitMockRecorder) FetchAllProperties(ctx, getByProps, entType any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FetchAllProperties", reflect.TypeOf((*MockGit)(nil).FetchAllProperties), ctx, name, entType)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FetchAllProperties", reflect.TypeOf((*MockGit)(nil).FetchAllProperties), ctx, getByProps, entType)
 }
 
 // FetchProperty mocks base method.
-func (m *MockGit) FetchProperty(ctx context.Context, name string, entType v10.Entity, key string) (*properties.Property, error) {
+func (m *MockGit) FetchProperty(ctx context.Context, getByProps *properties.Properties, entType v10.Entity, key string) (*properties.Property, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "FetchProperty", ctx, name, entType, key)
+	ret := m.ctrl.Call(m, "FetchProperty", ctx, getByProps, entType, key)
 	ret0, _ := ret[0].(*properties.Property)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // FetchProperty indicates an expected call of FetchProperty.
-func (mr *MockGitMockRecorder) FetchProperty(ctx, name, entType, key any) *gomock.Call {
+func (mr *MockGitMockRecorder) FetchProperty(ctx, getByProps, entType, key any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FetchProperty", reflect.TypeOf((*MockGit)(nil).FetchProperty), ctx, name, entType, key)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FetchProperty", reflect.TypeOf((*MockGit)(nil).FetchProperty), ctx, getByProps, entType, key)
 }
 
 // GetEntityName mocks base method.
@@ -257,33 +257,33 @@ func (mr *MockRESTMockRecorder) Do(ctx, req any) *gomock.Call {
 }
 
 // FetchAllProperties mocks base method.
-func (m *MockREST) FetchAllProperties(ctx context.Context, name string, entType v10.Entity) (*properties.Properties, error) {
+func (m *MockREST) FetchAllProperties(ctx context.Context, getByProps *properties.Properties, entType v10.Entity) (*properties.Properties, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "FetchAllProperties", ctx, name, entType)
+	ret := m.ctrl.Call(m, "FetchAllProperties", ctx, getByProps, entType)
 	ret0, _ := ret[0].(*properties.Properties)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // FetchAllProperties indicates an expected call of FetchAllProperties.
-func (mr *MockRESTMockRecorder) FetchAllProperties(ctx, name, entType any) *gomock.Call {
+func (mr *MockRESTMockRecorder) FetchAllProperties(ctx, getByProps, entType any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FetchAllProperties", reflect.TypeOf((*MockREST)(nil).FetchAllProperties), ctx, name, entType)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FetchAllProperties", reflect.TypeOf((*MockREST)(nil).FetchAllProperties), ctx, getByProps, entType)
 }
 
 // FetchProperty mocks base method.
-func (m *MockREST) FetchProperty(ctx context.Context, name string, entType v10.Entity, key string) (*properties.Property, error) {
+func (m *MockREST) FetchProperty(ctx context.Context, getByProps *properties.Properties, entType v10.Entity, key string) (*properties.Property, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "FetchProperty", ctx, name, entType, key)
+	ret := m.ctrl.Call(m, "FetchProperty", ctx, getByProps, entType, key)
 	ret0, _ := ret[0].(*properties.Property)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // FetchProperty indicates an expected call of FetchProperty.
-func (mr *MockRESTMockRecorder) FetchProperty(ctx, name, entType, key any) *gomock.Call {
+func (mr *MockRESTMockRecorder) FetchProperty(ctx, getByProps, entType, key any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FetchProperty", reflect.TypeOf((*MockREST)(nil).FetchProperty), ctx, name, entType, key)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FetchProperty", reflect.TypeOf((*MockREST)(nil).FetchProperty), ctx, getByProps, entType, key)
 }
 
 // GetBaseURL mocks base method.
@@ -368,33 +368,33 @@ func (mr *MockRepoListerMockRecorder) CanImplement(trait any) *gomock.Call {
 }
 
 // FetchAllProperties mocks base method.
-func (m *MockRepoLister) FetchAllProperties(ctx context.Context, name string, entType v10.Entity) (*properties.Properties, error) {
+func (m *MockRepoLister) FetchAllProperties(ctx context.Context, getByProps *properties.Properties, entType v10.Entity) (*properties.Properties, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "FetchAllProperties", ctx, name, entType)
+	ret := m.ctrl.Call(m, "FetchAllProperties", ctx, getByProps, entType)
 	ret0, _ := ret[0].(*properties.Properties)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // FetchAllProperties indicates an expected call of FetchAllProperties.
-func (mr *MockRepoListerMockRecorder) FetchAllProperties(ctx, name, entType any) *gomock.Call {
+func (mr *MockRepoListerMockRecorder) FetchAllProperties(ctx, getByProps, entType any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FetchAllProperties", reflect.TypeOf((*MockRepoLister)(nil).FetchAllProperties), ctx, name, entType)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FetchAllProperties", reflect.TypeOf((*MockRepoLister)(nil).FetchAllProperties), ctx, getByProps, entType)
 }
 
 // FetchProperty mocks base method.
-func (m *MockRepoLister) FetchProperty(ctx context.Context, name string, entType v10.Entity, key string) (*properties.Property, error) {
+func (m *MockRepoLister) FetchProperty(ctx context.Context, getByProps *properties.Properties, entType v10.Entity, key string) (*properties.Property, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "FetchProperty", ctx, name, entType, key)
+	ret := m.ctrl.Call(m, "FetchProperty", ctx, getByProps, entType, key)
 	ret0, _ := ret[0].(*properties.Property)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // FetchProperty indicates an expected call of FetchProperty.
-func (mr *MockRepoListerMockRecorder) FetchProperty(ctx, name, entType, key any) *gomock.Call {
+func (mr *MockRepoListerMockRecorder) FetchProperty(ctx, getByProps, entType, key any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FetchProperty", reflect.TypeOf((*MockRepoLister)(nil).FetchProperty), ctx, name, entType, key)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FetchProperty", reflect.TypeOf((*MockRepoLister)(nil).FetchProperty), ctx, getByProps, entType, key)
 }
 
 // GetEntityName mocks base method.
@@ -733,33 +733,33 @@ func (mr *MockGitHubMockRecorder) EditHook(ctx, owner, repo, id, hook any) *gomo
 }
 
 // FetchAllProperties mocks base method.
-func (m *MockGitHub) FetchAllProperties(ctx context.Context, name string, entType v10.Entity) (*properties.Properties, error) {
+func (m *MockGitHub) FetchAllProperties(ctx context.Context, getByProps *properties.Properties, entType v10.Entity) (*properties.Properties, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "FetchAllProperties", ctx, name, entType)
+	ret := m.ctrl.Call(m, "FetchAllProperties", ctx, getByProps, entType)
 	ret0, _ := ret[0].(*properties.Properties)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // FetchAllProperties indicates an expected call of FetchAllProperties.
-func (mr *MockGitHubMockRecorder) FetchAllProperties(ctx, name, entType any) *gomock.Call {
+func (mr *MockGitHubMockRecorder) FetchAllProperties(ctx, getByProps, entType any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FetchAllProperties", reflect.TypeOf((*MockGitHub)(nil).FetchAllProperties), ctx, name, entType)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FetchAllProperties", reflect.TypeOf((*MockGitHub)(nil).FetchAllProperties), ctx, getByProps, entType)
 }
 
 // FetchProperty mocks base method.
-func (m *MockGitHub) FetchProperty(ctx context.Context, name string, entType v10.Entity, key string) (*properties.Property, error) {
+func (m *MockGitHub) FetchProperty(ctx context.Context, getByProps *properties.Properties, entType v10.Entity, key string) (*properties.Property, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "FetchProperty", ctx, name, entType, key)
+	ret := m.ctrl.Call(m, "FetchProperty", ctx, getByProps, entType, key)
 	ret0, _ := ret[0].(*properties.Property)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // FetchProperty indicates an expected call of FetchProperty.
-func (mr *MockGitHubMockRecorder) FetchProperty(ctx, name, entType, key any) *gomock.Call {
+func (mr *MockGitHubMockRecorder) FetchProperty(ctx, getByProps, entType, key any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FetchProperty", reflect.TypeOf((*MockGitHub)(nil).FetchProperty), ctx, name, entType, key)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FetchProperty", reflect.TypeOf((*MockGitHub)(nil).FetchProperty), ctx, getByProps, entType, key)
 }
 
 // GetArtifactVersions mocks base method.
@@ -1245,33 +1245,33 @@ func (mr *MockImageListerMockRecorder) CanImplement(trait any) *gomock.Call {
 }
 
 // FetchAllProperties mocks base method.
-func (m *MockImageLister) FetchAllProperties(ctx context.Context, name string, entType v10.Entity) (*properties.Properties, error) {
+func (m *MockImageLister) FetchAllProperties(ctx context.Context, getByProps *properties.Properties, entType v10.Entity) (*properties.Properties, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "FetchAllProperties", ctx, name, entType)
+	ret := m.ctrl.Call(m, "FetchAllProperties", ctx, getByProps, entType)
 	ret0, _ := ret[0].(*properties.Properties)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // FetchAllProperties indicates an expected call of FetchAllProperties.
-func (mr *MockImageListerMockRecorder) FetchAllProperties(ctx, name, entType any) *gomock.Call {
+func (mr *MockImageListerMockRecorder) FetchAllProperties(ctx, getByProps, entType any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FetchAllProperties", reflect.TypeOf((*MockImageLister)(nil).FetchAllProperties), ctx, name, entType)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FetchAllProperties", reflect.TypeOf((*MockImageLister)(nil).FetchAllProperties), ctx, getByProps, entType)
 }
 
 // FetchProperty mocks base method.
-func (m *MockImageLister) FetchProperty(ctx context.Context, name string, entType v10.Entity, key string) (*properties.Property, error) {
+func (m *MockImageLister) FetchProperty(ctx context.Context, getByProps *properties.Properties, entType v10.Entity, key string) (*properties.Property, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "FetchProperty", ctx, name, entType, key)
+	ret := m.ctrl.Call(m, "FetchProperty", ctx, getByProps, entType, key)
 	ret0, _ := ret[0].(*properties.Property)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // FetchProperty indicates an expected call of FetchProperty.
-func (mr *MockImageListerMockRecorder) FetchProperty(ctx, name, entType, key any) *gomock.Call {
+func (mr *MockImageListerMockRecorder) FetchProperty(ctx, getByProps, entType, key any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FetchProperty", reflect.TypeOf((*MockImageLister)(nil).FetchProperty), ctx, name, entType, key)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FetchProperty", reflect.TypeOf((*MockImageLister)(nil).FetchProperty), ctx, getByProps, entType, key)
 }
 
 // GetEntityName mocks base method.
@@ -1356,33 +1356,33 @@ func (mr *MockOCIMockRecorder) CanImplement(trait any) *gomock.Call {
 }
 
 // FetchAllProperties mocks base method.
-func (m *MockOCI) FetchAllProperties(ctx context.Context, name string, entType v10.Entity) (*properties.Properties, error) {
+func (m *MockOCI) FetchAllProperties(ctx context.Context, getByProps *properties.Properties, entType v10.Entity) (*properties.Properties, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "FetchAllProperties", ctx, name, entType)
+	ret := m.ctrl.Call(m, "FetchAllProperties", ctx, getByProps, entType)
 	ret0, _ := ret[0].(*properties.Properties)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // FetchAllProperties indicates an expected call of FetchAllProperties.
-func (mr *MockOCIMockRecorder) FetchAllProperties(ctx, name, entType any) *gomock.Call {
+func (mr *MockOCIMockRecorder) FetchAllProperties(ctx, getByProps, entType any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FetchAllProperties", reflect.TypeOf((*MockOCI)(nil).FetchAllProperties), ctx, name, entType)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FetchAllProperties", reflect.TypeOf((*MockOCI)(nil).FetchAllProperties), ctx, getByProps, entType)
 }
 
 // FetchProperty mocks base method.
-func (m *MockOCI) FetchProperty(ctx context.Context, name string, entType v10.Entity, key string) (*properties.Property, error) {
+func (m *MockOCI) FetchProperty(ctx context.Context, getByProps *properties.Properties, entType v10.Entity, key string) (*properties.Property, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "FetchProperty", ctx, name, entType, key)
+	ret := m.ctrl.Call(m, "FetchProperty", ctx, getByProps, entType, key)
 	ret0, _ := ret[0].(*properties.Property)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // FetchProperty indicates an expected call of FetchProperty.
-func (mr *MockOCIMockRecorder) FetchProperty(ctx, name, entType, key any) *gomock.Call {
+func (mr *MockOCIMockRecorder) FetchProperty(ctx, getByProps, entType, key any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FetchProperty", reflect.TypeOf((*MockOCI)(nil).FetchProperty), ctx, name, entType, key)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FetchProperty", reflect.TypeOf((*MockOCI)(nil).FetchProperty), ctx, getByProps, entType, key)
 }
 
 // GetArtifactVersions mocks base method.

--- a/internal/providers/github/properties.go
+++ b/internal/providers/github/properties.go
@@ -137,9 +137,16 @@ func getRepoWrapper(ctx context.Context, ghCli *GitHub, name string) (map[string
 
 // FetchProperty fetches a single property for the given entity
 func (c *GitHub) FetchProperty(
-	ctx context.Context, name string, entType minderv1.Entity, key string,
+	ctx context.Context, getByProps *properties.Properties, entType minderv1.Entity, key string,
 ) (*properties.Property, error) {
 	pf := newPropertyFetcher(c, entType)
+
+	// TODO: right now github only supports fetching by name, but we could add support for more
+	// properties to e.g. get-repo-by-id if the upstream REST API supports that
+	name, err := getByProps.GetProperty(properties.PropertyName).AsString()
+	if err != nil {
+		return nil, err
+	}
 
 	for _, po := range pf.propertyOrigins {
 		for _, k := range po.keys {
@@ -163,11 +170,18 @@ func (c *GitHub) FetchProperty(
 
 // FetchAllProperties fetches all properties for the given entity
 func (c *GitHub) FetchAllProperties(
-	ctx context.Context, name string, entType minderv1.Entity,
+	ctx context.Context, getByProps *properties.Properties, entType minderv1.Entity,
 ) (*properties.Properties, error) {
 	pf := newPropertyFetcher(c, entType)
 
 	result := make(map[string]any)
+
+	// TODO: right now github only supports fetching by name, but we could add support for more
+	// properties to e.g. get-repo-by-id if the upstream REST API supports that
+	name, err := getByProps.GetProperty(properties.PropertyName).AsString()
+	if err != nil {
+		return nil, err
+	}
 
 	for _, po := range pf.propertyOrigins {
 		props, err := po.wrapper(ctx, pf.ghCli, name)

--- a/internal/providers/gitlab/gitlab.go
+++ b/internal/providers/gitlab/gitlab.go
@@ -118,13 +118,15 @@ func (c *gitlabClient) GetCredential() provifv1.GitLabCredential {
 
 // FetchAllProperties implements the provider interface
 // TODO: Implement this
-func (_ *gitlabClient) FetchAllProperties(_ context.Context, _ string, _ minderv1.Entity) (*properties.Properties, error) {
+func (_ *gitlabClient) FetchAllProperties(
+	_ context.Context, _ *properties.Properties, _ minderv1.Entity) (*properties.Properties, error) {
 	return nil, nil
 }
 
 // FetchProperty implements the provider interface
 // TODO: Implement this
-func (_ *gitlabClient) FetchProperty(_ context.Context, _ string, _ minderv1.Entity, _ string) (*properties.Property, error) {
+func (_ *gitlabClient) FetchProperty(
+	_ context.Context, _ *properties.Properties, _ minderv1.Entity, _ string) (*properties.Property, error) {
 	return nil, nil
 }
 

--- a/internal/providers/selectors/mock/interface.go
+++ b/internal/providers/selectors/mock/interface.go
@@ -57,33 +57,33 @@ func (mr *MockRepoSelectorConverterMockRecorder) CanImplement(trait any) *gomock
 }
 
 // FetchAllProperties mocks base method.
-func (m *MockRepoSelectorConverter) FetchAllProperties(ctx context.Context, name string, entType v1.Entity) (*properties.Properties, error) {
+func (m *MockRepoSelectorConverter) FetchAllProperties(ctx context.Context, getByProps *properties.Properties, entType v1.Entity) (*properties.Properties, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "FetchAllProperties", ctx, name, entType)
+	ret := m.ctrl.Call(m, "FetchAllProperties", ctx, getByProps, entType)
 	ret0, _ := ret[0].(*properties.Properties)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // FetchAllProperties indicates an expected call of FetchAllProperties.
-func (mr *MockRepoSelectorConverterMockRecorder) FetchAllProperties(ctx, name, entType any) *gomock.Call {
+func (mr *MockRepoSelectorConverterMockRecorder) FetchAllProperties(ctx, getByProps, entType any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FetchAllProperties", reflect.TypeOf((*MockRepoSelectorConverter)(nil).FetchAllProperties), ctx, name, entType)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FetchAllProperties", reflect.TypeOf((*MockRepoSelectorConverter)(nil).FetchAllProperties), ctx, getByProps, entType)
 }
 
 // FetchProperty mocks base method.
-func (m *MockRepoSelectorConverter) FetchProperty(ctx context.Context, name string, entType v1.Entity, key string) (*properties.Property, error) {
+func (m *MockRepoSelectorConverter) FetchProperty(ctx context.Context, getByProps *properties.Properties, entType v1.Entity, key string) (*properties.Property, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "FetchProperty", ctx, name, entType, key)
+	ret := m.ctrl.Call(m, "FetchProperty", ctx, getByProps, entType, key)
 	ret0, _ := ret[0].(*properties.Property)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // FetchProperty indicates an expected call of FetchProperty.
-func (mr *MockRepoSelectorConverterMockRecorder) FetchProperty(ctx, name, entType, key any) *gomock.Call {
+func (mr *MockRepoSelectorConverterMockRecorder) FetchProperty(ctx, getByProps, entType, key any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FetchProperty", reflect.TypeOf((*MockRepoSelectorConverter)(nil).FetchProperty), ctx, name, entType, key)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FetchProperty", reflect.TypeOf((*MockRepoSelectorConverter)(nil).FetchProperty), ctx, getByProps, entType, key)
 }
 
 // GetEntityName mocks base method.
@@ -167,33 +167,33 @@ func (mr *MockArtifactSelectorConverterMockRecorder) CanImplement(trait any) *go
 }
 
 // FetchAllProperties mocks base method.
-func (m *MockArtifactSelectorConverter) FetchAllProperties(ctx context.Context, name string, entType v1.Entity) (*properties.Properties, error) {
+func (m *MockArtifactSelectorConverter) FetchAllProperties(ctx context.Context, getByProps *properties.Properties, entType v1.Entity) (*properties.Properties, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "FetchAllProperties", ctx, name, entType)
+	ret := m.ctrl.Call(m, "FetchAllProperties", ctx, getByProps, entType)
 	ret0, _ := ret[0].(*properties.Properties)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // FetchAllProperties indicates an expected call of FetchAllProperties.
-func (mr *MockArtifactSelectorConverterMockRecorder) FetchAllProperties(ctx, name, entType any) *gomock.Call {
+func (mr *MockArtifactSelectorConverterMockRecorder) FetchAllProperties(ctx, getByProps, entType any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FetchAllProperties", reflect.TypeOf((*MockArtifactSelectorConverter)(nil).FetchAllProperties), ctx, name, entType)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FetchAllProperties", reflect.TypeOf((*MockArtifactSelectorConverter)(nil).FetchAllProperties), ctx, getByProps, entType)
 }
 
 // FetchProperty mocks base method.
-func (m *MockArtifactSelectorConverter) FetchProperty(ctx context.Context, name string, entType v1.Entity, key string) (*properties.Property, error) {
+func (m *MockArtifactSelectorConverter) FetchProperty(ctx context.Context, getByProps *properties.Properties, entType v1.Entity, key string) (*properties.Property, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "FetchProperty", ctx, name, entType, key)
+	ret := m.ctrl.Call(m, "FetchProperty", ctx, getByProps, entType, key)
 	ret0, _ := ret[0].(*properties.Property)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // FetchProperty indicates an expected call of FetchProperty.
-func (mr *MockArtifactSelectorConverterMockRecorder) FetchProperty(ctx, name, entType, key any) *gomock.Call {
+func (mr *MockArtifactSelectorConverterMockRecorder) FetchProperty(ctx, getByProps, entType, key any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FetchProperty", reflect.TypeOf((*MockArtifactSelectorConverter)(nil).FetchProperty), ctx, name, entType, key)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FetchProperty", reflect.TypeOf((*MockArtifactSelectorConverter)(nil).FetchProperty), ctx, getByProps, entType, key)
 }
 
 // GetEntityName mocks base method.
@@ -249,33 +249,33 @@ func (mr *MockPullRequestSelectorConverterMockRecorder) CanImplement(trait any) 
 }
 
 // FetchAllProperties mocks base method.
-func (m *MockPullRequestSelectorConverter) FetchAllProperties(ctx context.Context, name string, entType v1.Entity) (*properties.Properties, error) {
+func (m *MockPullRequestSelectorConverter) FetchAllProperties(ctx context.Context, getByProps *properties.Properties, entType v1.Entity) (*properties.Properties, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "FetchAllProperties", ctx, name, entType)
+	ret := m.ctrl.Call(m, "FetchAllProperties", ctx, getByProps, entType)
 	ret0, _ := ret[0].(*properties.Properties)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // FetchAllProperties indicates an expected call of FetchAllProperties.
-func (mr *MockPullRequestSelectorConverterMockRecorder) FetchAllProperties(ctx, name, entType any) *gomock.Call {
+func (mr *MockPullRequestSelectorConverterMockRecorder) FetchAllProperties(ctx, getByProps, entType any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FetchAllProperties", reflect.TypeOf((*MockPullRequestSelectorConverter)(nil).FetchAllProperties), ctx, name, entType)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FetchAllProperties", reflect.TypeOf((*MockPullRequestSelectorConverter)(nil).FetchAllProperties), ctx, getByProps, entType)
 }
 
 // FetchProperty mocks base method.
-func (m *MockPullRequestSelectorConverter) FetchProperty(ctx context.Context, name string, entType v1.Entity, key string) (*properties.Property, error) {
+func (m *MockPullRequestSelectorConverter) FetchProperty(ctx context.Context, getByProps *properties.Properties, entType v1.Entity, key string) (*properties.Property, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "FetchProperty", ctx, name, entType, key)
+	ret := m.ctrl.Call(m, "FetchProperty", ctx, getByProps, entType, key)
 	ret0, _ := ret[0].(*properties.Property)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // FetchProperty indicates an expected call of FetchProperty.
-func (mr *MockPullRequestSelectorConverterMockRecorder) FetchProperty(ctx, name, entType, key any) *gomock.Call {
+func (mr *MockPullRequestSelectorConverterMockRecorder) FetchProperty(ctx, getByProps, entType, key any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FetchProperty", reflect.TypeOf((*MockPullRequestSelectorConverter)(nil).FetchProperty), ctx, name, entType, key)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FetchProperty", reflect.TypeOf((*MockPullRequestSelectorConverter)(nil).FetchProperty), ctx, getByProps, entType, key)
 }
 
 // GetEntityName mocks base method.

--- a/internal/providers/selectors/selector_entity_test.go
+++ b/internal/providers/selectors/selector_entity_test.go
@@ -116,11 +116,11 @@ func (m *fullProvider) PullRequestToSelectorEntity(_ context.Context, pr *minder
 	return pullRequestToSelectorEntity(m.t, m.name, m.class, pr)
 }
 
-func (_ *fullProvider) FetchAllProperties(_ context.Context, _ string, _ minderv1.Entity) (*properties.Properties, error) {
+func (_ *fullProvider) FetchAllProperties(_ context.Context, _ *properties.Properties, _ minderv1.Entity) (*properties.Properties, error) {
 	return nil, nil
 }
 
-func (_ *fullProvider) FetchProperty(_ context.Context, _ string, _ minderv1.Entity, _ string) (*properties.Property, error) {
+func (_ *fullProvider) FetchProperty(_ context.Context, _ *properties.Properties, _ minderv1.Entity, _ string) (*properties.Property, error) {
 	return nil, nil
 }
 
@@ -158,11 +158,11 @@ func (_ *repoOnlyProvider) CanImplement(_ minderv1.ProviderType) bool {
 	return true
 }
 
-func (_ *repoOnlyProvider) FetchAllProperties(_ context.Context, _ string, _ minderv1.Entity) (*properties.Properties, error) {
+func (_ *repoOnlyProvider) FetchAllProperties(_ context.Context, _ *properties.Properties, _ minderv1.Entity) (*properties.Properties, error) {
 	return nil, nil
 }
 
-func (_ *repoOnlyProvider) FetchProperty(_ context.Context, _ string, _ minderv1.Entity, _ string) (*properties.Property, error) {
+func (_ *repoOnlyProvider) FetchProperty(_ context.Context, _ *properties.Properties, _ minderv1.Entity, _ string) (*properties.Property, error) {
 	return nil, nil
 }
 

--- a/internal/providers/testproviders/git.go
+++ b/internal/providers/testproviders/git.go
@@ -46,13 +46,13 @@ func (_ *GitProvider) CanImplement(trait minderv1.ProviderType) bool {
 
 // FetchAllProperties implements the Provider interface
 func (_ *GitProvider) FetchAllProperties(
-	_ context.Context, _ string, _ minderv1.Entity) (*properties.Properties, error) {
+	_ context.Context, _ *properties.Properties, _ minderv1.Entity) (*properties.Properties, error) {
 	return nil, nil
 }
 
 // FetchProperty implements the Provider interface
 func (_ *GitProvider) FetchProperty(
-	_ context.Context, _ string, _ minderv1.Entity, _ string) (*properties.Property, error) {
+	_ context.Context, _ *properties.Properties, _ minderv1.Entity, _ string) (*properties.Property, error) {
 	return nil, nil
 }
 

--- a/internal/providers/testproviders/rest.go
+++ b/internal/providers/testproviders/rest.go
@@ -55,13 +55,13 @@ func (_ *RESTProvider) CanImplement(trait minderv1.ProviderType) bool {
 
 // FetchAllProperties implements the Provider interface
 func (_ *RESTProvider) FetchAllProperties(
-	_ context.Context, _ string, _ minderv1.Entity) (*properties.Properties, error) {
+	_ context.Context, _ *properties.Properties, _ minderv1.Entity) (*properties.Properties, error) {
 	return nil, nil
 }
 
 // FetchProperty implements the Provider interface
 func (_ *RESTProvider) FetchProperty(
-	_ context.Context, _ string, _ minderv1.Entity, _ string) (*properties.Property, error) {
+	_ context.Context, _ *properties.Properties, _ minderv1.Entity, _ string) (*properties.Property, error) {
 	return nil, nil
 }
 

--- a/internal/repositories/github/service.go
+++ b/internal/repositories/github/service.go
@@ -150,9 +150,16 @@ func (r *repositoryService) CreateRepository(
 		return nil, fmt.Errorf("error instantiating properties client: %w", err)
 	}
 
+	fetchByProps, err := properties.NewProperties(map[string]any{
+		properties.PropertyName: fmt.Sprintf("%s/%s", repoOwner, repoName),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("error creating properties: %w", err)
+	}
+
 	repoProperties, err := propClient.FetchAllProperties(
 		ctx,
-		fmt.Sprintf("%s/%s", repoOwner, repoName),
+		fetchByProps,
 		pb.Entity_ENTITY_REPOSITORIES)
 	if err != nil {
 		return nil, fmt.Errorf("error fetching properties for repository: %w", err)

--- a/pkg/providers/v1/providers.go
+++ b/pkg/providers/v1/providers.go
@@ -47,9 +47,11 @@ type Provider interface {
 	CanImplement(trait minderv1.ProviderType) bool
 
 	// FetchAllProperties fetches all properties for the given entity
-	FetchAllProperties(ctx context.Context, name string, entType minderv1.Entity) (*properties.Properties, error)
+	FetchAllProperties(
+		ctx context.Context, getByProps *properties.Properties, entType minderv1.Entity) (*properties.Properties, error)
 	// FetchProperty fetches a single property for the given entity
-	FetchProperty(ctx context.Context, name string, entType minderv1.Entity, key string) (*properties.Property, error)
+	FetchProperty(
+		ctx context.Context, getByProps *properties.Properties, entType minderv1.Entity, key string) (*properties.Property, error)
 	// GetEntityName forms an entity name from the given properties
 	// The name is used to identify the entity within minder and is how
 	// it will be stored in the database.


### PR DESCRIPTION
# Summary

The initial implementation of the `FetchProperty/FetchAllProperties`
methods was very github specific in the sense that it only allowed
looking up the entity by name. Other providers might not have a name and
the provider is best equipped to know what to look by.

Let's send Properties instead and let the provider pick the right ones
or return an error.

Related: #4171

## Change Type

- [ ] Bug fix (resolves an issue without affecting existing features)
- [ ] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [x] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

repo register + unit tests

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [ ] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [ ] Included tests that validate the fix or feature.
- [ ] Checked that related changes are merged.
