### PR TITLE
Decouple minder core from entities.

### DIFF
--- a/internal/controlplane/handlers_entities.go
+++ b/internal/controlplane/handlers_entities.go
@@ -127,13 +127,12 @@ func createEntityMessage(
 	msg := message.NewMessage(uuid.New().String(), nil)
 	msg.SetContext(ctx)
 
-	event := messages.NewMinderEvent[*messages.RepoEvent]().
+	event := messages.NewMinderEvent().
 		WithProjectID(projectID).
 		WithProviderID(providerID).
-		WithEntity(messages.NewRepoEvent().
-			WithRepoName(repoName).
-			WithRepoOwner(repoOwner),
-		)
+		WithEntityType("repository").
+		WithAttribute("repoName", repoName).
+		WithAttribute("repoOwner", repoOwner)
 
 	err := event.ToMessage(msg)
 	if err != nil {

--- a/internal/controlplane/handlers_entities.go
+++ b/internal/controlplane/handlers_entities.go
@@ -127,11 +127,13 @@ func createEntityMessage(
 	msg := message.NewMessage(uuid.New().String(), nil)
 	msg.SetContext(ctx)
 
-	event := messages.NewRepoEvent().
+	event := messages.NewMinderEvent[*messages.RepoEvent]().
 		WithProjectID(projectID).
 		WithProviderID(providerID).
-		WithRepoName(repoName).
-		WithRepoOwner(repoOwner)
+		WithEntity(messages.NewRepoEvent().
+			WithRepoName(repoName).
+			WithRepoOwner(repoOwner),
+		)
 
 	err := event.ToMessage(msg)
 	if err != nil {

--- a/internal/controlplane/handlers_githubwebhooks.go
+++ b/internal/controlplane/handlers_githubwebhooks.go
@@ -368,7 +368,7 @@ type toMessage interface {
 
 var _ toMessage = (*entities.EntityInfoWrapper)(nil)
 var _ toMessage = (*installations.InstallationInfoWrapper)(nil)
-var _ toMessage = (*messages.MinderEvent[*messages.RepoEvent])(nil)
+var _ toMessage = (*messages.MinderEvent)(nil)
 
 // processingResult struct contains the sole information necessary to
 // send a message out from the handler, namely a destination topic and
@@ -834,12 +834,11 @@ func (s *Server) processRelevantRepositoryEvent(
 	// type.
 	if event.GetAction() == webhookActionEventDeleted ||
 		event.GetAction() == webhookActionEventTransferred {
-		repoEvent := messages.NewMinderEvent[*messages.RepoEvent]().
+		repoEvent := messages.NewMinderEvent().
 			WithProjectID(dbrepo.ProjectID).
 			WithProviderID(dbrepo.ProviderID).
-			WithEntity(messages.NewRepoEvent().
-				WithRepoID(dbrepo.ID),
-			)
+			WithEntityType("repository").
+			WithAttribute("repoID", dbrepo.ID.String())
 
 		return &processingResult{
 			topic:   events.TopicQueueReconcileEntityDelete,
@@ -1151,12 +1150,11 @@ func (s *Server) repositoryRemoved(
 		return nil, err
 	}
 
-	event := messages.NewMinderEvent[*messages.RepoEvent]().
+	event := messages.NewMinderEvent().
 		WithProjectID(dbrepo.ProjectID).
 		WithProviderID(dbrepo.ProviderID).
-		WithEntity(messages.NewRepoEvent().
-			WithRepoID(dbrepo.ID),
-		)
+		WithEntityType("repository").
+		WithAttribute("repoID", dbrepo.ID.String())
 
 	return &processingResult{
 		topic:   events.TopicQueueReconcileEntityDelete,
@@ -1173,13 +1171,12 @@ func (_ *Server) repositoryAdded(
 		return nil, errors.New("invalid repository name")
 	}
 
-	event := messages.NewMinderEvent[*messages.RepoEvent]().
+	event := messages.NewMinderEvent().
 		WithProjectID(installation.ProjectID.UUID).
 		WithProviderID(installation.ProviderID.UUID).
-		WithEntity(messages.NewRepoEvent().
-			WithRepoName(repo.GetName()).
-			WithRepoOwner(repo.GetOwner()),
-		)
+		WithEntityType("repository").
+		WithAttribute("repoName", repo.GetName()).
+		WithAttribute("repoOwner", repo.GetOwner())
 
 	return &processingResult{
 		topic:   events.TopicQueueReconcileEntityAdd,

--- a/internal/controlplane/handlers_githubwebhooks.go
+++ b/internal/controlplane/handlers_githubwebhooks.go
@@ -838,6 +838,7 @@ func (s *Server) processRelevantRepositoryEvent(
 			WithProjectID(dbrepo.ProjectID).
 			WithProviderID(dbrepo.ProviderID).
 			WithEntityType("repository").
+			WithEntityID(dbrepo.ID).
 			WithAttribute("repoID", dbrepo.ID.String())
 
 		return &processingResult{
@@ -1154,6 +1155,7 @@ func (s *Server) repositoryRemoved(
 		WithProjectID(dbrepo.ProjectID).
 		WithProviderID(dbrepo.ProviderID).
 		WithEntityType("repository").
+		WithEntityID(dbrepo.ID).
 		WithAttribute("repoID", dbrepo.ID.String())
 
 	return &processingResult{

--- a/internal/controlplane/handlers_githubwebhooks_test.go
+++ b/internal/controlplane/handlers_githubwebhooks_test.go
@@ -295,15 +295,15 @@ func (s *UnitTestSuite) TestHandleWebHookRepository() {
 	assert.Equal(t, "12345", received.Metadata["id"])
 	assert.Equal(t, "meta", received.Metadata["type"])
 	assert.Equal(t, "https://api.github.com/", received.Metadata["source"])
-	var inner messages.RepoEvent
+	var inner messages.MinderEvent[*messages.RepoEvent]
 	err = json.Unmarshal(received.Payload, &inner)
 	require.NoError(t, err)
 	require.NoError(t, validator.New().Struct(&inner))
 	require.Equal(t, providerID, inner.ProviderID)
 	require.Equal(t, projectID, inner.ProjectID)
-	require.Equal(t, repositoryID, inner.RepoID)
-	require.Equal(t, "", inner.RepoName)  // optional
-	require.Equal(t, "", inner.RepoOwner) // optional
+	require.Equal(t, repositoryID, inner.Entity.RepoID)
+	require.Equal(t, "", inner.Entity.RepoName)  // optional
+	require.Equal(t, "", inner.Entity.RepoOwner) // optional
 
 	// test that if no secret matches we get back a 400
 	req, err = http.NewRequest("POST", ts.URL, bytes.NewBuffer(packageJson))
@@ -1049,15 +1049,15 @@ func (s *UnitTestSuite) TestHandleGitHubWebHook() {
 				timeout := 1 * time.Second
 				received := withTimeout(ch, timeout)
 				require.NotNilf(t, received, "no event received after waiting %s", timeout)
-				var evt messages.RepoEvent
+				var evt messages.MinderEvent[*messages.RepoEvent]
 				err := json.Unmarshal(received.Payload, &evt)
 				require.NoError(t, err)
 				require.NoError(t, validator.New().Struct(&evt))
 				require.Equal(t, providerID, evt.ProviderID)
 				require.Equal(t, projectID, evt.ProjectID)
-				require.Equal(t, repositoryID, evt.RepoID)
-				require.Equal(t, "", evt.RepoName)  // optional
-				require.Equal(t, "", evt.RepoOwner) // optional
+				require.Equal(t, repositoryID, evt.Entity.RepoID)
+				require.Equal(t, "", evt.Entity.RepoName)  // optional
+				require.Equal(t, "", evt.Entity.RepoOwner) // optional
 			},
 		},
 		{
@@ -1093,15 +1093,15 @@ func (s *UnitTestSuite) TestHandleGitHubWebHook() {
 				timeout := 1 * time.Second
 				received := withTimeout(ch, timeout)
 				require.NotNilf(t, received, "no event received after waiting %s", timeout)
-				var evt messages.RepoEvent
+				var evt messages.MinderEvent[*messages.RepoEvent]
 				err := json.Unmarshal(received.Payload, &evt)
 				require.NoError(t, err)
 				require.NoError(t, validator.New().Struct(&evt))
 				require.Equal(t, providerID, evt.ProviderID)
 				require.Equal(t, projectID, evt.ProjectID)
-				require.Equal(t, repositoryID, evt.RepoID)
-				require.Equal(t, "", evt.RepoName)  // optional
-				require.Equal(t, "", evt.RepoOwner) // optional
+				require.Equal(t, repositoryID, evt.Entity.RepoID)
+				require.Equal(t, "", evt.Entity.RepoName)  // optional
+				require.Equal(t, "", evt.Entity.RepoOwner) // optional
 			},
 		},
 		{
@@ -1531,15 +1531,15 @@ func (s *UnitTestSuite) TestHandleGitHubWebHook() {
 				timeout := 1 * time.Second
 				received := withTimeout(ch, timeout)
 				require.NotNilf(t, received, "no event received after waiting %s", timeout)
-				var evt messages.RepoEvent
+				var evt messages.MinderEvent[*messages.RepoEvent]
 				err := json.Unmarshal(received.Payload, &evt)
 				require.NoError(t, err)
 				require.NoError(t, validator.New().Struct(&evt))
 				require.Equal(t, providerID, evt.ProviderID)
 				require.Equal(t, projectID, evt.ProjectID)
-				require.Equal(t, repositoryID, evt.RepoID)
-				require.Equal(t, "", evt.RepoName)  // optional
-				require.Equal(t, "", evt.RepoOwner) // optional
+				require.Equal(t, repositoryID, evt.Entity.RepoID)
+				require.Equal(t, "", evt.Entity.RepoName)  // optional
+				require.Equal(t, "", evt.Entity.RepoOwner) // optional
 			},
 		},
 		{
@@ -1578,15 +1578,15 @@ func (s *UnitTestSuite) TestHandleGitHubWebHook() {
 				timeout := 1 * time.Second
 				received := withTimeout(ch, timeout)
 				require.NotNilf(t, received, "no event received after waiting %s", timeout)
-				var evt messages.RepoEvent
+				var evt messages.MinderEvent[*messages.RepoEvent]
 				err := json.Unmarshal(received.Payload, &evt)
 				require.NoError(t, err)
 				require.NoError(t, validator.New().Struct(&evt))
 				require.Equal(t, providerID, evt.ProviderID)
 				require.Equal(t, projectID, evt.ProjectID)
-				require.Equal(t, repositoryID, evt.RepoID)
-				require.Equal(t, "", evt.RepoName)  // optional
-				require.Equal(t, "", evt.RepoOwner) // optional
+				require.Equal(t, repositoryID, evt.Entity.RepoID)
+				require.Equal(t, "", evt.Entity.RepoName)  // optional
+				require.Equal(t, "", evt.Entity.RepoOwner) // optional
 			},
 		},
 		{
@@ -1781,15 +1781,15 @@ func (s *UnitTestSuite) TestHandleGitHubWebHook() {
 				timeout := 1 * time.Second
 				received := withTimeout(ch, timeout)
 				require.NotNilf(t, received, "no event received after waiting %s", timeout)
-				var evt messages.RepoEvent
+				var evt messages.MinderEvent[*messages.RepoEvent]
 				err := json.Unmarshal(received.Payload, &evt)
 				require.NoError(t, err)
 				require.NoError(t, validator.New().Struct(&evt))
 				require.Equal(t, providerID, evt.ProviderID)
 				require.Equal(t, projectID, evt.ProjectID)
-				require.Equal(t, repositoryID, evt.RepoID)
-				require.Equal(t, "", evt.RepoName)  // optional
-				require.Equal(t, "", evt.RepoOwner) // optional
+				require.Equal(t, repositoryID, evt.Entity.RepoID)
+				require.Equal(t, "", evt.Entity.RepoName)  // optional
+				require.Equal(t, "", evt.Entity.RepoOwner) // optional
 			},
 		},
 		{
@@ -3605,7 +3605,7 @@ func (s *UnitTestSuite) TestHandleGitHubAppWebHook() {
 				t.Helper()
 				timeout := 1 * time.Second
 
-				var evt messages.RepoEvent
+				var evt messages.MinderEvent[*messages.RepoEvent]
 
 				received := withTimeout(ch, timeout)
 				require.NotNilf(t, received, "no event received after waiting %s", timeout)
@@ -3615,8 +3615,8 @@ func (s *UnitTestSuite) TestHandleGitHubAppWebHook() {
 
 				err := json.Unmarshal(received.Payload, &evt)
 				require.NoError(t, err)
-				require.Equal(t, providerID.String(), evt.ProviderID.String())
-				require.Equal(t, projectID.String(), evt.ProjectID.String())
+				require.Equal(t, providerID, evt.ProviderID)
+				require.Equal(t, projectID, evt.ProjectID)
 
 				received = withTimeout(ch, timeout)
 				require.NotNilf(t, received, "no event received after waiting %s", timeout)
@@ -3626,8 +3626,8 @@ func (s *UnitTestSuite) TestHandleGitHubAppWebHook() {
 
 				err = json.Unmarshal(received.Payload, &evt)
 				require.NoError(t, err)
-				require.Equal(t, providerID.String(), evt.ProviderID.String())
-				require.Equal(t, projectID.String(), evt.ProjectID.String())
+				require.Equal(t, providerID, evt.ProviderID)
+				require.Equal(t, projectID, evt.ProjectID)
 			},
 		},
 		{
@@ -3759,7 +3759,7 @@ func (s *UnitTestSuite) TestHandleGitHubAppWebHook() {
 				t.Helper()
 				timeout := 1 * time.Second
 
-				var evt messages.RepoEvent
+				var evt messages.MinderEvent[*messages.RepoEvent]
 
 				received := withTimeout(ch, timeout)
 				require.NotNilf(t, received, "no event received after waiting %s", timeout)
@@ -3769,9 +3769,9 @@ func (s *UnitTestSuite) TestHandleGitHubAppWebHook() {
 
 				err := json.Unmarshal(received.Payload, &evt)
 				require.NoError(t, err)
-				require.Equal(t, providerID.String(), evt.ProviderID.String())
-				require.Equal(t, projectID.String(), evt.ProjectID.String())
-				require.Equal(t, repositoryID.String(), evt.RepoID.String())
+				require.Equal(t, providerID, evt.ProviderID)
+				require.Equal(t, projectID, evt.ProjectID)
+				require.Equal(t, repositoryID, evt.Entity.RepoID)
 
 				received = withTimeout(ch, timeout)
 				require.NotNilf(t, received, "no event received after waiting %s", timeout)
@@ -3781,9 +3781,9 @@ func (s *UnitTestSuite) TestHandleGitHubAppWebHook() {
 
 				err = json.Unmarshal(received.Payload, &evt)
 				require.NoError(t, err)
-				require.Equal(t, providerID.String(), evt.ProviderID.String())
-				require.Equal(t, projectID.String(), evt.ProjectID.String())
-				require.Equal(t, repositoryID.String(), evt.RepoID.String())
+				require.Equal(t, providerID, evt.ProviderID)
+				require.Equal(t, projectID, evt.ProjectID)
+				require.Equal(t, repositoryID, evt.Entity.RepoID)
 			},
 		},
 

--- a/internal/controlplane/handlers_githubwebhooks_test.go
+++ b/internal/controlplane/handlers_githubwebhooks_test.go
@@ -295,15 +295,15 @@ func (s *UnitTestSuite) TestHandleWebHookRepository() {
 	assert.Equal(t, "12345", received.Metadata["id"])
 	assert.Equal(t, "meta", received.Metadata["type"])
 	assert.Equal(t, "https://api.github.com/", received.Metadata["source"])
-	var inner messages.MinderEvent[*messages.RepoEvent]
+	var inner messages.MinderEvent
 	err = json.Unmarshal(received.Payload, &inner)
 	require.NoError(t, err)
 	require.NoError(t, validator.New().Struct(&inner))
 	require.Equal(t, providerID, inner.ProviderID)
 	require.Equal(t, projectID, inner.ProjectID)
-	require.Equal(t, repositoryID, inner.Entity.RepoID)
-	require.Equal(t, "", inner.Entity.RepoName)  // optional
-	require.Equal(t, "", inner.Entity.RepoOwner) // optional
+	require.Equal(t, repositoryID.String(), inner.Entity["repoID"])
+	require.Equal(t, nil, inner.Entity["repoName"])  // optional
+	require.Equal(t, nil, inner.Entity["repoOwner"]) // optional
 
 	// test that if no secret matches we get back a 400
 	req, err = http.NewRequest("POST", ts.URL, bytes.NewBuffer(packageJson))
@@ -1049,15 +1049,15 @@ func (s *UnitTestSuite) TestHandleGitHubWebHook() {
 				timeout := 1 * time.Second
 				received := withTimeout(ch, timeout)
 				require.NotNilf(t, received, "no event received after waiting %s", timeout)
-				var evt messages.MinderEvent[*messages.RepoEvent]
+				var evt messages.MinderEvent
 				err := json.Unmarshal(received.Payload, &evt)
 				require.NoError(t, err)
 				require.NoError(t, validator.New().Struct(&evt))
 				require.Equal(t, providerID, evt.ProviderID)
 				require.Equal(t, projectID, evt.ProjectID)
-				require.Equal(t, repositoryID, evt.Entity.RepoID)
-				require.Equal(t, "", evt.Entity.RepoName)  // optional
-				require.Equal(t, "", evt.Entity.RepoOwner) // optional
+				require.Equal(t, repositoryID.String(), evt.Entity["repoID"])
+				require.Equal(t, nil, evt.Entity["repoName"])  // optional
+				require.Equal(t, nil, evt.Entity["repoOwner"]) // optional
 			},
 		},
 		{
@@ -1093,15 +1093,15 @@ func (s *UnitTestSuite) TestHandleGitHubWebHook() {
 				timeout := 1 * time.Second
 				received := withTimeout(ch, timeout)
 				require.NotNilf(t, received, "no event received after waiting %s", timeout)
-				var evt messages.MinderEvent[*messages.RepoEvent]
+				var evt messages.MinderEvent
 				err := json.Unmarshal(received.Payload, &evt)
 				require.NoError(t, err)
 				require.NoError(t, validator.New().Struct(&evt))
 				require.Equal(t, providerID, evt.ProviderID)
 				require.Equal(t, projectID, evt.ProjectID)
-				require.Equal(t, repositoryID, evt.Entity.RepoID)
-				require.Equal(t, "", evt.Entity.RepoName)  // optional
-				require.Equal(t, "", evt.Entity.RepoOwner) // optional
+				require.Equal(t, repositoryID.String(), evt.Entity["repoID"])
+				require.Equal(t, nil, evt.Entity["repoName"])  // optional
+				require.Equal(t, nil, evt.Entity["repoOwner"]) // optional
 			},
 		},
 		{
@@ -1531,15 +1531,15 @@ func (s *UnitTestSuite) TestHandleGitHubWebHook() {
 				timeout := 1 * time.Second
 				received := withTimeout(ch, timeout)
 				require.NotNilf(t, received, "no event received after waiting %s", timeout)
-				var evt messages.MinderEvent[*messages.RepoEvent]
+				var evt messages.MinderEvent
 				err := json.Unmarshal(received.Payload, &evt)
 				require.NoError(t, err)
 				require.NoError(t, validator.New().Struct(&evt))
 				require.Equal(t, providerID, evt.ProviderID)
 				require.Equal(t, projectID, evt.ProjectID)
-				require.Equal(t, repositoryID, evt.Entity.RepoID)
-				require.Equal(t, "", evt.Entity.RepoName)  // optional
-				require.Equal(t, "", evt.Entity.RepoOwner) // optional
+				require.Equal(t, repositoryID.String(), evt.Entity["repoID"])
+				require.Equal(t, nil, evt.Entity["repoName"])  // optional
+				require.Equal(t, nil, evt.Entity["repoOwner"]) // optional
 			},
 		},
 		{
@@ -1578,15 +1578,15 @@ func (s *UnitTestSuite) TestHandleGitHubWebHook() {
 				timeout := 1 * time.Second
 				received := withTimeout(ch, timeout)
 				require.NotNilf(t, received, "no event received after waiting %s", timeout)
-				var evt messages.MinderEvent[*messages.RepoEvent]
+				var evt messages.MinderEvent
 				err := json.Unmarshal(received.Payload, &evt)
 				require.NoError(t, err)
 				require.NoError(t, validator.New().Struct(&evt))
 				require.Equal(t, providerID, evt.ProviderID)
 				require.Equal(t, projectID, evt.ProjectID)
-				require.Equal(t, repositoryID, evt.Entity.RepoID)
-				require.Equal(t, "", evt.Entity.RepoName)  // optional
-				require.Equal(t, "", evt.Entity.RepoOwner) // optional
+				require.Equal(t, repositoryID.String(), evt.Entity["repoID"])
+				require.Equal(t, nil, evt.Entity["repoName"])  // optional
+				require.Equal(t, nil, evt.Entity["repoOwner"]) // optional
 			},
 		},
 		{
@@ -1781,15 +1781,15 @@ func (s *UnitTestSuite) TestHandleGitHubWebHook() {
 				timeout := 1 * time.Second
 				received := withTimeout(ch, timeout)
 				require.NotNilf(t, received, "no event received after waiting %s", timeout)
-				var evt messages.MinderEvent[*messages.RepoEvent]
+				var evt messages.MinderEvent
 				err := json.Unmarshal(received.Payload, &evt)
 				require.NoError(t, err)
 				require.NoError(t, validator.New().Struct(&evt))
 				require.Equal(t, providerID, evt.ProviderID)
 				require.Equal(t, projectID, evt.ProjectID)
-				require.Equal(t, repositoryID, evt.Entity.RepoID)
-				require.Equal(t, "", evt.Entity.RepoName)  // optional
-				require.Equal(t, "", evt.Entity.RepoOwner) // optional
+				require.Equal(t, repositoryID.String(), evt.Entity["repoID"])
+				require.Equal(t, nil, evt.Entity["repoName"])  // optional
+				require.Equal(t, nil, evt.Entity["repoOwner"]) // optional
 			},
 		},
 		{
@@ -3605,7 +3605,7 @@ func (s *UnitTestSuite) TestHandleGitHubAppWebHook() {
 				t.Helper()
 				timeout := 1 * time.Second
 
-				var evt messages.MinderEvent[*messages.RepoEvent]
+				var evt messages.MinderEvent
 
 				received := withTimeout(ch, timeout)
 				require.NotNilf(t, received, "no event received after waiting %s", timeout)
@@ -3759,7 +3759,7 @@ func (s *UnitTestSuite) TestHandleGitHubAppWebHook() {
 				t.Helper()
 				timeout := 1 * time.Second
 
-				var evt messages.MinderEvent[*messages.RepoEvent]
+				var evt messages.MinderEvent
 
 				received := withTimeout(ch, timeout)
 				require.NotNilf(t, received, "no event received after waiting %s", timeout)
@@ -3771,7 +3771,7 @@ func (s *UnitTestSuite) TestHandleGitHubAppWebHook() {
 				require.NoError(t, err)
 				require.Equal(t, providerID, evt.ProviderID)
 				require.Equal(t, projectID, evt.ProjectID)
-				require.Equal(t, repositoryID, evt.Entity.RepoID)
+				require.Equal(t, repositoryID.String(), evt.Entity["repoID"])
 
 				received = withTimeout(ch, timeout)
 				require.NotNilf(t, received, "no event received after waiting %s", timeout)
@@ -3783,7 +3783,7 @@ func (s *UnitTestSuite) TestHandleGitHubAppWebHook() {
 				require.NoError(t, err)
 				require.Equal(t, providerID, evt.ProviderID)
 				require.Equal(t, projectID, evt.ProjectID)
-				require.Equal(t, repositoryID, evt.Entity.RepoID)
+				require.Equal(t, repositoryID.String(), evt.Entity["repoID"])
 			},
 		},
 

--- a/internal/reconcilers/entity_add_test.go
+++ b/internal/reconcilers/entity_add_test.go
@@ -44,8 +44,17 @@ func TestHandleEntityAdd(t *testing.T) {
 			mockStoreFunc: df.NewMockStore(
 				df.WithSuccessfulGetProviderByID(
 					db.Provider{
-						ID:   providerID,
-						Name: "providerName",
+						ID:    providerID,
+						Name:  "providerName",
+						Class: db.ProviderClassGithub,
+					},
+					providerID,
+				),
+				df.WithSuccessfulGetProviderByID(
+					db.Provider{
+						ID:    providerID,
+						Name:  "providerName",
+						Class: db.ProviderClassGithub,
 					},
 					providerID,
 				),
@@ -61,11 +70,14 @@ func TestHandleEntityAdd(t *testing.T) {
 			//nolint:thelper
 			messageFunc: func(t *testing.T) *message.Message {
 				m := message.NewMessage(uuid.New().String(), nil)
-				err := messages.NewRepoEvent().
+				err := messages.NewMinderEvent[*messages.RepoEvent]().
 					WithProviderID(providerID).
 					WithProjectID(projectID).
-					WithRepoName(repoName).
-					WithRepoOwner(repoOwner).
+					WithEntity(
+						messages.NewRepoEvent().
+							WithRepoName(repoName).
+							WithRepoOwner(repoOwner),
+					).
 					ToMessage(m)
 				require.NoError(t, err, "invalid message")
 				return m
@@ -82,11 +94,14 @@ func TestHandleEntityAdd(t *testing.T) {
 			//nolint:thelper
 			messageFunc: func(t *testing.T) *message.Message {
 				m := message.NewMessage(uuid.New().String(), nil)
-				err := messages.NewRepoEvent().
+				err := messages.NewMinderEvent[*messages.RepoEvent]().
 					WithProviderID(providerID).
 					WithProjectID(projectID).
-					WithRepoName(repoName).
-					WithRepoOwner(repoOwner).
+					WithEntity(
+						messages.NewRepoEvent().
+							WithRepoName(repoName).
+							WithRepoOwner(repoOwner),
+					).
 					ToMessage(m)
 				require.NoError(t, err, "invalid message")
 				return m
@@ -98,8 +113,17 @@ func TestHandleEntityAdd(t *testing.T) {
 			mockStoreFunc: df.NewMockStore(
 				df.WithSuccessfulGetProviderByID(
 					db.Provider{
-						ID:   providerID,
-						Name: "providerName",
+						ID:    providerID,
+						Name:  "providerName",
+						Class: db.ProviderClassGithubApp,
+					},
+					providerID,
+				),
+				df.WithSuccessfulGetProviderByID(
+					db.Provider{
+						ID:    providerID,
+						Name:  "providerName",
+						Class: db.ProviderClassGithubApp,
 					},
 					providerID,
 				),
@@ -115,11 +139,14 @@ func TestHandleEntityAdd(t *testing.T) {
 			//nolint:thelper
 			messageFunc: func(t *testing.T) *message.Message {
 				m := message.NewMessage(uuid.New().String(), nil)
-				err := messages.NewRepoEvent().
+				err := messages.NewMinderEvent[*messages.RepoEvent]().
 					WithProviderID(providerID).
 					WithProjectID(projectID).
-					WithRepoName(repoName).
-					WithRepoOwner(repoOwner).
+					WithEntity(
+						messages.NewRepoEvent().
+							WithRepoName(repoName).
+							WithRepoOwner(repoOwner),
+					).
 					ToMessage(m)
 				require.NoError(t, err, "invalid message")
 				return m

--- a/internal/reconcilers/entity_add_test.go
+++ b/internal/reconcilers/entity_add_test.go
@@ -67,17 +67,15 @@ func TestHandleEntityAdd(t *testing.T) {
 					&pb.Repository{},
 				),
 			),
-			//nolint:thelper
 			messageFunc: func(t *testing.T) *message.Message {
+				t.Helper()
 				m := message.NewMessage(uuid.New().String(), nil)
-				err := messages.NewMinderEvent[*messages.RepoEvent]().
+				err := messages.NewMinderEvent().
 					WithProviderID(providerID).
 					WithProjectID(projectID).
-					WithEntity(
-						messages.NewRepoEvent().
-							WithRepoName(repoName).
-							WithRepoOwner(repoOwner),
-					).
+					WithEntityType("repository").
+					WithAttribute("repoName", repoName).
+					WithAttribute("repoOwner", repoOwner).
 					ToMessage(m)
 				require.NoError(t, err, "invalid message")
 				return m
@@ -91,17 +89,15 @@ func TestHandleEntityAdd(t *testing.T) {
 				),
 			),
 			mockReposFunc: rf.NewRepoService(),
-			//nolint:thelper
 			messageFunc: func(t *testing.T) *message.Message {
+				t.Helper()
 				m := message.NewMessage(uuid.New().String(), nil)
-				err := messages.NewMinderEvent[*messages.RepoEvent]().
+				err := messages.NewMinderEvent().
 					WithProviderID(providerID).
 					WithProjectID(projectID).
-					WithEntity(
-						messages.NewRepoEvent().
-							WithRepoName(repoName).
-							WithRepoOwner(repoOwner),
-					).
+					WithEntityType("repository").
+					WithAttribute("repoName", repoName).
+					WithAttribute("repoOwner", repoOwner).
 					ToMessage(m)
 				require.NoError(t, err, "invalid message")
 				return m
@@ -136,17 +132,15 @@ func TestHandleEntityAdd(t *testing.T) {
 					repoName,
 				),
 			),
-			//nolint:thelper
 			messageFunc: func(t *testing.T) *message.Message {
+				t.Helper()
 				m := message.NewMessage(uuid.New().String(), nil)
-				err := messages.NewMinderEvent[*messages.RepoEvent]().
+				err := messages.NewMinderEvent().
 					WithProviderID(providerID).
 					WithProjectID(projectID).
-					WithEntity(
-						messages.NewRepoEvent().
-							WithRepoName(repoName).
-							WithRepoOwner(repoOwner),
-					).
+					WithEntityType("repository").
+					WithAttribute("repoName", repoName).
+					WithAttribute("repoOwner", repoOwner).
 					ToMessage(m)
 				require.NoError(t, err, "invalid message")
 				return m
@@ -156,8 +150,8 @@ func TestHandleEntityAdd(t *testing.T) {
 		{
 			name:          "bad message",
 			mockStoreFunc: nil,
-			//nolint:thelper
 			messageFunc: func(_ *testing.T) *message.Message {
+				t.Helper()
 				return message.NewMessage(uuid.New().String(), nil)
 			},
 			err: true,

--- a/internal/reconcilers/entity_add_test.go
+++ b/internal/reconcilers/entity_add_test.go
@@ -50,14 +50,6 @@ func TestHandleEntityAdd(t *testing.T) {
 					},
 					providerID,
 				),
-				df.WithSuccessfulGetProviderByID(
-					db.Provider{
-						ID:    providerID,
-						Name:  "providerName",
-						Class: db.ProviderClassGithub,
-					},
-					providerID,
-				),
 			),
 			mockReposFunc: rf.NewRepoService(
 				rf.WithSuccessfulCreate(
@@ -107,14 +99,6 @@ func TestHandleEntityAdd(t *testing.T) {
 		{
 			name: "repo service failure",
 			mockStoreFunc: df.NewMockStore(
-				df.WithSuccessfulGetProviderByID(
-					db.Provider{
-						ID:    providerID,
-						Name:  "providerName",
-						Class: db.ProviderClassGithubApp,
-					},
-					providerID,
-				),
 				df.WithSuccessfulGetProviderByID(
 					db.Provider{
 						ID:    providerID,

--- a/internal/reconcilers/entity_delete.go
+++ b/internal/reconcilers/entity_delete.go
@@ -15,99 +15,26 @@
 package reconcilers
 
 import (
-	"context"
-	"database/sql"
 	"encoding/json"
-	"errors"
 	"fmt"
 
 	"github.com/ThreeDotsLabs/watermill/message"
 	"github.com/go-playground/validator/v10"
-	"github.com/google/uuid"
 	"github.com/rs/zerolog"
 
-	"github.com/stacklok/minder/internal/db"
-	"github.com/stacklok/minder/internal/logger"
+	minderlogger "github.com/stacklok/minder/internal/logger"
 	"github.com/stacklok/minder/internal/reconcilers/messages"
 )
 
 //nolint:exhaustive
 func (r *Reconciler) handleEntityDeleteEvent(msg *message.Message) error {
 	ctx := msg.Context()
+	l := zerolog.Ctx(ctx).With().Logger()
 
-	providerID, err := uuid.Parse(msg.Metadata.Get("providerID"))
-	if err != nil {
-		return fmt.Errorf("invalid provider id: %w", err)
-	}
-	projectID, err := uuid.Parse(msg.Metadata.Get("projectID"))
-	if err != nil {
-		return fmt.Errorf("invalid project id: %w", err)
-	}
-	wcontext := &messages.CoreContext{
-		ProviderID: providerID,
-		ProjectID:  projectID,
-		Type:       msg.Metadata.Get("entityType"),
-		Payload:    msg.Payload,
-	}
-
-	dbProvider, err := r.store.GetProviderByID(ctx, wcontext.ProviderID)
-	if err != nil {
-		return fmt.Errorf("error retrieving provider: %w", err)
-	}
-
-	switch dbProvider.Class {
-	case db.ProviderClassGithub,
-		db.ProviderClassGithubApp:
-		// This should be a hook into provider-specific code.
-		return r.deleteGithubEntity(ctx, wcontext)
-	// case db.ProviderClassGhcr:
-	// case db.ProviderClassDockerhub:
-	// case db.ProviderClassGitlab:
-	default:
-		return fmt.Errorf("unknown provider class: %s", dbProvider.Class)
-	}
-}
-
-// NOTE: This should be moved to the github provider package.
-func (r *Reconciler) deleteGithubEntity(
-	ctx context.Context,
-	wcontext *messages.CoreContext,
-) error {
-	// This switch statement should handle artifacts and pull
-	// requests as well.
-	switch wcontext.Type {
-	case "repository":
-		return r.deleteGithubRepository(ctx, wcontext)
-	default:
-		return fmt.Errorf("unknown entity type: %s", wcontext.Type)
-	}
-}
-
-// NOTE: This should be moved to the github provider package.
-func (r *Reconciler) deleteGithubRepository(
-	ctx context.Context,
-	wcontext *messages.CoreContext,
-) error {
 	var event messages.MinderEvent
-	if err := json.Unmarshal(wcontext.Payload, &event); err != nil {
+	if err := json.Unmarshal(msg.Payload, &event); err != nil {
 		return fmt.Errorf("error unmarshalling payload: %w", err)
 	}
-
-	var repoIDStr string
-	var ok bool
-	if repoIDStr, ok = event.Entity["repoID"].(string); !ok {
-		return errors.New("invalid repo id")
-	}
-	repoID, err := uuid.Parse(repoIDStr)
-	if err != nil {
-		return fmt.Errorf("invalid repo id: %w", err)
-	}
-
-	l := zerolog.Ctx(ctx).With().
-		Str("provider_id", event.ProviderID.String()).
-		Str("project_id", event.ProjectID.String()).
-		Str("repo_id", repoID.String()).
-		Logger()
 
 	// validate event
 	validate := validator.New()
@@ -118,20 +45,23 @@ func (r *Reconciler) deleteGithubRepository(
 		return nil
 	}
 
+	l = zerolog.Ctx(ctx).With().
+		Str("provider_id", event.ProviderID.String()).
+		Str("project_id", event.ProjectID.String()).
+		Str("entity_id", event.EntityID.String()).
+		Logger()
+
 	// Telemetry logging
-	logger.BusinessRecord(ctx).ProviderID = event.ProviderID
-	logger.BusinessRecord(ctx).Project = event.ProjectID
+	minderlogger.BusinessRecord(ctx).ProviderID = event.ProviderID
+	minderlogger.BusinessRecord(ctx).Project = event.ProjectID
 
 	l.Info().Msg("handling entity delete event")
 	// Remove the entry in the DB. There's no need to clean any webhook we created for this repository, as GitHub
 	// will automatically remove them when the repository is deleted.
-	if err := r.repos.DeleteByID(ctx, repoID, event.ProjectID); err != nil {
-		if errors.Is(err, sql.ErrNoRows) {
-			return nil
-		}
+	if err := r.repos.DeleteByID(ctx, event.EntityID, event.ProjectID); err != nil {
 		return fmt.Errorf("error deleting repository from DB: %w", err)
 	}
 
-	logger.BusinessRecord(ctx).Repository = repoID
+	minderlogger.BusinessRecord(ctx).Repository = event.EntityID
 	return nil
 }

--- a/internal/reconcilers/entity_delete_test.go
+++ b/internal/reconcilers/entity_delete_test.go
@@ -27,7 +27,6 @@ import (
 	mockdb "github.com/stacklok/minder/database/mock"
 	df "github.com/stacklok/minder/database/mock/fixtures"
 	serverconfig "github.com/stacklok/minder/internal/config/server"
-	db "github.com/stacklok/minder/internal/db"
 	"github.com/stacklok/minder/internal/events"
 	"github.com/stacklok/minder/internal/reconcilers/messages"
 	mockghrepo "github.com/stacklok/minder/internal/repositories/github/mock"
@@ -53,17 +52,8 @@ func TestHandleEntityDelete(t *testing.T) {
 
 	tests := []testCase{
 		{
-			name: "happy path",
-			mockStoreFunc: df.NewMockStore(
-				df.WithSuccessfulGetProviderByID(
-					db.Provider{
-						ID:    providerID,
-						Name:  "providerName",
-						Class: db.ProviderClassGithub,
-					},
-					providerID,
-				),
-			),
+			name:          "happy path",
+			mockStoreFunc: nil,
 			mockReposFunc: rf.NewRepoService(
 				rf.WithSuccessfulDeleteByIDDetailed(
 					repositoryID,
@@ -77,6 +67,7 @@ func TestHandleEntityDelete(t *testing.T) {
 					WithProviderID(providerID).
 					WithProjectID(projectID).
 					WithEntityType("repository").
+					WithEntityID(repositoryID).
 					WithAttribute("repoID", repositoryID.String())
 				err := eiw.ToMessage(m)
 				require.NoError(t, err, "invalid message")
@@ -84,17 +75,8 @@ func TestHandleEntityDelete(t *testing.T) {
 			},
 		},
 		{
-			name: "db failure",
-			mockStoreFunc: df.NewMockStore(
-				df.WithSuccessfulGetProviderByID(
-					db.Provider{
-						ID:    providerID,
-						Name:  "providerName",
-						Class: db.ProviderClassGithub,
-					},
-					providerID,
-				),
-			),
+			name:          "db failure",
+			mockStoreFunc: nil,
 			mockReposFunc: rf.NewRepoService(
 				rf.WithFailedDeleteByID(
 					errors.New("oops"),
@@ -107,6 +89,7 @@ func TestHandleEntityDelete(t *testing.T) {
 					WithProviderID(providerID).
 					WithProjectID(projectID).
 					WithEntityType("repository").
+					WithEntityID(repositoryID).
 					WithAttribute("repoID", repositoryID.String())
 				err := eiw.ToMessage(m)
 				require.NoError(t, err, "invalid message")

--- a/internal/reconcilers/entity_delete_test.go
+++ b/internal/reconcilers/entity_delete_test.go
@@ -70,16 +70,14 @@ func TestHandleEntityDelete(t *testing.T) {
 					projectID,
 				),
 			),
-			//nolint:thelper
 			messageFunc: func(t *testing.T) *message.Message {
+				t.Helper()
 				m := message.NewMessage(uuid.New().String(), nil)
-				eiw := messages.NewMinderEvent[*messages.RepoEvent]().
+				eiw := messages.NewMinderEvent().
 					WithProviderID(providerID).
 					WithProjectID(projectID).
-					WithEntity(
-						messages.NewRepoEvent().
-							WithRepoID(repositoryID),
-					)
+					WithEntityType("repository").
+					WithAttribute("repoID", repositoryID.String())
 				err := eiw.ToMessage(m)
 				require.NoError(t, err, "invalid message")
 				return m
@@ -102,16 +100,14 @@ func TestHandleEntityDelete(t *testing.T) {
 					errors.New("oops"),
 				),
 			),
-			//nolint:thelper
 			messageFunc: func(t *testing.T) *message.Message {
+				t.Helper()
 				m := message.NewMessage(uuid.New().String(), nil)
-				eiw := messages.NewMinderEvent[*messages.RepoEvent]().
+				eiw := messages.NewMinderEvent().
 					WithProviderID(providerID).
 					WithProjectID(projectID).
-					WithEntity(
-						messages.NewRepoEvent().
-							WithRepoID(repositoryID),
-					)
+					WithEntityType("repository").
+					WithAttribute("repoID", repositoryID.String())
 				err := eiw.ToMessage(m)
 				require.NoError(t, err, "invalid message")
 				return m
@@ -121,8 +117,8 @@ func TestHandleEntityDelete(t *testing.T) {
 		{
 			name:          "bad message",
 			mockStoreFunc: nil,
-			//nolint:thelper
 			messageFunc: func(_ *testing.T) *message.Message {
+				t.Helper()
 				return message.NewMessage(uuid.New().String(), nil)
 			},
 			err: true,

--- a/internal/reconcilers/messages/messages.go
+++ b/internal/reconcilers/messages/messages.go
@@ -68,6 +68,7 @@ type MinderEvent struct {
 	ProviderID uuid.UUID      `json:"provider_id" validate:"required"`
 	ProjectID  uuid.UUID      `json:"project_id" validate:"required"`
 	EntityType string         `json:"entity_type" validate:"required"`
+	EntityID   uuid.UUID      `json:"entity_id"`
 	Entity     map[string]any `json:"entity" validate:"required"`
 }
 
@@ -93,6 +94,12 @@ func (e *MinderEvent) WithProjectID(projectID uuid.UUID) *MinderEvent {
 // WithAttribute sets attributes of the entity for a MinderEvent.
 func (e *MinderEvent) WithAttribute(key string, val any) *MinderEvent {
 	e.Entity[key] = val
+	return e
+}
+
+// WithEntityID sets the id of the entity.
+func (e *MinderEvent) WithEntityID(entityID uuid.UUID) *MinderEvent {
+	e.EntityID = entityID
 	return e
 }
 


### PR DESCRIPTION
# Summary

Webhook handlers should pack all the necessary information to allow Minder Core to process creations, deletions, and reconciliations of entities, regardless of their kind. To achieve extensibility, (a) entities cannot be part of the message topic used for communication, and (b) messagess cannot be tied to specific entities.

To achieve that, reconciler handlers must dispatch an event to provider-specific code, shipping the minimal mandatory information explicitly (i.e. project id and provider id), and entity specific information in an opaque, provider-specific way.

This change introduces a bit of boilerplate to decouple message handling from provider-specific code, but does not move the code from the reconciler to the provider.

Fixes #4247

## Change Type

***Mark the type of change your PR introduces:***

- [ ] Bug fix (resolves an issue without affecting existing features)
- [X] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [X] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

Unit tested.

# Review Checklist:

- [ ] Reviewed my own code for quality and clarity.
- [X] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [X] Included tests that validate the fix or feature.
- [ ] Checked that related changes are merged.
