### PR TITLE
Add database helpers for managing entity properties

### DIFF
--- a/database/mock/store.go
+++ b/database/mock/store.go
@@ -401,6 +401,20 @@ func (mr *MockStoreMockRecorder) CreateUser(arg0, arg1 any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateUser", reflect.TypeOf((*MockStore)(nil).CreateUser), arg0, arg1)
 }
 
+// DeleteAllPropertiesForEntity mocks base method.
+func (m *MockStore) DeleteAllPropertiesForEntity(arg0 context.Context, arg1 uuid.UUID) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteAllPropertiesForEntity", arg0, arg1)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DeleteAllPropertiesForEntity indicates an expected call of DeleteAllPropertiesForEntity.
+func (mr *MockStoreMockRecorder) DeleteAllPropertiesForEntity(arg0, arg1 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteAllPropertiesForEntity", reflect.TypeOf((*MockStore)(nil).DeleteAllPropertiesForEntity), arg0, arg1)
+}
+
 // DeleteArtifact mocks base method.
 func (m *MockStore) DeleteArtifact(arg0 context.Context, arg1 uuid.UUID) error {
 	m.ctrl.T.Helper()
@@ -557,6 +571,20 @@ func (m *MockStore) DeleteProject(arg0 context.Context, arg1 uuid.UUID) ([]db.De
 func (mr *MockStoreMockRecorder) DeleteProject(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteProject", reflect.TypeOf((*MockStore)(nil).DeleteProject), arg0, arg1)
+}
+
+// DeleteProperty mocks base method.
+func (m *MockStore) DeleteProperty(arg0 context.Context, arg1 db.DeletePropertyParams) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteProperty", arg0, arg1)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DeleteProperty indicates an expected call of DeleteProperty.
+func (mr *MockStoreMockRecorder) DeleteProperty(arg0, arg1 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteProperty", reflect.TypeOf((*MockStore)(nil).DeleteProperty), arg0, arg1)
 }
 
 // DeleteProvider mocks base method.
@@ -774,6 +802,21 @@ func (m *MockStore) GetAccessTokenSinceDate(arg0 context.Context, arg1 db.GetAcc
 func (mr *MockStoreMockRecorder) GetAccessTokenSinceDate(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAccessTokenSinceDate", reflect.TypeOf((*MockStore)(nil).GetAccessTokenSinceDate), arg0, arg1)
+}
+
+// GetAllPropertiesForEntity mocks base method.
+func (m *MockStore) GetAllPropertiesForEntity(arg0 context.Context, arg1 uuid.UUID) ([]db.Property, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetAllPropertiesForEntity", arg0, arg1)
+	ret0, _ := ret[0].([]db.Property)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetAllPropertiesForEntity indicates an expected call of GetAllPropertiesForEntity.
+func (mr *MockStoreMockRecorder) GetAllPropertiesForEntity(arg0, arg1 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAllPropertiesForEntity", reflect.TypeOf((*MockStore)(nil).GetAllPropertiesForEntity), arg0, arg1)
 }
 
 // GetArtifactByID mocks base method.
@@ -1224,6 +1267,21 @@ func (m *MockStore) GetProjectIDBySessionState(arg0 context.Context, arg1 string
 func (mr *MockStoreMockRecorder) GetProjectIDBySessionState(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetProjectIDBySessionState", reflect.TypeOf((*MockStore)(nil).GetProjectIDBySessionState), arg0, arg1)
+}
+
+// GetProperty mocks base method.
+func (m *MockStore) GetProperty(arg0 context.Context, arg1 db.GetPropertyParams) (db.Property, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetProperty", arg0, arg1)
+	ret0, _ := ret[0].(db.Property)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetProperty indicates an expected call of GetProperty.
+func (mr *MockStoreMockRecorder) GetProperty(arg0, arg1 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetProperty", reflect.TypeOf((*MockStore)(nil).GetProperty), arg0, arg1)
 }
 
 // GetProviderByID mocks base method.
@@ -2363,6 +2421,21 @@ func (m *MockStore) UpsertProfileForEntity(arg0 context.Context, arg1 db.UpsertP
 func (mr *MockStoreMockRecorder) UpsertProfileForEntity(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpsertProfileForEntity", reflect.TypeOf((*MockStore)(nil).UpsertProfileForEntity), arg0, arg1)
+}
+
+// UpsertProperty mocks base method.
+func (m *MockStore) UpsertProperty(arg0 context.Context, arg1 db.UpsertPropertyParams) (db.Property, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpsertProperty", arg0, arg1)
+	ret0, _ := ret[0].(db.Property)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// UpsertProperty indicates an expected call of UpsertProperty.
+func (mr *MockStoreMockRecorder) UpsertProperty(arg0, arg1 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpsertProperty", reflect.TypeOf((*MockStore)(nil).UpsertProperty), arg0, arg1)
 }
 
 // UpsertPullRequest mocks base method.

--- a/database/mock/store.go
+++ b/database/mock/store.go
@@ -819,6 +819,21 @@ func (mr *MockStoreMockRecorder) GetAllPropertiesForEntity(arg0, arg1 any) *gomo
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAllPropertiesForEntity", reflect.TypeOf((*MockStore)(nil).GetAllPropertiesForEntity), arg0, arg1)
 }
 
+// GetAllPropertyValuesV1 mocks base method.
+func (m *MockStore) GetAllPropertyValuesV1(arg0 context.Context, arg1 uuid.UUID) ([]db.PropertyValueV1, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetAllPropertyValuesV1", arg0, arg1)
+	ret0, _ := ret[0].([]db.PropertyValueV1)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetAllPropertyValuesV1 indicates an expected call of GetAllPropertyValuesV1.
+func (mr *MockStoreMockRecorder) GetAllPropertyValuesV1(arg0, arg1 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAllPropertyValuesV1", reflect.TypeOf((*MockStore)(nil).GetAllPropertyValuesV1), arg0, arg1)
+}
+
 // GetArtifactByID mocks base method.
 func (m *MockStore) GetArtifactByID(arg0 context.Context, arg1 db.GetArtifactByIDParams) (db.Artifact, error) {
 	m.ctrl.T.Helper()
@@ -1282,6 +1297,21 @@ func (m *MockStore) GetProperty(arg0 context.Context, arg1 db.GetPropertyParams)
 func (mr *MockStoreMockRecorder) GetProperty(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetProperty", reflect.TypeOf((*MockStore)(nil).GetProperty), arg0, arg1)
+}
+
+// GetPropertyValueV1 mocks base method.
+func (m *MockStore) GetPropertyValueV1(arg0 context.Context, arg1 uuid.UUID, arg2 string) (db.PropertyValueV1, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetPropertyValueV1", arg0, arg1, arg2)
+	ret0, _ := ret[0].(db.PropertyValueV1)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetPropertyValueV1 indicates an expected call of GetPropertyValueV1.
+func (mr *MockStoreMockRecorder) GetPropertyValueV1(arg0, arg1, arg2 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPropertyValueV1", reflect.TypeOf((*MockStore)(nil).GetPropertyValueV1), arg0, arg1, arg2)
 }
 
 // GetProviderByID mocks base method.
@@ -2436,6 +2466,21 @@ func (m *MockStore) UpsertProperty(arg0 context.Context, arg1 db.UpsertPropertyP
 func (mr *MockStoreMockRecorder) UpsertProperty(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpsertProperty", reflect.TypeOf((*MockStore)(nil).UpsertProperty), arg0, arg1)
+}
+
+// UpsertPropertyValueV1 mocks base method.
+func (m *MockStore) UpsertPropertyValueV1(arg0 context.Context, arg1 db.UpsertPropertyValueV1Params) (db.Property, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpsertPropertyValueV1", arg0, arg1)
+	ret0, _ := ret[0].(db.Property)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// UpsertPropertyValueV1 indicates an expected call of UpsertPropertyValueV1.
+func (mr *MockStoreMockRecorder) UpsertPropertyValueV1(arg0, arg1 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpsertPropertyValueV1", reflect.TypeOf((*MockStore)(nil).UpsertPropertyValueV1), arg0, arg1)
 }
 
 // UpsertPullRequest mocks base method.

--- a/internal/db/entity_helpers.go
+++ b/internal/db/entity_helpers.go
@@ -1,0 +1,154 @@
+//
+// Copyright 2024 Stacklok, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package db
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+const propValueV1 = "v1"
+
+// ErrBadPropVersion is returned when a property has an unexpected version
+var ErrBadPropVersion = errors.New("unexpected property version")
+
+// PropertyWrapper is a wrapper around a property value that includes a version to serialize as JSON
+type PropertyWrapper struct {
+	Version string `json:"version"`
+	Value   any    `json:"value"`
+}
+
+func propValueFromDb(rawValue json.RawMessage, expVersion string) (any, error) {
+	var prop PropertyWrapper
+	err := json.Unmarshal(rawValue, &prop)
+	if err != nil {
+		return nil, err
+	}
+
+	if prop.Version != expVersion {
+		return nil, ErrBadPropVersion
+	}
+
+	return prop.Value, nil
+}
+
+func propValueToDb(value any, version string) (json.RawMessage, error) {
+	prop := PropertyWrapper{
+		Version: version,
+		Value:   value,
+	}
+
+	rawValue, err := json.Marshal(prop)
+	if err != nil {
+		return nil, err
+	}
+
+	return rawValue, nil
+}
+
+// PropValueToDbV1 serializes a property value to a JSON byte slice
+func PropValueToDbV1(value any) (json.RawMessage, error) {
+	return propValueToDb(value, propValueV1)
+}
+
+// PropValueFromDbV1 deserializes a property value from a JSON byte slice
+func PropValueFromDbV1(rawValue json.RawMessage) (any, error) {
+	return propValueFromDb(rawValue, propValueV1)
+}
+
+// UpsertPropertyValueV1Params is the input parameter for the UpsertProperty query
+type UpsertPropertyValueV1Params struct {
+	EntityID uuid.UUID `json:"entity_id"`
+	Key      string    `json:"key"`
+	Value    any       `json:"value"`
+}
+
+// UpsertPropertyValueV1 upserts a property value for an entity
+func (q *Queries) UpsertPropertyValueV1(ctx context.Context, params UpsertPropertyValueV1Params) (Property, error) {
+	jsonVal, err := PropValueToDbV1(params.Value)
+	if err != nil {
+		return Property{}, err
+	}
+	dbParams := UpsertPropertyParams{
+		EntityID: params.EntityID,
+		Key:      params.Key,
+		Value:    jsonVal,
+	}
+	return q.UpsertProperty(ctx, dbParams)
+}
+
+// PropertyValueV1 is a property value for an entity
+type PropertyValueV1 struct {
+	ID        uuid.UUID `json:"id"`
+	EntityID  uuid.UUID `json:"entity_id"`
+	Key       string    `json:"key"`
+	Value     any       `json:"value"`
+	UpdatedAt time.Time `json:"updated_at"`
+}
+
+// GetPropertyValueV1 retrieves a property value for an entity
+func (q *Queries) GetPropertyValueV1(ctx context.Context, entityID uuid.UUID, key string) (PropertyValueV1, error) {
+	dbProp, err := q.GetProperty(ctx, GetPropertyParams{
+		EntityID: entityID,
+		Key:      key,
+	})
+	if err != nil {
+		return PropertyValueV1{}, err
+	}
+
+	value, err := PropValueFromDbV1(dbProp.Value)
+	if err != nil {
+		return PropertyValueV1{}, err
+	}
+
+	return PropertyValueV1{
+		ID:        dbProp.ID,
+		EntityID:  dbProp.EntityID,
+		Key:       dbProp.Key,
+		Value:     value,
+		UpdatedAt: dbProp.UpdatedAt,
+	}, nil
+}
+
+// GetAllPropertyValuesV1 retrieves all property values for an entity
+func (q *Queries) GetAllPropertyValuesV1(ctx context.Context, entityID uuid.UUID) ([]PropertyValueV1, error) {
+	dbProps, err := q.GetAllPropertiesForEntity(ctx, entityID)
+	if err != nil {
+		return nil, err
+	}
+
+	props := make([]PropertyValueV1, len(dbProps))
+	for i, dbProp := range dbProps {
+		value, err := PropValueFromDbV1(dbProp.Value)
+		if err != nil {
+			return nil, err
+		}
+
+		props[i] = PropertyValueV1{
+			ID:        dbProp.ID,
+			EntityID:  dbProp.EntityID,
+			Key:       dbProp.Key,
+			Value:     value,
+			UpdatedAt: dbProp.UpdatedAt,
+		}
+	}
+
+	return props, nil
+}

--- a/internal/db/querier.go
+++ b/internal/db/querier.go
@@ -43,6 +43,7 @@ type Querier interface {
 	// Subscriptions --
 	CreateSubscription(ctx context.Context, arg CreateSubscriptionParams) (Subscription, error)
 	CreateUser(ctx context.Context, identitySubject string) (User, error)
+	DeleteAllPropertiesForEntity(ctx context.Context, entityID uuid.UUID) error
 	DeleteArtifact(ctx context.Context, id uuid.UUID) error
 	// DeleteEntity removes an entity from the entity_instances table for a project.
 	DeleteEntity(ctx context.Context, arg DeleteEntityParams) error
@@ -59,6 +60,7 @@ type Querier interface {
 	DeleteProfile(ctx context.Context, arg DeleteProfileParams) error
 	DeleteProfileForEntity(ctx context.Context, arg DeleteProfileForEntityParams) error
 	DeleteProject(ctx context.Context, id uuid.UUID) ([]DeleteProjectRow, error)
+	DeleteProperty(ctx context.Context, arg DeletePropertyParams) error
 	DeleteProvider(ctx context.Context, arg DeleteProviderParams) error
 	DeletePullRequest(ctx context.Context, arg DeletePullRequestParams) error
 	DeleteRepository(ctx context.Context, id uuid.UUID) error
@@ -77,6 +79,7 @@ type Querier interface {
 	GetAccessTokenByProjectID(ctx context.Context, arg GetAccessTokenByProjectIDParams) (ProviderAccessToken, error)
 	GetAccessTokenByProvider(ctx context.Context, provider string) ([]ProviderAccessToken, error)
 	GetAccessTokenSinceDate(ctx context.Context, arg GetAccessTokenSinceDateParams) (ProviderAccessToken, error)
+	GetAllPropertiesForEntity(ctx context.Context, entityID uuid.UUID) ([]Property, error)
 	GetArtifactByID(ctx context.Context, arg GetArtifactByIDParams) (Artifact, error)
 	GetArtifactByName(ctx context.Context, arg GetArtifactByNameParams) (Artifact, error)
 	GetBundle(ctx context.Context, arg GetBundleParams) (Bundle, error)
@@ -139,6 +142,7 @@ type Querier interface {
 	GetProjectByID(ctx context.Context, id uuid.UUID) (Project, error)
 	GetProjectByName(ctx context.Context, name string) (Project, error)
 	GetProjectIDBySessionState(ctx context.Context, sessionState string) (GetProjectIDBySessionStateRow, error)
+	GetProperty(ctx context.Context, arg GetPropertyParams) (Property, error)
 	GetProviderByID(ctx context.Context, id uuid.UUID) (Provider, error)
 	GetProviderByIDAndProject(ctx context.Context, arg GetProviderByIDAndProjectParams) (Provider, error)
 	// GetProviderByName allows us to get a provider by its name. This takes
@@ -281,6 +285,7 @@ type Querier interface {
 	UpsertInstallationID(ctx context.Context, arg UpsertInstallationIDParams) (ProviderGithubAppInstallation, error)
 	UpsertLatestEvaluationStatus(ctx context.Context, arg UpsertLatestEvaluationStatusParams) error
 	UpsertProfileForEntity(ctx context.Context, arg UpsertProfileForEntityParams) (EntityProfile, error)
+	UpsertProperty(ctx context.Context, arg UpsertPropertyParams) (Property, error)
 	UpsertPullRequest(ctx context.Context, arg UpsertPullRequestParams) (PullRequest, error)
 	// Copyright 2024 Stacklok, Inc
 	//

--- a/internal/db/store.go
+++ b/internal/db/store.go
@@ -28,6 +28,9 @@ type ExtendQuerier interface {
 	Querier
 	GetRuleEvaluationByProfileIdAndRuleType(ctx context.Context, profileID uuid.UUID, entityType NullEntities,
 		ruleName sql.NullString, entityID uuid.NullUUID, ruleTypeName sql.NullString) (*ListRuleEvaluationsByProfileIdRow, error)
+	UpsertPropertyValueV1(ctx context.Context, params UpsertPropertyValueV1Params) (Property, error)
+	GetPropertyValueV1(ctx context.Context, entityID uuid.UUID, key string) (PropertyValueV1, error)
+	GetAllPropertyValuesV1(ctx context.Context, entityID uuid.UUID) ([]PropertyValueV1, error)
 }
 
 // Store provides all functions to execute db queries and transactions


### PR DESCRIPTION
# Summary

- **Add SQL functions for handling entity properties** - Adds CRUD SQL functions to retrieve properties for entities.
- **Add convenience DB interface for handling property marshalling** - We are serializing properties as JSON. To avoid the caller from having to do the serialization, we introduce several helpers that accept an `any` parameter and marshall the data before saving.
- **Add unit tests for property database functions** - Just adds tests for the new code

Related: #4171

## Change Type

- [ ] Bug fix (resolves an issue without affecting existing features)
- [x] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [ ] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

as part of a larger branch + unit tests

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [ ] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [x] Included tests that validate the fix or feature.
- [ ] Checked that related changes are merged.
