### PR TITLE
Decouple legacy entity tables from results queries

### DIFF
--- a/cmd/server/app/history_purge_test.go
+++ b/cmd/server/app/history_purge_test.go
@@ -41,13 +41,13 @@ func TestRecordSize(t *testing.T) {
 		db.ListEvaluationHistoryStaleRecordsRow{
 			ID:             uuid.Nil,
 			EvaluationTime: time.Now(),
-			EntityType:     int32(1),
+			EntityType:     db.EntitiesArtifact,
 			EntityID:       uuid.Nil,
 			RuleID:         uuid.Nil,
 		},
 	)
 
-	require.Equal(t, uintptr(96), size)
+	require.Equal(t, uintptr(88), size)
 }
 
 func TestPurgeLoop(t *testing.T) {
@@ -76,7 +76,7 @@ func TestPurgeLoop(t *testing.T) {
 						EvaluationTime: time.Now(),
 						ID:             uuid1,
 						RuleID:         ruleID1,
-						EntityType:     int32(1),
+						EntityType:     db.EntitiesArtifact,
 						EntityID:       entityID1,
 					},
 				),
@@ -104,7 +104,7 @@ func TestPurgeLoop(t *testing.T) {
 						EvaluationTime: time.Now(),
 						ID:             uuid1,
 						RuleID:         ruleID1,
-						EntityType:     int32(1),
+						EntityType:     db.EntitiesArtifact,
 						EntityID:       entityID1,
 					},
 				),
@@ -126,21 +126,21 @@ func TestPurgeLoop(t *testing.T) {
 						EvaluationTime: time.Now(),
 						ID:             uuid1,
 						RuleID:         ruleID1,
-						EntityType:     int32(1),
+						EntityType:     db.EntitiesArtifact,
 						EntityID:       entityID1,
 					},
 					db.ListEvaluationHistoryStaleRecordsRow{
 						EvaluationTime: time.Now(),
 						ID:             uuid2,
 						RuleID:         ruleID2,
-						EntityType:     int32(1),
+						EntityType:     db.EntitiesArtifact,
 						EntityID:       entityID2,
 					},
 					db.ListEvaluationHistoryStaleRecordsRow{
 						EvaluationTime: time.Now(),
 						ID:             uuid3,
 						RuleID:         ruleID3,
-						EntityType:     int32(1),
+						EntityType:     db.EntitiesArtifact,
 						EntityID:       entityID3,
 					},
 				),
@@ -201,7 +201,7 @@ func TestPurgeLoop(t *testing.T) {
 						EvaluationTime: time.Now(),
 						ID:             uuid1,
 						RuleID:         ruleID1,
-						EntityType:     int32(1),
+						EntityType:     db.EntitiesArtifact,
 						EntityID:       entityID1,
 					},
 				),
@@ -434,14 +434,14 @@ var (
 	ruleID3      = uuid.MustParse("00000000-0000-0000-0000-000000000333")
 	evaluatedAt1 = time.Now()
 	evaluatedAt2 = evaluatedAt1.Add(-1 * time.Hour)
-	entityType   = int32(1)
+	entityType   = db.EntitiesRepository
 )
 
 //nolint:unparam
 func makeHistoryRow(
 	id uuid.UUID,
 	evaluatedAt time.Time,
-	entityType int32,
+	entityType db.Entities,
 	entityID uuid.UUID,
 	ruleID uuid.UUID,
 ) db.ListEvaluationHistoryStaleRecordsRow {

--- a/database/migrations/000104_rm_one_entity_id_constraint.down.sql
+++ b/database/migrations/000104_rm_one_entity_id_constraint.down.sql
@@ -1,0 +1,18 @@
+-- Copyright 2024 Stacklok, Inc
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--      http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+BEGIN;
+
+-- recreate `one_entity_id` constraint
+ALTER TABLE evaluation_rule_entities ADD CONSTRAINT one_entity_id CHECK (num_nonnulls(repository_id, artifact_id, pull_request_id) = 1);

--- a/database/migrations/000104_rm_one_entity_id_constraint.up.sql
+++ b/database/migrations/000104_rm_one_entity_id_constraint.up.sql
@@ -1,0 +1,19 @@
+-- Copyright 2024 Stacklok, Inc
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--      http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+BEGIN;
+
+ALTER TABLE evaluation_rule_entities DROP CONSTRAINT one_entity_id;
+
+COMMIT;

--- a/database/mock/store.go
+++ b/database/mock/store.go
@@ -1463,36 +1463,6 @@ func (mr *MockStoreMockRecorder) GetQuerierWithTransaction(arg0 any) *gomock.Cal
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetQuerierWithTransaction", reflect.TypeOf((*MockStore)(nil).GetQuerierWithTransaction), arg0)
 }
 
