### PR TITLE
Fix splitting artifact name property

### DIFF
--- a/internal/providers/github/properties/artifact.go
+++ b/internal/providers/github/properties/artifact.go
@@ -109,14 +109,20 @@ func getNameFromParams(owner, name string) string {
 }
 
 func parseArtifactName(name string) (string, string, string, error) {
-	parts := strings.Split(name, "/")
-	if len(parts) == 2 {
-		return parts[0], parts[1], string(verifyif.ArtifactTypeContainer), nil
-	} else if len(parts) == 1 {
-		return "", parts[0], string(verifyif.ArtifactTypeContainer), nil
+	index := strings.Index(name, "/")
+	if index == -1 {
+		// No slash found, treat the entire name as the artifact name
+		return "", name, string(verifyif.ArtifactTypeContainer), nil
 	}
 
-	return "", "", "", fmt.Errorf("invalid name format")
+	owner := name[:index]
+	artifactName := name[index+1:]
+
+	if owner == "" || artifactName == "" {
+		return "", "", "", fmt.Errorf("invalid name format")
+	}
+
+	return owner, artifactName, string(verifyif.ArtifactTypeContainer), nil
 }
 
 func getArtifactWrapper(
@@ -126,7 +132,6 @@ func getArtifactWrapper(
 	if err != nil {
 		return nil, fmt.Errorf("failed to get artifact properties: %w", err)
 	}
-	fmt.Println(owner, name, pkgType)
 
 	var fetchErr error
 	var pkg *go_github.Package


### PR DESCRIPTION
# Summary

If the artifact name had contained a slash, we would have failed to
parse it. Treat the owner as what's up to the first slash and the rest
as the artifact name.

## Change Type

- [x] Bug fix (resolves an issue without affecting existing features)
- [ ] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [ ] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

I used this artifact for testing: https://github.com/jakubtestorg/demo-repo-go/pkgs/container/demo-repo-go%2Fimage

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [ ] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [ ] Included tests that validate the fix or feature.
- [ ] Checked that related changes are merged.
