### PR TITLE
EEA: Rely solely on entity instances table

### DIFF
--- a/database/query/entity_execution_lock.sql
+++ b/database/query/entity_execution_lock.sql
@@ -9,18 +9,12 @@ INSERT INTO entity_execution_lock(
     entity,
     locked_by,
     last_lock_time,
-    repository_id,
-    artifact_id,
-    pull_request_id,
     project_id,
     entity_instance_id
 ) VALUES(
     sqlc.arg(entity)::entities,
     gen_random_uuid(),
     NOW(),
-    sqlc.narg(repository_id)::UUID,
-    sqlc.narg(artifact_id)::UUID,
-    sqlc.narg(pull_request_id)::UUID,
     sqlc.arg(project_id)::UUID,
     sqlc.arg(entity_instance_id)::UUID
 ) ON CONFLICT(entity_instance_id)
@@ -45,16 +39,10 @@ WHERE entity_instance_id = $1 AND locked_by = sqlc.arg(locked_by)::UUID;
 -- name: EnqueueFlush :one
 INSERT INTO flush_cache(
     entity,
-    repository_id,
-    artifact_id,
-    pull_request_id,
     project_id,
     entity_instance_id
 ) VALUES(
     sqlc.arg(entity)::entities,
-    sqlc.narg(repository_id)::UUID,
-    sqlc.narg(artifact_id)::UUID,
-    sqlc.narg(pull_request_id)::UUID,
     sqlc.arg(project_id)::UUID,
     sqlc.arg(entity_instance_id)::UUID
 ) ON CONFLICT(entity_instance_id)

--- a/internal/db/entity_execution_lock.sql_test.go
+++ b/internal/db/entity_execution_lock.sql_test.go
@@ -25,7 +25,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -51,9 +50,6 @@ func TestQueries_LockIfThresholdNotExceeded(t *testing.T) {
 			defer wg.Done()
 			_, err := testQueries.LockIfThresholdNotExceeded(context.Background(), LockIfThresholdNotExceededParams{
 				Entity:           EntitiesRepository,
-				RepositoryID:     uuid.NullUUID{UUID: repo.ID, Valid: true},
-				ArtifactID:       uuid.NullUUID{},
-				PullRequestID:    uuid.NullUUID{},
 				Interval:         fmt.Sprintf("%d", threshold),
 				ProjectID:        project.ID,
 				EntityInstanceID: repo.ID,
@@ -66,9 +62,6 @@ func TestQueries_LockIfThresholdNotExceeded(t *testing.T) {
 
 				_, err := testQueries.EnqueueFlush(context.Background(), EnqueueFlushParams{
 					Entity:           EntitiesRepository,
-					RepositoryID:     uuid.NullUUID{UUID: repo.ID, Valid: true},
-					ArtifactID:       uuid.NullUUID{},
-					PullRequestID:    uuid.NullUUID{},
 					ProjectID:        project.ID,
 					EntityInstanceID: repo.ID,
 				})
@@ -93,9 +86,6 @@ func TestQueries_LockIfThresholdNotExceeded(t *testing.T) {
 
 	_, err := testQueries.LockIfThresholdNotExceeded(context.Background(), LockIfThresholdNotExceededParams{
 		Entity:           EntitiesRepository,
-		RepositoryID:     uuid.NullUUID{UUID: repo.ID, Valid: true},
-		ArtifactID:       uuid.NullUUID{},
-		PullRequestID:    uuid.NullUUID{},
 		Interval:         fmt.Sprintf("%d", threshold),
 		EntityInstanceID: repo.ID,
 	})

--- a/internal/eea/eea.go
+++ b/internal/eea/eea.go
@@ -136,9 +136,6 @@ func (e *EEA) aggregate(msg *message.Message) (*message.Message, error) {
 
 	res, err := e.querier.LockIfThresholdNotExceeded(ctx, db.LockIfThresholdNotExceededParams{
 		Entity:           entities.EntityTypeToDB(inf.Type),
-		RepositoryID:     repoID,
-		ArtifactID:       artifactID,
-		PullRequestID:    pullRequestID,
 		EntityInstanceID: entityID,
 		ProjectID:        projectID,
 		Interval:         fmt.Sprintf("%d", e.cfg.LockInterval),
@@ -163,9 +160,6 @@ func (e *EEA) aggregate(msg *message.Message) (*message.Message, error) {
 
 		_, err := e.querier.EnqueueFlush(ctx, db.EnqueueFlushParams{
 			Entity:           entities.EntityTypeToDB(inf.Type),
-			RepositoryID:     repoID,
-			ArtifactID:       artifactID,
-			PullRequestID:    pullRequestID,
 			EntityInstanceID: entityID,
 			ProjectID:        projectID,
 		})


### PR DESCRIPTION
# Summary

This removes the usage of the per-entity tables from the EEA queries to
rely solely on the entity instances table. A further PR will remove the
columsn from that table.

Related-to: #4169

## Change Type

***Mark the type of change your PR introduces:***

- [ ] Bug fix (resolves an issue without affecting existing features)
- [x] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [x] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

***Outline how the changes were tested, including steps to reproduce and any relevant configurations. 
Attach screenshots if helpful.***

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [ ] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [ ] Included tests that validate the fix or feature.
- [ ] Checked that related changes are merged.
