### PR TITLE
Checkpoint: Add HTTP URL and Method to HTTP/REST ingester

### DIFF
--- a/internal/engine/ingester/rest/rest.go
+++ b/internal/engine/ingester/rest/rest.go
@@ -156,7 +156,7 @@ func (rdi *Ingestor) Ingest(ctx context.Context, ent protoreflect.ProtoMessage, 
 
 	return &engif.Result{
 		Object:     data,
-		Checkpoint: checkpoints.NewCheckpointV1Now(),
+		Checkpoint: checkpoints.NewCheckpointV1Now().WithHTTP(endpoint, rdi.method),
 	}, nil
 }
 

--- a/internal/entities/checkpoints/checkpoints.go
+++ b/internal/entities/checkpoints/checkpoints.go
@@ -48,6 +48,12 @@ type CheckpointV1 struct {
 	// Digest is the digest of the entity that the checkpoint is for.
 	// This may be a container image digest, or some other digest.
 	Digest *string `json:"digest,omitempty" yaml:"digest,omitempty"`
+
+	// HTTPURL is the URL that was used to verify the entity.
+	HTTPURL *string `json:"httpURL,omitempty" yaml:"httpURL,omitempty"`
+
+	// HTTPMethod is the HTTP method that was used to verify the entity.
+	HTTPMethod *string `json:"httpMethod,omitempty" yaml:"httpMethod,omitempty"`
 }
 
 // NewCheckpointV1Now creates a new CheckpointV1 with the current time.
@@ -86,6 +92,13 @@ func (c *CheckpointEnvelopeV1) WithVersion(version string) *CheckpointEnvelopeV1
 // WithDigest sets the digest on the checkpoint.
 func (c *CheckpointEnvelopeV1) WithDigest(digest string) *CheckpointEnvelopeV1 {
 	c.Checkpoint.Digest = &digest
+	return c
+}
+
+// WithHTTP sets the HTTP URL and method on the checkpoint.
+func (c *CheckpointEnvelopeV1) WithHTTP(url, method string) *CheckpointEnvelopeV1 {
+	c.Checkpoint.HTTPURL = &url
+	c.Checkpoint.HTTPMethod = &method
 	return c
 }
 

--- a/internal/entities/checkpoints/checkpoints_test.go
+++ b/internal/entities/checkpoints/checkpoints_test.go
@@ -57,6 +57,12 @@ func TestCheckpointEnvelopeV1_MarshalJSON(t *testing.T) {
 				WithBranch("main"),
 			expected: `{"version":"v1","checkpoint":{"timestamp":"2023-07-31T12:00:00Z","commitHash":"abc123","branch":"main"}}`,
 		},
+		{
+			name: "With HTTP info",
+			input: NewCheckpointV1(timestamp).
+				WithHTTP("http://example.com", "GET"),
+			expected: `{"version":"v1","checkpoint":{"timestamp":"2023-07-31T12:00:00Z","httpURL":"http://example.com","httpMethod":"GET"}}`,
+		},
 	}
 
 	for _, tt := range tests {
@@ -104,6 +110,12 @@ func TestCheckpointEnvelopeV1_UnmarshalJson(t *testing.T) {
 			expected: NewCheckpointV1(timestamp).
 				WithCommitHash("abc123").
 				WithBranch("main"),
+		},
+		{
+			name:  "With HTTP info",
+			input: `{"version":"v1","checkpoint":{"timestamp":"2023-07-31T12:00:00Z","httpURL":"http://example.com","httpMethod":"GET"}}`,
+			expected: NewCheckpointV1(timestamp).
+				WithHTTP("http://example.com", "GET"),
 		},
 	}
 


### PR DESCRIPTION
# Summary

This adds the URL and HTTP method to the checkpoint information. This is
handy to know what path, method and even API version was used at a given
time when evaluating an entity.

## Change Type

***Mark the type of change your PR introduces:***

- [ ] Bug fix (resolves an issue without affecting existing features)
- [x] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [ ] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

***Outline how the changes were tested, including steps to reproduce and any relevant configurations. 
Attach screenshots if helpful.***

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [ ] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [ ] Included tests that validate the fix or feature.
- [ ] Checked that related changes are merged.
