### PR TITLE
Fetch and store the language property

### DIFF
--- a/internal/providers/github/properties/repository.go
+++ b/internal/providers/github/properties/repository.go
@@ -44,6 +44,8 @@ const (
 	RepoPropertyDefaultBranch = "github/default_branch"
 	// RepoPropertyLicense represents the github repository license
 	RepoPropertyLicense = "github/license"
+	// RepoPropertyPrimaryLanguage represents the github repository language
+	RepoPropertyPrimaryLanguage = "github/primary_language"
 
 	// RepoPropertyHookId represents the github repository hook ID
 	RepoPropertyHookId = "github/hook_id"
@@ -80,6 +82,7 @@ var repoPropertyDefinitions = []propertyOrigin{
 			RepoPropertyCloneURL,
 			RepoPropertyDefaultBranch,
 			RepoPropertyLicense,
+			RepoPropertyPrimaryLanguage,
 		},
 		wrapper: getRepoWrapper,
 	},
@@ -111,13 +114,14 @@ func getRepoWrapper(
 		properties.RepoPropertyIsArchived: repo.GetArchived(),
 		properties.RepoPropertyIsFork:     repo.GetFork(),
 		// github-specific
-		RepoPropertyId:            repo.GetID(),
-		RepoPropertyName:          repo.GetName(),
-		RepoPropertyOwner:         repo.GetOwner().GetLogin(),
-		RepoPropertyDeployURL:     repo.GetDeploymentsURL(),
-		RepoPropertyCloneURL:      repo.GetCloneURL(),
-		RepoPropertyDefaultBranch: repo.GetDefaultBranch(),
-		RepoPropertyLicense:       repo.GetLicense().GetSPDXID(),
+		RepoPropertyId:              repo.GetID(),
+		RepoPropertyName:            repo.GetName(),
+		RepoPropertyOwner:           repo.GetOwner().GetLogin(),
+		RepoPropertyDeployURL:       repo.GetDeploymentsURL(),
+		RepoPropertyCloneURL:        repo.GetCloneURL(),
+		RepoPropertyDefaultBranch:   repo.GetDefaultBranch(),
+		RepoPropertyLicense:         repo.GetLicense().GetSPDXID(),
+		RepoPropertyPrimaryLanguage: repo.GetLanguage(),
 	}
 
 	repoProps[properties.PropertyName] = fmt.Sprintf("%s/%s", repo.GetOwner().GetLogin(), repo.GetName())


### PR DESCRIPTION
# Summary

Since we already can get the language property in the REST call to get
most of the properties, we might as well store it as a property in the
database and let it be usable in selectors.

## Change Type

- [ ] Bug fix (resolves an issue without affecting existing features)
- [x] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [ ] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

I really need to add automated smoke tests for the selectors, but for now I have used:
```
selector: repository.properties['github/promary_language'] == 'Go'
```

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [ ] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [ ] Included tests that validate the fix or feature.
- [ ] Checked that related changes are merged.
