### PR TITLE
Pass Provider ID to the GetEntity calls from the provider service

### DIFF
--- a/database/query/entities.sql
+++ b/database/query/entities.sql
@@ -62,7 +62,11 @@ LIMIT 1;
 -- GetEntityByName retrieves an entity by its name for a project or hierarchy of projects.
 -- name: GetEntityByName :one
 SELECT * FROM entity_instances
-WHERE entity_instances.name = sqlc.arg(name) AND entity_instances.project_id = $1 AND entity_instances.entity_type = $2
+WHERE
+    entity_instances.name = sqlc.arg(name)
+    AND entity_instances.project_id = $1
+    AND entity_instances.entity_type = $2
+    AND entity_instances.provider_id = sqlc.arg(provider_id)
 LIMIT 1;
 
 -- GetEntitiesByType retrieves all entities of a given type for a project or hierarchy of projects.

--- a/internal/controlplane/handlers_githubwebhooks.go
+++ b/internal/controlplane/handlers_githubwebhooks.go
@@ -1628,7 +1628,9 @@ func (s *Server) updatePullRequestInfoFromProvider(
 		return fmt.Errorf("error creating properties: %w", err)
 	}
 
-	_, err = s.props.RetrieveAllProperties(ctx, provider, repoEnt.Entity.ProjectID, lookupProperties, pb.Entity_ENTITY_PULL_REQUESTS)
+	_, err = s.props.RetrieveAllProperties(ctx, provider,
+		repoEnt.Entity.ProjectID, repoEnt.Entity.ProviderID,
+		lookupProperties, pb.Entity_ENTITY_PULL_REQUESTS)
 	if err != nil {
 		return fmt.Errorf("error retrieving properties: %w", err)
 	}

--- a/internal/controlplane/handlers_githubwebhooks_test.go
+++ b/internal/controlplane/handlers_githubwebhooks_test.go
@@ -96,7 +96,7 @@ func newPropSvcMock(opts ...func(mck propSvcMock)) propSvcMockBuilder {
 func withSuccessRetrieveAllProperties(entity v1.Entity, retProps *properties.Properties) func(mck propSvcMock) {
 	return func(mock propSvcMock) {
 		mock.EXPECT().
-			RetrieveAllProperties(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), entity).
+			RetrieveAllProperties(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), entity).
 			Return(retProps, nil)
 	}
 }

--- a/internal/db/entities.sql.go
+++ b/internal/db/entities.sql.go
@@ -315,7 +315,11 @@ func (q *Queries) GetEntityByID(ctx context.Context, arg GetEntityByIDParams) (E
 
 const getEntityByName = `-- name: GetEntityByName :one
 SELECT id, entity_type, name, project_id, provider_id, created_at, originated_from FROM entity_instances
-WHERE entity_instances.name = $3 AND entity_instances.project_id = $1 AND entity_instances.entity_type = $2
+WHERE
+    entity_instances.name = $3
+    AND entity_instances.project_id = $1
+    AND entity_instances.entity_type = $2
+    AND entity_instances.provider_id = $4
 LIMIT 1
 `
 
@@ -323,11 +327,17 @@ type GetEntityByNameParams struct {
 	ProjectID  uuid.UUID `json:"project_id"`
 	EntityType Entities  `json:"entity_type"`
 	Name       string    `json:"name"`
+	ProviderID uuid.UUID `json:"provider_id"`
 }
 
 // GetEntityByName retrieves an entity by its name for a project or hierarchy of projects.
 func (q *Queries) GetEntityByName(ctx context.Context, arg GetEntityByNameParams) (EntityInstance, error) {
-	row := q.db.QueryRowContext(ctx, getEntityByName, arg.ProjectID, arg.EntityType, arg.Name)
+	row := q.db.QueryRowContext(ctx, getEntityByName,
+		arg.ProjectID,
+		arg.EntityType,
+		arg.Name,
+		arg.ProviderID,
+	)
 	var i EntityInstance
 	err := row.Scan(
 		&i.ID,

--- a/internal/db/entities_test.go
+++ b/internal/db/entities_test.go
@@ -80,6 +80,7 @@ func Test_EntityCrud(t *testing.T) {
 			ProjectID:  proj.ID,
 			Name:       "garbage/nosuchentity",
 			EntityType: EntitiesRepository,
+			ProviderID: prov.ID,
 		})
 		require.ErrorIs(t, err, sql.ErrNoRows)
 		require.Empty(t, ent)
@@ -127,6 +128,7 @@ func Test_EntityCrud(t *testing.T) {
 			ProjectID:  proj.ID,
 			Name:       testEntName,
 			EntityType: EntitiesRepository,
+			ProviderID: prov.ID,
 		})
 		require.NoError(t, err)
 		require.NotEmpty(t, getRepo)
@@ -136,6 +138,7 @@ func Test_EntityCrud(t *testing.T) {
 			ProjectID:  proj.ID,
 			Name:       testEntName,
 			EntityType: EntitiesRepository,
+			ProviderID: prov.ID,
 		})
 		require.NoError(t, err)
 		require.NotEmpty(t, getRepo)

