### PR TITLE
Validate rule `guidance` strictly.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -39,6 +39,7 @@ require (
 	github.com/hashicorp/go-version v1.7.0
 	github.com/itchyny/gojq v0.12.16
 	github.com/lib/pq v1.10.9
+	github.com/microcosm-cc/bluemonday v1.0.27
 	github.com/motemen/go-loghttp v0.0.0-20231107055348-29ae44b293f4
 	github.com/nats-io/nats-server/v2 v2.10.19
 	github.com/nats-io/nats.go v1.37.0
@@ -155,7 +156,6 @@ require (
 	github.com/lestrrat-go/option v1.0.1 // indirect
 	github.com/mattn/go-localereader v0.0.1 // indirect
 	github.com/mfridman/interpolate v0.0.2 // indirect
-	github.com/microcosm-cc/bluemonday v1.0.27 // indirect
 	github.com/minio/highwayhash v1.0.3 // indirect
 	github.com/mitchellh/mapstructure v1.5.0 // indirect
 	github.com/moby/buildkit v0.15.2 // indirect

--- a/internal/controlplane/handlers_ruletype_test.go
+++ b/internal/controlplane/handlers_ruletype_test.go
@@ -1,0 +1,240 @@
+//
+// Copyright 2024 Stacklok, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package controlplane
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+
+	mockdb "github.com/stacklok/minder/database/mock"
+	df "github.com/stacklok/minder/database/mock/fixtures"
+	db "github.com/stacklok/minder/internal/db"
+	sf "github.com/stacklok/minder/internal/ruletypes/mock/fixtures"
+	minderv1 "github.com/stacklok/minder/pkg/api/protobuf/go/minder/v1"
+)
+
+func TestCreateRuleType(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name                string
+		mockStoreFunc       df.MockStoreBuilder
+		ruleTypeServiceFunc sf.RuleTypeSvcMockBuilder
+		request             *minderv1.CreateRuleTypeRequest
+		error               bool
+	}{
+		{
+			name: "happy path",
+			mockStoreFunc: df.NewMockStore(
+				df.WithTransaction(),
+				WithSuccessfulGetProjectByID(uuid.Nil),
+			),
+			ruleTypeServiceFunc: sf.NewRuleTypeServiceMock(
+				sf.WithSuccessfulCreateRuleType,
+			),
+			request: &minderv1.CreateRuleTypeRequest{
+				RuleType: &minderv1.RuleType{},
+			},
+		},
+		{
+			name: "guidance sanitize error",
+			mockStoreFunc: df.NewMockStore(
+				WithSuccessfulGetProjectByID(uuid.Nil),
+			),
+			ruleTypeServiceFunc: sf.NewRuleTypeServiceMock(),
+			request: &minderv1.CreateRuleTypeRequest{
+				RuleType: &minderv1.RuleType{
+					Guidance: "<div>foo</div>",
+				},
+			},
+			error: true,
+		},
+		{
+			name: "guidance not utf-8",
+			mockStoreFunc: df.NewMockStore(
+				WithSuccessfulGetProjectByID(uuid.Nil),
+			),
+			ruleTypeServiceFunc: sf.NewRuleTypeServiceMock(),
+			request: &minderv1.CreateRuleTypeRequest{
+				RuleType: &minderv1.RuleType{
+					Guidance: string([]byte{0xff, 0xfe, 0xfd}),
+				},
+			},
+			error: true,
+		},
+		{
+			name: "guidance too long",
+			mockStoreFunc: df.NewMockStore(
+				WithSuccessfulGetProjectByID(uuid.Nil),
+			),
+			ruleTypeServiceFunc: sf.NewRuleTypeServiceMock(),
+			request: &minderv1.CreateRuleTypeRequest{
+				RuleType: &minderv1.RuleType{
+					Guidance: strings.Repeat("a", 4*1<<10),
+				},
+			},
+			error: true,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			var mockStore *mockdb.MockStore
+			if tt.mockStoreFunc != nil {
+				mockStore = tt.mockStoreFunc(ctrl)
+			} else {
+				mockStore = mockdb.NewMockStore(ctrl)
+			}
+
+			var mockSvc sf.RuleTypeSvcMock
+			if tt.ruleTypeServiceFunc != nil {
+				mockSvc = tt.ruleTypeServiceFunc(ctrl)
+			}
+
+			srv, _ := newDefaultServer(t, mockStore, nil, nil)
+			srv.ruleTypes = mockSvc
+
+			resp, err := srv.CreateRuleType(context.Background(), tt.request)
+			if tt.error {
+				require.Error(t, err)
+				require.Nil(t, resp)
+				return
+			}
+
+			require.NoError(t, err)
+			require.NotNil(t, resp)
+		})
+	}
+}
+
+func TestUpdateRuleType(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name                string
+		mockStoreFunc       df.MockStoreBuilder
+		ruleTypeServiceFunc sf.RuleTypeSvcMockBuilder
+		request             *minderv1.UpdateRuleTypeRequest
+		error               bool
+	}{
+		{
+			name: "happy path",
+			mockStoreFunc: df.NewMockStore(
+				df.WithTransaction(),
+				WithSuccessfulGetProjectByID(uuid.Nil),
+			),
+			ruleTypeServiceFunc: sf.NewRuleTypeServiceMock(
+				sf.WithSuccessfulUpdateRuleType,
+			),
+			request: &minderv1.UpdateRuleTypeRequest{
+				RuleType: &minderv1.RuleType{},
+			},
+		},
+		{
+			name: "guidance sanitize error",
+			mockStoreFunc: df.NewMockStore(
+				WithSuccessfulGetProjectByID(uuid.Nil),
+			),
+			ruleTypeServiceFunc: sf.NewRuleTypeServiceMock(),
+			request: &minderv1.UpdateRuleTypeRequest{
+				RuleType: &minderv1.RuleType{
+					Guidance: "<div>foo</div>",
+				},
+			},
+			error: true,
+		},
+		{
+			name: "guidance not utf-8",
+			mockStoreFunc: df.NewMockStore(
+				WithSuccessfulGetProjectByID(uuid.Nil),
+			),
+			ruleTypeServiceFunc: sf.NewRuleTypeServiceMock(),
+			request: &minderv1.UpdateRuleTypeRequest{
+				RuleType: &minderv1.RuleType{
+					Guidance: string([]byte{0xff, 0xfe, 0xfd}),
+				},
+			},
+			error: true,
+		},
+		{
+			name: "guidance too long",
+			mockStoreFunc: df.NewMockStore(
+				WithSuccessfulGetProjectByID(uuid.Nil),
+			),
+			ruleTypeServiceFunc: sf.NewRuleTypeServiceMock(),
+			request: &minderv1.UpdateRuleTypeRequest{
+				RuleType: &minderv1.RuleType{
+					Guidance: strings.Repeat("a", 4*1<<10),
+				},
+			},
+			error: true,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			var mockStore *mockdb.MockStore
+			if tt.mockStoreFunc != nil {
+				mockStore = tt.mockStoreFunc(ctrl)
+			} else {
+				mockStore = mockdb.NewMockStore(ctrl)
+			}
+
+			var mockSvc sf.RuleTypeSvcMock
+			if tt.ruleTypeServiceFunc != nil {
+				mockSvc = tt.ruleTypeServiceFunc(ctrl)
+			}
+
+			srv, _ := newDefaultServer(t, mockStore, nil, nil)
+			srv.ruleTypes = mockSvc
+
+			resp, err := srv.UpdateRuleType(context.Background(), tt.request)
+			if tt.error {
+				require.Error(t, err)
+				require.Nil(t, resp)
+				return
+			}
+
+			require.NoError(t, err)
+			require.NotNil(t, resp)
+		})
+	}
+}
+
+func WithSuccessfulGetProjectByID(projectID uuid.UUID) func(*mockdb.MockStore) {
+	return func(mockStore *mockdb.MockStore) {
+		mockStore.EXPECT().
+			GetProjectByID(gomock.Any(), gomock.Any()).
+			Return(db.Project{ID: projectID}, nil)
+	}
+}

