### PR TITLE
Fix entity refresh for entities that have not been migrated

### DIFF
--- a/internal/controlplane/handlers_evalstatus.go
+++ b/internal/controlplane/handlers_evalstatus.go
@@ -594,7 +594,7 @@ func (s *Server) buildRuleEvaluationStatusFromDBEvaluation(
 
 	err = s.props.RetrieveAllPropertiesForEntity(ctx, efp, s.providerManager)
 	if err != nil {
-		return nil, fmt.Errorf("error fetching properties for entity: %w", err)
+		return nil, fmt.Errorf("error fetching properties for entity: %s: %w", efp.Entity.ID.String(), err)
 	}
 
 	entityInfo := map[string]string{}

--- a/internal/entities/properties/properties.go
+++ b/internal/entities/properties/properties.go
@@ -255,6 +255,29 @@ func (p *Properties) GetProperty(key string) *Property {
 	return &prop
 }
 
+// SetProperty sets the Property for a given key
+func (p *Properties) SetProperty(key string, prop *Property) {
+	if p == nil {
+		return
+	}
+
+	p.props.Store(key, *prop)
+}
+
+// SetKeyValue sets the key value pair in the Properties
+func (p *Properties) SetKeyValue(key string, value any) error {
+	if p == nil {
+		return nil
+	}
+
+	prop, err := NewProperty(value)
+	if err != nil {
+		return fmt.Errorf("failed to create property for key %s: %w", key, err)
+	}
+	p.props.Store(key, *prop)
+	return nil
+}
+
 // Iterate implements the seq2 iterator so that the caller can call for key, prop := range Iterate()
 func (p *Properties) Iterate() iter.Seq2[string, *Property] {
 	return func(yield func(string, *Property) bool) {

--- a/internal/entities/properties/properties_test.go
+++ b/internal/entities/properties/properties_test.go
@@ -674,3 +674,86 @@ func TestNewPropertiesWithSkipPrefixCheck(t *testing.T) {
 		t.Errorf("Expected value 'value', got '%s'", val)
 	}
 }
+
+func TestProperties_SetKeyValue(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		key     string
+		value   any
+		wantErr bool
+	}{
+		{
+			name:    "Set string value",
+			key:     "testKey",
+			value:   "testValue",
+			wantErr: false,
+		},
+		{
+			name:    "Set int64 value",
+			key:     "intKey",
+			value:   int64(42),
+			wantErr: false,
+		},
+		{
+			name:    "Set uint64 value",
+			key:     "uintKey",
+			value:   uint64(42),
+			wantErr: false,
+		},
+		{
+			name:    "Set bool value",
+			key:     "boolKey",
+			value:   true,
+			wantErr: false,
+		},
+		{
+			name:    "Set invalid value",
+			key:     "invalidKey",
+			value:   complex(1, 2),
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			p, _ := NewProperties(map[string]any{}, WithSkipPrefixCheckTestOnly())
+			err := p.SetKeyValue(tt.key, tt.value)
+
+			if (err != nil) != tt.wantErr {
+				t.Errorf("SetKeyValue() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+
+			if !tt.wantErr {
+				prop := p.GetProperty(tt.key)
+				if prop == nil {
+					t.Errorf("Property not set for key %s", tt.key)
+					return
+				}
+
+				switch v := tt.value.(type) {
+				case string:
+					if got := prop.GetString(); got != v {
+						t.Errorf("Expected string value %v, got %v", v, got)
+					}
+				case int64:
+					if got := prop.GetInt64(); got != v {
+						t.Errorf("Expected int64 value %v, got %v", v, got)
+					}
+				case uint64:
+					if got := prop.GetUint64(); got != v {
+						t.Errorf("Expected uint64 value %v, got %v", v, got)
+					}
+				case bool:
+					if got := prop.GetBool(); got != v {
+						t.Errorf("Expected bool value %v, got %v", v, got)
+					}
+				}
+			}
+		})
+	}
+}

--- a/internal/entities/properties/service/service.go
+++ b/internal/entities/properties/service/service.go
@@ -336,6 +336,17 @@ func (ps *propertiesService) EntityWithProperties(
 		return nil, fmt.Errorf("failed to convert properties to model: %w", err)
 	}
 
+	// temporary migration case - if we had an entity but no properties for it from
+	// our live-on-demand migration case, we might not have a name. In this case, we
+	// fill the name property from the entity name which is always there
+	nameP := props.GetProperty(properties.PropertyName)
+	if nameP == nil {
+		err := props.SetKeyValue(properties.PropertyName, ent.Name)
+		if err != nil {
+			return nil, fmt.Errorf("failed to set name property: %w", err)
+		}
+	}
+
 	return models.NewEntityWithProperties(ent, props), nil
 }
 


### PR DESCRIPTION
# Summary

- **Add a setter for properties** - Adds a utility function to set a property so that we don't have to construct a map to construct properties to merge properties.
- **Derive the name property from entity name for entities that have not migrated fully** - We have entities in the database that have an entity instance, but no corresponding property because they have not been migrated properly. In that case, we can't use properties to refresh the entity because the properties are not there. The entity itself has a name, though, so let's use it to backfill the name property so that the properties object can always be used to refresh the rest.
- **Improve error message** - This would actually tell us what entity failed to refresh

## Change Type

- [x] Bug fix (resolves an issue without affecting existing features)
- [ ] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [ ] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

unit tests

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [x] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [x] Included tests that validate the fix or feature.
- [ ] Checked that related changes are merged.