-// GetRepoPathFromArtifactID mocks base method.
-func (m *MockStore) GetRepoPathFromArtifactID(arg0 context.Context, arg1 uuid.UUID) (db.GetRepoPathFromArtifactIDRow, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetRepoPathFromArtifactID", arg0, arg1)
-	ret0, _ := ret[0].(db.GetRepoPathFromArtifactIDRow)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetRepoPathFromArtifactID indicates an expected call of GetRepoPathFromArtifactID.
-func (mr *MockStoreMockRecorder) GetRepoPathFromArtifactID(arg0, arg1 any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRepoPathFromArtifactID", reflect.TypeOf((*MockStore)(nil).GetRepoPathFromArtifactID), arg0, arg1)
-}
-
-// GetRepoPathFromPullRequestID mocks base method.
-func (m *MockStore) GetRepoPathFromPullRequestID(arg0 context.Context, arg1 uuid.UUID) (db.GetRepoPathFromPullRequestIDRow, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetRepoPathFromPullRequestID", arg0, arg1)
-	ret0, _ := ret[0].(db.GetRepoPathFromPullRequestIDRow)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetRepoPathFromPullRequestID indicates an expected call of GetRepoPathFromPullRequestID.
-func (mr *MockStoreMockRecorder) GetRepoPathFromPullRequestID(arg0, arg1 any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRepoPathFromPullRequestID", reflect.TypeOf((*MockStore)(nil).GetRepoPathFromPullRequestID), arg0, arg1)
-}
-
 // GetRepositoryByID mocks base method.
 func (m *MockStore) GetRepositoryByID(arg0 context.Context, arg1 uuid.UUID) (db.Repository, error) {
 	m.ctrl.T.Helper()
@@ -1554,18 +1524,18 @@ func (mr *MockStoreMockRecorder) GetRepositoryByRepoName(arg0, arg1 any) *gomock
 }
 
 // GetRuleEvaluationByProfileIdAndRuleType mocks base method.
-func (m *MockStore) GetRuleEvaluationByProfileIdAndRuleType(arg0 context.Context, arg1 uuid.UUID, arg2 db.NullEntities, arg3 sql.NullString, arg4 uuid.NullUUID, arg5 sql.NullString) (*db.ListRuleEvaluationsByProfileIdRow, error) {
+func (m *MockStore) GetRuleEvaluationByProfileIdAndRuleType(arg0 context.Context, arg1 uuid.UUID, arg2 sql.NullString, arg3 uuid.NullUUID, arg4 sql.NullString) (*db.ListRuleEvaluationsByProfileIdRow, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetRuleEvaluationByProfileIdAndRuleType", arg0, arg1, arg2, arg3, arg4, arg5)
+	ret := m.ctrl.Call(m, "GetRuleEvaluationByProfileIdAndRuleType", arg0, arg1, arg2, arg3, arg4)
 	ret0, _ := ret[0].(*db.ListRuleEvaluationsByProfileIdRow)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetRuleEvaluationByProfileIdAndRuleType indicates an expected call of GetRuleEvaluationByProfileIdAndRuleType.
-func (mr *MockStoreMockRecorder) GetRuleEvaluationByProfileIdAndRuleType(arg0, arg1, arg2, arg3, arg4, arg5 any) *gomock.Call {
+func (mr *MockStoreMockRecorder) GetRuleEvaluationByProfileIdAndRuleType(arg0, arg1, arg2, arg3, arg4 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRuleEvaluationByProfileIdAndRuleType", reflect.TypeOf((*MockStore)(nil).GetRuleEvaluationByProfileIdAndRuleType), arg0, arg1, arg2, arg3, arg4, arg5)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRuleEvaluationByProfileIdAndRuleType", reflect.TypeOf((*MockStore)(nil).GetRuleEvaluationByProfileIdAndRuleType), arg0, arg1, arg2, arg3, arg4)
 }
 
 // GetRuleInstancesEntityInProjects mocks base method.

--- a/database/query/profile_status.sql
+++ b/database/query/profile_status.sql
@@ -17,12 +17,13 @@ WHERE p.project_id = $1;
 -- cast after MIN is required due to a known bug in sqlc: https://github.com/sqlc-dev/sqlc/issues/1965
 
 -- name: ListOldestRuleEvaluationsByRepositoryId :many
-SELECT ere.repository_id::uuid AS repository_id, MIN(es.evaluation_time)::timestamp AS oldest_last_updated
+SELECT ere.entity_instance_id::uuid AS repository_id, MIN(es.evaluation_time)::timestamp AS oldest_last_updated
 FROM evaluation_rule_entities AS ere
     INNER JOIN latest_evaluation_statuses AS les ON ere.id = les.rule_entity_id
     INNER JOIN evaluation_statuses AS es ON les.evaluation_history_id = es.id
-WHERE ere.repository_id = ANY (sqlc.arg('repository_ids')::uuid[])
-GROUP BY ere.repository_id;
+WHERE ere.entity_instance_id = ANY (sqlc.arg('repository_ids')::uuid[])
+AND ere.entity_type = 'repository'
+GROUP BY ere.entity_instance_id;
 
 -- name: ListRuleEvaluationsByProfileId :many
 WITH
@@ -66,23 +67,16 @@ SELECT
     ad.alert_metadata,
     ad.alert_last_updated,
     ed.id AS rule_evaluation_id,
-    ere.repository_id,
     ere.entity_type,
     ri.name AS rule_name,
-    repo.repo_name,
-    repo.repo_owner,
-    repo.provider,
+    prov.name AS provider,
     rt.name AS rule_type_name,
     rt.severity_value as rule_type_severity_value,
     rt.id AS rule_type_id,
     rt.guidance as rule_type_guidance,
     rt.display_name as rule_type_display_name,
-    -- TODO: store entity ID directly in evaluation_rule_entities
-    CASE
-        WHEN ere.entity_type = 'artifact'::entities THEN ere.artifact_id
-        WHEN ere.entity_type = 'repository'::entities THEN ere.repository_id
-        WHEN ere.entity_type = 'pull_request'::entities THEN ere.pull_request_id
-    END::uuid as entity_id,
+    ere.entity_instance_id as entity_id,
+    ei.project_id as project_id,
     rt.release_phase as rule_type_release_phase
 FROM latest_evaluation_statuses les
          INNER JOIN evaluation_rule_entities ere ON ere.id = les.rule_entity_id
@@ -91,16 +85,10 @@ FROM latest_evaluation_statuses les
          INNER JOIN alert_details ad ON ad.evaluation_id = les.evaluation_history_id
          INNER JOIN rule_instances AS ri ON ri.id = ere.rule_id
          INNER JOIN rule_type rt ON rt.id = ri.rule_type_id
-         LEFT JOIN repositories repo ON repo.id = ere.repository_id
+         INNER JOIN entity_instances ei ON ei.id = ere.entity_instance_id
+         INNER JOIN providers prov ON prov.id = ei.provider_id
 WHERE les.profile_id = $1 AND
-    (
-        CASE
-            WHEN sqlc.narg(entity_type)::entities = 'repository' AND ere.repository_id = sqlc.narg(entity_id)::UUID THEN true
-            WHEN sqlc.narg(entity_type)::entities  = 'artifact' AND ere.artifact_id = sqlc.narg(entity_id)::UUID THEN true
-            WHEN sqlc.narg(entity_type)::entities  = 'pull_request' AND ere.pull_request_id = sqlc.narg(entity_id)::UUID THEN true
-            WHEN sqlc.narg(entity_id)::UUID IS NULL THEN true
-            ELSE false
-            END
-        ) AND (rt.name = sqlc.narg(rule_type_name) OR sqlc.narg(rule_type_name) IS NULL)
-          AND (lower(ri.name) = lower(sqlc.narg(rule_name)) OR sqlc.narg(rule_name) IS NULL)
+    (ere.entity_instance_id = sqlc.narg(entity_id)::UUID OR sqlc.narg(entity_id)::UUID IS NULL)
+    AND (rt.name = sqlc.narg(rule_type_name) OR sqlc.narg(rule_type_name) IS NULL)
+    AND (lower(ri.name) = lower(sqlc.narg(rule_name)) OR sqlc.narg(rule_name) IS NULL)
 ;

--- a/database/query/repositories.sql
+++ b/database/query/repositories.sql
@@ -82,12 +82,3 @@ WHERE project_id = $1;
 SELECT repo_owner, repo_name, webhook_id FROM repositories
 WHERE webhook_id IS NOT NULL AND provider_id = $1;
 
--- name: GetRepoPathFromArtifactID :one
-SELECT r.repo_owner AS owner , r.repo_name AS name FROM repositories AS r
-JOIN artifacts AS a ON a.repository_id = r.id
-WHERE a.id = $1;
-
--- name: GetRepoPathFromPullRequestID :one
-SELECT r.repo_owner AS owner , r.repo_name AS name FROM repositories AS r
-JOIN pull_requests AS p ON p.repository_id = r.id
-WHERE p.id = $1;

--- a/internal/controlplane/handlers_evalstatus.go
+++ b/internal/controlplane/handlers_evalstatus.go
@@ -200,7 +200,7 @@ func (s *Server) ListEvaluationHistory(
 }
 
 func fromEvaluationHistoryRows(
-	rows []history.OneEvalHistoryAndEntity,
+	rows []*history.OneEvalHistoryAndEntity,
 ) ([]*minderv1.EvaluationHistory, error) {
 	res := make([]*minderv1.EvaluationHistory, len(rows))
 
@@ -560,7 +560,7 @@ func filterProfileLists(
 func (s *Server) buildRuleEvaluationStatusFromDBEvaluation(
 	ctx context.Context,
 	profile *db.ListProfilesByProjectIDAndLabelRow, eval db.ListRuleEvaluationsByProfileIdRow,
-	efp entmodels.EntityWithProperties,
+	efp *entmodels.EntityWithProperties,
 ) (*minderv1.RuleEvaluationStatus, error) {
 	guidance := ""
 	// Only return the rule type guidance text when there is a problem
@@ -650,7 +650,7 @@ func (s *Server) buildRuleEvaluationStatusFromDBEvaluation(
 	}, nil
 }
 
-func buildEntityFromEvaluation(efp entmodels.EntityWithProperties) *minderv1.EntityTypedId {
+func buildEntityFromEvaluation(efp *entmodels.EntityWithProperties) *minderv1.EntityTypedId {
 	ent := &minderv1.EntityTypedId{
 		Type: efp.Entity.Type,
 	}
@@ -688,7 +688,8 @@ func buildProfileStatus(
 // buildEvalResultAlertFromLRERow build the evaluation result alert from a
 // database row.
 func buildEvalResultAlertFromLRERow(
-	eval *db.ListRuleEvaluationsByProfileIdRow, ent entmodels.EntityWithProperties) *minderv1.EvalResultAlert {
+	eval *db.ListRuleEvaluationsByProfileIdRow, ent *entmodels.EntityWithProperties,
+) *minderv1.EvalResultAlert {
 	era := &minderv1.EvalResultAlert{
 		Status:      string(eval.AlertStatus),
 		LastUpdated: timestamppb.New(eval.AlertLastUpdated),

--- a/internal/controlplane/handlers_evalstatus.go
+++ b/internal/controlplane/handlers_evalstatus.go
@@ -31,10 +31,14 @@ import (
 
 	"github.com/stacklok/minder/internal/db"
 	"github.com/stacklok/minder/internal/engine/engcontext"
+	entmodels "github.com/stacklok/minder/internal/entities/models"
+	"github.com/stacklok/minder/internal/entities/properties"
 	"github.com/stacklok/minder/internal/history"
+	ghprop "github.com/stacklok/minder/internal/providers/github/properties"
 	"github.com/stacklok/minder/internal/ruletypes"
 	"github.com/stacklok/minder/internal/util"
 	minderv1 "github.com/stacklok/minder/pkg/api/protobuf/go/minder/v1"
+	provifv1 "github.com/stacklok/minder/pkg/providers/v1"
 )
 
 const (
@@ -77,25 +81,13 @@ func (s *Server) GetEvaluationHistory(
 		return nil, status.Error(codes.Internal, evalErrMsg)
 	}
 
-	entityName, err := getEntityName(
-		eval.EntityType,
-		eval.RepoOwner,
-		eval.RepoName,
-		eval.PrNumber,
-		eval.ArtifactName,
-	)
-	if err != nil {
-		zerolog.Ctx(ctx).Error().Err(err).Msg(evalErrMsg)
-		return nil, status.Error(codes.Internal, evalErrMsg)
-	}
-
 	pbEval := &minderv1.EvaluationHistory{
 		Id:          eval.EvaluationID.String(),
 		EvaluatedAt: timestamppb.New(eval.EvaluatedAt),
 		Entity: &minderv1.EvaluationHistoryEntity{
 			Id:   eval.EntityID.String(),
 			Type: dbEntityToEntity(eval.EntityType),
-			Name: entityName,
+			Name: eval.EntityName,
 		},
 		Rule: &minderv1.EvaluationHistoryRule{
 			Name:     eval.RuleName,
@@ -208,48 +200,39 @@ func (s *Server) ListEvaluationHistory(
 }
 
 func fromEvaluationHistoryRows(
-	rows []db.ListEvaluationHistoryRow,
+	rows []history.OneEvalHistoryAndEntity,
 ) ([]*minderv1.EvaluationHistory, error) {
 	res := make([]*minderv1.EvaluationHistory, len(rows))
 
 	for i, row := range rows {
-		entityType := dbEntityToEntity(row.EntityType)
-		entityName, err := getEntityName(
-			row.EntityType,
-			row.RepoOwner,
-			row.RepoName,
-			row.PrNumber,
-			row.ArtifactName,
-		)
-		if err != nil {
-			return nil, err
-		}
+		entityType := row.Entity.Type
+		entityName := row.Entity.Name
 
-		ruleSeverity, err := dbSeverityToSeverity(row.RuleSeverity)
+		ruleSeverity, err := dbSeverityToSeverity(row.EvalHistoryRow.RuleSeverity)
 		if err != nil {
 			return nil, err
 		}
 
 		res[i] = &minderv1.EvaluationHistory{
-			Id:          row.EvaluationID.String(),
-			EvaluatedAt: timestamppb.New(row.EvaluatedAt),
+			Id:          row.EvalHistoryRow.EvaluationID.String(),
+			EvaluatedAt: timestamppb.New(row.EvalHistoryRow.EvaluatedAt),
 			Entity: &minderv1.EvaluationHistoryEntity{
-				Id:   row.EntityID.String(),
+				Id:   row.Entity.ID.String(),
 				Type: entityType,
 				Name: entityName,
 			},
 			Rule: &minderv1.EvaluationHistoryRule{
-				Name:     row.RuleName,
-				RuleType: row.RuleType,
+				Name:     row.EvalHistoryRow.RuleName,
+				RuleType: row.EvalHistoryRow.RuleType,
 				Severity: ruleSeverity,
-				Profile:  row.ProfileName,
+				Profile:  row.EvalHistoryRow.ProfileName,
 			},
 			Status: &minderv1.EvaluationHistoryStatus{
-				Status:  string(row.EvaluationStatus),
-				Details: row.EvaluationDetails,
+				Status:  string(row.EvalHistoryRow.EvaluationStatus),
+				Details: row.EvalHistoryRow.EvaluationDetails,
 			},
-			Alert:       getAlert(row.AlertStatus, row.AlertDetails.String),
-			Remediation: getRemediation(row.RemediationStatus, row.RemediationDetails.String),
+			Alert:       getAlert(row.EvalHistoryRow.AlertStatus, row.EvalHistoryRow.AlertDetails.String),
+			Remediation: getRemediation(row.EvalHistoryRow.RemediationStatus, row.EvalHistoryRow.RemediationDetails.String),
 		}
 	}
 
@@ -342,7 +325,7 @@ func (s *Server) ListEvaluationResults(
 	profileList, profileStatusList = filterProfileLists(in, profileList, profileStatusList)
 
 	// Do the final sort of all the data
-	entities, profileStatuses, statusByEntity, err := sortEntitiesEvaluationStatus(
+	entities, profileStatuses, statusByEntity, err := s.sortEntitiesEvaluationStatus(
 		ctx, s.store, profileList, profileStatusList, rtIndex, entIdIndex, entTypeIndex,
 	)
 	if err != nil {
@@ -356,7 +339,9 @@ func (s *Server) ListEvaluationResults(
 // and compiles the unified entities map, the map of profile statuses and the
 // status by entity map that will be assembled into the evaluation status
 // response.
-func sortEntitiesEvaluationStatus(
+//
+//nolint:gocyclo // This function is complex by nature
+func (s *Server) sortEntitiesEvaluationStatus(
 	ctx context.Context, store db.Store,
 	profileList []db.ListProfilesByProjectIDAndLabelRow,
 	profileStatusList map[uuid.UUID]db.GetProfileStatusByProjectRow,
@@ -376,6 +361,10 @@ func sortEntitiesEvaluationStatus(
 			ctx, db.ListRuleEvaluationsByProfileIdParams{ProfileID: p.Profile.ID},
 		)
 		if err != nil {
+			if errors.Is(err, sql.ErrNoRows) {
+				return nil, nil, nil,
+					util.UserVisibleError(codes.NotFound, "profile not found")
+			}
 			return nil, nil, nil,
 				status.Errorf(codes.Internal,
 					"error reading evaluations from profile %q: %v", p.Profile.ID.String(), err)
@@ -387,7 +376,23 @@ func sortEntitiesEvaluationStatus(
 				continue
 			}
 
-			ent := buildEntityFromEvaluation(e)
+			efp, err := s.props.EntityForProperties(ctx, e.EntityID, e.ProjectID, s.providerManager, nil)
+			if err != nil {
+				if errors.Is(err, sql.ErrNoRows) || errors.Is(err, provifv1.ErrEntityNotFound) {
+					// If the entity is not found, log and skip
+					zerolog.Ctx(ctx).Error().
+						Str("entity_id", e.EntityID.String()).
+						Err(err).Msg("Entity not found while building rule evaluation status")
+					continue
+				}
+
+				zerolog.Ctx(ctx).Error().
+					Str("entity_id", e.EntityID.String()).
+					Err(err).Msg("error building entity for rule evaluation status")
+				continue
+			}
+
+			ent := buildEntityFromEvaluation(efp)
 			entString := fmt.Sprintf("%s/%s", ent.Type, ent.Id)
 
 			/// If we're constrained to a single entity type, ignore others
@@ -406,7 +411,7 @@ func sortEntitiesEvaluationStatus(
 				profileStatuses[p.Profile.ID] = buildProfileStatus(&p, profileStatusList)
 			}
 
-			stat, err := buildRuleEvaluationStatusFromDBEvaluation(ctx, &p, e)
+			stat, err := s.buildRuleEvaluationStatusFromDBEvaluation(ctx, &p, e, efp)
 			if err != nil {
 				// A failure parsing the PR metadata points to a corrupt record. Log but don't err.
 				zerolog.Ctx(ctx).Error().Err(err).Msg("error building rule evaluation status")
@@ -552,9 +557,10 @@ func filterProfileLists(
 
 // buildRuleEvaluationStatusFromDBEvaluation converts from an evaluation and a
 // profile from the database to a minder RuleEvaluationStatus
-func buildRuleEvaluationStatusFromDBEvaluation(
+func (s *Server) buildRuleEvaluationStatusFromDBEvaluation(
 	ctx context.Context,
 	profile *db.ListProfilesByProjectIDAndLabelRow, eval db.ListRuleEvaluationsByProfileIdRow,
+	efp *entmodels.EntityForProperties,
 ) (*minderv1.RuleEvaluationStatus, error) {
 	guidance := ""
 	// Only return the rule type guidance text when there is a problem
@@ -574,17 +580,36 @@ func buildRuleEvaluationStatusFromDBEvaluation(
 			Msg("error converting severity will use defaults")
 	}
 
+	err = s.props.RetrieveAllPropertiesForEntity(ctx, efp)
+	if err != nil {
+		return nil, fmt.Errorf("error fetching properties for entity: %w", err)
+	}
+
 	entityInfo := map[string]string{}
+	entityInfo["entity_id"] = eval.EntityID.String()
+
+	if uid := efp.Properties.GetProperty(properties.PropertyUpstreamID); uid != nil {
+		entityInfo["upstream_id"] = uid.GetString()
+	}
+
 	remediationURL := ""
 	if eval.EntityType == db.EntitiesRepository {
 		// If any fields are missing, just leave them empty in the response
-		entityInfo["provider"] = eval.Provider.String
-		entityInfo["repo_owner"] = eval.RepoOwner.String
-		entityInfo["repo_name"] = eval.RepoName.String
-		entityInfo["repository_id"] = eval.RepositoryID.UUID.String()
+		entityInfo["provider"] = eval.Provider
+		// TODO: We'll probably remove these fields in the future as we
+		// introduce more providers
+		if owner := efp.Properties.GetProperty(ghprop.RepoPropertyOwner); owner != nil {
+			entityInfo["repo_owner"] = owner.GetString()
+		}
+		if name := efp.Properties.GetProperty(ghprop.RepoPropertyName); name != nil {
+			entityInfo["repo_name"] = name.GetString()
+		}
+
+		// TODO: This will be removed in favor of entity_id
+		entityInfo["repository_id"] = efp.Entity.ID.String()
 
 		remediationURL, err = getRemediationURLFromMetadata(
-			eval.RemMetadata, fmt.Sprintf("%s/%s", eval.RepoOwner.String, eval.RepoName.String),
+			eval.RemMetadata, efp.Entity.Name,
 		)
 		if err != nil {
 			return nil, fmt.Errorf("parsing remediation pull request data: %w", err)
@@ -619,19 +644,19 @@ func buildRuleEvaluationStatusFromDBEvaluation(
 		RemediationUrl:         remediationURL,
 		RuleDisplayName:        nString,
 		RuleTypeName:           eval.RuleTypeName,
-		Alert:                  buildEvalResultAlertFromLRERow(&eval),
+		Alert:                  buildEvalResultAlertFromLRERow(&eval, efp),
 		Severity:               sev,
 		ReleasePhase:           rp,
 	}, nil
 }
 
-func buildEntityFromEvaluation(eval db.ListRuleEvaluationsByProfileIdRow) *minderv1.EntityTypedId {
+func buildEntityFromEvaluation(efp *entmodels.EntityForProperties) *minderv1.EntityTypedId {
 	ent := &minderv1.EntityTypedId{
-		Type: dbEntityToEntity(eval.EntityType),
+		Type: efp.Entity.Type,
 	}
 
-	if ent.Type == minderv1.Entity_ENTITY_REPOSITORIES && eval.RepoOwner.String != "" && eval.RepoName.String != "" {
-		ent.Id = eval.RepositoryID.UUID.String()
+	if ent.Type == minderv1.Entity_ENTITY_REPOSITORIES {
+		ent.Id = efp.Entity.ID.String()
 	}
 	return ent
 }
@@ -662,7 +687,8 @@ func buildProfileStatus(
 
 // buildEvalResultAlertFromLRERow build the evaluation result alert from a
 // database row.
-func buildEvalResultAlertFromLRERow(eval *db.ListRuleEvaluationsByProfileIdRow) *minderv1.EvalResultAlert {
+func buildEvalResultAlertFromLRERow(
+	eval *db.ListRuleEvaluationsByProfileIdRow, ent *entmodels.EntityForProperties) *minderv1.EvalResultAlert {
 	era := &minderv1.EvalResultAlert{
 		Status:      string(eval.AlertStatus),
 		LastUpdated: timestamppb.New(eval.AlertLastUpdated),
@@ -670,12 +696,8 @@ func buildEvalResultAlertFromLRERow(eval *db.ListRuleEvaluationsByProfileIdRow) 
 	}
 
 	if eval.AlertStatus == db.AlertStatusTypesOn {
-		repoSlug := ""
-		if eval.RepoOwner.String != "" && eval.RepoName.String != "" {
-			repoSlug = fmt.Sprintf("%s/%s", eval.RepoOwner.String, eval.RepoName.String)
-		}
 		urlString, err := getAlertURLFromMetadata(
-			eval.AlertMetadata, repoSlug,
+			eval.AlertMetadata, ent.Entity.Name,
 		)
 		if err == nil {
 			era.Url = urlString
@@ -719,54 +741,4 @@ func dbSeverityToSeverity(dbSev db.Severity) (*minderv1.Severity, error) {
 	}
 
 	return severity, nil
-}
-
-// ugly function signature needed to handle the fact that we have two different
-// row types with the same fields, but no mechanism in the language to treat
-// them as the same thing.
-func getEntityName(
-	entityType db.Entities,
-	repoOwner sql.NullString,
-	repoName sql.NullString,
-	prNumber sql.NullInt64,
-	artifactName sql.NullString,
-) (string, error) {
-	switch entityType {
-	case db.EntitiesPullRequest:
-		if !repoOwner.Valid {
-			return "", errors.New("repo_owner is missing")
-		}
-		if !repoName.Valid {
-			return "", errors.New("repo_name is missing")
-		}
-		if !prNumber.Valid {
-			return "", errors.New("pr_number is missing")
-		}
-		return fmt.Sprintf("%s/%s#%d",
-			repoOwner.String,
-			repoName.String,
-			prNumber.Int64,
-		), nil
-	case db.EntitiesArtifact:
-		if !artifactName.Valid {
-			return "", errors.New("artifact_name is missing")
-		}
-		return artifactName.String, nil
-	case db.EntitiesRepository:
-		if !repoOwner.Valid {
-			return "", errors.New("repo_owner is missing")
-		}
-		if !repoName.Valid {
-			return "", errors.New("repo_name is missing")
-		}
-		return fmt.Sprintf("%s/%s",
-			repoOwner.String,
-			repoName.String,
-		), nil
-	case db.EntitiesBuildEnvironment, db.EntitiesRelease,
-		db.EntitiesPipelineRun, db.EntitiesTaskRun, db.EntitiesBuild:
-		return "", errors.New("invalid entity type")
-	default:
-		return "", errors.New("invalid entity type")
-	}
 }

--- a/internal/controlplane/handlers_evalstatus.go
+++ b/internal/controlplane/handlers_evalstatus.go
@@ -376,7 +376,7 @@ func (s *Server) sortEntitiesEvaluationStatus(
 				continue
 			}
 
-			efp, err := s.props.EntityForProperties(ctx, e.EntityID, e.ProjectID, s.providerManager, nil)
+			efp, err := s.props.EntityWithProperties(ctx, e.EntityID, e.ProjectID, nil)
 			if err != nil {
 				if errors.Is(err, sql.ErrNoRows) || errors.Is(err, provifv1.ErrEntityNotFound) {
 					// If the entity is not found, log and skip
@@ -560,7 +560,7 @@ func filterProfileLists(
 func (s *Server) buildRuleEvaluationStatusFromDBEvaluation(
 	ctx context.Context,
 	profile *db.ListProfilesByProjectIDAndLabelRow, eval db.ListRuleEvaluationsByProfileIdRow,
-	efp *entmodels.EntityForProperties,
+	efp entmodels.EntityWithProperties,
 ) (*minderv1.RuleEvaluationStatus, error) {
 	guidance := ""
 	// Only return the rule type guidance text when there is a problem
@@ -580,7 +580,7 @@ func (s *Server) buildRuleEvaluationStatusFromDBEvaluation(
 			Msg("error converting severity will use defaults")
 	}
 
-	err = s.props.RetrieveAllPropertiesForEntity(ctx, efp)
+	err = s.props.RetrieveAllPropertiesForEntity(ctx, efp, s.providerManager)
 	if err != nil {
 		return nil, fmt.Errorf("error fetching properties for entity: %w", err)
 	}
@@ -650,7 +650,7 @@ func (s *Server) buildRuleEvaluationStatusFromDBEvaluation(
 	}, nil
 }
 
-func buildEntityFromEvaluation(efp *entmodels.EntityForProperties) *minderv1.EntityTypedId {
+func buildEntityFromEvaluation(efp entmodels.EntityWithProperties) *minderv1.EntityTypedId {
 	ent := &minderv1.EntityTypedId{
 		Type: efp.Entity.Type,
 	}
@@ -688,7 +688,7 @@ func buildProfileStatus(
 // buildEvalResultAlertFromLRERow build the evaluation result alert from a
 // database row.
 func buildEvalResultAlertFromLRERow(
-	eval *db.ListRuleEvaluationsByProfileIdRow, ent *entmodels.EntityForProperties) *minderv1.EvalResultAlert {
+	eval *db.ListRuleEvaluationsByProfileIdRow, ent entmodels.EntityWithProperties) *minderv1.EvalResultAlert {
 	era := &minderv1.EvalResultAlert{
 		Status:      string(eval.AlertStatus),
 		LastUpdated: timestamppb.New(eval.AlertLastUpdated),

--- a/internal/controlplane/handlers_evalstatus_test.go
+++ b/internal/controlplane/handlers_evalstatus_test.go
@@ -36,7 +36,7 @@ func TestBuildEvalResultAlertFromLRERow(t *testing.T) {
 	for _, tc := range []struct {
 		name   string
 		sut    *db.ListRuleEvaluationsByProfileIdRow
-		efp    entmodels.EntityWithProperties
+		efp    *entmodels.EntityWithProperties
 		expect *minderv1.EvalResultAlert
 	}{
 		{
@@ -187,17 +187,17 @@ func TestFromEvaluationHistoryRows(t *testing.T) {
 
 	tests := []struct {
 		name   string
-		rows   []history.OneEvalHistoryAndEntity
+		rows   []*history.OneEvalHistoryAndEntity
 		checkf func(*testing.T, db.ListEvaluationHistoryRow, *minderv1.EvaluationHistory)
 		err    bool
 	}{
 		{
 			name: "empty",
-			rows: []history.OneEvalHistoryAndEntity{},
+			rows: []*history.OneEvalHistoryAndEntity{},
 		},
 		{
 			name: "happy path",
-			rows: []history.OneEvalHistoryAndEntity{
+			rows: []*history.OneEvalHistoryAndEntity{
 				{
 					EntityWithProperties: entmodels.NewEntityWithPropertiesFromInstance(
 						entmodels.EntityInstance{
@@ -221,7 +221,7 @@ func TestFromEvaluationHistoryRows(t *testing.T) {
 		},
 		{
 			name: "order preserved",
-			rows: []history.OneEvalHistoryAndEntity{
+			rows: []*history.OneEvalHistoryAndEntity{
 				{
 					EntityWithProperties: entmodels.NewEntityWithPropertiesFromInstance(
 						entmodels.EntityInstance{
@@ -264,7 +264,7 @@ func TestFromEvaluationHistoryRows(t *testing.T) {
 		},
 		{
 			name: "optional alert",
-			rows: []history.OneEvalHistoryAndEntity{
+			rows: []*history.OneEvalHistoryAndEntity{
 				{
 					EntityWithProperties: entmodels.NewEntityWithPropertiesFromInstance(
 						entmodels.EntityInstance{
@@ -290,7 +290,7 @@ func TestFromEvaluationHistoryRows(t *testing.T) {
 		},
 		{
 			name: "optional remediation",
-			rows: []history.OneEvalHistoryAndEntity{
+			rows: []*history.OneEvalHistoryAndEntity{
 				{
 					EntityWithProperties: entmodels.NewEntityWithPropertiesFromInstance(
 						entmodels.EntityInstance{

--- a/internal/controlplane/handlers_evalstatus_test.go
+++ b/internal/controlplane/handlers_evalstatus_test.go
@@ -36,7 +36,7 @@ func TestBuildEvalResultAlertFromLRERow(t *testing.T) {
 	for _, tc := range []struct {
 		name   string
 		sut    *db.ListRuleEvaluationsByProfileIdRow
-		efp    *entmodels.EntityForProperties
+		efp    entmodels.EntityWithProperties
 		expect *minderv1.EvalResultAlert
 	}{
 		{
@@ -47,11 +47,11 @@ func TestBuildEvalResultAlertFromLRERow(t *testing.T) {
 				AlertDetails:     "details go here",
 				AlertMetadata:    []byte(`{"ghsa_id": "GHAS-advisory_ID_here"}`),
 			},
-			efp: entmodels.NewEntityForPropertiesFromInstance(entmodels.EntityInstance{
+			efp: entmodels.NewEntityWithPropertiesFromInstance(entmodels.EntityInstance{
 				ID:   uuid.New(),
 				Type: minderv1.Entity_ENTITY_REPOSITORIES,
 				Name: "example/test",
-			}, nil, nil),
+			}, nil),
 			expect: &minderv1.EvalResultAlert{
 				Status:      string(db.AlertStatusTypesOn),
 				LastUpdated: timestamppb.New(d),
@@ -66,11 +66,11 @@ func TestBuildEvalResultAlertFromLRERow(t *testing.T) {
 				AlertLastUpdated: d,
 				AlertDetails:     "details go here",
 			},
-			efp: entmodels.NewEntityForPropertiesFromInstance(entmodels.EntityInstance{
+			efp: entmodels.NewEntityWithPropertiesFromInstance(entmodels.EntityInstance{
 				ID:   uuid.New(),
 				Type: minderv1.Entity_ENTITY_REPOSITORIES,
 				Name: "example/test",
-			}, nil, nil),
+			}, nil),
 			expect: &minderv1.EvalResultAlert{
 				Status:      string(db.AlertStatusTypesOn),
 				LastUpdated: timestamppb.New(d),
@@ -86,11 +86,11 @@ func TestBuildEvalResultAlertFromLRERow(t *testing.T) {
 				AlertDetails:     "details go here",
 				AlertMetadata:    []byte(`{"ghsa_id": "GHAS-advisory_ID_here"}`),
 			},
-			efp: entmodels.NewEntityForPropertiesFromInstance(entmodels.EntityInstance{
+			efp: entmodels.NewEntityWithPropertiesFromInstance(entmodels.EntityInstance{
 				ID:   uuid.New(),
 				Type: minderv1.Entity_ENTITY_REPOSITORIES,
 				Name: "test",
-			}, nil, nil),
+			}, nil),
 			expect: &minderv1.EvalResultAlert{
 				Status:      string(db.AlertStatusTypesOn),
 				LastUpdated: timestamppb.New(d),

--- a/internal/controlplane/handlers_profile.go
+++ b/internal/controlplane/handlers_profile.go
@@ -280,7 +280,7 @@ func getProfilePBFromDB(
 // probably coming from the properties.
 func getRuleEvalEntityInfo(
 	rs db.ListRuleEvaluationsByProfileIdRow,
-	efp entmodels.EntityWithProperties,
+	efp *entmodels.EntityWithProperties,
 ) map[string]string {
 	entityInfo := map[string]string{}
 

--- a/internal/controlplane/handlers_profile.go
+++ b/internal/controlplane/handlers_profile.go
@@ -31,11 +31,14 @@ import (
 	"github.com/stacklok/minder/internal/db"
 	"github.com/stacklok/minder/internal/engine/engcontext"
 	"github.com/stacklok/minder/internal/engine/entities"
+	entmodels "github.com/stacklok/minder/internal/entities/models"
 	"github.com/stacklok/minder/internal/logger"
 	prof "github.com/stacklok/minder/internal/profiles"
+	ghprop "github.com/stacklok/minder/internal/providers/github/properties"
 	"github.com/stacklok/minder/internal/ruletypes"
 	"github.com/stacklok/minder/internal/util"
 	minderv1 "github.com/stacklok/minder/pkg/api/protobuf/go/minder/v1"
+	provifv1 "github.com/stacklok/minder/pkg/providers/v1"
 )
 
 // CreateProfile creates a profile for a project
@@ -273,41 +276,38 @@ func getProfilePBFromDB(
 	return nil, fmt.Errorf("profile not found")
 }
 
-func (s *Server) getRuleEvalEntityInfo(
-	ctx context.Context,
-	entityType *db.NullEntities,
-	selector *uuid.NullUUID,
+// TODO: We need to replace this with a more generic method that can be used for all entities
+// probably coming from the properties.
+func getRuleEvalEntityInfo(
 	rs db.ListRuleEvaluationsByProfileIdRow,
-	projectID uuid.UUID,
+	efp *entmodels.EntityForProperties,
 ) map[string]string {
-	l := zerolog.Ctx(ctx)
 	entityInfo := map[string]string{}
 
-	if rs.RepositoryID.Valid {
-		// this is always true now but might not be when we support entities not tied to a repo
-		entityInfo["repo_name"] = rs.RepoName.String
-		entityInfo["repo_owner"] = rs.RepoOwner.String
-		entityInfo["provider"] = rs.Provider.String
-		entityInfo["repository_id"] = rs.RepositoryID.UUID.String()
+	if owner := efp.Properties.GetProperty(ghprop.RepoPropertyOwner); owner != nil {
+		entityInfo["repo_owner"] = owner.GetString()
+	}
+	if name := efp.Properties.GetProperty(ghprop.RepoPropertyName); name != nil {
+		entityInfo["repo_name"] = name.GetString()
 	}
 
-	if !selector.Valid || !entityType.Valid {
-		return entityInfo
+	if artName := efp.Properties.GetProperty(ghprop.ArtifactPropertyName); artName != nil {
+		entityInfo["artifact_name"] = artName.GetString()
 	}
 
-	if entityType.Entities == db.EntitiesArtifact {
-		artifact, err := s.store.GetArtifactByID(ctx, db.GetArtifactByIDParams{
-			ID:        selector.UUID,
-			ProjectID: projectID,
-		})
-		if err != nil {
-			l.Err(err).Msg("error getting artifact by ID")
-			return entityInfo
-		}
-		entityInfo["artifact_id"] = artifact.ID.String()
-		entityInfo["artifact_name"] = artifact.ArtifactName
-		entityInfo["artifact_type"] = artifact.ArtifactType
-		entityInfo["provider"] = artifact.ProviderName
+	if artType := efp.Properties.GetProperty(ghprop.ArtifactPropertyType); artType != nil {
+		entityInfo["artifact_type"] = artType.GetString()
+	}
+
+	entityInfo["provider"] = rs.Provider
+	entityInfo["entity_type"] = efp.Entity.Type.ToString()
+	entityInfo["entity_id"] = rs.EntityID.String()
+
+	// temporary: These will be replaced by entity_id
+	if rs.EntityType == db.EntitiesRepository {
+		entityInfo["repository_id"] = efp.Entity.ID.String()
+	} else if rs.EntityType == db.EntitiesArtifact {
+		entityInfo["artifact_id"] = efp.Entity.ID.String()
 	}
 
 	return entityInfo
@@ -319,7 +319,6 @@ func (s *Server) GetProfileStatusByName(ctx context.Context,
 	in *minderv1.GetProfileStatusByNameRequest) (*minderv1.GetProfileStatusByNameResponse, error) {
 
 	entityCtx := engcontext.EntityFromContext(ctx)
-	projectID := entityCtx.Project.ID
 
 	err := entityCtx.ValidateProject(ctx, s.store)
 	if err != nil {
@@ -339,13 +338,11 @@ func (s *Server) GetProfileStatusByName(ctx context.Context,
 
 	var ruleEvaluationStatuses []*minderv1.RuleEvaluationStatus
 	var selector *uuid.NullUUID
-	var dbEntity *db.NullEntities
 	var ruleType *sql.NullString
 	var ruleName *sql.NullString
 
 	if in.GetAll() {
 		selector = &uuid.NullUUID{}
-		dbEntity = &db.NullEntities{}
 	} else if e := in.GetEntity(); e != nil {
 		if !e.GetType().IsValid() {
 			return nil, util.UserVisibleError(codes.InvalidArgument,
@@ -356,7 +353,6 @@ func (s *Server) GetProfileStatusByName(ctx context.Context,
 		if err := selector.Scan(e.GetId()); err != nil {
 			return nil, util.UserVisibleError(codes.InvalidArgument, "invalid entity ID in selector")
 		}
-		dbEntity = &db.NullEntities{Entities: entities.EntityTypeToDB(e.GetType()), Valid: true}
 	}
 
 	ruleType = &sql.NullString{
@@ -383,7 +379,6 @@ func (s *Server) GetProfileStatusByName(ctx context.Context,
 		dbRuleEvaluationStatuses, err := s.store.ListRuleEvaluationsByProfileId(ctx, db.ListRuleEvaluationsByProfileIdParams{
 			ProfileID:    dbProfileStatus.ID,
 			EntityID:     *selector,
-			EntityType:   *dbEntity,
 			RuleTypeName: *ruleType,
 			RuleName:     *ruleName,
 		})
@@ -391,11 +386,9 @@ func (s *Server) GetProfileStatusByName(ctx context.Context,
 			return nil, status.Errorf(codes.Unknown, "failed to list rule evaluation status: %s", err)
 		}
 
-		ruleEvaluationStatuses = s.
-			getRuleEvaluationStatuses(
-				ctx, dbRuleEvaluationStatuses, dbProfileStatus.ID.String(),
-				dbEntity, selector, projectID,
-			)
+		ruleEvaluationStatuses = s.getRuleEvaluationStatuses(
+			ctx, dbRuleEvaluationStatuses, dbProfileStatus.ID.String(),
+		)
 		// TODO: Add other entities once we have database entries for them
 	}
 
@@ -418,9 +411,6 @@ func (s *Server) getRuleEvaluationStatuses(
 	ctx context.Context,
 	dbRuleEvaluationStatuses []db.ListRuleEvaluationsByProfileIdRow,
 	profileId string,
-	dbEntity *db.NullEntities,
-	selector *uuid.NullUUID,
-	projectID uuid.UUID,
 ) []*minderv1.RuleEvaluationStatus {
 	ruleEvaluationStatuses := make(
 		[]*minderv1.RuleEvaluationStatus, 0, len(dbRuleEvaluationStatuses),
@@ -428,7 +418,24 @@ func (s *Server) getRuleEvaluationStatuses(
 	// Loop through the rule evaluation statuses and convert them to protobuf
 	for _, dbRuleEvalStat := range dbRuleEvaluationStatuses {
 		// Get the rule evaluation status
-		st := s.getRuleEvalStatus(ctx, profileId, dbEntity, selector, dbRuleEvalStat, projectID)
+		st, err := s.getRuleEvalStatus(ctx, profileId, dbRuleEvalStat)
+		if err != nil {
+			if errors.Is(err, sql.ErrNoRows) || errors.Is(err, provifv1.ErrEntityNotFound) {
+				zerolog.Ctx(ctx).Error().
+					Str("profile_id", profileId).
+					Str("rule_id", dbRuleEvalStat.RuleTypeID.String()).
+					Str("entity_id", dbRuleEvalStat.EntityID.String()).
+					Err(err).Msg("entity not found. error getting rule evaluation status")
+				continue
+			}
+
+			zerolog.Ctx(ctx).Error().
+				Str("profile_id", profileId).
+				Str("rule_id", dbRuleEvalStat.RuleTypeID.String()).
+				Str("entity_id", dbRuleEvalStat.EntityID.String()).
+				Err(err).Msg("error getting rule evaluation status")
+			continue
+		}
 		// Append the rule evaluation status to the list
 		ruleEvaluationStatuses = append(ruleEvaluationStatuses, st)
 	}
@@ -441,14 +448,22 @@ func (s *Server) getRuleEvaluationStatuses(
 func (s *Server) getRuleEvalStatus(
 	ctx context.Context,
 	profileID string,
-	dbEntity *db.NullEntities,
-	selector *uuid.NullUUID,
 	dbRuleEvalStat db.ListRuleEvaluationsByProfileIdRow,
-	projectID uuid.UUID,
-) *minderv1.RuleEvaluationStatus {
+) (*minderv1.RuleEvaluationStatus, error) {
 	l := zerolog.Ctx(ctx)
 	var guidance string
 	var err error
+
+	efp, err := s.props.EntityForProperties(
+		ctx, dbRuleEvalStat.EntityID, dbRuleEvalStat.ProjectID, s.providerManager, nil)
+	if err != nil {
+		return nil, fmt.Errorf("error fetching entity for properties: %w", err)
+	}
+
+	err = s.props.RetrieveAllPropertiesForEntity(ctx, efp)
+	if err != nil {
+		return nil, fmt.Errorf("error fetching properties for entity: %w", err)
+	}
 
 	if dbRuleEvalStat.EvalStatus == db.EvalStatusTypesFailure ||
 		dbRuleEvalStat.EvalStatus == db.EvalStatusTypesError {
@@ -463,7 +478,7 @@ func (s *Server) getRuleEvalStatus(
 	if dbRuleEvalStat.EntityType == db.EntitiesRepository {
 		remediationURL, err = getRemediationURLFromMetadata(
 			dbRuleEvalStat.RemMetadata,
-			fmt.Sprintf("%s/%s", dbRuleEvalStat.RepoOwner.String, dbRuleEvalStat.RepoName.String),
+			efp.Entity.Name,
 		)
 		if err != nil {
 			// A failure parsing the alert metadata points to a corrupt record. Log but don't err.
@@ -486,7 +501,7 @@ func (s *Server) getRuleEvalStatus(
 		Entity:              string(dbRuleEvalStat.EntityType),
 		Status:              string(dbRuleEvalStat.EvalStatus),
 		Details:             dbRuleEvalStat.EvalDetails,
-		EntityInfo:          s.getRuleEvalEntityInfo(ctx, dbEntity, selector, dbRuleEvalStat, projectID),
+		EntityInfo:          getRuleEvalEntityInfo(dbRuleEvalStat, efp),
 		Guidance:            guidance,
 		LastUpdated:         timestamppb.New(dbRuleEvalStat.EvalLastUpdated),
 		RemediationStatus:   string(dbRuleEvalStat.RemStatus),
@@ -513,19 +528,17 @@ func (s *Server) getRuleEvalStatus(
 		if dbRuleEvalStat.EntityType == db.EntitiesRepository {
 			repoPath = fmt.Sprintf("%s/%s", st.EntityInfo["repo_owner"], st.EntityInfo["repo_name"])
 		} else if dbRuleEvalStat.EntityType == db.EntitiesArtifact {
-			repoDetails, err := s.store.GetRepoPathFromArtifactID(ctx, dbRuleEvalStat.EntityID)
-			if err != nil {
-				l.Err(err).Msg("error getting repo details from db")
-				return st
+			artRepoOwner := efp.Properties.GetProperty(ghprop.ArtifactPropertyRepoOwner).GetString()
+			artRepoName := efp.Properties.GetProperty(ghprop.ArtifactPropertyRepoName).GetString()
+			if artRepoOwner != "" && artRepoName != "" {
+				repoPath = fmt.Sprintf("%s/%s", artRepoOwner, artRepoName)
 			}
-			repoPath = fmt.Sprintf("%s/%s", repoDetails.Owner, repoDetails.Name)
 		} else if dbRuleEvalStat.EntityType == db.EntitiesPullRequest {
-			repoDetails, err := s.store.GetRepoPathFromPullRequestID(ctx, dbRuleEvalStat.EntityID)
-			if err != nil {
-				l.Err(err).Msg("error getting repo details from db")
-				return st
+			prRepoOwner := efp.Properties.GetProperty(ghprop.PullPropertyRepoOwner).GetString()
+			prRepoName := efp.Properties.GetProperty(ghprop.PullPropertyRepoName).GetString()
+			if prRepoOwner != "" && prRepoName != "" {
+				repoPath = fmt.Sprintf("%s/%s", prRepoOwner, prRepoName)
 			}
-			repoPath = fmt.Sprintf("%s/%s", repoDetails.Owner, repoDetails.Name)
 		}
 		alertURL, err := getAlertURLFromMetadata(
 			dbRuleEvalStat.AlertMetadata,
@@ -537,7 +550,7 @@ func (s *Server) getRuleEvalStatus(
 			st.Alert.Url = alertURL
 		}
 	}
-	return st
+	return st, nil
 }
 
 // GetProfileStatusByProject is a method to get profile status for a project

--- a/internal/controlplane/handlers_profile.go
+++ b/internal/controlplane/handlers_profile.go
@@ -280,7 +280,7 @@ func getProfilePBFromDB(
 // probably coming from the properties.
 func getRuleEvalEntityInfo(
 	rs db.ListRuleEvaluationsByProfileIdRow,
-	efp *entmodels.EntityForProperties,
+	efp entmodels.EntityWithProperties,
 ) map[string]string {
 	entityInfo := map[string]string{}
 
@@ -454,13 +454,13 @@ func (s *Server) getRuleEvalStatus(
 	var guidance string
 	var err error
 
-	efp, err := s.props.EntityForProperties(
-		ctx, dbRuleEvalStat.EntityID, dbRuleEvalStat.ProjectID, s.providerManager, nil)
+	efp, err := s.props.EntityWithProperties(
+		ctx, dbRuleEvalStat.EntityID, dbRuleEvalStat.ProjectID, nil)
 	if err != nil {
 		return nil, fmt.Errorf("error fetching entity for properties: %w", err)
 	}
 
-	err = s.props.RetrieveAllPropertiesForEntity(ctx, efp)
+	err = s.props.RetrieveAllPropertiesForEntity(ctx, efp, s.providerManager)
 	if err != nil {
 		return nil, fmt.Errorf("error fetching properties for entity: %w", err)
 	}

--- a/internal/db/eval_history_test.go
+++ b/internal/db/eval_history_test.go
@@ -70,8 +70,6 @@ func TestListEvaluationHistoryFilters(t *testing.T) {
 				require.Equal(t, es1, row.EvaluationID)
 				require.Equal(t, EntitiesRepository, row.EntityType)
 				require.Equal(t, repo1.ID, row.EntityID)
-				require.Equal(t, repo1.RepoOwner, row.RepoOwner.String)
-				require.Equal(t, repo1.RepoName, row.RepoName.String)
 			},
 		},
 
@@ -94,8 +92,6 @@ func TestListEvaluationHistoryFilters(t *testing.T) {
 				require.Equal(t, es1, row.EvaluationID)
 				require.Equal(t, EntitiesRepository, row.EntityType)
 				require.Equal(t, repo1.ID, row.EntityID)
-				require.Equal(t, repo1.RepoOwner, row.RepoOwner.String)
-				require.Equal(t, repo1.RepoName, row.RepoName.String)
 			},
 		},
 		{
@@ -148,8 +144,6 @@ func TestListEvaluationHistoryFilters(t *testing.T) {
 				require.Equal(t, es1, row.EvaluationID)
 				require.Equal(t, EntitiesRepository, row.EntityType)
 				require.Equal(t, repo1.ID, row.EntityID)
-				require.Equal(t, repo1.RepoOwner, row.RepoOwner.String)
-				require.Equal(t, repo1.RepoName, row.RepoName.String)
 			},
 		},
 		{
@@ -170,8 +164,6 @@ func TestListEvaluationHistoryFilters(t *testing.T) {
 				require.Equal(t, es1, row.EvaluationID)
 				require.Equal(t, EntitiesRepository, row.EntityType)
 				require.Equal(t, repo1.ID, row.EntityID)
-				require.Equal(t, repo1.RepoOwner, row.RepoOwner.String)
-				require.Equal(t, repo1.RepoName, row.RepoName.String)
 			},
 		},
 		{
@@ -210,8 +202,6 @@ func TestListEvaluationHistoryFilters(t *testing.T) {
 				require.Equal(t, es1, row.EvaluationID)
 				require.Equal(t, EntitiesRepository, row.EntityType)
 				require.Equal(t, repo1.ID, row.EntityID)
-				require.Equal(t, repo1.RepoOwner, row.RepoOwner.String)
-				require.Equal(t, repo1.RepoName, row.RepoName.String)
 			},
 		},
 		{
@@ -264,8 +254,6 @@ func TestListEvaluationHistoryFilters(t *testing.T) {
 				require.Equal(t, es1, row.EvaluationID)
 				require.Equal(t, EntitiesRepository, row.EntityType)
 				require.Equal(t, repo1.ID, row.EntityID)
-				require.Equal(t, repo1.RepoOwner, row.RepoOwner.String)
-				require.Equal(t, repo1.RepoName, row.RepoName.String)
 			},
 		},
 		{
@@ -286,8 +274,6 @@ func TestListEvaluationHistoryFilters(t *testing.T) {
 				require.Equal(t, es1, row.EvaluationID)
 				require.Equal(t, EntitiesRepository, row.EntityType)
 				require.Equal(t, repo1.ID, row.EntityID)
-				require.Equal(t, repo1.RepoOwner, row.RepoOwner.String)
-				require.Equal(t, repo1.RepoName, row.RepoName.String)
 			},
 		},
 		{
@@ -326,8 +312,6 @@ func TestListEvaluationHistoryFilters(t *testing.T) {
 				require.Equal(t, es1, row.EvaluationID)
 				require.Equal(t, EntitiesRepository, row.EntityType)
 				require.Equal(t, repo1.ID, row.EntityID)
-				require.Equal(t, repo1.RepoOwner, row.RepoOwner.String)
-				require.Equal(t, repo1.RepoName, row.RepoName.String)
 			},
 		},
 		{
@@ -380,8 +364,6 @@ func TestListEvaluationHistoryFilters(t *testing.T) {
 				require.Equal(t, es1, row.EvaluationID)
 				require.Equal(t, EntitiesRepository, row.EntityType)
 				require.Equal(t, repo1.ID, row.EntityID)
-				require.Equal(t, repo1.RepoOwner, row.RepoOwner.String)
-				require.Equal(t, repo1.RepoName, row.RepoName.String)
 			},
 		},
 		{
@@ -402,8 +384,6 @@ func TestListEvaluationHistoryFilters(t *testing.T) {
 				require.Equal(t, es1, row.EvaluationID)
 				require.Equal(t, EntitiesRepository, row.EntityType)
 				require.Equal(t, repo1.ID, row.EntityID)
-				require.Equal(t, repo1.RepoOwner, row.RepoOwner.String)
-				require.Equal(t, repo1.RepoName, row.RepoName.String)
 			},
 		},
 		{
@@ -464,8 +444,6 @@ func TestListEvaluationHistoryFilters(t *testing.T) {
 				require.Equal(t, es1, row.EvaluationID)
 				require.Equal(t, EntitiesRepository, row.EntityType)
 				require.Equal(t, repo1.ID, row.EntityID)
-				require.Equal(t, repo1.RepoOwner, row.RepoOwner.String)
-				require.Equal(t, repo1.RepoName, row.RepoName.String)
 			},
 		},
 		{
@@ -489,8 +467,6 @@ func TestListEvaluationHistoryFilters(t *testing.T) {
 				require.Equal(t, es1, row.EvaluationID)
 				require.Equal(t, EntitiesRepository, row.EntityType)
 				require.Equal(t, repo1.ID, row.EntityID)
-				require.Equal(t, repo1.RepoOwner, row.RepoOwner.String)
-				require.Equal(t, repo1.RepoName, row.RepoName.String)
 			},
 		},
 		{
@@ -601,8 +577,6 @@ func TestListEvaluationHistoryPagination(t *testing.T) {
 				require.Equal(t, ess[9], row.EvaluationID)
 				require.Equal(t, EntitiesRepository, row.EntityType)
 				require.Equal(t, repos[9].ID, row.EntityID)
-				require.Equal(t, repos[9].RepoOwner, row.RepoOwner.String)
-				require.Equal(t, repos[9].RepoName, row.RepoName.String)
 			},
 		},
 		{
@@ -646,8 +620,6 @@ func TestListEvaluationHistoryPagination(t *testing.T) {
 				require.Equal(t, ess[0], row.EvaluationID)
 				require.Equal(t, EntitiesRepository, row.EntityType)
 				require.Equal(t, repos[0].ID, row.EntityID)
-				require.Equal(t, repos[0].RepoOwner, row.RepoOwner.String)
-				require.Equal(t, repos[0].RepoName, row.RepoName.String)
 			},
 		},
 		{
@@ -713,11 +685,7 @@ func createRandomEvaluationRuleEntity(
 	ereID, err := testQueries.InsertEvaluationRuleEntity(
 		context.Background(),
 		InsertEvaluationRuleEntityParams{
-			RuleID: ruleID,
-			RepositoryID: uuid.NullUUID{
-				UUID:  entityID,
-				Valid: true,
-			},
+			RuleID:           ruleID,
 			EntityType:       EntitiesRepository,
 			EntityInstanceID: entityID,
 		},

--- a/internal/db/profiles_test.go
+++ b/internal/db/profiles_test.go
@@ -158,13 +158,7 @@ func createRuleEntity(
 
 	id, err := testQueries.InsertEvaluationRuleEntity(ctx,
 		InsertEvaluationRuleEntityParams{
-			RuleID: ruleID,
-			RepositoryID: uuid.NullUUID{
-				UUID:  repoID,
-				Valid: true,
-			},
-			PullRequestID:    uuid.NullUUID{},
-			ArtifactID:       uuid.NullUUID{},
+			RuleID:           ruleID,
 			EntityType:       EntitiesRepository,
 			EntityInstanceID: repoID,
 		},
@@ -3427,7 +3421,15 @@ func TestCreateProfileStatusStoredDeleteProcedure(t *testing.T) {
 			},
 			expectedStatusAfterSetup: EvalStatusTypesFailure,
 			ruleStatusDeleteFn: func(delRepo *Repository) {
+				// TODO: This will be removed once we fully move
+				// to using the entity_instances table.
 				err := testQueries.DeleteRepository(context.Background(), delRepo.ID)
+				require.NoError(t, err)
+
+				err = testQueries.DeleteEntity(context.Background(), DeleteEntityParams{
+					ID:        delRepo.ID,
+					ProjectID: delRepo.ProjectID,
+				})
 				require.NoError(t, err)
 			},
 			expectedStatusAfterModify: EvalStatusTypesSuccess,
@@ -3477,7 +3479,15 @@ func TestCreateProfileStatusStoredDeleteProcedure(t *testing.T) {
 
 			expectedStatusAfterSetup: EvalStatusTypesError,
 			ruleStatusDeleteFn: func(delRepo *Repository) {
+				// TODO: This will be removed once we fully move
+				// to using the entity_instances table.
 				err := testQueries.DeleteRepository(context.Background(), delRepo.ID)
+				require.NoError(t, err)
+
+				err = testQueries.DeleteEntity(context.Background(), DeleteEntityParams{
+					ID:        delRepo.ID,
+					ProjectID: delRepo.ProjectID,
+				})
 				require.NoError(t, err)
 			},
 			expectedStatusAfterModify: EvalStatusTypesFailure,
@@ -3527,7 +3537,15 @@ func TestCreateProfileStatusStoredDeleteProcedure(t *testing.T) {
 
 			expectedStatusAfterSetup: EvalStatusTypesError,
 			ruleStatusDeleteFn: func(delRepo *Repository) {
+				// TODO: This will be removed once we fully move
+				// to using the entity_instances table.
 				err := testQueries.DeleteRepository(context.Background(), delRepo.ID)
+				require.NoError(t, err)
+
+				err = testQueries.DeleteEntity(context.Background(), DeleteEntityParams{
+					ID:        delRepo.ID,
+					ProjectID: delRepo.ProjectID,
+				})
 				require.NoError(t, err)
 			},
 			expectedStatusAfterModify: EvalStatusTypesError,
@@ -3558,7 +3576,15 @@ func TestCreateProfileStatusStoredDeleteProcedure(t *testing.T) {
 
 			expectedStatusAfterSetup: EvalStatusTypesFailure,
 			ruleStatusDeleteFn: func(delRepo *Repository) {
+				// TODO: This will be removed once we fully move
+				// to using the entity_instances table.
 				err := testQueries.DeleteRepository(context.Background(), delRepo.ID)
+				require.NoError(t, err)
+
+				err = testQueries.DeleteEntity(context.Background(), DeleteEntityParams{
+					ID:        delRepo.ID,
+					ProjectID: delRepo.ProjectID,
+				})
 				require.NoError(t, err)
 			},
 			expectedStatusAfterModify: EvalStatusTypesSkipped,
@@ -3640,7 +3666,6 @@ func verifyRow(
 	expectedRow *ListRuleEvaluationsByProfileIdRow,
 	fetchedRows []ListRuleEvaluationsByProfileIdRow,
 	rt RuleType,
-	randomEntities *testRandomEntities,
 ) {
 	t.Helper()
 
@@ -3652,11 +3677,6 @@ func verifyRow(
 
 	require.Equal(t, rt.ID, row.RuleTypeID)
 	require.Equal(t, rt.Name, row.RuleTypeName)
-
-	require.Equal(t, randomEntities.repo.RepoName, row.RepoName.String)
-	require.Equal(t, randomEntities.repo.RepoOwner, row.RepoOwner.String)
-
-	require.Equal(t, randomEntities.prov.Name, row.Provider.String)
 }
 
 func TestListRuleEvaluations(t *testing.T) {
@@ -3864,8 +3884,8 @@ func TestListRuleEvaluations(t *testing.T) {
 			require.Len(t, evalStatusRows, tt.totalRows)
 			require.Equal(t, getStatusCount(t, evalStatusRows), tt.sc)
 
-			verifyRow(t, tt.rule1Expected, evalStatusRows, randomEntities.ruleType1, randomEntities)
-			verifyRow(t, tt.rule2Expected, evalStatusRows, randomEntities.ruleType2, randomEntities)
+			verifyRow(t, tt.rule1Expected, evalStatusRows, randomEntities.ruleType1)
+			verifyRow(t, tt.rule2Expected, evalStatusRows, randomEntities.ruleType2)
 		})
 	}
 }

--- a/internal/db/querier.go
+++ b/internal/db/querier.go
@@ -158,8 +158,6 @@ type Querier interface {
 	GetProviderWebhooks(ctx context.Context, providerID uuid.UUID) ([]GetProviderWebhooksRow, error)
 	GetPullRequest(ctx context.Context, arg GetPullRequestParams) (PullRequest, error)
 	GetPullRequestByID(ctx context.Context, id uuid.UUID) (PullRequest, error)
-	GetRepoPathFromArtifactID(ctx context.Context, id uuid.UUID) (GetRepoPathFromArtifactIDRow, error)
-	GetRepoPathFromPullRequestID(ctx context.Context, id uuid.UUID) (GetRepoPathFromPullRequestIDRow, error)
 	// avoid using this, where possible use GetRepositoryByIDAndProject instead
 	GetRepositoryByID(ctx context.Context, id uuid.UUID) (Repository, error)
 	GetRepositoryByIDAndProject(ctx context.Context, arg GetRepositoryByIDAndProjectParams) (Repository, error)

--- a/internal/db/repositories.sql.go
+++ b/internal/db/repositories.sql.go
@@ -160,42 +160,6 @@ func (q *Queries) GetProviderWebhooks(ctx context.Context, providerID uuid.UUID)
 	return items, nil
 }
 
-const getRepoPathFromArtifactID = `-- name: GetRepoPathFromArtifactID :one
-SELECT r.repo_owner AS owner , r.repo_name AS name FROM repositories AS r
-JOIN artifacts AS a ON a.repository_id = r.id
-WHERE a.id = $1
-`
-
-type GetRepoPathFromArtifactIDRow struct {
-	Owner string `json:"owner"`
-	Name  string `json:"name"`
-}
-
-func (q *Queries) GetRepoPathFromArtifactID(ctx context.Context, id uuid.UUID) (GetRepoPathFromArtifactIDRow, error) {
-	row := q.db.QueryRowContext(ctx, getRepoPathFromArtifactID, id)
-	var i GetRepoPathFromArtifactIDRow
-	err := row.Scan(&i.Owner, &i.Name)
-	return i, err
-}
-
-const getRepoPathFromPullRequestID = `-- name: GetRepoPathFromPullRequestID :one
-SELECT r.repo_owner AS owner , r.repo_name AS name FROM repositories AS r
-JOIN pull_requests AS p ON p.repository_id = r.id
-WHERE p.id = $1
-`
-
-type GetRepoPathFromPullRequestIDRow struct {
-	Owner string `json:"owner"`
-	Name  string `json:"name"`
-}
-
-func (q *Queries) GetRepoPathFromPullRequestID(ctx context.Context, id uuid.UUID) (GetRepoPathFromPullRequestIDRow, error) {
-	row := q.db.QueryRowContext(ctx, getRepoPathFromPullRequestID, id)
-	var i GetRepoPathFromPullRequestIDRow
-	err := row.Scan(&i.Owner, &i.Name)
-	return i, err
-}
-
 const getRepositoryByID = `-- name: GetRepositoryByID :one
 SELECT id, provider, project_id, repo_owner, repo_name, repo_id, is_private, is_fork, webhook_id, webhook_url, deploy_url, clone_url, created_at, updated_at, default_branch, license, provider_id, reminder_last_sent FROM repositories WHERE id = $1
 `

--- a/internal/db/repositories_test.go
+++ b/internal/db/repositories_test.go
@@ -18,6 +18,7 @@ package db
 import (
 	"context"
 	"database/sql"
+	"fmt"
 	"testing"
 	"time"
 
@@ -69,7 +70,7 @@ func createRandomRepository(t *testing.T, project uuid.UUID, prov Provider, opts
 
 	ei, err := testQueries.CreateEntityWithID(context.Background(), CreateEntityWithIDParams{
 		ID:         repo.ID,
-		Name:       arg.RepoName,
+		Name:       fmt.Sprintf("%s/%s", arg.RepoOwner, arg.RepoName),
 		ProjectID:  project,
 		ProviderID: prov.ID,
 		EntityType: EntitiesRepository,

--- a/internal/db/store.go
+++ b/internal/db/store.go
@@ -26,7 +26,7 @@ import (
 // ExtendQuerier extends the Querier interface with custom queries
 type ExtendQuerier interface {
 	Querier
-	GetRuleEvaluationByProfileIdAndRuleType(ctx context.Context, profileID uuid.UUID, entityType NullEntities,
+	GetRuleEvaluationByProfileIdAndRuleType(ctx context.Context, profileID uuid.UUID,
 		ruleName sql.NullString, entityID uuid.NullUUID, ruleTypeName sql.NullString) (*ListRuleEvaluationsByProfileIdRow, error)
 	UpsertPropertyValueV1(ctx context.Context, params UpsertPropertyValueV1Params) (Property, error)
 	GetPropertyValueV1(ctx context.Context, entityID uuid.UUID, key string) (PropertyValueV1, error)
@@ -112,14 +112,12 @@ func NewStore(db *sql.DB) Store {
 func (q *Queries) GetRuleEvaluationByProfileIdAndRuleType(
 	ctx context.Context,
 	profileID uuid.UUID,
-	entityType NullEntities,
 	ruleName sql.NullString,
 	entityID uuid.NullUUID,
 	ruleTypeName sql.NullString,
 ) (*ListRuleEvaluationsByProfileIdRow, error) {
 	params := ListRuleEvaluationsByProfileIdParams{
 		ProfileID:    profileID,
-		EntityType:   entityType,
 		EntityID:     entityID,
 		RuleName:     ruleName,
 		RuleTypeName: ruleTypeName,

--- a/internal/engine/eval_status.go
+++ b/internal/engine/eval_status.go
@@ -56,11 +56,6 @@ func (e *executor) createEvalStatusParams(
 		ExecutionID:   *inf.ExecutionID, // Execution ID is required in the executor.
 	}
 
-	// Prepare params for fetching the current rule evaluation from the database
-	entityType := db.NullEntities{
-		Entities: params.EntityType,
-		Valid:    true,
-	}
 	entityID := uuid.NullUUID{}
 	switch params.EntityType {
 	case db.EntitiesArtifact:
@@ -94,7 +89,6 @@ func (e *executor) createEvalStatusParams(
 	// Get the current rule evaluation from the database
 	evalStatus, err := e.querier.GetRuleEvaluationByProfileIdAndRuleType(ctx,
 		params.Profile.ID,
-		entityType,
 		ruleName,
 		entityID,
 		nullableRuleTypeName,

--- a/internal/engine/executor_test.go
+++ b/internal/engine/executor_test.go
@@ -107,7 +107,6 @@ func TestExecutor_handleEntityEvent(t *testing.T) {
 		gomock.Any(),
 		gomock.Any(),
 		gomock.Any(),
-		gomock.Any(),
 	).Return(nil, nil)
 
 	mockStore.EXPECT().

--- a/internal/entities/models/models.go
+++ b/internal/entities/models/models.go
@@ -22,6 +22,7 @@ import (
 	"github.com/stacklok/minder/internal/engine/entities"
 	"github.com/stacklok/minder/internal/entities/properties"
 	minderv1 "github.com/stacklok/minder/pkg/api/protobuf/go/minder/v1"
+	provifv1 "github.com/stacklok/minder/pkg/providers/v1"
 )
 
 // EntityInstance represents an entity instance
@@ -51,4 +52,47 @@ func NewEntityWithProperties(dbEntity db.EntityInstance, props *properties.Prope
 		},
 		Properties: props,
 	}
+}
+
+// NewEntityWithPropertiesFromInstance creates a new EntityWithProperties instance from an existing entity instance
+func NewEntityWithPropertiesFromInstance(entity EntityInstance, props *properties.Properties) EntityWithProperties {
+	return EntityWithProperties{
+		Entity:     entity,
+		Properties: props,
+	}
+}
+
+// EntityForProperties gives us the necessary fields to fetch properties
+type EntityForProperties struct {
+	*EntityWithProperties
+
+	// Provider is the provider for the entity
+	Provider provifv1.Provider
+}
+
+// NewEntityForProperties creates a new EntityForProperties instance
+func NewEntityForProperties(
+	dbEntity db.EntityInstance, props *properties.Properties, provider provifv1.Provider,
+) *EntityForProperties {
+	ewp := NewEntityWithProperties(dbEntity, props)
+	return &EntityForProperties{
+		EntityWithProperties: &ewp,
+		Provider:             provider,
+	}
+}
+
+// NewEntityForPropertiesFromInstance creates a new EntityForProperties instance from an existing entity instance
+func NewEntityForPropertiesFromInstance(
+	entity EntityInstance, props *properties.Properties, provider provifv1.Provider,
+) *EntityForProperties {
+	ewp := NewEntityWithPropertiesFromInstance(entity, props)
+	return &EntityForProperties{
+		EntityWithProperties: &ewp,
+		Provider:             provider,
+	}
+}
+
+// UpdateProperties updates the properties for the "entity for properties" instance
+func (e *EntityForProperties) UpdateProperties(props *properties.Properties) {
+	e.Properties = props
 }

--- a/internal/entities/models/models.go
+++ b/internal/entities/models/models.go
@@ -22,7 +22,6 @@ import (
 	"github.com/stacklok/minder/internal/engine/entities"
 	"github.com/stacklok/minder/internal/entities/properties"
 	minderv1 "github.com/stacklok/minder/pkg/api/protobuf/go/minder/v1"
-	provifv1 "github.com/stacklok/minder/pkg/providers/v1"
 )
 
 // EntityInstance represents an entity instance
@@ -39,6 +38,9 @@ type EntityWithProperties struct {
 	Entity     EntityInstance
 	Properties *properties.Properties
 }
+
+// NilEntityWithProperties is a nil EntityWithProperties instance
+var NilEntityWithProperties = EntityWithProperties{}
 
 // NewEntityWithProperties creates a new EntityWithProperties instance
 func NewEntityWithProperties(dbEntity db.EntityInstance, props *properties.Properties) EntityWithProperties {
@@ -62,37 +64,7 @@ func NewEntityWithPropertiesFromInstance(entity EntityInstance, props *propertie
 	}
 }
 
-// EntityForProperties gives us the necessary fields to fetch properties
-type EntityForProperties struct {
-	*EntityWithProperties
-
-	// Provider is the provider for the entity
-	Provider provifv1.Provider
-}
-
-// NewEntityForProperties creates a new EntityForProperties instance
-func NewEntityForProperties(
-	dbEntity db.EntityInstance, props *properties.Properties, provider provifv1.Provider,
-) *EntityForProperties {
-	ewp := NewEntityWithProperties(dbEntity, props)
-	return &EntityForProperties{
-		EntityWithProperties: &ewp,
-		Provider:             provider,
-	}
-}
-
-// NewEntityForPropertiesFromInstance creates a new EntityForProperties instance from an existing entity instance
-func NewEntityForPropertiesFromInstance(
-	entity EntityInstance, props *properties.Properties, provider provifv1.Provider,
-) *EntityForProperties {
-	ewp := NewEntityWithPropertiesFromInstance(entity, props)
-	return &EntityForProperties{
-		EntityWithProperties: &ewp,
-		Provider:             provider,
-	}
-}
-
 // UpdateProperties updates the properties for the "entity for properties" instance
-func (e *EntityForProperties) UpdateProperties(props *properties.Properties) {
+func (e *EntityWithProperties) UpdateProperties(props *properties.Properties) {
 	e.Properties = props
 }

--- a/internal/entities/models/models.go
+++ b/internal/entities/models/models.go
@@ -39,12 +39,9 @@ type EntityWithProperties struct {
 	Properties *properties.Properties
 }
 
-// NilEntityWithProperties is a nil EntityWithProperties instance
-var NilEntityWithProperties = EntityWithProperties{}
-
 // NewEntityWithProperties creates a new EntityWithProperties instance
-func NewEntityWithProperties(dbEntity db.EntityInstance, props *properties.Properties) EntityWithProperties {
-	return EntityWithProperties{
+func NewEntityWithProperties(dbEntity db.EntityInstance, props *properties.Properties) *EntityWithProperties {
+	return &EntityWithProperties{
 		Entity: EntityInstance{
 			ID:         dbEntity.ID,
 			Type:       entities.EntityTypeFromDB(dbEntity.EntityType),
@@ -57,8 +54,8 @@ func NewEntityWithProperties(dbEntity db.EntityInstance, props *properties.Prope
 }
 
 // NewEntityWithPropertiesFromInstance creates a new EntityWithProperties instance from an existing entity instance
-func NewEntityWithPropertiesFromInstance(entity EntityInstance, props *properties.Properties) EntityWithProperties {
-	return EntityWithProperties{
+func NewEntityWithPropertiesFromInstance(entity EntityInstance, props *properties.Properties) *EntityWithProperties {
+	return &EntityWithProperties{
 		Entity:     entity,
 		Properties: props,
 	}

--- a/internal/entities/properties/service/mock/service.go
+++ b/internal/entities/properties/service/mock/service.go
@@ -46,19 +46,19 @@ func (m *MockPropertiesService) EXPECT() *MockPropertiesServiceMockRecorder {
 	return m.recorder
 }
 
-// EntityForProperties mocks base method.
-func (m *MockPropertiesService) EntityForProperties(ctx context.Context, entityID, projectId uuid.UUID, provMan manager.ProviderManager, qtx db.ExtendQuerier) (*models.EntityForProperties, error) {
+// EntityWithProperties mocks base method.
+func (m *MockPropertiesService) EntityWithProperties(ctx context.Context, entityID, projectId uuid.UUID, qtx db.ExtendQuerier) (models.EntityWithProperties, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "EntityForProperties", ctx, entityID, projectId, provMan, qtx)
-	ret0, _ := ret[0].(*models.EntityForProperties)
+	ret := m.ctrl.Call(m, "EntityWithProperties", ctx, entityID, projectId, qtx)
+	ret0, _ := ret[0].(models.EntityWithProperties)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// EntityForProperties indicates an expected call of EntityForProperties.
-func (mr *MockPropertiesServiceMockRecorder) EntityForProperties(ctx, entityID, projectId, provMan, qtx any) *gomock.Call {
+// EntityWithProperties indicates an expected call of EntityWithProperties.
+func (mr *MockPropertiesServiceMockRecorder) EntityWithProperties(ctx, entityID, projectId, qtx any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EntityForProperties", reflect.TypeOf((*MockPropertiesService)(nil).EntityForProperties), ctx, entityID, projectId, provMan, qtx)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EntityWithProperties", reflect.TypeOf((*MockPropertiesService)(nil).EntityWithProperties), ctx, entityID, projectId, qtx)
 }
 
 // ReplaceAllProperties mocks base method.
@@ -105,17 +105,17 @@ func (mr *MockPropertiesServiceMockRecorder) RetrieveAllProperties(ctx, provider
 }
 
 // RetrieveAllPropertiesForEntity mocks base method.
-func (m *MockPropertiesService) RetrieveAllPropertiesForEntity(ctx context.Context, efp *models.EntityForProperties) error {
+func (m *MockPropertiesService) RetrieveAllPropertiesForEntity(ctx context.Context, efp models.EntityWithProperties, provMan manager.ProviderManager) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "RetrieveAllPropertiesForEntity", ctx, efp)
+	ret := m.ctrl.Call(m, "RetrieveAllPropertiesForEntity", ctx, efp, provMan)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // RetrieveAllPropertiesForEntity indicates an expected call of RetrieveAllPropertiesForEntity.
-func (mr *MockPropertiesServiceMockRecorder) RetrieveAllPropertiesForEntity(ctx, efp any) *gomock.Call {
+func (mr *MockPropertiesServiceMockRecorder) RetrieveAllPropertiesForEntity(ctx, efp, provMan any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RetrieveAllPropertiesForEntity", reflect.TypeOf((*MockPropertiesService)(nil).RetrieveAllPropertiesForEntity), ctx, efp)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RetrieveAllPropertiesForEntity", reflect.TypeOf((*MockPropertiesService)(nil).RetrieveAllPropertiesForEntity), ctx, efp, provMan)
 }
 
 // RetrieveProperty mocks base method.

--- a/internal/entities/properties/service/mock/service.go
+++ b/internal/entities/properties/service/mock/service.go
@@ -15,7 +15,9 @@ import (
 
 	uuid "github.com/google/uuid"
 	db "github.com/stacklok/minder/internal/db"
+	models "github.com/stacklok/minder/internal/entities/models"
 	properties "github.com/stacklok/minder/internal/entities/properties"
+	manager "github.com/stacklok/minder/internal/providers/manager"
 	v1 "github.com/stacklok/minder/pkg/api/protobuf/go/minder/v1"
 	v10 "github.com/stacklok/minder/pkg/providers/v1"
 	gomock "go.uber.org/mock/gomock"
@@ -42,6 +44,21 @@ func NewMockPropertiesService(ctrl *gomock.Controller) *MockPropertiesService {
 // EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockPropertiesService) EXPECT() *MockPropertiesServiceMockRecorder {
 	return m.recorder
+}
+
+// EntityForProperties mocks base method.
+func (m *MockPropertiesService) EntityForProperties(ctx context.Context, entityID, projectId uuid.UUID, provMan manager.ProviderManager, qtx db.ExtendQuerier) (*models.EntityForProperties, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "EntityForProperties", ctx, entityID, projectId, provMan, qtx)
+	ret0, _ := ret[0].(*models.EntityForProperties)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// EntityForProperties indicates an expected call of EntityForProperties.
+func (mr *MockPropertiesServiceMockRecorder) EntityForProperties(ctx, entityID, projectId, provMan, qtx any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EntityForProperties", reflect.TypeOf((*MockPropertiesService)(nil).EntityForProperties), ctx, entityID, projectId, provMan, qtx)
 }
 
 // ReplaceAllProperties mocks base method.
@@ -85,6 +102,20 @@ func (m *MockPropertiesService) RetrieveAllProperties(ctx context.Context, provi
 func (mr *MockPropertiesServiceMockRecorder) RetrieveAllProperties(ctx, provider, projectId, providerID, lookupProperties, entType any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RetrieveAllProperties", reflect.TypeOf((*MockPropertiesService)(nil).RetrieveAllProperties), ctx, provider, projectId, providerID, lookupProperties, entType)
+}
+
+// RetrieveAllPropertiesForEntity mocks base method.
+func (m *MockPropertiesService) RetrieveAllPropertiesForEntity(ctx context.Context, efp *models.EntityForProperties) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "RetrieveAllPropertiesForEntity", ctx, efp)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// RetrieveAllPropertiesForEntity indicates an expected call of RetrieveAllPropertiesForEntity.
+func (mr *MockPropertiesServiceMockRecorder) RetrieveAllPropertiesForEntity(ctx, efp any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RetrieveAllPropertiesForEntity", reflect.TypeOf((*MockPropertiesService)(nil).RetrieveAllPropertiesForEntity), ctx, efp)
 }
 
 // RetrieveProperty mocks base method.

--- a/internal/entities/properties/service/mock/service.go
+++ b/internal/entities/properties/service/mock/service.go
@@ -47,10 +47,10 @@ func (m *MockPropertiesService) EXPECT() *MockPropertiesServiceMockRecorder {
 }
 
 // EntityWithProperties mocks base method.
-func (m *MockPropertiesService) EntityWithProperties(ctx context.Context, entityID, projectId uuid.UUID, qtx db.ExtendQuerier) (models.EntityWithProperties, error) {
+func (m *MockPropertiesService) EntityWithProperties(ctx context.Context, entityID, projectId uuid.UUID, qtx db.ExtendQuerier) (*models.EntityWithProperties, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "EntityWithProperties", ctx, entityID, projectId, qtx)
-	ret0, _ := ret[0].(models.EntityWithProperties)
+	ret0, _ := ret[0].(*models.EntityWithProperties)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -105,7 +105,7 @@ func (mr *MockPropertiesServiceMockRecorder) RetrieveAllProperties(ctx, provider
 }
 
 // RetrieveAllPropertiesForEntity mocks base method.
-func (m *MockPropertiesService) RetrieveAllPropertiesForEntity(ctx context.Context, efp models.EntityWithProperties, provMan manager.ProviderManager) error {
+func (m *MockPropertiesService) RetrieveAllPropertiesForEntity(ctx context.Context, efp *models.EntityWithProperties, provMan manager.ProviderManager) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "RetrieveAllPropertiesForEntity", ctx, efp, provMan)
 	ret0, _ := ret[0].(error)

--- a/internal/entities/properties/service/service.go
+++ b/internal/entities/properties/service/service.go
@@ -28,9 +28,11 @@ import (
 
 	"github.com/stacklok/minder/internal/db"
 	"github.com/stacklok/minder/internal/engine/entities"
+	"github.com/stacklok/minder/internal/entities/models"
 	"github.com/stacklok/minder/internal/entities/properties"
+	"github.com/stacklok/minder/internal/providers/manager"
 	minderv1 "github.com/stacklok/minder/pkg/api/protobuf/go/minder/v1"
-	v1 "github.com/stacklok/minder/pkg/providers/v1"
+	provifv1 "github.com/stacklok/minder/pkg/providers/v1"
 )
 
 //go:generate go run go.uber.org/mock/mockgen -package mock_$GOPACKAGE -destination=./mock/$GOFILE -source=./$GOFILE
@@ -45,15 +47,21 @@ const (
 
 // PropertiesService is the interface for the properties service
 type PropertiesService interface {
+	// Fetches an Entity by ID and Project in order to refresh the properties
+	EntityForProperties(ctx context.Context, entityID, projectId uuid.UUID,
+		provMan manager.ProviderManager, qtx db.ExtendQuerier) (*models.EntityForProperties, error)
 	// RetrieveAllProperties fetches all properties for the given entity
 	RetrieveAllProperties(
-		ctx context.Context, provider v1.Provider, projectId uuid.UUID,
+		ctx context.Context, provider provifv1.Provider, projectId uuid.UUID,
 		providerID uuid.UUID,
 		lookupProperties *properties.Properties, entType minderv1.Entity,
 	) (*properties.Properties, error)
+	// RetrieveAllPropertiesForEntity fetches all properties for the given entity
+	// for properties model. Note that properties will be updated in place.
+	RetrieveAllPropertiesForEntity(ctx context.Context, efp *models.EntityForProperties) error
 	// RetrieveProperty fetches a single property for the given entity
 	RetrieveProperty(
-		ctx context.Context, provider v1.Provider, projectId uuid.UUID,
+		ctx context.Context, provider provifv1.Provider, projectId uuid.UUID,
 		providerID uuid.UUID,
 		lookupProperties *properties.Properties, entType minderv1.Entity, key string,
 	) (*properties.Property, error)
@@ -68,7 +76,7 @@ type PropertiesService interface {
 type propertiesServiceOption func(*propertiesService)
 
 type propertiesService struct {
-	store         db.Store
+	store         db.ExtendQuerier
 	entityTimeout time.Duration
 }
 
@@ -81,7 +89,7 @@ func WithEntityTimeout(timeout time.Duration) propertiesServiceOption {
 
 // NewPropertiesService creates a new properties service
 func NewPropertiesService(
-	store db.Store,
+	store db.ExtendQuerier,
 	opts ...propertiesServiceOption,
 ) PropertiesService {
 	ps := &propertiesService{
@@ -98,7 +106,7 @@ func NewPropertiesService(
 
 // RetrieveAllProperties fetches a single property for the given entity
 func (ps *propertiesService) RetrieveAllProperties(
-	ctx context.Context, provider v1.Provider, projectId uuid.UUID,
+	ctx context.Context, provider provifv1.Provider, projectId uuid.UUID,
 	providerID uuid.UUID,
 	lookupProperties *properties.Properties, entType minderv1.Entity,
 ) (*properties.Properties, error) {
@@ -156,9 +164,29 @@ func (ps *propertiesService) RetrieveAllProperties(
 	return refreshedProps, nil
 }
 
+// RetrieveAllPropertiesForEntity fetches a single property for the given an entity
+// for properties model. Note that properties will be updated in place.
+func (ps *propertiesService) RetrieveAllPropertiesForEntity(
+	ctx context.Context, efp *models.EntityForProperties,
+) error {
+	props, err := ps.RetrieveAllProperties(
+		ctx,
+		efp.Provider,
+		efp.Entity.ProjectID,
+		efp.Entity.ProviderID,
+		efp.Properties,
+		efp.Entity.Type)
+	if err != nil {
+		return fmt.Errorf("error fetching properties for repository: %w", err)
+	}
+
+	efp.UpdateProperties(props)
+	return nil
+}
+
 // RetrieveProperty fetches a single property for the given entity
 func (ps *propertiesService) RetrieveProperty(
-	ctx context.Context, provider v1.Provider, projectId uuid.UUID,
+	ctx context.Context, provider provifv1.Provider, projectId uuid.UUID,
 	providerID uuid.UUID,
 	lookupProperties *properties.Properties, entType minderv1.Entity, key string,
 ) (*properties.Property, error) {
@@ -271,6 +299,41 @@ func (_ *propertiesService) ReplaceProperty(
 		Value:    prop.RawValue(),
 	})
 	return err
+}
+
+func (ps *propertiesService) EntityForProperties(
+	ctx context.Context, entityID, projectID uuid.UUID,
+	provMan manager.ProviderManager, qtx db.ExtendQuerier,
+) (*models.EntityForProperties, error) {
+	// use the transaction if provided, otherwise use the store
+	var q db.Querier
+	if qtx != nil {
+		q = qtx
+	} else {
+		q = ps.store
+	}
+
+	ent, err := q.GetEntityByID(ctx, db.GetEntityByIDParams{
+		ID:       entityID,
+		Projects: []uuid.UUID{projectID},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("error getting entity: %w", err)
+	}
+
+	propClient, err := provMan.InstantiateFromID(ctx, ent.ProviderID)
+	if err != nil {
+		return nil, fmt.Errorf("error instantiating provider: %w", err)
+	}
+
+	fetchByProps, err := properties.NewProperties(map[string]any{
+		properties.PropertyName: ent.Name,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("error creating properties: %w", err)
+	}
+
+	return models.NewEntityForProperties(ent, fetchByProps, propClient), nil
 }
 
 func (ps *propertiesService) areDatabasePropertiesValid(dbProps []db.Property) bool {

--- a/internal/history/mock/service.go
+++ b/internal/history/mock/service.go
@@ -43,7 +43,7 @@ func (m *MockEvaluationHistoryService) EXPECT() *MockEvaluationHistoryServiceMoc
 }
 
 // ListEvaluationHistory mocks base method.
-func (m *MockEvaluationHistoryService) ListEvaluationHistory(ctx context.Context, qtx db.Querier, cursor *history.ListEvaluationCursor, size uint32, filter history.ListEvaluationFilter) (*history.ListEvaluationHistoryResult, error) {
+func (m *MockEvaluationHistoryService) ListEvaluationHistory(ctx context.Context, qtx db.ExtendQuerier, cursor *history.ListEvaluationCursor, size uint32, filter history.ListEvaluationFilter) (*history.ListEvaluationHistoryResult, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListEvaluationHistory", ctx, qtx, cursor, size, filter)
 	ret0, _ := ret[0].(*history.ListEvaluationHistoryResult)

--- a/internal/history/models.go
+++ b/internal/history/models.go
@@ -638,7 +638,7 @@ func NewListEvaluationFilter(opts ...FilterOpt) (ListEvaluationFilter, error) {
 // OneEvalHistoryAndEntity is a struct representing a combination of an
 // evaluation and an entity.
 type OneEvalHistoryAndEntity struct {
-	em.EntityWithProperties
+	*em.EntityWithProperties
 	EvalHistoryRow db.ListEvaluationHistoryRow
 }
 
@@ -646,7 +646,7 @@ type OneEvalHistoryAndEntity struct {
 // ListEvaluationHistory function.
 type ListEvaluationHistoryResult struct {
 	// Data is an ordered collection of evaluation events.
-	Data []OneEvalHistoryAndEntity
+	Data []*OneEvalHistoryAndEntity
 	// Next is an object usable as cursor to fetch the next
 	// page. The page is absent if Next is nil.
 	Next []byte

--- a/internal/history/models.go
+++ b/internal/history/models.go
@@ -26,6 +26,7 @@ import (
 	"github.com/google/uuid"
 
 	"github.com/stacklok/minder/internal/db"
+	em "github.com/stacklok/minder/internal/entities/models"
 )
 
 var (
@@ -634,11 +635,18 @@ func NewListEvaluationFilter(opts ...FilterOpt) (ListEvaluationFilter, error) {
 	return filter, nil
 }
 
+// OneEvalHistoryAndEntity is a struct representing a combination of an
+// evaluation and an entity.
+type OneEvalHistoryAndEntity struct {
+	em.EntityWithProperties
+	EvalHistoryRow db.ListEvaluationHistoryRow
+}
+
 // ListEvaluationHistoryResult is the return value of
 // ListEvaluationHistory function.
 type ListEvaluationHistoryResult struct {
 	// Data is an ordered collection of evaluation events.
-	Data []db.ListEvaluationHistoryRow
+	Data []OneEvalHistoryAndEntity
 	// Next is an object usable as cursor to fetch the next
 	// page. The page is absent if Next is nil.
 	Next []byte

--- a/internal/history/service.go
+++ b/internal/history/service.go
@@ -218,18 +218,18 @@ func (ehs *evaluationHistoryService) ListEvaluationHistory(
 
 	data := make([]OneEvalHistoryAndEntity, 0, len(rows))
 	for _, row := range rows {
-		efp, err := propsvc.EntityForProperties(ctx, row.EntityID, row.ProjectID, ehs.providerManager, qtx)
+		efp, err := propsvc.EntityWithProperties(ctx, row.EntityID, row.ProjectID, qtx)
 		if err != nil {
 			return nil, fmt.Errorf("error fetching entity for properties: %w", err)
 		}
 
-		err = propsvc.RetrieveAllPropertiesForEntity(ctx, efp)
+		err = propsvc.RetrieveAllPropertiesForEntity(ctx, efp, ehs.providerManager)
 		if err != nil {
 			return nil, fmt.Errorf("error fetching properties for entity: %w", err)
 		}
 
 		data = append(data, OneEvalHistoryAndEntity{
-			EntityWithProperties: *efp.EntityWithProperties,
+			EntityWithProperties: efp,
 			EvalHistoryRow:       row,
 		})
 	}

--- a/internal/history/service.go
+++ b/internal/history/service.go
@@ -216,7 +216,7 @@ func (ehs *evaluationHistoryService) ListEvaluationHistory(
 
 	propsvc := ehs.propServiceBuilder(qtx)
 
-	data := make([]OneEvalHistoryAndEntity, 0, len(rows))
+	data := make([]*OneEvalHistoryAndEntity, 0, len(rows))
 	for _, row := range rows {
 		efp, err := propsvc.EntityWithProperties(ctx, row.EntityID, row.ProjectID, qtx)
 		if err != nil {
@@ -228,7 +228,7 @@ func (ehs *evaluationHistoryService) ListEvaluationHistory(
 			return nil, fmt.Errorf("error fetching properties for entity: %w", err)
 		}
 
-		data = append(data, OneEvalHistoryAndEntity{
+		data = append(data, &OneEvalHistoryAndEntity{
 			EntityWithProperties: efp,
 			EvalHistoryRow:       row,
 		})

--- a/internal/history/service_test.go
+++ b/internal/history/service_test.go
@@ -163,13 +163,13 @@ func TestListEvaluationHistory(t *testing.T) {
 		filter                   ListEvaluationFilter
 		checkf                   func(*testing.T, *ListEvaluationHistoryResult)
 		err                      bool
-		efp                      []entmodels.EntityWithProperties
+		efp                      []*entmodels.EntityWithProperties
 		entityForPropertiesError error
 		retrieveAllPropsErr      error
 	}{
 		{
 			name: "records",
-			efp: []entmodels.EntityWithProperties{
+			efp: []*entmodels.EntityWithProperties{
 				entmodels.NewEntityWithPropertiesFromInstance(entmodels.EntityInstance{
 					ID: uuid1,
 				}, nil),
@@ -250,7 +250,7 @@ func TestListEvaluationHistory(t *testing.T) {
 					),
 				),
 			),
-			efp: []entmodels.EntityWithProperties{
+			efp: []*entmodels.EntityWithProperties{
 				entmodels.NewEntityWithPropertiesFromInstance(entmodels.EntityInstance{
 					ID: uuid1,
 				}, nil),
@@ -299,7 +299,7 @@ func TestListEvaluationHistory(t *testing.T) {
 					),
 				),
 			),
-			efp: []entmodels.EntityWithProperties{
+			efp: []*entmodels.EntityWithProperties{
 				entmodels.NewEntityWithPropertiesFromInstance(entmodels.EntityInstance{
 					ID: uuid1,
 				}, nil),
@@ -786,7 +786,7 @@ func TestListEvaluationHistory(t *testing.T) {
 			name:                "error getting properties",
 			err:                 true,
 			retrieveAllPropsErr: errors.New("whoops"),
-			efp: []entmodels.EntityWithProperties{
+			efp: []*entmodels.EntityWithProperties{
 				// Only called once
 				entmodels.NewEntityWithPropertiesFromInstance(entmodels.EntityInstance{
 					ID: uuid1,
@@ -842,7 +842,7 @@ func TestListEvaluationHistory(t *testing.T) {
 
 			if tt.entityForPropertiesError != nil && len(tt.efp) == 0 {
 				propsSvc.EXPECT().EntityWithProperties(ctx, gomock.Any(), gomock.Any(), gomock.Any()).
-					Return(entmodels.NilEntityWithProperties, tt.entityForPropertiesError).AnyTimes()
+					Return(nil, tt.entityForPropertiesError).AnyTimes()
 			}
 			propsSvc.EXPECT().RetrieveAllPropertiesForEntity(ctx, gomock.Any(), gomock.Any()).
 				Return(tt.retrieveAllPropsErr).AnyTimes()

--- a/internal/history/service_test.go
+++ b/internal/history/service_test.go
@@ -163,22 +163,22 @@ func TestListEvaluationHistory(t *testing.T) {
 		filter                   ListEvaluationFilter
 		checkf                   func(*testing.T, *ListEvaluationHistoryResult)
 		err                      bool
-		efp                      []*entmodels.EntityForProperties
+		efp                      []entmodels.EntityWithProperties
 		entityForPropertiesError error
 		retrieveAllPropsErr      error
 	}{
 		{
 			name: "records",
-			efp: []*entmodels.EntityForProperties{
-				entmodels.NewEntityForPropertiesFromInstance(entmodels.EntityInstance{
+			efp: []entmodels.EntityWithProperties{
+				entmodels.NewEntityWithPropertiesFromInstance(entmodels.EntityInstance{
 					ID: uuid1,
-				}, nil, nil),
-				entmodels.NewEntityForPropertiesFromInstance(entmodels.EntityInstance{
+				}, nil),
+				entmodels.NewEntityWithPropertiesFromInstance(entmodels.EntityInstance{
 					ID: uuid2,
-				}, nil, nil),
-				entmodels.NewEntityForPropertiesFromInstance(entmodels.EntityInstance{
+				}, nil),
+				entmodels.NewEntityWithPropertiesFromInstance(entmodels.EntityInstance{
 					ID: uuid3,
-				}, nil, nil),
+				}, nil),
 			},
 			dbSetup: dbf.NewDBMock(
 				withListEvaluationHistory(nil, nil,
@@ -250,13 +250,13 @@ func TestListEvaluationHistory(t *testing.T) {
 					),
 				),
 			),
-			efp: []*entmodels.EntityForProperties{
-				entmodels.NewEntityForPropertiesFromInstance(entmodels.EntityInstance{
+			efp: []entmodels.EntityWithProperties{
+				entmodels.NewEntityWithPropertiesFromInstance(entmodels.EntityInstance{
 					ID: uuid1,
-				}, nil, nil),
-				entmodels.NewEntityForPropertiesFromInstance(entmodels.EntityInstance{
+				}, nil),
+				entmodels.NewEntityWithPropertiesFromInstance(entmodels.EntityInstance{
 					ID: uuid2,
-				}, nil, nil),
+				}, nil),
 			},
 			cursor: &ListEvaluationCursor{
 				Direction: Next,
@@ -299,13 +299,13 @@ func TestListEvaluationHistory(t *testing.T) {
 					),
 				),
 			),
-			efp: []*entmodels.EntityForProperties{
-				entmodels.NewEntityForPropertiesFromInstance(entmodels.EntityInstance{
+			efp: []entmodels.EntityWithProperties{
+				entmodels.NewEntityWithPropertiesFromInstance(entmodels.EntityInstance{
 					ID: uuid1,
-				}, nil, nil),
-				entmodels.NewEntityForPropertiesFromInstance(entmodels.EntityInstance{
+				}, nil),
+				entmodels.NewEntityWithPropertiesFromInstance(entmodels.EntityInstance{
 					ID: uuid2,
-				}, nil, nil),
+				}, nil),
 			},
 			cursor: &ListEvaluationCursor{
 				Direction: Prev,
@@ -786,11 +786,11 @@ func TestListEvaluationHistory(t *testing.T) {
 			name:                "error getting properties",
 			err:                 true,
 			retrieveAllPropsErr: errors.New("whoops"),
-			efp: []*entmodels.EntityForProperties{
+			efp: []entmodels.EntityWithProperties{
 				// Only called once
-				entmodels.NewEntityForPropertiesFromInstance(entmodels.EntityInstance{
+				entmodels.NewEntityWithPropertiesFromInstance(entmodels.EntityInstance{
 					ID: uuid1,
-				}, nil, nil),
+				}, nil),
 			},
 			dbSetup: dbf.NewDBMock(
 				withListEvaluationHistory(nil, nil,
@@ -836,15 +836,15 @@ func TestListEvaluationHistory(t *testing.T) {
 			pm := pmMock.NewMockProviderManager(ctrl)
 			propsSvc := propsSvcMock.NewMockPropertiesService(ctrl)
 			for _, efp := range tt.efp {
-				propsSvc.EXPECT().EntityForProperties(ctx, gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+				propsSvc.EXPECT().EntityWithProperties(ctx, gomock.Any(), gomock.Any(), gomock.Any()).
 					Return(efp, tt.entityForPropertiesError)
 			}
 
 			if tt.entityForPropertiesError != nil && len(tt.efp) == 0 {
-				propsSvc.EXPECT().EntityForProperties(ctx, gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
-					Return(nil, tt.entityForPropertiesError).AnyTimes()
+				propsSvc.EXPECT().EntityWithProperties(ctx, gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(entmodels.NilEntityWithProperties, tt.entityForPropertiesError).AnyTimes()
 			}
-			propsSvc.EXPECT().RetrieveAllPropertiesForEntity(ctx, gomock.Any()).
+			propsSvc.EXPECT().RetrieveAllPropertiesForEntity(ctx, gomock.Any(), gomock.Any()).
 				Return(tt.retrieveAllPropsErr).AnyTimes()
 
 			service := NewEvaluationHistoryService(pm, withPropertiesServiceBuilder(func(_ db.ExtendQuerier) service.PropertiesService {

--- a/internal/repositories/github/service.go
+++ b/internal/repositories/github/service.go
@@ -377,7 +377,7 @@ func (r *repositoryService) RefreshRepositoryByUpstreamID(
 		if errors.Is(err, provifv1.ErrEntityNotFound) {
 			// return the entity without properties in case the upstream entity is not found
 			ewp := models.NewEntityWithProperties(entRepo, repoProperties)
-			return &ewp, nil
+			return ewp, nil
 		} else if err != nil {
 			return nil, fmt.Errorf("error fetching properties for repository: %w", err)
 		}
@@ -385,7 +385,7 @@ func (r *repositoryService) RefreshRepositoryByUpstreamID(
 		if !isLegacy {
 			// this is not a migration from the legacy tables, we're done
 			ewp := models.NewEntityWithProperties(entRepo, repoProperties)
-			return &ewp, nil
+			return ewp, nil
 		}
 
 		zerolog.Ctx(ctx).Debug().Str("repo_name", entRepo.Name).Msg("migrating legacy repository")
@@ -403,7 +403,7 @@ func (r *repositoryService) RefreshRepositoryByUpstreamID(
 
 		// we could as well call RetrieveAllProperties again, we should just get the same data
 		ewp := models.NewEntityWithProperties(entRepo, repoProperties.Merge(legacyProps))
-		return &ewp, nil
+		return ewp, nil
 	})
 
 	if err != nil {

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -97,7 +97,6 @@ func AllInOneServerService(
 	serverconfig.FallbackOAuthClientConfigValues("github", &cfg.Provider.GitHub.OAuthClientConfig)
 	serverconfig.FallbackOAuthClientConfigValues("github-app", &cfg.Provider.GitHubApp.OAuthClientConfig)
 
-	historySvc := history.NewEvaluationHistoryService()
 	inviteSvc := invites.NewInviteService()
 	selChecker := selectors.NewEnv()
 	profileSvc := profiles.NewProfileService(evt, selChecker)
@@ -153,6 +152,7 @@ func AllInOneServerService(
 		return fmt.Errorf("failed to create provider auth manager: %w", err)
 	}
 	propSvc := propService.NewPropertiesService(store)
+	historySvc := history.NewEvaluationHistoryService(providerManager)
 	repos := github.NewRepositoryService(whManager, store, propSvc, evt, providerManager)
 	projectDeleter := projects.NewProjectDeleter(authzClient, providerManager)
 	sessionsService := session.NewProviderSessionService(providerManager, providerStore, store)
@@ -210,7 +210,7 @@ func AllInOneServerService(
 		store,
 		providerManager,
 		executorMetrics,
-		history.NewEvaluationHistoryService(),
+		historySvc,
 		featureFlagClient,
 		profileStore,
 		selEnv,


### PR DESCRIPTION
# Summary

This is another step into moving away from the central entity tables and
into the new per-entity tables.

Fixes #4316

## Change Type

***Mark the type of change your PR introduces:***

- [ ] Bug fix (resolves an issue without affecting existing features)
- [x] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [ ] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [ ] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [x] Included tests that validate the fix or feature.
- [ ] Checked that related changes are merged.
