### PR TITLE
Ignore sql.ErrNoRows on deleting repos by ID

### DIFF
--- a/internal/reconcilers/entity_delete.go
+++ b/internal/reconcilers/entity_delete.go
@@ -15,7 +15,9 @@
 package reconcilers
 
 import (
+	"database/sql"
 	"encoding/json"
+	"errors"
 	"fmt"
 
 	"github.com/ThreeDotsLabs/watermill/message"
@@ -58,8 +60,11 @@ func (r *Reconciler) handleEntityDeleteEvent(msg *message.Message) error {
 	l.Info().Msg("handling entity delete event")
 	// Remove the entry in the DB. There's no need to clean any webhook we created for this repository, as GitHub
 	// will automatically remove them when the repository is deleted.
-	if err := r.repos.DeleteByID(ctx, event.EntityID, event.ProjectID); err != nil {
-		return fmt.Errorf("error deleting repository from DB: %w", err)
+	err := r.repos.DeleteByID(ctx, event.EntityID, event.ProjectID)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil
+	} else if err != nil {
+		return fmt.Errorf("error deleting repository: %w", err)
 	}
 
 	minderlogger.BusinessRecord(ctx).Repository = event.EntityID


### PR DESCRIPTION
# Summary

We've seen this in minder cloud staging:
```
587a40169630","topic":"internal.entity.delete.event","handler":"github.com/stacklok/minder/internal/reconcilers.(*Reconciler).handleEntityDeleteEvent-fm-internal.entity.delete.event","component":"eventer","Timestamp":1725611382257727611,"message":"Found
error handling message"}
{"level":"error","component":"watermill","exception.message":"error
deleting repository from DB: error retrieving repository
e0e9fdde-bb2d-4a1d-9e0f-b8f5c006b42a in project
a5d7a1e4-f6a9-4282-8cc6-1a0e1613d1ae: sql: no rows in result
set","retry_no":3,"max_retries":3,"wait_time":0,"elapsed_time":105398463,"Timestamp":1725611382257739431,"message":"Error
occurred, retrying"}
```

## Change Type

- [x] Bug fix (resolves an issue without affecting existing features)
- [ ] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [ ] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

added a unit test

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [ ] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [x] Included tests that validate the fix or feature.
- [ ] Checked that related changes are merged.
