### PR TITLE
Finally remove per-entity columns from EEA

### DIFF
--- a/database/migrations/000103_eea_rm_per_entities_columns.down.sql
+++ b/database/migrations/000103_eea_rm_per_entities_columns.down.sql
@@ -1,0 +1,29 @@
+-- Copyright 2024 Stacklok, Inc
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--      http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+BEGIN;
+
+ALTER TABLE entity_execution_lock ADD COLUMN IF NOT EXISTS repository_id UUID NOT NULL REFERENCES repositories(id) ON DELETE CASCADE;
+ALTER TABLE entity_execution_lock ADD COLUMN IF NOT EXISTS artifact_id UUID REFERENCES artifacts(id) ON DELETE CASCADE;
+ALTER TABLE entity_execution_lock ADD COLUMN IF NOT EXISTS pull_request_id UUID REFERENCES pull_requests(id) ON DELETE CASCADE;
+
+ALTER TABLE flush_cache ADD COLUMN IF NOT EXISTS repository_id UUID NOT NULL REFERENCES repositories(id) ON DELETE CASCADE;
+ALTER TABLE flush_cache ADD COLUMN IF NOT EXISTS artifact_id UUID REFERENCES artifacts(id) ON DELETE CASCADE;
+ALTER TABLE flush_cache ADD COLUMN IF NOT EXISTS pull_request_id UUID REFERENCES pull_requests(id) ON DELETE CASCADE;
+
+-- make project_id nullable
+ALTER TABLE entity_execution_lock ALTER COLUMN project_id DROP NOT NULL;
+ALTER TABLE flush_cache ALTER COLUMN project_id DROP NOT NULL;
+
+COMMIT;

--- a/database/migrations/000103_eea_rm_per_entities_columns.up.sql
+++ b/database/migrations/000103_eea_rm_per_entities_columns.up.sql
@@ -1,0 +1,29 @@
+-- Copyright 2024 Stacklok, Inc
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--      http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+BEGIN;
+
+ALTER TABLE entity_execution_lock DROP COLUMN IF EXISTS repository_id;
+ALTER TABLE entity_execution_lock DROP COLUMN IF EXISTS artifact_id;
+ALTER TABLE entity_execution_lock DROP COLUMN IF EXISTS pull_request_id;
+
+ALTER TABLE flush_cache DROP COLUMN IF EXISTS repository_id;
+ALTER TABLE flush_cache DROP COLUMN IF EXISTS artifact_id;
+ALTER TABLE flush_cache DROP COLUMN IF EXISTS pull_request_id;
+
+-- make project_id not nullable
+ALTER TABLE entity_execution_lock ALTER COLUMN project_id SET NOT NULL;
+ALTER TABLE flush_cache ALTER COLUMN project_id SET NOT NULL;
+
+COMMIT;

--- a/internal/db/entity_execution_lock.sql.go
+++ b/internal/db/entity_execution_lock.sql.go
@@ -22,7 +22,7 @@ INSERT INTO flush_cache(
     $3::UUID
 ) ON CONFLICT(entity_instance_id)
 DO NOTHING
-RETURNING id, entity, repository_id, artifact_id, pull_request_id, queued_at, project_id, entity_instance_id
+RETURNING id, entity, queued_at, project_id, entity_instance_id
 `
 
 type EnqueueFlushParams struct {
@@ -37,9 +37,6 @@ func (q *Queries) EnqueueFlush(ctx context.Context, arg EnqueueFlushParams) (Flu
 	err := row.Scan(
 		&i.ID,
 		&i.Entity,
-		&i.RepositoryID,
-		&i.ArtifactID,
-		&i.PullRequestID,
 		&i.QueuedAt,
 		&i.ProjectID,
 		&i.EntityInstanceID,
@@ -50,7 +47,7 @@ func (q *Queries) EnqueueFlush(ctx context.Context, arg EnqueueFlushParams) (Flu
 const flushCache = `-- name: FlushCache :one
 DELETE FROM flush_cache
 WHERE entity_instance_id= $1