--- a/internal/ruletypes/mock/fixtures/service.go
+++ b/internal/ruletypes/mock/fixtures/service.go
@@ -54,3 +54,15 @@ func WithFailedUpsertRuleType(mock RuleTypeSvcMock) {
 		UpsertRuleType(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 		Return(errDefault)
 }
+
+func WithSuccessfulCreateRuleType(mock RuleTypeSvcMock) {
+	mock.EXPECT().
+		CreateRuleType(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+		Return(nil, nil)
+}
+
+func WithSuccessfulUpdateRuleType(mock RuleTypeSvcMock) {
+	mock.EXPECT().
+		UpdateRuleType(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+		Return(nil, nil)
+}


### PR DESCRIPTION
# Summary

This change uses `bluemonday` library to perform strict validation of `guidance` field of rule types. In case sanitized input is different from the input itself, rule type creation/update is rejected returning a meaningful error message.

The way input is sanitized is in line with the way it is rendered in the CLI by the `glamour` library.

## Change Type

***Mark the type of change your PR introduces:***

- [ ] Bug fix (resolves an issue without affecting existing features)
- [X] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [ ] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

Manual tests.

# Review Checklist:

- [X] Reviewed my own code for quality and clarity.
- [X] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [ ] Included tests that validate the fix or feature.
- [X] Checked that related changes are merged.
