### PR TITLE
Implement caching of providers on the provider manager

### DIFF
--- a/internal/controlplane/handlers_oauth_test.go
+++ b/internal/controlplane/handlers_oauth_test.go
@@ -672,8 +672,11 @@ func TestProviderCallback(t *testing.T) {
 			s.providerAuthManager = authManager
 
 			providerStore := providers.NewProviderStore(store)
-			providerManager, err := manager.NewProviderManager(providerStore, githubProviderManager, dockerhubProviderManager)
+			providerManager, closer, err := manager.NewProviderManager(context.Background(), providerStore, githubProviderManager, dockerhubProviderManager)
 			require.NoError(t, err)
+
+			defer closer()
+
 			s.providerManager = providerManager
 
 			sessionService := session.NewProviderSessionService(providerManager, providerStore, store)

--- a/internal/controlplane/handlers_providers_test.go
+++ b/internal/controlplane/handlers_providers_test.go
@@ -95,8 +95,11 @@ func testServer(t *testing.T, ctrl *gomock.Controller) *mockServer {
 	)
 	dockerhubProviderManager := dockerhub.NewDockerHubProviderClassManager(mockCryptoEngine, mockStore)
 
-	providerManager, err := manager.NewProviderManager(providerStore, githubProviderManager, dockerhubProviderManager)
+	providerManager, closer, err := manager.NewProviderManager(context.Background(), providerStore, githubProviderManager, dockerhubProviderManager)
 	require.NoError(t, err)
+
+	// We don't need the cache for these tests
+	closer()
 
 	authzClient := &mock.SimpleClient{
 		Allowed: []uuid.UUID{uuid.New()},
@@ -577,8 +580,12 @@ func TestDeleteProvider(t *testing.T) {
 		mockStore,
 		mockProvidersSvc,
 	)
-	providerManager, err := manager.NewProviderManager(providerStore, githubProviderManager)
+	ctx := context.Background()
+	providerManager, closer, err := manager.NewProviderManager(context.Background(), providerStore, githubProviderManager)
 	require.NoError(t, err)
+
+	// We don't need the cache for these tests
+	closer()
 
 	server := Server{
 		cryptoEngine:    mockCryptoEngine,
@@ -590,7 +597,6 @@ func TestDeleteProvider(t *testing.T) {
 		cfg:             &serverconfig.Config{},
 	}
 
-	ctx := context.Background()
 	ctx = jwt.WithAuthTokenContext(ctx, user)
 	ctx = engcontext.WithEntityContext(ctx, &engcontext.EntityContext{
 		Project:  engcontext.Project{ID: projectID},
@@ -690,8 +696,12 @@ func TestDeleteProviderByID(t *testing.T) {
 		mockStore,
 		mockProvidersSvc,
 	)
-	providerManager, err := manager.NewProviderManager(providerStore, githubProviderManager)
+	ctx := context.Background()
+	providerManager, closer, err := manager.NewProviderManager(context.Background(), providerStore, githubProviderManager)
 	require.NoError(t, err)
+
+	// We don't need the cache for these tests
+	closer()
 
 	server := Server{
 		cryptoEngine:    mockCryptoEngine,
@@ -703,7 +713,6 @@ func TestDeleteProviderByID(t *testing.T) {
 		cfg:             &serverconfig.Config{},
 	}
 
-	ctx := context.Background()
 	ctx = jwt.WithAuthTokenContext(ctx, user)
 	ctx = engcontext.WithEntityContext(ctx, &engcontext.EntityContext{
 		Project: engcontext.Project{ID: projectID},

--- a/internal/engine/executor_test.go
+++ b/internal/engine/executor_test.go
@@ -292,8 +292,10 @@ default allow = true`,
 	)
 
 	providerStore := providers.NewProviderStore(mockStore)
-	providerManager, err := manager.NewProviderManager(providerStore, githubProviderManager)
+	providerManager, closer, err := manager.NewProviderManager(context.Background(), providerStore, githubProviderManager)
 	require.NoError(t, err)
+
+	defer closer()
 
 	execMetrics, err := engine.NewExecutorMetrics(&meters.NoopMeterFactory{})
 	require.NoError(t, err)

--- a/internal/providers/manager/manager.go
+++ b/internal/providers/manager/manager.go
@@ -20,12 +20,14 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/rs/zerolog"
 
 	"github.com/stacklok/minder/internal/db"
 	"github.com/stacklok/minder/internal/providers"
+	"github.com/stacklok/minder/internal/util/cache"
 	v1 "github.com/stacklok/minder/pkg/providers/v1"
 )
 
@@ -125,23 +127,33 @@ func newClassTracker(
 
 type providerManager struct {
 	classTracker
-	store providers.ProviderStore
+	store         providers.ProviderStore
+	providerCache *cache.ExpiringCache[v1.Provider]
 }
 
 // NewProviderManager creates a new instance of ProviderManager
 func NewProviderManager(
+	ctx context.Context,
 	store providers.ProviderStore,
 	classManagers ...ProviderClassManager,
-) (ProviderManager, error) {
+) (ProviderManager, func(), error) {
+	noop := func() {}
 	classes, err := newClassTracker(classManagers...)
 	if err != nil {
-		return nil, fmt.Errorf("error creating class tracker: %w", err)
+		return nil, noop, fmt.Errorf("error creating class tracker: %w", err)
 	}
 
+	pcache := cache.NewExpiringCache[v1.Provider](ctx, &cache.ExpiringCacheConfig{
+		EvictionTime: 1 * time.Minute,
+	})
+
 	return &providerManager{
-		classTracker: *classes,
-		store:        store,
-	}, nil
+			classTracker:  *classes,
+			store:         store,
+			providerCache: pcache,
+		}, func() {
+			pcache.Close()
+		}, nil
 }
 
 func (p *providerManager) CreateFromConfig(
@@ -161,21 +173,43 @@ func (p *providerManager) CreateFromConfig(
 }
 
 func (p *providerManager) InstantiateFromID(ctx context.Context, providerID uuid.UUID) (v1.Provider, error) {
+	cachedProv, ok := p.providerCache.Get(providerID.String())
+	if ok {
+		return cachedProv, nil
+	}
+
 	config, err := p.store.GetByID(ctx, providerID)
 	if err != nil {
 		return nil, fmt.Errorf("error retrieving db record: %w", err)
 	}
 
-	return p.buildFromDBRecord(ctx, config)
+	builtProv, err := p.buildFromDBRecord(ctx, config)
+	if err != nil {
+		return nil, err
+	}
+
+	p.providerCache.Set(providerID.String(), builtProv)
+	return builtProv, nil
 }
 
 func (p *providerManager) InstantiateFromNameProject(ctx context.Context, name string, projectID uuid.UUID) (v1.Provider, error) {
+	key := fmt.Sprintf("%s-%s", projectID.String(), name)
+	cachedProv, ok := p.providerCache.Get(key)
+	if ok {
+		return cachedProv, nil
+	}
 	config, err := p.store.GetByName(ctx, projectID, name)
 	if err != nil {
 		return nil, fmt.Errorf("error retrieving db record: %w", err)
 	}
 
-	return p.buildFromDBRecord(ctx, config)
+	buitProv, err := p.buildFromDBRecord(ctx, config)
+	if err != nil {
+		return nil, err
+	}
+
+	p.providerCache.Set(key, buitProv)
+	return buitProv, nil
 }
 
 func (p *providerManager) BulkInstantiateByTrait(
@@ -205,6 +239,7 @@ func (p *providerManager) BulkInstantiateByTrait(
 }
 
 func (p *providerManager) DeleteByID(ctx context.Context, providerID uuid.UUID, projectID uuid.UUID) error {
+	defer p.providerCache.Delete(providerID.String())
 	config, err := p.store.GetByIDProject(ctx, providerID, projectID)
 	if err != nil {
 		return fmt.Errorf("error retrieving db record: %w", err)
@@ -214,6 +249,7 @@ func (p *providerManager) DeleteByID(ctx context.Context, providerID uuid.UUID, 
 }
 
 func (p *providerManager) DeleteByName(ctx context.Context, name string, projectID uuid.UUID) error {
+	defer p.providerCache.Delete(fmt.Sprintf("%s-%s", projectID.String(), name))
 	config, err := p.store.GetByNameInSpecificProject(ctx, projectID, name)
 	if err != nil {
 		return fmt.Errorf("error retrieving db record: %w", err)

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -142,11 +142,13 @@ func AllInOneServerService(
 		store,
 		cfg.Provider.GitLab,
 	)
-	providerManager, err := manager.NewProviderManager(providerStore,
+	providerManager, closer, err := manager.NewProviderManager(ctx, providerStore,
 		githubProviderManager, dockerhubProviderManager, gitlabProviderManager)
 	if err != nil {
 		return fmt.Errorf("failed to create provider manager: %w", err)
 	}
+	defer closer()
+
 	providerAuthManager, err := manager.NewAuthManager(githubProviderManager, dockerhubProviderManager, gitlabProviderManager)
 	if err != nil {
 		return fmt.Errorf("failed to create provider auth manager: %w", err)

--- a/internal/util/cache/cache.go
+++ b/internal/util/cache/cache.go
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//	http://www.apache.org/licenses/LICENSE-2.0
+//     http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -12,4 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package ratecache
+// Package cache contains cache utilities and implementations
+package cache
+
+// Cacher is the interface for the cache. It provides methods to get and set
+type Cacher[T any] interface {
+	Get(key string) (T, bool)
+	Set(key string, value T)
+}

--- a/internal/util/cache/expiration_cache_test.go
+++ b/internal/util/cache/expiration_cache_test.go
@@ -1,0 +1,213 @@
+// Copyright 2024 Stacklok, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cache
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	backoffv4 "github.com/cenkalti/backoff/v4"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestExpirationCacheCache_GetSet(t *testing.T) {
+	t.Parallel()
+
+	cache := NewExpiringCache[int](context.Background(), &ExpiringCacheConfig{
+		EvictionTime: 10 * time.Millisecond,
+	})
+	defer cache.Close()
+
+	expect := 42
+	cache.Set("foo", expect)
+
+	numOfGoroutines := 50
+	var wg sync.WaitGroup
+
+	for i := 0; i < numOfGoroutines; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			got, ok := cache.Get("foo")
+			assert.True(t, ok)
+			assert.Equal(t, expect, got)
+		}()
+	}
+
+	wg.Wait()
+}
+
+func TestExpirationCacheCache_evictExpiredEntriesRoutine(t *testing.T) {
+	t.Parallel()
+
+	cache := NewExpiringCache[int](context.Background(), &ExpiringCacheConfig{
+		EvictionTime: 10 * time.Millisecond,
+	})
+	defer cache.Close()
+
+	value := 42
+	cache.Set("foo", value)
+
+	op := func() error {
+		_, ok := cache.Get("foo")
+		if ok {
+			return fmt.Errorf("entry not evicted")
+		}
+		return nil
+	}
+
+	err := backoffv4.Retry(op, getBackoffPolicy(t))
+	assert.NoError(t, err)
+}
+
+func TestExpirationCacheCache_evictMultipleExpiredEntries(t *testing.T) {
+	t.Parallel()
+
+	cache := NewExpiringCache[int](context.Background(), &ExpiringCacheConfig{
+		EvictionTime: 10 * time.Millisecond,
+	})
+	defer cache.Close()
+
+	op := func() error {
+		size := cache.Size()
+		if size != 0 {
+			return fmt.Errorf("cache not empty")
+		}
+		return nil
+	}
+
+	cache.Set("foo", 42)
+	require.NoError(t, backoffv4.Retry(op, getBackoffPolicy(t)))
+
+	cache.Set("bar", 43)
+	require.NoError(t, backoffv4.Retry(op, getBackoffPolicy(t)))
+}
+
+func TestExpirationCacheCache_contextCancellation(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	cache := NewExpiringCache[int](ctx, &ExpiringCacheConfig{
+		EvictionTime: 10 * time.Millisecond,
+	})
+
+	cache.Set("foo", 42)
+	_, ok := cache.Get("foo")
+	require.True(t, ok)
+
+	// cancel the context, which would stop the eviction routine and close the store
+	cancel()
+
+	cache.Set("bar", 43)
+	_, ok = cache.Get("bar")
+	require.False(t, ok)
+	require.Equal(t, 1, cache.Size())
+}
+
+func TestExpirationCacheCache_Close(t *testing.T) {
+	t.Parallel()
+
+	cache := NewExpiringCache[int](context.Background(), &ExpiringCacheConfig{
+		EvictionTime: 10 * time.Minute,
+	})
+
+	wg := sync.WaitGroup{}
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		cache.evictExpiredEntriesRoutine(cache.ctx)
+	}()
+
+	cache.Set("foo", 42)
+	cache.Close()
+
+	// Ensure that the eviction routine has stopped
+	wg.Wait()
+
+	cache.Set("bar", 43)
+	_, ok := cache.Get("bar")
+
+	// Assert that setting a value after the cache has been closed does not work (non context cancellation)
+	require.False(t, ok)
+
+	// Assert that the cache has not been cleared
+	require.Equal(t, 1, cache.cache.Size())
+
+	// Assert that the cache has been stopped (closeChan has been closed)
+	require.Equal(t, struct{}{}, <-cache.closeChan)
+}
+
+func TestExpirationCache_Delete(t *testing.T) {
+	t.Parallel()
+
+	cache := NewExpiringCache[int](context.Background(), &ExpiringCacheConfig{
+		EvictionTime: 10 * time.Millisecond,
+	})
+	defer cache.Close()
+
+	key := "foo"
+	value := 42
+	cache.Set(key, value)
+
+	got, ok := cache.Get(key)
+	require.True(t, ok)
+	require.Equal(t, value, got)
+	require.Equal(t, 1, cache.Size())
+
+	// Delete a non-existent key
+	cache.Delete("bar")
+
+	// Ensure that the key still exists
+	got, ok = cache.Get(key)
+	require.True(t, ok)
+	require.Equal(t, value, got)
+	require.Equal(t, 1, cache.Size())
+
+	cache.Delete(key)
+
+	_, ok = cache.Get(key)
+	require.False(t, ok)
+
+	require.Equal(t, 0, cache.Size())
+}
+
+func TestExpirationCache_Size(t *testing.T) {
+	t.Parallel()
+
+	cache := NewExpiringCache[int](context.Background(), &ExpiringCacheConfig{
+		EvictionTime: 10 * time.Millisecond,
+	})
+	defer cache.Close()
+
+	key := "foo"
+	value := 42
+	cache.Set(key, value)
+
+	size := cache.Size()
+	require.Equal(t, 1, size)
+}
+
+func getBackoffPolicy(t *testing.T) backoffv4.BackOff {
+	t.Helper()
+
+	constBackoff := backoffv4.NewConstantBackOff(2 * time.Second)
+	return backoffv4.WithMaxRetries(constBackoff, 5)
+}

--- a/internal/util/cache/expirationcache.go
+++ b/internal/util/cache/expirationcache.go
@@ -1,0 +1,168 @@
+// Copyright 2024 Stacklok, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cache
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	xsyncv3 "github.com/puzpuzpuz/xsync/v3"
+)
+
+const (
+	defaultCacheExpiration = 30 * time.Minute
+)
+
+// Expiring is an interface for an expiring cache entry
+// It provides a method to get the expiration time and the value
+type Expiring[T any] interface {
+	Expiration() time.Time
+	Value() T
+}
+
+type expiringImpl[T any] struct {
+	expiration time.Time
+	value      T
+}
+
+// NewExpiring creates a new Expiring entry
+func NewExpiring[T any](value T, expiration time.Time) Expiring[T] {
+	return &expiringImpl[T]{
+		expiration: expiration,
+		value:      value,
+	}
+}
+
+// Expiration returns the expiration time of the entry
+func (e *expiringImpl[T]) Expiration() time.Time {
+	return e.expiration
+}
+
+// Value returns the value of the entry
+func (e *expiringImpl[T]) Value() T {
+	return e.value
+}
+
+// ExpiringCache is a cache that expires entries after a certain time
+type ExpiringCache[T any] struct {
+	cache          *xsyncv3.MapOf[string, Expiring[T]]
+	evictionTime   time.Duration
+	ctx            context.Context
+	evictionTicker *time.Ticker
+	closeChan      chan struct{}
+	closeOnce      sync.Once
+}
+
+// ExpiringCacheConfig is the configuration for the ExpiringCache
+type ExpiringCacheConfig struct {
+	EvictionTime time.Duration
+}
+
+// NewExpiringCache creates a new ExpiringCache based on the configuration
+// If the configuration is nil, the default eviction time is 30 minutes
+func NewExpiringCache[T any](ctx context.Context, cfg *ExpiringCacheConfig) *ExpiringCache[T] {
+	if cfg == nil {
+		cfg = &ExpiringCacheConfig{
+			EvictionTime: defaultCacheExpiration,
+		}
+	}
+
+	if cfg.EvictionTime <= 0 {
+		cfg.EvictionTime = defaultCacheExpiration
+	}
+
+	// We check for expired entries every half of the eviction time
+	evictionDuration := cfg.EvictionTime / 2
+	c := &ExpiringCache[T]{
+		cache:          xsyncv3.NewMapOf[string, Expiring[T]](),
+		evictionTime:   cfg.EvictionTime,
+		ctx:            ctx,
+		evictionTicker: time.NewTicker(evictionDuration),
+		closeChan:      make(chan struct{}),
+	}
+
+	go c.evictExpiredEntriesRoutine(ctx)
+	return c
+}
+
+// Get returns the value of the entry and a boolean indicating if the entry exists
+func (ec *ExpiringCache[T]) Get(key string) (T, bool) {
+	entry, ok := ec.cache.Load(key)
+	if !ok || time.Now().After(entry.Expiration()) {
+		// Entry doesn't exist or has expired
+		var emptyT T
+		return emptyT, false
+	}
+	return entry.Value(), true
+}
+
+// Set sets the value of the entry
+func (ec *ExpiringCache[T]) Set(key string, value T) {
+	select {
+	case <-ec.ctx.Done():
+		return
+	case <-ec.closeChan:
+		return
+	default:
+	}
+
+	ec.cache.Store(key, NewExpiring(value, time.Now().Add(ec.evictionTime)))
+}
+
+// Delete deletes the entry from the cache
+func (ec *ExpiringCache[T]) Delete(key string) {
+	ec.cache.Delete(key)
+}
+
+// Close stops the eviction routine and disallows setting new entries
+func (ec *ExpiringCache[T]) Close() {
+	ec.closeOnce.Do(func() {
+		defer ec.evictionTicker.Stop()
+		close(ec.closeChan)
+	})
+}
+
+// Size returns the number of entries in the cache. This is useful
+// for testing purposes
+func (ec *ExpiringCache[T]) Size() int {
+	return ec.cache.Size()
+}
+
+func (ec *ExpiringCache[T]) evictExpiredEntries() {
+	now := time.Now()
+	ec.cache.Range(func(key string, entry Expiring[T]) bool {
+		if now.After(entry.Expiration()) {
+			ec.cache.Delete(key)
+		}
+		return true
+	})
+}
+
+func (ec *ExpiringCache[T]) evictExpiredEntriesRoutine(ctx context.Context) {
+	defer ec.Close()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		// If ctx is not done but the ticker has expired, this would allow the goroutine to stop
+		// Stopping the ticker does not close the C channel, so we need to check for the closeChan
+		case <-ec.closeChan:
+			return
+		case <-ec.evictionTicker.C:
+			ec.evictExpiredEntries()
+		}
+	}
+}


### PR DESCRIPTION
# Summary

This generalized the expiration cache that was first introduced for REST
clients and introduced it as a general caching mechanism.

Subsequently, this was used to implement a 1 min cache for provider
fetching. This optimizes for cases where the provider is fetched
frequently for a single operation. Now there's no need to go multiple
times to the database.

Fixes #4391

## Change Type

***Mark the type of change your PR introduces:***

- [x] Bug fix (resolves an issue without affecting existing features)
- [x] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [ ] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

***Outline how the changes were tested, including steps to reproduce and any relevant configurations. 
Attach screenshots if helpful.***

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [ ] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [x] Included tests that validate the fix or feature.
- [ ] Checked that related changes are merged.