--- a/internal/entities/properties/service/mock/service.go
+++ b/internal/entities/properties/service/mock/service.go
@@ -73,33 +73,33 @@ func (mr *MockPropertiesServiceMockRecorder) ReplaceProperty(ctx, entityID, key,
 }
 
 // RetrieveAllProperties mocks base method.
-func (m *MockPropertiesService) RetrieveAllProperties(ctx context.Context, provider v10.Provider, projectId uuid.UUID, lookupProperties *properties.Properties, entType v1.Entity) (*properties.Properties, error) {
+func (m *MockPropertiesService) RetrieveAllProperties(ctx context.Context, provider v10.Provider, projectId, providerID uuid.UUID, lookupProperties *properties.Properties, entType v1.Entity) (*properties.Properties, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "RetrieveAllProperties", ctx, provider, projectId, lookupProperties, entType)
+	ret := m.ctrl.Call(m, "RetrieveAllProperties", ctx, provider, projectId, providerID, lookupProperties, entType)
 	ret0, _ := ret[0].(*properties.Properties)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // RetrieveAllProperties indicates an expected call of RetrieveAllProperties.
-func (mr *MockPropertiesServiceMockRecorder) RetrieveAllProperties(ctx, provider, projectId, lookupProperties, entType any) *gomock.Call {
+func (mr *MockPropertiesServiceMockRecorder) RetrieveAllProperties(ctx, provider, projectId, providerID, lookupProperties, entType any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RetrieveAllProperties", reflect.TypeOf((*MockPropertiesService)(nil).RetrieveAllProperties), ctx, provider, projectId, lookupProperties, entType)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RetrieveAllProperties", reflect.TypeOf((*MockPropertiesService)(nil).RetrieveAllProperties), ctx, provider, projectId, providerID, lookupProperties, entType)
 }
 
 // RetrieveProperty mocks base method.
-func (m *MockPropertiesService) RetrieveProperty(ctx context.Context, provider v10.Provider, projectId uuid.UUID, lookupProperties *properties.Properties, entType v1.Entity, key string) (*properties.Property, error) {
+func (m *MockPropertiesService) RetrieveProperty(ctx context.Context, provider v10.Provider, projectId, providerID uuid.UUID, lookupProperties *properties.Properties, entType v1.Entity, key string) (*properties.Property, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "RetrieveProperty", ctx, provider, projectId, lookupProperties, entType, key)
+	ret := m.ctrl.Call(m, "RetrieveProperty", ctx, provider, projectId, providerID, lookupProperties, entType, key)
 	ret0, _ := ret[0].(*properties.Property)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // RetrieveProperty indicates an expected call of RetrieveProperty.
-func (mr *MockPropertiesServiceMockRecorder) RetrieveProperty(ctx, provider, projectId, lookupProperties, entType, key any) *gomock.Call {
+func (mr *MockPropertiesServiceMockRecorder) RetrieveProperty(ctx, provider, projectId, providerID, lookupProperties, entType, key any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RetrieveProperty", reflect.TypeOf((*MockPropertiesService)(nil).RetrieveProperty), ctx, provider, projectId, lookupProperties, entType, key)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RetrieveProperty", reflect.TypeOf((*MockPropertiesService)(nil).RetrieveProperty), ctx, provider, projectId, providerID, lookupProperties, entType, key)
 }
 
 // SaveAllProperties mocks base method.

--- a/internal/entities/properties/service/service_test.go
+++ b/internal/entities/properties/service/service_test.go
@@ -541,7 +541,7 @@ func TestPropertiesService_RetrieveProperty(t *testing.T) {
 			})
 			require.NoError(t, err)
 
-			gotProps, err := propSvc.RetrieveProperty(ctx, githubMock, tctx.dbProj.ID, getByProps, tt.params.entType, tt.propName)
+			gotProps, err := propSvc.RetrieveProperty(ctx, githubMock, tctx.dbProj.ID, tctx.ghAppProvider.ID, getByProps, tt.params.entType, tt.propName)
 
 			if tt.expectErr != "" {
 				require.Contains(t, err.Error(), tt.expectErr)
@@ -706,7 +706,7 @@ func TestPropertiesService_RetrieveAllProperties(t *testing.T) {
 			})
 			require.NoError(t, err)
 
-			gotProps, err := propSvc.RetrieveAllProperties(ctx, githubMock, tctx.dbProj.ID, getByProps, tt.params.entType)
+			gotProps, err := propSvc.RetrieveAllProperties(ctx, githubMock, tctx.dbProj.ID, tctx.ghAppProvider.ID, getByProps, tt.params.entType)
 
 			if tt.expectErr != "" {
 				require.Contains(t, err.Error(), tt.expectErr)

--- a/internal/repositories/github/service.go
+++ b/internal/repositories/github/service.go
@@ -175,6 +175,7 @@ func (r *repositoryService) CreateRepository(
 		ctx,
 		propClient,
 		projectID,
+		provider.ID,
 		fetchByProps,
 		pb.Entity_ENTITY_REPOSITORIES)
 	if err != nil {
@@ -370,6 +371,7 @@ func (r *repositoryService) RefreshRepositoryByUpstreamID(
 			ctx,
 			prov,
 			entRepo.ProjectID,
+			entRepo.ProviderID,
 			fetchByProps,
 			pb.Entity_ENTITY_REPOSITORIES)
 		if errors.Is(err, provifv1.ErrEntityNotFound) {

--- a/internal/repositories/github/service_test.go
+++ b/internal/repositories/github/service_test.go
@@ -644,14 +644,14 @@ func withSuccessfulReplaceProps(mock propSvcMock) {
 
 func withFailingGet(mock propSvcMock) {
 	mock.EXPECT().
-		RetrieveAllProperties(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+		RetrieveAllProperties(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 		Return(nil, errDefault)
 }
 
 func withSuccessfulPropFetch(prop *properties.Properties) func(svcMock propSvcMock) {
 	return func(mock propSvcMock) {
 		mock.EXPECT().
-			RetrieveAllProperties(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+			RetrieveAllProperties(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 			Return(prop, nil)
 	}
 }


### PR DESCRIPTION
# Summary

The `entity_instances` table has the following index:
```
UNIQUE(project_id, provider_id, entity_type, name)
```
let's pass in the provider ID to take the index into account


## Change Type

- [x] Bug fix (resolves an issue without affecting existing features)
- [ ] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [ ] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

make test

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [ ] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [ ] Included tests that validate the fix or feature.
- [ ] Checked that related changes are merged.
