### PR TITLE
The Go GitHub API doesn't seem to escape user package names, only org package names

### DIFF
--- a/internal/providers/github/common.go
+++ b/internal/providers/github/common.go
@@ -307,6 +307,7 @@ func (c *GitHub) getPackageVersions(ctx context.Context, owner string, package_t
 		if c.IsOrg() {
 			v, resp, err = c.client.Organizations.PackageGetAllVersions(ctx, owner, package_type, package_name, opt)
 		} else {
+			package_name = url.PathEscape(package_name)
 			v, resp, err = c.client.Users.PackageGetAllVersions(ctx, owner, package_type, package_name, opt)
 		}
 		if err != nil {
@@ -364,6 +365,7 @@ func (c *GitHub) GetPackageVersionById(ctx context.Context, owner string, packag
 			return nil, err
 		}
 	} else {
+		packageName = url.PathEscape(packageName)
 		pkgVersion, _, err = c.client.Users.PackageGetVersion(ctx, owner, packageType, packageName, version)
 		if err != nil {
 			return nil, err

--- a/internal/providers/github/properties/artifact.go
+++ b/internal/providers/github/properties/artifact.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"net/url"
 	"strconv"
 	"strings"
 	"time"
@@ -152,6 +153,7 @@ func getArtifactWrapper(
 		pkg, result, fetchErr = ghCli.Organizations.GetPackage(ctx, owner, pkgType, name)
 	} else {
 		l.Debug().Msg("fetching user package")
+		name = url.PathEscape(name)
 		pkg, result, fetchErr = ghCli.Users.GetPackage(ctx, owner, pkgType, name)
 	}
 


### PR DESCRIPTION
# Summary

For some reason, the Go github API doesn't escape package names when
listing user packages:
https://github.com/google/go-github/blob/662da6f8e9f32b7da649ad0bfac19948e5acdd85/github/users_packages.go#L58
but does so when listing org packages:
https://github.com/google/go-github/blob/662da6f8e9f32b7da649ad0bfac19948e5acdd85/github/orgs_packages.go#L48

This tripped us up when trying to refresh properties of a package that
belonged to a user and had e.g. a slash in the name.

It seems that evaluating these packages did not work since we upgraded to
github-go v60 as we had the same bug in the ingester and the properties
changes just made the bug more prominent in the sense that it would manifest
already in the handlers.

Fixes: #4444

## Change Type

- [x] Bug fix (resolves an issue without affecting existing features)
- [ ] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [ ] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

Using a fork of https://github.com/ethomson/calculator

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [ ] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [ ] Included tests that validate the fix or feature.
- [ ] Checked that related changes are merged.
