### PR TITLE
Handle calling the property service in transaction better

### DIFF
--- a/internal/controlplane/handlers_evalstatus.go
+++ b/internal/controlplane/handlers_evalstatus.go
@@ -192,6 +192,11 @@ func (s *Server) ListEvaluationHistory(
 		return nil, err
 	}
 
+	if err := s.store.Commit(tx); err != nil {
+		// non: fatal - this handler just refreshes properties but doesn't write any new data
+		zerolog.Ctx(ctx).Error().Err(err).Msg("error committing transaction")
+	}
+
 	// return data set to client
 	resp := &minderv1.ListEvaluationHistoryResponse{}
 	if len(data) == 0 {

--- a/internal/controlplane/handlers_evalstatus.go
+++ b/internal/controlplane/handlers_evalstatus.go
@@ -592,7 +592,7 @@ func (s *Server) buildRuleEvaluationStatusFromDBEvaluation(
 			Msg("error converting severity will use defaults")
 	}
 
-	err = s.props.RetrieveAllPropertiesForEntity(ctx, efp, s.providerManager)
+	err = s.props.RetrieveAllPropertiesForEntity(ctx, efp, s.providerManager, s.store)
 	if err != nil {
 		return nil, fmt.Errorf("error fetching properties for entity: %s: %w", efp.Entity.ID.String(), err)
 	}

--- a/internal/controlplane/handlers_githubwebhooks_test.go
+++ b/internal/controlplane/handlers_githubwebhooks_test.go
@@ -101,7 +101,7 @@ func withSuccessRetrieveAllProperties(entity v1.Entity, retPropsMap map[string]a
 
 	return func(mock propSvcMock) {
 		mock.EXPECT().
-			RetrieveAllProperties(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), entity).
+			RetrieveAllProperties(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), entity, gomock.Any()).
 			Return(retProps, nil)
 	}
 }

