### PR TITLE
Show can_remediate: false for the ruletype cli commands

### DIFF
--- a/cmd/cli/app/ruletype/ruletype_list.go
+++ b/cmd/cli/app/ruletype/ruletype_list.go
@@ -76,7 +76,7 @@ func listCommand(ctx context.Context, cmd *cobra.Command, _ []string, conn *grpc
 	case app.Table:
 		table := initializeTableForList()
 		for _, rt := range resp.RuleTypes {
-			name := mapRuleTypeReleasePhase(rt.Name, rt.ReleasePhase)
+			name := appendRuleTypePropertiesToName(rt)
 			table.AddRow(
 				*rt.Context.Project,
 				*rt.Id,


### PR DESCRIPTION
# Summary

The following PR shows the `can_remediate: false` property in the `ruletype list, apply and create` tables. The table from `ruletype get` is different (row based) and we already show `Remediate: unsupported`. This is shown in case the ruletype has an empty/null `Remediation` field in its Def section (which in practice means no remediation support).

Fixes #4240 

## Change Type

***Mark the type of change your PR introduces:***

- [ ] Bug fix (resolves an issue without affecting existing features)
- [x] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [ ] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

***Outline how the changes were tested, including steps to reproduce and any relevant configurations. 
Attach screenshots if helpful.***

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [ ] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [ ] Included tests that validate the fix or feature.
- [ ] Checked that related changes are merged.
