### PR TITLE
Refresh properties before reconcile and profile init

### DIFF
--- a/internal/reconcilers/run_profile.go
+++ b/internal/reconcilers/run_profile.go
@@ -102,9 +102,15 @@ func (r *Reconciler) publishProfileInitEvents(
 	}
 
 	for _, dbrepo := range dbrepos {
+		_, err := r.repos.RefreshRepositoryByUpstreamID(ctx, dbrepo.RepoID)
+		if err != nil {
+			zerolog.Ctx(ctx).Debug().Err(err).Str("repository", dbrepo.ID.String()).Msg("error refreshing repository")
+			continue
+		}
+
 		// protobufs are our API, so we always execute on these instead of the DB directly.
 		repo := repositories.PBRepositoryFromDB(dbrepo)
-		err := entities.NewEntityInfoWrapper().
+		err = entities.NewEntityInfoWrapper().
 			WithProviderID(dbrepo.ProviderID).
 			WithProjectID(projectID).
 			WithRepository(repo).


### PR DESCRIPTION
# Summary

Refreshing the repositories ensures that when the requests get to the
executor, the properties will have been fetched.

Related: #4173

## Change Type

- [ ] Bug fix (resolves an issue without affecting existing features)
- [x] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [ ] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

manual

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [ ] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [ ] Included tests that validate the fix or feature.
- [ ] Checked that related changes are merged.
