### PR TITLE
EEA: Rely solely on entity instances table

### DIFF
--- a/database/migrations/000101_eea_rm_indexes.down.sql
+++ b/database/migrations/000101_eea_rm_indexes.down.sql
@@ -1,0 +1,29 @@
+-- Copyright 2023 Stacklok, Inc
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--      http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+BEGIN;
+
+CREATE UNIQUE INDEX IF NOT EXISTS entity_execution_lock_idx ON entity_execution_lock(
+    entity,
+    repository_id,
+    COALESCE(artifact_id, '00000000-0000-0000-0000-000000000000'::UUID),
+    COALESCE(pull_request_id, '00000000-0000-0000-0000-000000000000'::UUID));
+
+CREATE UNIQUE INDEX IF NOT EXISTS flush_cache_idx ON flush_cache(
+    entity,
+    repository_id,
+    COALESCE(artifact_id, '00000000-0000-0000-0000-000000000000'::UUID),
+    COALESCE(pull_request_id, '00000000-0000-0000-0000-000000000000'::UUID));
+
+COMMIT;

--- a/database/migrations/000101_eea_rm_indexes.up.sql
+++ b/database/migrations/000101_eea_rm_indexes.up.sql
@@ -1,0 +1,20 @@
+-- Copyright 2023 Stacklok, Inc
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--      http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+BEGIN;
+
+DROP INDEX IF EXISTS entity_execution_lock_idx;
+DROP INDEX IF EXISTS flush_cache_idx;
+
+COMMIT;

--- a/database/query/entity_execution_lock.sql
+++ b/database/query/entity_execution_lock.sql
@@ -9,18 +9,12 @@ INSERT INTO entity_execution_lock(
     entity,
     locked_by,
     last_lock_time,
-    repository_id,
-    artifact_id,
-    pull_request_id,
     project_id,
     entity_instance_id
 ) VALUES(
     sqlc.arg(entity)::entities,
     gen_random_uuid(),
     NOW(),
-    sqlc.narg(repository_id)::UUID,
-    sqlc.narg(artifact_id)::UUID,
-    sqlc.narg(pull_request_id)::UUID,
     sqlc.arg(project_id)::UUID,
     sqlc.arg(entity_instance_id)::UUID
 ) ON CONFLICT(entity_instance_id)
@@ -45,16 +39,10 @@ WHERE entity_instance_id = $1 AND locked_by = sqlc.arg(locked_by)::UUID;
 -- name: EnqueueFlush :one
 INSERT INTO flush_cache(
     entity,
-    repository_id,
-    artifact_id,
-    pull_request_id,
     project_id,
     entity_instance_id
 ) VALUES(
     sqlc.arg(entity)::entities,
-    sqlc.narg(repository_id)::UUID,
-    sqlc.narg(artifact_id)::UUID,
-    sqlc.narg(pull_request_id)::UUID,
     sqlc.arg(project_id)::UUID,
     sqlc.arg(entity_instance_id)::UUID
 ) ON CONFLICT(entity_instance_id)

--- a/internal/db/entity_execution_lock.sql_test.go
+++ b/internal/db/entity_execution_lock.sql_test.go
@@ -25,7 +25,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -51,9 +50,6 @@ func TestQueries_LockIfThresholdNotExceeded(t *testing.T) {
 			defer wg.Done()
 			_, err := testQueries.LockIfThresholdNotExceeded(context.Background(), LockIfThresholdNotExceededParams{
 				Entity:           EntitiesRepository,
-				RepositoryID:     uuid.NullUUID{UUID: repo.ID, Valid: true},
-				ArtifactID:       uuid.NullUUID{},
-				PullRequestID:    uuid.NullUUID{},
 				Interval:         fmt.Sprintf("%d", threshold),
 				ProjectID:        project.ID,
 				EntityInstanceID: repo.ID,
@@ -66,9 +62,6 @@ func TestQueries_LockIfThresholdNotExceeded(t *testing.T) {
 
 				_, err := testQueries.EnqueueFlush(context.Background(), EnqueueFlushParams{
 					Entity:           EntitiesRepository,
-					RepositoryID:     uuid.NullUUID{UUID: repo.ID, Valid: true},
-					ArtifactID:       uuid.NullUUID{},
-					PullRequestID:    uuid.NullUUID{},
 					ProjectID:        project.ID,
 					EntityInstanceID: repo.ID,
 				})
@@ -93,9 +86,6 @@ func TestQueries_LockIfThresholdNotExceeded(t *testing.T) {
 
 	_, err := testQueries.LockIfThresholdNotExceeded(context.Background(), LockIfThresholdNotExceededParams{
 		Entity:           EntitiesRepository,
-		RepositoryID:     uuid.NullUUID{UUID: repo.ID, Valid: true},
-		ArtifactID:       uuid.NullUUID{},
-		PullRequestID:    uuid.NullUUID{},
 		Interval:         fmt.Sprintf("%d", threshold),
 		EntityInstanceID: repo.ID,
 	})

--- a/internal/eea/eea.go
+++ b/internal/eea/eea.go
@@ -136,9 +136,6 @@ func (e *EEA) aggregate(msg *message.Message) (*message.Message, error) {
 
 	res, err := e.querier.LockIfThresholdNotExceeded(ctx, db.LockIfThresholdNotExceededParams{
 		Entity:           entities.EntityTypeToDB(inf.Type),
-		RepositoryID:     repoID,
-		ArtifactID:       artifactID,
-		PullRequestID:    pullRequestID,
 		EntityInstanceID: entityID,
 		ProjectID:        projectID,
 		Interval:         fmt.Sprintf("%d", e.cfg.LockInterval),
@@ -163,9 +160,6 @@ func (e *EEA) aggregate(msg *message.Message) (*message.Message, error) {
 
 		_, err := e.querier.EnqueueFlush(ctx, db.EnqueueFlushParams{
 			Entity:           entities.EntityTypeToDB(inf.Type),
-			RepositoryID:     repoID,
-			ArtifactID:       artifactID,
-			PullRequestID:    pullRequestID,
 			EntityInstanceID: entityID,
 			ProjectID:        projectID,
 		})


### PR DESCRIPTION
# Summary

This re-attempts #4287, but now actually drops the indexes which prevented parallel execution of entities.

Related-to: [#4169](https://github.com/stacklok/minder/issues/4169)

## Change Type

***Mark the type of change your PR introduces:***

- [ ] Bug fix (resolves an issue without affecting existing features)
- [x] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [ ] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

***Outline how the changes were tested, including steps to reproduce and any relevant configurations. 
Attach screenshots if helpful.***

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [ ] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [ ] Included tests that validate the fix or feature.
- [ ] Checked that related changes are merged.
