### PR TITLE
Bump Go to 1.23.1 including tools

### DIFF
--- a/docker/minder/Dockerfile
+++ b/docker/minder/Dockerfile
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM index.docker.io/library/golang@sha256:613a108a4a4b1dfb6923305db791a19d088f77632317cfc3446825c54fb862cd AS builder
+FROM index.docker.io/library/golang@sha256:4a3c2bcd243d3dbb7b15237eecb0792db3614900037998c2cd6a579c46888c1e AS builder
 ENV APP_ROOT=/opt/app-root
 ENV GOPATH=$APP_ROOT
 

--- a/docker/reminder/Dockerfile
+++ b/docker/reminder/Dockerfile
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM index.docker.io/library/golang@sha256:613a108a4a4b1dfb6923305db791a19d088f77632317cfc3446825c54fb862cd AS builder
+FROM index.docker.io/library/golang@sha256:4a3c2bcd243d3dbb7b15237eecb0792db3614900037998c2cd6a579c46888c1e AS builder
 ENV APP_ROOT=/opt/app-root
 ENV GOPATH=$APP_ROOT
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/stacklok/minder
 
-go 1.23.0
+go 1.23.1
 
 require (
 	github.com/ThreeDotsLabs/watermill v1.3.7

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -1,6 +1,6 @@
 module github.com/stacklok/minder/tools
 
-go 1.22.5
+go 1.23.1
 
 require (
 	github.com/bufbuild/buf v1.39.0


### PR DESCRIPTION
# Summary

When I upgraded to 1.23.0, I forgot to upgrade tools. Let's migrate to
the latest version and also upgrade the version for tools at the same
time.

The SHAs in Dockerfiles were generated by:
```
frizbee image golang:1.23.1
```

## Change Type

- [ ] Bug fix (resolves an issue without affecting existing features)
- [ ] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [x] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

make build, make bootstrap, make run-docker

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [ ] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [ ] Included tests that validate the fix or feature.
- [ ] Checked that related changes are merged.