-RETURNING id, entity, repository_id, artifact_id, pull_request_id, queued_at, project_id, entity_instance_id
+RETURNING id, entity, queued_at, project_id, entity_instance_id
 `
 
 func (q *Queries) FlushCache(ctx context.Context, entityInstanceID uuid.UUID) (FlushCache, error) {
@@ -59,9 +56,6 @@ func (q *Queries) FlushCache(ctx context.Context, entityInstanceID uuid.UUID) (F
 	err := row.Scan(
 		&i.ID,
 		&i.Entity,
-		&i.RepositoryID,
-		&i.ArtifactID,
-		&i.PullRequestID,
 		&i.QueuedAt,
 		&i.ProjectID,
 		&i.EntityInstanceID,
@@ -70,7 +64,7 @@ func (q *Queries) FlushCache(ctx context.Context, entityInstanceID uuid.UUID) (F
 }
 
 const listFlushCache = `-- name: ListFlushCache :many
-SELECT id, entity, repository_id, artifact_id, pull_request_id, queued_at, project_id, entity_instance_id FROM flush_cache
+SELECT id, entity, queued_at, project_id, entity_instance_id FROM flush_cache
 `
 
 func (q *Queries) ListFlushCache(ctx context.Context) ([]FlushCache, error) {
@@ -85,9 +79,6 @@ func (q *Queries) ListFlushCache(ctx context.Context) ([]FlushCache, error) {
 		if err := rows.Scan(
 			&i.ID,
 			&i.Entity,
-			&i.RepositoryID,
-			&i.ArtifactID,
-			&i.PullRequestID,
 			&i.QueuedAt,
 			&i.ProjectID,
 			&i.EntityInstanceID,
@@ -124,7 +115,7 @@ DO UPDATE SET
     locked_by = gen_random_uuid(),
     last_lock_time = NOW()
 WHERE entity_execution_lock.last_lock_time < (NOW() - ($4::TEXT || ' seconds')::interval)
-RETURNING id, entity, locked_by, last_lock_time, repository_id, artifact_id, pull_request_id, project_id, entity_instance_id
+RETURNING id, entity, locked_by, last_lock_time, project_id, entity_instance_id
 `
 
 type LockIfThresholdNotExceededParams struct {
@@ -152,9 +143,6 @@ func (q *Queries) LockIfThresholdNotExceeded(ctx context.Context, arg LockIfThre
 		&i.Entity,
 		&i.LockedBy,
 		&i.LastLockTime,
-		&i.RepositoryID,
-		&i.ArtifactID,
-		&i.PullRequestID,
 		&i.ProjectID,
 		&i.EntityInstanceID,
 	)

--- a/internal/db/models.go
+++ b/internal/db/models.go
@@ -503,15 +503,12 @@ type Entitlement struct {
 }
 
 type EntityExecutionLock struct {
-	ID               uuid.UUID     `json:"id"`
-	Entity           Entities      `json:"entity"`
-	LockedBy         uuid.UUID     `json:"locked_by"`
-	LastLockTime     time.Time     `json:"last_lock_time"`
-	RepositoryID     uuid.NullUUID `json:"repository_id"`
-	ArtifactID       uuid.NullUUID `json:"artifact_id"`
-	PullRequestID    uuid.NullUUID `json:"pull_request_id"`
-	ProjectID        uuid.NullUUID `json:"project_id"`
-	EntityInstanceID uuid.UUID     `json:"entity_instance_id"`
+	ID               uuid.UUID `json:"id"`
+	Entity           Entities  `json:"entity"`
+	LockedBy         uuid.UUID `json:"locked_by"`
+	LastLockTime     time.Time `json:"last_lock_time"`
+	ProjectID        uuid.UUID `json:"project_id"`
+	EntityInstanceID uuid.UUID `json:"entity_instance_id"`
 }
 
 type EntityInstance struct {
@@ -561,14 +558,11 @@ type Feature struct {
 }
 
 type FlushCache struct {
-	ID               uuid.UUID     `json:"id"`
-	Entity           Entities      `json:"entity"`
-	RepositoryID     uuid.NullUUID `json:"repository_id"`
-	ArtifactID       uuid.NullUUID `json:"artifact_id"`
-	PullRequestID    uuid.NullUUID `json:"pull_request_id"`
-	QueuedAt         time.Time     `json:"queued_at"`
-	ProjectID        uuid.NullUUID `json:"project_id"`
-	EntityInstanceID uuid.UUID     `json:"entity_instance_id"`
+	ID               uuid.UUID `json:"id"`
+	Entity           Entities  `json:"entity"`
+	QueuedAt         time.Time `json:"queued_at"`
+	ProjectID        uuid.UUID `json:"project_id"`
+	EntityInstanceID uuid.UUID `json:"entity_instance_id"`
 }
 
 type LatestEvaluationStatus struct {

--- a/internal/eea/eea_test.go
+++ b/internal/eea/eea_test.go
@@ -212,21 +212,12 @@ func TestFlushAll(t *testing.T) {
 						{
 							ID:               uuid.New(),
 							Entity:           db.EntitiesRepository,
-							RepositoryID:     uuid.NullUUID{UUID: repoID, Valid: true},
 							QueuedAt:         time.Now(),
+							ProjectID:        projectID,
 							EntityInstanceID: repoID,
 						},
 					}, nil)
 
-				// 1 - fetch repo info for repo
-				// base repo info
-				mockStore.EXPECT().GetRepositoryByID(ctx, repoID).
-					Return(db.Repository{
-						ID:         repoID,
-						ProjectID:  projectID,
-						Provider:   providerName,
-						ProviderID: providerID,
-					}, nil)
 				// subsequent repo fetch for protobuf conversion
 				mockStore.EXPECT().GetRepositoryByIDAndProject(ctx, gomock.Any()).
 					Return(db.Repository{
@@ -250,30 +241,14 @@ func TestFlushAll(t *testing.T) {
 				mockStore.EXPECT().ListFlushCache(ctx).
 					Return([]db.FlushCache{
 						{
-							ID:     uuid.New(),
-							Entity: db.EntitiesArtifact,
-							RepositoryID: uuid.NullUUID{
-								UUID:  repoID,
-								Valid: true,
-							},
-							ArtifactID: uuid.NullUUID{
-								UUID:  artID,
-								Valid: true,
-							},
+							ID:               uuid.New(),
+							Entity:           db.EntitiesArtifact,
 							EntityInstanceID: artID,
+							ProjectID:        projectID,
 							QueuedAt:         time.Now(),
 						},
 					}, nil)
 
-				// 1 - fetch repo info for repo
-				// base repo info
-				mockStore.EXPECT().GetRepositoryByID(ctx, repoID).
-					Return(db.Repository{
-						ID:         repoID,
-						ProjectID:  projectID,
-						Provider:   providerName,
-						ProviderID: providerID,
-					}, nil)
 				// subsequent artifact fetch for protobuf conversion
 				mockStore.EXPECT().GetRepositoryByIDAndProject(ctx, gomock.Any()).
 					Return(db.Repository{
@@ -305,21 +280,10 @@ func TestFlushAll(t *testing.T) {
 				mockStore.EXPECT().ListFlushCache(ctx).
 					Return([]db.FlushCache{
 						{
-							ID:     uuid.New(),
-							Entity: db.EntitiesArtifact,
-							RepositoryID: uuid.NullUUID{
-								UUID:  repoID,
-								Valid: true,
-							},
-							ArtifactID: uuid.NullUUID{
-								UUID:  artID,
-								Valid: true,
-							},
-							QueuedAt: time.Now(),
-							ProjectID: uuid.NullUUID{
-								UUID:  projectID,
-								Valid: true,
-							},
+							ID:               uuid.New(),
+							Entity:           db.EntitiesArtifact,
+							QueuedAt:         time.Now(),
+							ProjectID:        projectID,
 							EntityInstanceID: artID,
 						},
 					}, nil)
@@ -348,28 +312,16 @@ func TestFlushAll(t *testing.T) {
 		{
 			name: "flushes one artifact with no repo and a set project ID in the flush",
 			mockDBSetup: func(ctx context.Context, mockStore *mockdb.MockStore) {
-				repoID := uuid.New()
 				artID := uuid.New()
 				projectID := uuid.New()
 
 				mockStore.EXPECT().ListFlushCache(ctx).
 					Return([]db.FlushCache{
 						{
-							ID:     uuid.New(),
-							Entity: db.EntitiesArtifact,
-							RepositoryID: uuid.NullUUID{
-								UUID:  repoID,
-								Valid: true,
-							},
-							ArtifactID: uuid.NullUUID{
-								UUID:  artID,
-								Valid: true,
-							},
-							QueuedAt: time.Now(),
-							ProjectID: uuid.NullUUID{
-								UUID:  projectID,
-								Valid: true,
-							},
+							ID:               uuid.New(),
+							Entity:           db.EntitiesArtifact,
+							QueuedAt:         time.Now(),
+							ProjectID:        projectID,
 							EntityInstanceID: artID,
 						},
 					}, nil)
@@ -396,29 +348,14 @@ func TestFlushAll(t *testing.T) {
 				mockStore.EXPECT().ListFlushCache(ctx).
 					Return([]db.FlushCache{
 						{
-							ID:     uuid.New(),
-							Entity: db.EntitiesPullRequest,
-							RepositoryID: uuid.NullUUID{
-								UUID:  repoID,
-								Valid: true,
-							},
-							PullRequestID: uuid.NullUUID{
-								UUID:  prID,
-								Valid: true,
-							},
-							QueuedAt: time.Now(),
+							ID:               uuid.New(),
+							Entity:           db.EntitiesPullRequest,
+							ProjectID:        projectID,
+							EntityInstanceID: prID,
+							QueuedAt:         time.Now(),
 						},
 					}, nil)
 
-				// 1 - fetch repo info for repo
-				// base repo info
-				mockStore.EXPECT().GetRepositoryByID(ctx, repoID).
-					Return(db.Repository{
-						ID:         repoID,
-						ProjectID:  projectID,
-						Provider:   providerName,
-						ProviderID: providerID,
-					}, nil)
 				// subsequent artifact fetch for protobuf conversion
 				mockStore.EXPECT().GetRepositoryByIDAndProject(ctx, gomock.Any()).
 					Return(db.Repository{
@@ -605,23 +542,21 @@ func TestFlushAllListFlushListsARepoThatGetsDeletedLater(t *testing.T) {
 	})
 
 	repoID := uuid.New()
+	projID := uuid.New()
 
 	// initial list flush
 	mockStore.EXPECT().ListFlushCache(ctx).
 		Return([]db.FlushCache{
 			{
-				ID:     uuid.New(),
-				Entity: db.EntitiesRepository,
-				RepositoryID: uuid.NullUUID{
-					UUID:  repoID,
-					Valid: true,
-				},
-				QueuedAt: time.Now(),
+				ID:               uuid.New(),
+				Entity:           db.EntitiesRepository,
+				ProjectID:        projID,
+				EntityInstanceID: repoID,
+				QueuedAt:         time.Now(),
 			},
 		}, nil)
 
-	// repo does not exist
-	mockStore.EXPECT().GetRepositoryByID(ctx, repoID).
+	mockStore.EXPECT().GetRepositoryByIDAndProject(ctx, gomock.Any()).
 		Return(db.Repository{}, sql.ErrNoRows)
 
 	t.Log("Flushing all")


### PR DESCRIPTION
# Summary

Now that the queries aren't using it and the main logic actually uses
the central entity instances table, we can drop these.

Closes: https://github.com/stacklok/minder/issues/4169

## Change Type

***Mark the type of change your PR introduces:***

- [ ] Bug fix (resolves an issue without affecting existing features)
- [x] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [x] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

***Outline how the changes were tested, including steps to reproduce and any relevant configurations. 
Attach screenshots if helpful.***

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [ ] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [ ] Included tests that validate the fix or feature.
- [ ] Checked that related changes are merged.