--- a/internal/controlplane/handlers_profile.go
+++ b/internal/controlplane/handlers_profile.go
@@ -454,12 +454,14 @@ func (s *Server) getRuleEvalStatus(
 	var guidance string
 	var err error
 
+	// the caller just ignores allt the errors anyway, so we don't start a transaction as the integrity issues
+	// would not be discovered anyway
 	efp, err := s.props.EntityWithProperties(ctx, dbRuleEvalStat.EntityID, nil)
 	if err != nil {
 		return nil, fmt.Errorf("error fetching entity for properties: %w", err)
 	}
 
-	err = s.props.RetrieveAllPropertiesForEntity(ctx, efp, s.providerManager)
+	err = s.props.RetrieveAllPropertiesForEntity(ctx, efp, s.providerManager, s.store)
 	if err != nil {
 		return nil, fmt.Errorf("error fetching properties for entity: %w", err)
 	}

--- a/internal/entities/properties/service/helpers.go
+++ b/internal/entities/properties/service/helpers.go
@@ -121,7 +121,7 @@ func (ps *propertiesService) getEntityIdByProperties(
 	return uuid.Nil, nil
 }
 
-func (ps *propertiesService) getEntityIdByName(
+func (_ *propertiesService) getEntityIdByName(
 	ctx context.Context, projectId uuid.UUID,
 	providerID uuid.UUID,
 	name string, entType minderv1.Entity,
@@ -142,7 +142,7 @@ func (ps *propertiesService) getEntityIdByName(
 	return ent.ID, nil
 }
 
-func (ps *propertiesService) getEntityIdByUpstreamID(
+func (_ *propertiesService) getEntityIdByUpstreamID(
 	ctx context.Context, projectId uuid.UUID,
 	providerID uuid.UUID,
 	upstreamID string, entType minderv1.Entity,

--- a/internal/entities/properties/service/mock/service.go
+++ b/internal/entities/properties/service/mock/service.go
@@ -90,32 +90,32 @@ func (mr *MockPropertiesServiceMockRecorder) ReplaceProperty(ctx, entityID, key,
 }
 
 // RetrieveAllProperties mocks base method.
-func (m *MockPropertiesService) RetrieveAllProperties(ctx context.Context, provider v10.Provider, projectId, providerID uuid.UUID, lookupProperties *properties.Properties, entType v1.Entity) (*properties.Properties, error) {
+func (m *MockPropertiesService) RetrieveAllProperties(ctx context.Context, provider v10.Provider, projectId, providerID uuid.UUID, lookupProperties *properties.Properties, entType v1.Entity, qtx db.ExtendQuerier) (*properties.Properties, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "RetrieveAllProperties", ctx, provider, projectId, providerID, lookupProperties, entType)
+	ret := m.ctrl.Call(m, "RetrieveAllProperties", ctx, provider, projectId, providerID, lookupProperties, entType, qtx)
 	ret0, _ := ret[0].(*properties.Properties)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // RetrieveAllProperties indicates an expected call of RetrieveAllProperties.
-func (mr *MockPropertiesServiceMockRecorder) RetrieveAllProperties(ctx, provider, projectId, providerID, lookupProperties, entType any) *gomock.Call {
+func (mr *MockPropertiesServiceMockRecorder) RetrieveAllProperties(ctx, provider, projectId, providerID, lookupProperties, entType, qtx any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RetrieveAllProperties", reflect.TypeOf((*MockPropertiesService)(nil).RetrieveAllProperties), ctx, provider, projectId, providerID, lookupProperties, entType)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RetrieveAllProperties", reflect.TypeOf((*MockPropertiesService)(nil).RetrieveAllProperties), ctx, provider, projectId, providerID, lookupProperties, entType, qtx)
 }
 
 // RetrieveAllPropertiesForEntity mocks base method.
-func (m *MockPropertiesService) RetrieveAllPropertiesForEntity(ctx context.Context, efp *models.EntityWithProperties, provMan manager.ProviderManager) error {
+func (m *MockPropertiesService) RetrieveAllPropertiesForEntity(ctx context.Context, efp *models.EntityWithProperties, provMan manager.ProviderManager, qtx db.ExtendQuerier) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "RetrieveAllPropertiesForEntity", ctx, efp, provMan)
+	ret := m.ctrl.Call(m, "RetrieveAllPropertiesForEntity", ctx, efp, provMan, qtx)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // RetrieveAllPropertiesForEntity indicates an expected call of RetrieveAllPropertiesForEntity.
-func (mr *MockPropertiesServiceMockRecorder) RetrieveAllPropertiesForEntity(ctx, efp, provMan any) *gomock.Call {
+func (mr *MockPropertiesServiceMockRecorder) RetrieveAllPropertiesForEntity(ctx, efp, provMan, qtx any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RetrieveAllPropertiesForEntity", reflect.TypeOf((*MockPropertiesService)(nil).RetrieveAllPropertiesForEntity), ctx, efp, provMan)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RetrieveAllPropertiesForEntity", reflect.TypeOf((*MockPropertiesService)(nil).RetrieveAllPropertiesForEntity), ctx, efp, provMan, qtx)
 }
 
 // RetrieveProperty mocks base method.

--- a/internal/entities/properties/service/service_test.go
+++ b/internal/entities/properties/service/service_test.go
@@ -803,7 +803,7 @@ func TestPropertiesService_RetrieveAllProperties(t *testing.T) {
 			getByProps, err := properties.NewProperties(tt.lookupProps)
 			require.NoError(t, err)
 
-			gotProps, err := propSvc.RetrieveAllProperties(ctx, githubMock, tctx.dbProj.ID, tctx.ghAppProvider.ID, getByProps, tt.params.entType)
+			gotProps, err := propSvc.RetrieveAllProperties(ctx, githubMock, tctx.dbProj.ID, tctx.ghAppProvider.ID, getByProps, tt.params.entType, tctx.testQueries)
 
 			if tt.expectErr != "" {
 				require.Contains(t, err.Error(), tt.expectErr)

--- a/internal/history/service.go
+++ b/internal/history/service.go
@@ -223,7 +223,7 @@ func (ehs *evaluationHistoryService) ListEvaluationHistory(
 			return nil, fmt.Errorf("error fetching entity for properties: %w", err)
 		}
 
-		err = propsvc.RetrieveAllPropertiesForEntity(ctx, efp, ehs.providerManager)
+		err = propsvc.RetrieveAllPropertiesForEntity(ctx, efp, ehs.providerManager, qtx)
 		if err != nil {
 			return nil, fmt.Errorf("error fetching properties for entity: %w", err)
 		}

--- a/internal/history/service_test.go
+++ b/internal/history/service_test.go
@@ -844,7 +844,7 @@ func TestListEvaluationHistory(t *testing.T) {
 				propsSvc.EXPECT().EntityWithProperties(ctx, gomock.Any(), gomock.Any()).
 					Return(nil, tt.entityForPropertiesError).AnyTimes()
 			}
-			propsSvc.EXPECT().RetrieveAllPropertiesForEntity(ctx, gomock.Any(), gomock.Any()).
+			propsSvc.EXPECT().RetrieveAllPropertiesForEntity(ctx, gomock.Any(), gomock.Any(), gomock.Any()).
 				Return(tt.retrieveAllPropsErr).AnyTimes()
 
 			service := NewEvaluationHistoryService(pm, withPropertiesServiceBuilder(func(_ db.ExtendQuerier) service.PropertiesService {

--- a/internal/repositories/service.go
+++ b/internal/repositories/service.go
@@ -161,7 +161,8 @@ func (r *repositoryService) CreateRepository(
 		projectID,
 		provider.ID,
 		fetchByProps,
-		pb.Entity_ENTITY_REPOSITORIES)
+		pb.Entity_ENTITY_REPOSITORIES,
+		r.store) // a transaction is used in the service. The repo is not cached here anyway
 	if err != nil {
 		return nil, fmt.Errorf("error fetching properties for repository: %w", err)
 	}
@@ -360,7 +361,7 @@ func (r *repositoryService) RefreshRepositoryByUpstreamID(
 			entRepo.ProjectID,
 			entRepo.ProviderID,
 			fetchByProps,
-			pb.Entity_ENTITY_REPOSITORIES)
+			pb.Entity_ENTITY_REPOSITORIES, qtx)
 		if errors.Is(err, service.ErrEntityNotFound) {
 			// return the entity without properties in case the upstream entity is not found
 			ewp := models.NewEntityWithProperties(entRepo, repoProperties)

--- a/internal/repositories/service_test.go
+++ b/internal/repositories/service_test.go
@@ -669,14 +669,14 @@ func withSuccessfulReplaceProps(mock propSvcMock) {
 
 func withFailingGet(mock propSvcMock) {
 	mock.EXPECT().
-		RetrieveAllProperties(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+		RetrieveAllProperties(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 		Return(nil, errDefault)
 }
 
 func withSuccessfulPropFetch(prop *properties.Properties) func(svcMock propSvcMock) {
 	return func(mock propSvcMock) {
 		mock.EXPECT().
-			RetrieveAllProperties(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+			RetrieveAllProperties(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 			Return(prop, nil)
 	}
 }


### PR DESCRIPTION

# Summary

- **Pass a transaction handle to RetrieveAllProperties and RetrieveAllPropertiesForEntity** - These interface methods wouldn't take transaction into account.
- **Call an explicit commit in ListEvaluationHistory handler** - We refresh the properties in the historical evaluation endpoint (which btw should just be temporary to convert from the old tables to the new general tables) and missed the fact that the handler starts a transaction and then always rolls back - that was probably a way to keep consistence.  This means that the transactions that refresh properties are rolled back and on next call fetched again. This hurts performance quite a bit on repeated listHistory calls.

Fixes: #4393

## Change Type

- [x] Bug fix (resolves an issue without affecting existing features)
- [ ] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [ ] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

by calling the list history endpoint with expired entities

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [ ] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [ ] Included tests that validate the fix or feature.
- [ ] Checked that related changes are merged.
