### PR TITLE
Don't overwrite UserVisibleError when updating selectors fails

### DIFF
--- a/internal/profiles/service.go
+++ b/internal/profiles/service.go
@@ -285,7 +285,7 @@ func (p *profileService) UpdateProfile(
 	}
 
 	if err := p.updateSelectors(ctx, updatedProfile.ID, qtx, profile.GetSelection()); err != nil {
-		return nil, status.Errorf(codes.Internal, "error updating profile: %v", err)
+		return nil, err
 	}
 
 	logger.BusinessRecord(ctx).Profile = logger.Profile{Name: updatedProfile.Name, ID: updatedProfile.ID}


### PR DESCRIPTION
# Summary

We would return a UserVisibleError when updating selectors, but then
overwrite it in the caller who caled the validation, which resulted in
the server returning a 500 HTTP code to the client.

## Change Type

- [x] Bug fix (resolves an issue without affecting existing features)
- [ ] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [ ] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

```
curl -XPUT -vv -H "Authorization: Bearer $MINDER_BEARER_TOKEN" 'http://localhost:8080/api/v1/profile' --data-binary @/Users/jakub/devel/playground/selectors/repro.json
```

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [ ] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [ ] Included tests that validate the fix or feature.
- [ ] Checked that related changes are merged.
