### PR TITLE
Fix retrieving properties by upstream ID and name

### DIFF
--- a/internal/controlplane/handlers_evalstatus.go
+++ b/internal/controlplane/handlers_evalstatus.go
@@ -33,6 +33,7 @@ import (
 	"github.com/stacklok/minder/internal/engine/engcontext"
 	entmodels "github.com/stacklok/minder/internal/entities/models"
 	"github.com/stacklok/minder/internal/entities/properties"
+	propSvc "github.com/stacklok/minder/internal/entities/properties/service"
 	"github.com/stacklok/minder/internal/history"
 	ghprop "github.com/stacklok/minder/internal/providers/github/properties"
 	"github.com/stacklok/minder/internal/ruletypes"
@@ -390,7 +391,7 @@ func (s *Server) sortEntitiesEvaluationStatus(
 
 			efp, err := s.props.EntityWithProperties(ctx, e.EntityID, nil)
 			if err != nil {
-				if errors.Is(err, sql.ErrNoRows) || errors.Is(err, provifv1.ErrEntityNotFound) {
+				if errors.Is(err, propSvc.ErrEntityNotFound) || errors.Is(err, provifv1.ErrEntityNotFound) {
 					// If the entity is not found, log and skip
 					zerolog.Ctx(ctx).Error().
 						Str("entity_id", e.EntityID.String()).

--- a/internal/controlplane/handlers_evalstatus.go
+++ b/internal/controlplane/handlers_evalstatus.go
@@ -39,7 +39,6 @@ import (
 	"github.com/stacklok/minder/internal/ruletypes"
 	"github.com/stacklok/minder/internal/util"
 	minderv1 "github.com/stacklok/minder/pkg/api/protobuf/go/minder/v1"
-	provifv1 "github.com/stacklok/minder/pkg/providers/v1"
 )
 
 const (
@@ -391,7 +390,7 @@ func (s *Server) sortEntitiesEvaluationStatus(
 
 			efp, err := s.props.EntityWithProperties(ctx, e.EntityID, nil)
 			if err != nil {
-				if errors.Is(err, propSvc.ErrEntityNotFound) || errors.Is(err, provifv1.ErrEntityNotFound) {
+				if errors.Is(err, propSvc.ErrEntityNotFound) {
 					// If the entity is not found, log and skip
 					zerolog.Ctx(ctx).Error().
 						Str("entity_id", e.EntityID.String()).

--- a/internal/controlplane/handlers_profile.go
+++ b/internal/controlplane/handlers_profile.go
@@ -32,13 +32,13 @@ import (
 	"github.com/stacklok/minder/internal/engine/engcontext"
 	"github.com/stacklok/minder/internal/engine/entities"
 	entmodels "github.com/stacklok/minder/internal/entities/models"
+	propSvc "github.com/stacklok/minder/internal/entities/properties/service"
 	"github.com/stacklok/minder/internal/logger"
 	prof "github.com/stacklok/minder/internal/profiles"
 	ghprop "github.com/stacklok/minder/internal/providers/github/properties"
 	"github.com/stacklok/minder/internal/ruletypes"
 	"github.com/stacklok/minder/internal/util"
 	minderv1 "github.com/stacklok/minder/pkg/api/protobuf/go/minder/v1"
-	provifv1 "github.com/stacklok/minder/pkg/providers/v1"
 )
 
 // CreateProfile creates a profile for a project
@@ -420,7 +420,7 @@ func (s *Server) getRuleEvaluationStatuses(
 		// Get the rule evaluation status
 		st, err := s.getRuleEvalStatus(ctx, profileId, dbRuleEvalStat)
 		if err != nil {
-			if errors.Is(err, sql.ErrNoRows) || errors.Is(err, provifv1.ErrEntityNotFound) {
+			if errors.Is(err, sql.ErrNoRows) || errors.Is(err, propSvc.ErrEntityNotFound) {
 				zerolog.Ctx(ctx).Error().
 					Str("profile_id", profileId).
 					Str("rule_id", dbRuleEvalStat.RuleTypeID.String()).

--- a/internal/entities/properties/service/service.go
+++ b/internal/entities/properties/service/service.go
@@ -162,7 +162,9 @@ func (ps *propertiesService) RetrieveAllProperties(
 	// if not, fetch from provider
 	l.Debug().Msg("properties are not valid, fetching from provider")
 	refreshedProps, err := provider.FetchAllProperties(ctx, lookupProperties, entType, modelProps)
-	if err != nil {
+	if errors.Is(err, provifv1.ErrEntityNotFound) {
+		return nil, fmt.Errorf("failed to fetch upstream properties: %w", ErrEntityNotFound)
+	} else if err != nil {
 		return nil, err
 	}
 
@@ -259,8 +261,10 @@ func (ps *propertiesService) RetrieveProperty(
 	// if not, fetch from provider
 	l.Debug().Msg("properties are not valid, fetching from provider")
 	prop, err := provider.FetchProperty(ctx, lookupProperties, entType, key)
-	if err != nil {
-		return nil, fmt.Errorf("failed to fetch property: %w", err)
+	if errors.Is(err, provifv1.ErrEntityNotFound) {
+		return nil, fmt.Errorf("failed to fetch upstream property: %w", ErrEntityNotFound)
+	} else if err != nil {
+		return nil, err
 	}
 
 	return prop, nil

--- a/internal/entities/properties/service/service_test.go
+++ b/internal/entities/properties/service/service_test.go
@@ -610,6 +610,7 @@ func TestPropertiesService_RetrieveAllProperties(t *testing.T) {
 		dbSetup     func(t *testing.T, store db.Store, params fetchParams)
 		githubSetup func(t *testing.T, params fetchParams) githubMockBuilder
 		params      fetchParams
+		lookupProps map[string]any
 		expectErr   string
 		checkResult func(t *testing.T, props *properties.Properties)
 		opts        []propertiesServiceOption
@@ -632,6 +633,10 @@ func TestPropertiesService_RetrieveAllProperties(t *testing.T) {
 			params: fetchParams{
 				entType: minderv1.Entity_ENTITY_REPOSITORIES,
 				entName: rand.RandomName(seed),
+			},
+			lookupProps: map[string]any{
+				properties.PropertyUpstreamID: "123",
+				properties.PropertyName:       rand.RandomName(seed),
 			},
 			checkResult: func(t *testing.T, props *properties.Properties) {
 				t.Helper()
@@ -676,6 +681,9 @@ func TestPropertiesService_RetrieveAllProperties(t *testing.T) {
 				entType: minderv1.Entity_ENTITY_REPOSITORIES,
 				entName: rand.RandomName(seed),
 			},
+			lookupProps: map[string]any{
+				properties.PropertyName: rand.RandomName(seed),
+			},
 			checkResult: func(t *testing.T, props *properties.Properties) {
 				t.Helper()
 
@@ -716,11 +724,56 @@ func TestPropertiesService_RetrieveAllProperties(t *testing.T) {
 				entType: minderv1.Entity_ENTITY_REPOSITORIES,
 				entName: "testorg/testrepo",
 			},
+			lookupProps: map[string]any{
+				properties.PropertyName: "testorg/testrepo",
+			},
 			checkResult: func(t *testing.T, props *properties.Properties) {
 				t.Helper()
 
 				require.Equal(t, props.GetProperty(properties.RepoPropertyIsPrivate).GetBool(), true)
 				require.Equal(t, props.GetProperty(ghprop.RepoPropertyId).GetInt64(), int64(123))
+			},
+		},
+		{
+			name: "Cache hit by upstream ID, fetch from cache",
+			dbSetup: func(t *testing.T, store db.Store, params fetchParams) {
+				t.Helper()
+
+				ent, err := store.CreateEntity(context.TODO(), db.CreateEntityParams{
+					EntityType: entities.EntityTypeToDB(params.entType),
+					Name:       params.entName,
+					ProjectID:  params.projectID,
+					ProviderID: params.providerID,
+				})
+				require.NoError(t, err)
+
+				propMap := map[string]any{
+					properties.PropertyUpstreamID:    "456",
+					properties.RepoPropertyIsPrivate: true,
+					ghprop.RepoPropertyId:            int64(456),
+				}
+				props, err := properties.NewProperties(propMap)
+				require.NoError(t, err)
+				insertProperties(context.TODO(), t, store, ent.ID, props)
+			},
+			githubSetup: func(t *testing.T, _ fetchParams) githubMockBuilder {
+				t.Helper()
+
+				return newGithubMock()
+			},
+			params: fetchParams{
+				entType: minderv1.Entity_ENTITY_REPOSITORIES,
+				entName: "testorg/testrepo2",
+			},
+			lookupProps: map[string]any{
+				// no name here, we're just looking up by upstream ID
+				properties.PropertyUpstreamID: "456",
+			},
+			checkResult: func(t *testing.T, props *properties.Properties) {
+				t.Helper()
+
+				require.Equal(t, props.GetProperty(properties.RepoPropertyIsPrivate).GetBool(), true)
+				require.Equal(t, props.GetProperty(ghprop.RepoPropertyId).GetInt64(), int64(456))
 			},
 		},
 	}
@@ -747,9 +800,7 @@ func TestPropertiesService_RetrieveAllProperties(t *testing.T) {
 
 			propSvc := NewPropertiesService(tctx.testQueries, tt.opts...)
 
-			getByProps, err := properties.NewProperties(map[string]any{
-				properties.PropertyName: tt.params.entName,
-			})
+			getByProps, err := properties.NewProperties(tt.lookupProps)
 			require.NoError(t, err)
 
 			gotProps, err := propSvc.RetrieveAllProperties(ctx, githubMock, tctx.dbProj.ID, tctx.ghAppProvider.ID, getByProps, tt.params.entType)

--- a/internal/repositories/service.go
+++ b/internal/repositories/service.go
@@ -361,7 +361,7 @@ func (r *repositoryService) RefreshRepositoryByUpstreamID(
 			entRepo.ProviderID,
 			fetchByProps,
 			pb.Entity_ENTITY_REPOSITORIES)
-		if errors.Is(err, provifv1.ErrEntityNotFound) {
+		if errors.Is(err, service.ErrEntityNotFound) {
 			// return the entity without properties in case the upstream entity is not found
 			ewp := models.NewEntityWithProperties(entRepo, repoProperties)
 			return ewp, nil


### PR DESCRIPTION

# Summary

- **Don't fail if lookupProperties include upstream ID but the entity does not** - We recently enhanced the property service to include lookup by ID in the cache, which is great, but we didn't handle the case where the lookup properties included the upstream ID but the entity properties in the database did not. In that case we should fall back to looking the property by name.
- **Don't return provifv1.ErrEntityNotFound from the property service** - It was irritating to have to handle two return codes. The caller really doesn't care why was the entity not found, just that it was not found.  Let's conver the provider NotFound into service Not found so that the callers have one less error to handle.

Fixes #4431

***Mark the type of change your PR introduces:***

- [x] Bug fix (resolves an issue without affecting existing features)
- [ ] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [ ] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

I added a unit test. I need to do better testing, I'm just running out of time right now. I'll continue in the evening.

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [x] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [x] Included tests that validate the fix or feature.
- [ ] Checked that related changes are merged.
