### PR TITLE
Handle pull requests as general entities

### DIFF
--- a/internal/controlplane/handlers_oauth_test.go
+++ b/internal/controlplane/handlers_oauth_test.go
@@ -613,7 +613,7 @@ func TestProviderCallback(t *testing.T) {
 
 			mockGhProviderService := mockprovsvc.NewMockGitHubProviderService(ctrl)
 			tc.buildStubs(mockGhProviderService)
-			s, _ := newDefaultServer(t, store, nil, clientFactory)
+			s, _ := newDefaultServer(t, store, nil, nil, clientFactory)
 			s.ghProviders = mockGhProviderService
 			s.cfg.Provider = serverconfig.ProviderConfig{
 				GitHub: &serverconfig.GitHubConfig{

--- a/internal/controlplane/handlers_ruletype_test.go
+++ b/internal/controlplane/handlers_ruletype_test.go
@@ -115,7 +115,7 @@ func TestCreateRuleType(t *testing.T) {
 				mockSvc = tt.ruleTypeServiceFunc(ctrl)
 			}
 
-			srv, _ := newDefaultServer(t, mockStore, nil, nil)
+			srv, _ := newDefaultServer(t, mockStore, nil, nil, nil)
 			srv.ruleTypes = mockSvc
 
 			resp, err := srv.CreateRuleType(context.Background(), tt.request)
@@ -215,7 +215,7 @@ func TestUpdateRuleType(t *testing.T) {
 				mockSvc = tt.ruleTypeServiceFunc(ctrl)
 			}
 
-			srv, _ := newDefaultServer(t, mockStore, nil, nil)
+			srv, _ := newDefaultServer(t, mockStore, nil, nil, nil)
 			srv.ruleTypes = mockSvc
 
 			resp, err := srv.UpdateRuleType(context.Background(), tt.request)

--- a/internal/controlplane/server.go
+++ b/internal/controlplane/server.go
@@ -56,6 +56,7 @@ import (
 	"github.com/stacklok/minder/internal/controlplane/metrics"
 	"github.com/stacklok/minder/internal/crypto"
 	"github.com/stacklok/minder/internal/db"
+	propSvc "github.com/stacklok/minder/internal/entities/properties/service"
 	"github.com/stacklok/minder/internal/events"
 	"github.com/stacklok/minder/internal/history"
 	"github.com/stacklok/minder/internal/invites"
@@ -99,6 +100,7 @@ type Server struct {
 	// We may want to start breaking up the server struct if we use it to
 	// inject more entity-specific interfaces. For example, we may want to
 	// consider having a struct per grpc service
+	props               propSvc.PropertiesService
 	invites             invites.InviteService
 	ruleTypes           ruletypes.RuleTypeService
 	repos               github.RepositoryService
@@ -140,6 +142,7 @@ func NewServer(
 	idClient auth.Resolver,
 	inviteService invites.InviteService,
 	repoService github.RepositoryService,
+	propertyService propSvc.PropertiesService,
 	roleService roles.RoleService,
 	profileService profiles.ProfileService,
 	historyService history.EvaluationHistoryService,
@@ -171,6 +174,7 @@ func NewServer(
 		sessionService:      sessionService,
 		invites:             inviteService,
 		repos:               repoService,
+		props:               propertyService,
 		roles:               roleService,
 		ghProviders:         ghProviders,
 		authzClient:         authzClient,

--- a/internal/controlplane/server_test.go
+++ b/internal/controlplane/server_test.go
@@ -40,6 +40,7 @@ import (
 	serverconfig "github.com/stacklok/minder/internal/config/server"
 	"github.com/stacklok/minder/internal/controlplane/metrics"
 	"github.com/stacklok/minder/internal/crypto"
+	mock_service "github.com/stacklok/minder/internal/entities/properties/service/mock"
 	"github.com/stacklok/minder/internal/events"
 	"github.com/stacklok/minder/internal/providers"
 	ghclient "github.com/stacklok/minder/internal/providers/github/clients"
@@ -78,6 +79,7 @@ func newDefaultServer(
 	t *testing.T,
 	mockStore *mockdb.MockStore,
 	mockRepoSvc *mock_github.MockRepositoryService,
+	mockPropSvc *mock_service.MockPropertiesService,
 	ghClientFactory ghclient.GitHubClientFactory,
 ) (*Server, events.Interface) {
 	t.Helper()
@@ -129,6 +131,7 @@ func newDefaultServer(
 		ghProviders:   ghClientService,
 		providerStore: providers.NewProviderStore(mockStore),
 		repos:         mockRepoSvc,
+		props:         mockPropSvc,
 		cryptoEngine:  eng,
 	}
 

--- a/internal/providers/github/mock/fixtures/github.go
+++ b/internal/providers/github/mock/fixtures/github.go
@@ -80,3 +80,15 @@ func WithSuccessfulGetPullRequest(pr any) func(mock GitHubMock) {
 			Return(pr, nil)
 	}
 }
+
+func WithSuccessfulGetEntityName(name string) func(mock GitHubMock) {
+	return func(mock GitHubMock) {
+		mock.EXPECT().
+			GetEntityName(
+				gomock.Any(),
+				gomock.Any(),
+			).
+			AnyTimes().
+			Return(name, nil)
+	}
+}

--- a/internal/providers/github/properties.go
+++ b/internal/providers/github/properties.go
@@ -35,12 +35,8 @@ func (c *GitHub) FetchProperty(
 	}
 
 	fetcher := c.propertyFetchers.EntityPropertyFetcher(entType)
-
-	// TODO: right now github only supports fetching by name, but we could add support for more
-	// properties to e.g. get-repo-by-id if the upstream REST API supports that
-	name, err := getByProps.GetProperty(properties.PropertyName).AsString()
-	if err != nil {
-		return nil, fmt.Errorf("name is not a string: %w", err)
+	if fetcher == nil {
+		return nil, fmt.Errorf("entity %s not supported", entType)
 	}
 
 	wrapper := fetcher.WrapperForProperty(key)
@@ -48,7 +44,7 @@ func (c *GitHub) FetchProperty(
 		return nil, fmt.Errorf("property %s not supported for entity %s", key, entType)
 	}
 
-	props, err := wrapper(ctx, c.client, name)
+	props, err := wrapper(ctx, c.client, getByProps)
 	if err != nil {
 		return nil, fmt.Errorf("error fetching property %s for entity %s: %w", key, entType, err)
 	}
@@ -67,17 +63,10 @@ func (c *GitHub) FetchAllProperties(
 		return nil, errors.New("property fetchers not initialized")
 	}
 
-	// TODO: right now github only supports fetching by name, but we could add support for more
-	// properties to e.g. get-repo-by-id if the upstream REST API supports that
-	name, err := getByProps.GetProperty(properties.PropertyName).AsString()
-	if err != nil {
-		return nil, fmt.Errorf("name is not a string: %w", err)
-	}
-
 	fetcher := c.propertyFetchers.EntityPropertyFetcher(entType)
 	result := make(map[string]any)
 	for _, wrapper := range fetcher.AllPropertyWrappers() {
-		props, err := wrapper(ctx, c.client, name)
+		props, err := wrapper(ctx, c.client, getByProps)
 		if err != nil {
 			return nil, fmt.Errorf("error fetching properties for entity %s: %w", entType, err)
 		}

--- a/internal/providers/github/properties/fetcher.go
+++ b/internal/providers/github/properties/fetcher.go
@@ -18,7 +18,6 @@ package properties
 
 import (
 	"context"
-	"fmt"
 
 	go_github "github.com/google/go-github/v63/github"
 
@@ -27,14 +26,20 @@ import (
 )
 
 // GhPropertyWrapper is a function that fetches a property from the GitHub API
-type GhPropertyWrapper func(ctx context.Context, ghCli *go_github.Client, name string) (map[string]any, error)
+type GhPropertyWrapper func(
+	ctx context.Context, ghCli *go_github.Client, lookupProperties *properties.Properties,
+) (map[string]any, error)
 
 // GhPropertyFetcher is an interface for fetching properties from the GitHub API
 type GhPropertyFetcher interface {
+	ghPropertyFetcherBase
+	GetName(props *properties.Properties) (string, error)
+}
+
+type ghPropertyFetcherBase interface {
 	WrapperForProperty(propertyKey string) GhPropertyWrapper
 	AllPropertyWrappers() []GhPropertyWrapper
 	OperationalProperties() []string
-	GetName(props *properties.Properties) (string, error)
 }
 
 // GhPropertyFetcherFactory is an interface for creating GhPropertyFetcher instances
@@ -51,56 +56,52 @@ func NewPropertyFetcherFactory() GhPropertyFetcherFactory {
 
 // EntityPropertyFetcher returns a GhPropertyFetcher for the given entity type
 func (_ ghEntityFetcher) EntityPropertyFetcher(entType minderv1.Entity) GhPropertyFetcher {
-	if entType == minderv1.Entity_ENTITY_REPOSITORIES {
+	// nolint:exhaustive
+	switch entType {
+	case minderv1.Entity_ENTITY_PULL_REQUESTS:
+		return NewPullRequestFetcher()
+	case minderv1.Entity_ENTITY_REPOSITORIES:
 		return NewRepositoryFetcher()
 	}
 
 	return nil
 }
 
-// RepoV1FromProperties creates a minderv1.Repository from a properties.Properties
-func RepoV1FromProperties(repoProperties *properties.Properties) (*minderv1.Repository, error) {
-	name, err := repoProperties.GetProperty(RepoPropertyName).AsString()
-	if err != nil {
-		return nil, fmt.Errorf("error fetching name property: %w", err)
+type propertyOrigin struct {
+	keys    []string
+	wrapper GhPropertyWrapper
+}
+
+type propertyFetcherBase struct {
+	propertyOrigins       []propertyOrigin
+	operationalProperties []string
+}
+
+var _ ghPropertyFetcherBase = propertyFetcherBase{}
+
+// WrapperForProperty returns the property wrapper for the given property key
+func (pfb propertyFetcherBase) WrapperForProperty(propertyKey string) GhPropertyWrapper {
+	for _, po := range pfb.propertyOrigins {
+		for _, k := range po.keys {
+			if k == propertyKey {
+				return po.wrapper
+			}
+		}
 	}
 
-	owner, err := repoProperties.GetProperty(RepoPropertyOwner).AsString()
-	if err != nil {
-		return nil, fmt.Errorf("error fetching owner property: %w", err)
-	}
+	return nil
+}
 
-	repoId, err := repoProperties.GetProperty(RepoPropertyId).AsInt64()
-	if err != nil {
-		return nil, fmt.Errorf("error fetching repo_id property: %w", err)
+// AllPropertyWrappers returns all property wrappers for the repository
+func (pfb propertyFetcherBase) AllPropertyWrappers() []GhPropertyWrapper {
+	wrappers := make([]GhPropertyWrapper, 0, len(pfb.propertyOrigins))
+	for _, po := range pfb.propertyOrigins {
+		wrappers = append(wrappers, po.wrapper)
 	}
+	return wrappers
+}
 
-	isPrivate, err := repoProperties.GetProperty(properties.RepoPropertyIsPrivate).AsBool()
-	if err != nil {
-		return nil, fmt.Errorf("error fetching is_private property: %w", err)
-	}
-
-	isFork, err := repoProperties.GetProperty(properties.RepoPropertyIsFork).AsBool()
-	if err != nil {
-		return nil, fmt.Errorf("error fetching is_fork property: %w", err)
-	}
-
-	pbRepo := &minderv1.Repository{
-		Name:          name,
-		Owner:         owner,
-		RepoId:        repoId,
-		HookId:        repoProperties.GetProperty(RepoPropertyHookId).GetInt64(),
-		HookUrl:       repoProperties.GetProperty(RepoPropertyHookUrl).GetString(),
-		DeployUrl:     repoProperties.GetProperty(RepoPropertyDeployURL).GetString(),
-		CloneUrl:      repoProperties.GetProperty(RepoPropertyCloneURL).GetString(),
-		HookType:      repoProperties.GetProperty(RepoPropertyHookType).GetString(),
-		HookName:      repoProperties.GetProperty(RepoPropertyHookName).GetString(),
-		HookUuid:      repoProperties.GetProperty(RepoPropertyHookUiid).GetString(),
-		IsPrivate:     isPrivate,
-		IsFork:        isFork,
-		DefaultBranch: repoProperties.GetProperty(RepoPropertyDefaultBranch).GetString(),
-		License:       repoProperties.GetProperty(RepoPropertyLicense).GetString(),
-	}
-
-	return pbRepo, nil
+// OperationalProperties returns the operational properties for the repository
+func (pfb propertyFetcherBase) OperationalProperties() []string {
+	return pfb.operationalProperties
 }

--- a/internal/providers/github/properties/pull_request.go
+++ b/internal/providers/github/properties/pull_request.go
@@ -1,0 +1,183 @@
+//
+// Copyright 2024 Stacklok, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package properties provides utility functions for fetching and managing properties
+package properties
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strconv"
+	"strings"
+
+	go_github "github.com/google/go-github/v63/github"
+
+	"github.com/stacklok/minder/internal/entities/properties"
+	minderv1 "github.com/stacklok/minder/pkg/api/protobuf/go/minder/v1"
+	v1 "github.com/stacklok/minder/pkg/providers/v1"
+)
+
+const (
+	// PullPropertyURL is the URL of the pull request
+	PullPropertyURL = "github/pull_url"
+	// PullPropertyNumber is the number of the pull request
+	PullPropertyNumber = "github/pull_number"
+	// PullPropertySha is the sha of the pull request
+	PullPropertySha = "github/pull_sha"
+	// PullPropertyRepoOwner is the owner of the repository
+	PullPropertyRepoOwner = "github/repo_owner"
+	// PullPropertyRepoName is the name of the repository
+	PullPropertyRepoName = "github/repo_name"
+	// PullPropertyAuthorID is the ID of the author of the pull request
+	PullPropertyAuthorID = "github/pull_author_id"
+	// PullPropertyAction is an operational property that represents the action that was taken on the pull request
+	PullPropertyAction = "github/pull_action"
+)
+
+var prPropertyDefinitions = []propertyOrigin{
+	{
+		keys: []string{
+			// general entity
+			properties.PropertyName,
+			properties.PropertyUpstreamID,
+			// github-specific
+			PullPropertyURL,
+			PullPropertyNumber,
+			PullPropertySha,
+			PullPropertyRepoOwner,
+			PullPropertyRepoName,
+			PullPropertyAuthorID,
+			PullPropertyAction,
+		},
+		wrapper: getPrWrapper,
+	},
+}
+
+var prOperationalProperties = []string{
+	PullPropertyAction,
+}
+
+// PullRequestFetcher is a property fetcher for github repositories
+type PullRequestFetcher struct {
+	propertyFetcherBase
+}
+
+// NewPullRequestFetcher creates a new PullRequestFetcher
+func NewPullRequestFetcher() *PullRequestFetcher {
+	return &PullRequestFetcher{
+		propertyFetcherBase: propertyFetcherBase{
+			operationalProperties: prOperationalProperties,
+			propertyOrigins:       prPropertyDefinitions,
+		},
+	}
+}
+
+// GetName returns the name of the pull request
+func (_ *PullRequestFetcher) GetName(props *properties.Properties) (string, error) {
+	prOwner, err := props.GetProperty(PullPropertyRepoOwner).AsString()
+	if err != nil {
+		return "", fmt.Errorf("error fetching pr owner property: %w", err)
+	}
+
+	prName, err := props.GetProperty(PullPropertyRepoName).AsString()
+	if err != nil {
+		return "", fmt.Errorf("error fetching pr name property: %w", err)
+	}
+
+	prID, err := props.GetProperty(PullPropertyNumber).AsInt64()
+	if err != nil {
+		return "", fmt.Errorf("error fetching pr id property: %w", err)
+	}
+
+	return fmt.Sprintf("%s/%s/%d", prOwner, prName, prID), nil
+}
+
+func parsePrName(input string) (string, string, int64, error) {
+	parts := strings.Split(input, "/")
+	if len(parts) != 3 {
+		return "", "", 0, fmt.Errorf("invalid input format")
+	}
+
+	repoOwner := parts[0]
+	repoName := parts[1]
+	prNumber, err := strconv.ParseInt(parts[2], 10, 64)
+	if err != nil {
+		return "", "", 0, fmt.Errorf("invalid prNumber: %w", err)
+	}
+
+	return repoOwner, repoName, prNumber, nil
+}
+
+func getPrWrapper(
+	ctx context.Context, ghCli *go_github.Client, getByProps *properties.Properties,
+) (map[string]any, error) {
+	owner, name, id, err := getPrWrapperAttrsFromProps(getByProps)
+	if err != nil {
+		return nil, fmt.Errorf("error getting pr wrapper attributes: %w", err)
+	}
+
+	prReply, result, err := ghCli.PullRequests.Get(ctx, owner, name, int(id))
+	if err != nil {
+		if result != nil && result.StatusCode == http.StatusNotFound {
+			return nil, v1.ErrEntityNotFound
+		}
+		return nil, err
+	}
+
+	prProps := map[string]any{
+		// general entity
+		properties.PropertyUpstreamID: prReply.GetID(),
+		properties.PropertyName:       fmt.Sprintf("%s/%s/%d", owner, name, id),
+		// github-specific
+		PullPropertyURL:       prReply.GetHTMLURL(),
+		PullPropertyNumber:    prReply.GetNumber(),
+		PullPropertySha:       prReply.GetHead().GetSHA(),
+		PullPropertyRepoOwner: owner,
+		PullPropertyRepoName:  name,
+		PullPropertyAuthorID:  prReply.GetUser().GetID(),
+	}
+
+	return prProps, nil
+}
+
+func getPrWrapperAttrsFromProps(props *properties.Properties) (string, string, int64, error) {
+	repoOwnerP := props.GetProperty(PullPropertyRepoOwner)
+	repoNameP := props.GetProperty(PullPropertyRepoName)
+	repoIdP := props.GetProperty(PullPropertyNumber)
+	if repoOwnerP != nil && repoNameP != nil && repoIdP != nil {
+		return repoOwnerP.GetString(), repoNameP.GetString(), repoIdP.GetInt64(), nil
+	}
+
+	prNameP := props.GetProperty(properties.PropertyName)
+	if prNameP != nil {
+		return parsePrName(prNameP.GetString())
+	}
+
+	return "", "", 0, fmt.Errorf("missing required properties")
+}
+
+// PullRequestV1FromProperties creates a PullRequestV1 from a properties object
+func PullRequestV1FromProperties(props *properties.Properties) *minderv1.PullRequest {
+	return &minderv1.PullRequest{
+		Url:       props.GetProperty(PullPropertyURL).GetString(),
+		CommitSha: props.GetProperty(PullPropertySha).GetString(),
+		Number:    props.GetProperty(PullPropertyNumber).GetInt64(),
+		RepoOwner: props.GetProperty(PullPropertyRepoOwner).GetString(),
+		RepoName:  props.GetProperty(PullPropertyRepoName).GetString(),
+		AuthorId:  props.GetProperty(PullPropertyAuthorID).GetInt64(),
+		Action:    props.GetProperty(PullPropertyAction).GetString(),
+	}
+}

--- a/internal/providers/github/properties/repository.go
+++ b/internal/providers/github/properties/repository.go
@@ -25,6 +25,7 @@ import (
 	go_github "github.com/google/go-github/v63/github"
 
 	"github.com/stacklok/minder/internal/entities/properties"
+	minderv1 "github.com/stacklok/minder/pkg/api/protobuf/go/minder/v1"
 	v1 "github.com/stacklok/minder/pkg/providers/v1"
 )
 
@@ -56,13 +57,9 @@ const (
 	RepoPropertyHookUiid = "github/hook_uiid"
 )
 
-type propertyOrigin struct {
-	keys    []string
-	wrapper GhPropertyWrapper
-}
-
 var repoOperationalProperties = []string{
 	RepoPropertyHookId,
+	RepoPropertyHookUrl,
 }
 
 var repoPropertyDefinitions = []propertyOrigin{
@@ -88,14 +85,16 @@ var repoPropertyDefinitions = []propertyOrigin{
 	},
 }
 
-func getRepoWrapper(ctx context.Context, ghCli *go_github.Client, name string) (map[string]any, error) {
-	// TODO: this should be a provider interface, even if private
-	slice := strings.Split(name, "/")
-	if len(slice) != 2 {
-		return nil, errors.New("invalid name")
+func getRepoWrapper(
+	ctx context.Context, ghCli *go_github.Client, getByProps *properties.Properties,
+) (map[string]any, error) {
+
+	name, owner, err := getNameOwnerFromProps(getByProps)
+	if err != nil {
+		return nil, fmt.Errorf("error getting name and owner from properties: %w", err)
 	}
 
-	repo, result, err := ghCli.Repositories.Get(ctx, slice[0], slice[1])
+	repo, result, err := ghCli.Repositories.Get(ctx, owner, name)
 	if err != nil {
 		if result != nil && result.StatusCode == http.StatusNotFound {
 			return nil, v1.ErrEntityNotFound
@@ -120,54 +119,44 @@ func getRepoWrapper(ctx context.Context, ghCli *go_github.Client, name string) (
 		RepoPropertyLicense:       repo.GetLicense().GetSPDXID(),
 	}
 
-	//repoProps[properties.PropertyName], err = getEntityName(minderv1.Entity_ENTITY_REPOSITORIES, props)
 	repoProps[properties.PropertyName] = fmt.Sprintf("%s/%s", repo.GetOwner().GetLogin(), repo.GetName())
 
 	return repoProps, nil
 }
 
+func getNameOwnerFromProps(props *properties.Properties) (string, string, error) {
+	repoNameP := props.GetProperty(RepoPropertyName)
+	repoOwnerP := props.GetProperty(RepoPropertyOwner)
+	if repoNameP != nil && repoOwnerP != nil {
+		return repoNameP.GetString(), repoOwnerP.GetString(), nil
+	}
+
+	repoNameP = props.GetProperty(properties.PropertyName)
+	if repoNameP != nil {
+		slice := strings.Split(repoNameP.GetString(), "/")
+		if len(slice) != 2 {
+			return "", "", errors.New("invalid repo name")
+		}
+
+		return slice[1], slice[0], nil
+	}
+
+	return "", "", errors.New("missing required properties, either repo-name and repo-owner or name")
+}
+
 // RepositoryFetcher is a property fetcher for github repositories
 type RepositoryFetcher struct {
-	propertyOrigins       []propertyOrigin
-	operationalProperties []string
+	propertyFetcherBase
 }
 
 // NewRepositoryFetcher creates a new RepositoryFetcher
 func NewRepositoryFetcher() *RepositoryFetcher {
 	return &RepositoryFetcher{
-		propertyOrigins:       repoPropertyDefinitions,
-		operationalProperties: repoOperationalProperties,
+		propertyFetcherBase: propertyFetcherBase{
+			operationalProperties: repoOperationalProperties,
+			propertyOrigins:       repoPropertyDefinitions,
+		},
 	}
-}
-
-// OperationalProperties returns the operational properties for the repository
-func (_ *RepositoryFetcher) OperationalProperties() []string {
-	return []string{
-		RepoPropertyHookId,
-		RepoPropertyHookUrl,
-	}
-}
-
-// WrapperForProperty returns the property wrapper for the given property key
-func (r *RepositoryFetcher) WrapperForProperty(propertyKey string) GhPropertyWrapper {
-	for _, po := range r.propertyOrigins {
-		for _, k := range po.keys {
-			if k == propertyKey {
-				return po.wrapper
-			}
-		}
-	}
-
-	return nil
-}
-
-// AllPropertyWrappers returns all property wrappers for the repository
-func (r *RepositoryFetcher) AllPropertyWrappers() []GhPropertyWrapper {
-	wrappers := make([]GhPropertyWrapper, 0, len(r.propertyOrigins))
-	for _, po := range r.propertyOrigins {
-		wrappers = append(wrappers, po.wrapper)
-	}
-	return wrappers
 }
 
 // GetName returns the name of the repository
@@ -190,4 +179,51 @@ func (_ *RepositoryFetcher) GetName(props *properties.Properties) (string, error
 	}
 
 	return fmt.Sprintf("%s/%s", repoOwner, repoName), nil
+}
+
+// RepoV1FromProperties creates a minderv1.Repository from a properties.Properties
+func RepoV1FromProperties(repoProperties *properties.Properties) (*minderv1.Repository, error) {
+	name, err := repoProperties.GetProperty(RepoPropertyName).AsString()
+	if err != nil {
+		return nil, fmt.Errorf("error fetching name property: %w", err)
+	}
+
+	owner, err := repoProperties.GetProperty(RepoPropertyOwner).AsString()
+	if err != nil {
+		return nil, fmt.Errorf("error fetching owner property: %w", err)
+	}
+
+	repoId, err := repoProperties.GetProperty(RepoPropertyId).AsInt64()
+	if err != nil {
+		return nil, fmt.Errorf("error fetching repo_id property: %w", err)
+	}
+
+	isPrivate, err := repoProperties.GetProperty(properties.RepoPropertyIsPrivate).AsBool()
+	if err != nil {
+		return nil, fmt.Errorf("error fetching is_private property: %w", err)
+	}
+
+	isFork, err := repoProperties.GetProperty(properties.RepoPropertyIsFork).AsBool()
+	if err != nil {
+		return nil, fmt.Errorf("error fetching is_fork property: %w", err)
+	}
+
+	pbRepo := &minderv1.Repository{
+		Name:          name,
+		Owner:         owner,
+		RepoId:        repoId,
+		HookId:        repoProperties.GetProperty(RepoPropertyHookId).GetInt64(),
+		HookUrl:       repoProperties.GetProperty(RepoPropertyHookUrl).GetString(),
+		DeployUrl:     repoProperties.GetProperty(RepoPropertyDeployURL).GetString(),
+		CloneUrl:      repoProperties.GetProperty(RepoPropertyCloneURL).GetString(),
+		HookType:      repoProperties.GetProperty(RepoPropertyHookType).GetString(),
+		HookName:      repoProperties.GetProperty(RepoPropertyHookName).GetString(),
+		HookUuid:      repoProperties.GetProperty(RepoPropertyHookUiid).GetString(),
+		IsPrivate:     isPrivate,
+		IsFork:        isFork,
+		DefaultBranch: repoProperties.GetProperty(RepoPropertyDefaultBranch).GetString(),
+		License:       repoProperties.GetProperty(RepoPropertyLicense).GetString(),
+	}
+
+	return pbRepo, nil
 }

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -169,6 +169,7 @@ func AllInOneServerService(
 		idClient,
 		inviteSvc,
 		repos,
+		propSvc,
 		roleScv,
 		profileSvc,
 		historySvc,


### PR DESCRIPTION

# Summary

- **Slight generalization of the GH property fetching** - The implementation of FetchProperty and FetchAllProperties for GitHub was not generic enough as it required that the properties contain the `name` key. For some properties, like pull request, the provider must fetch by other keys, so let's just pass the properties to the wrapper and let the wrapper error out if the get-by-properties don't contain the necessary data for fetching the property.
   Also moves the propertyOrigin struct to the generic fetcher.go source to make it clearer that it's to be reused by other entities. Finally the `AllPropertyWrappers` and `WrapperForProperty` methods are now implemented by a common structure that the per-entity structures just embed to reduce code duplication.
- **Add a pull request entity module to GH provider** - This will enable us to handle the pull request entity instances and their properties.
- **Handle pull requests as entities with properties in the github webhook**

Fixes: #4171

## Change Type

- [ ] Bug fix (resolves an issue without affecting existing features)
- [ ] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [x] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

manually + unit tests

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [ ] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [x] Included tests that validate the fix or feature.
- [ ] Checked that related changes are merged.
