### PR TITLE
Fix rule type name that has no pills.

### DIFF
--- a/cmd/cli/app/ruletype/common.go
+++ b/cmd/cli/app/ruletype/common.go
@@ -180,6 +180,12 @@ func appendRuleTypePropertiesToName(rt *minderv1.RuleType) string {
 	if rt.Def.GetRemediate() == nil {
 		properties = append(properties, "can_remediate: false")
 	}
-	// return the name with the properties
-	return fmt.Sprintf("%s (%s)", name, strings.Join(properties, ", "))
+
+	// return the name with the properties if any
+	if len(properties) != 0 {
+		return fmt.Sprintf("%s (%s)", name, strings.Join(properties, ", "))
+	}
+
+	// return only name otherwise
+	return name
 }


### PR DESCRIPTION
# Summary

We recently added the possibility to display `can_remediate` and `release_phase` pills, if available, near to rule type name. If no pills were available, we erroneously displayed `()`.

## Change Type

- [X] Bug fix (resolves an issue without affecting existing features)
- [ ] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [ ] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

Manual tests.

# Review Checklist:

- [X] Reviewed my own code for quality and clarity.
- [X] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [ ] Included tests that validate the fix or feature.
- [X] Checked that related changes are merged.
