### PR TITLE
Don't pre-create github provider on registration

### DIFF
--- a/internal/controlplane/handlers_user.go
+++ b/internal/controlplane/handlers_user.go
@@ -89,7 +89,7 @@ func (s *Server) CreateUser(ctx context.Context,
 			}
 		}
 
-		project, err := s.projectCreator.ProvisionSelfEnrolledOAuthProject(
+		project, err := s.projectCreator.ProvisionSelfEnrolledProject(
 			ctx,
 			qtx,
 			baseName,

--- a/internal/controlplane/handlers_user_test.go
+++ b/internal/controlplane/handlers_user_test.go
@@ -84,7 +84,6 @@ func TestCreateUser_gRPC(t *testing.T) {
 						ID:   projectID,
 						Name: "subject1",
 					}, nil)
-				store.EXPECT().CreateProvider(gomock.Any(), gomock.Any())
 
 				returnedUser := db.User{
 					ID:              1,


### PR DESCRIPTION
# Summary
On the first user registration, a provider entry is created in the database. Although, the provider cannot be used to register repos due to the lack of credential. As part of this change, the default provider will not be created and user will continue with provider enroll step.

***Provide a brief overview of the changes and the issue being addressed. 
Explain the rationale and any background necessary for understanding the changes. 
List dependencies required by this change, if any.***

Fixes #(related issue)
#4213 
## Change Type

***Mark the type of change your PR introduces:***

- [x] Bug fix (resolves an issue without affecting existing features)
- [ ] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [ ] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

***Outline how the changes were tested, including steps to reproduce and any relevant configurations. 
Attach screenshots if helpful.***
After the first user login, verify the provider list returns empty. Continue with provider enrollment and repo registration should successfully complete.

# Review Checklist:

- [ ] Reviewed my own code for quality and clarity.
- [ ] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [ ] Included tests that validate the fix or feature.
- [ ] Checked that related changes are merged.
