### PR TITLE
Fix two bugs in PR properties

### DIFF
--- a/internal/providers/github/properties/pull_request.go
+++ b/internal/providers/github/properties/pull_request.go
@@ -142,8 +142,9 @@ func getPrWrapper(
 		properties.PropertyUpstreamID: prReply.GetID(),
 		properties.PropertyName:       fmt.Sprintf("%s/%s/%d", owner, name, id),
 		// github-specific
-		PullPropertyURL:       prReply.GetHTMLURL(),
-		PullPropertyNumber:    prReply.GetNumber(),
+		PullPropertyURL: prReply.GetHTMLURL(),
+		// our proto representation uses int64 for the number but GH uses int
+		PullPropertyNumber:    int64(prReply.GetNumber()),
 		PullPropertySha:       prReply.GetHead().GetSHA(),
 		PullPropertyRepoOwner: owner,
 		PullPropertyRepoName:  name,


### PR DESCRIPTION
# Summary

- **Save the refreshed PR properties, not the lookup ones** - I mixed up the properties that we use to look up the PR and those that we actually fetch from the provider. Let's save those that we use to look up the PR to ensure that we have all the data available. In this particular case, we were missing the SHA.
- **GitHub's PR number is not int64, but our protobuf is** - Our protobuf defines the PR number as int64, but I didn't notice that the GH API returns the PR number as plain int. It's easiest to upcast the GH value to int64.

## Change Type

- [x] Bug fix (resolves an issue without affecting existing features)
- [ ] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [ ] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

manually followed the steps in our smoke tests

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [ ] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [ ] Included tests that validate the fix or feature.
- [ ] Checked that related changes are merged.
