### PR TITLE
Increase timeout when deleting installations.

### DIFF
--- a/internal/providers/github/installations/installations.go
+++ b/internal/providers/github/installations/installations.go
@@ -21,6 +21,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"time"
 
 	"github.com/ThreeDotsLabs/watermill/message"
 	"github.com/rs/zerolog"
@@ -89,7 +90,10 @@ func (im *InstallationManager) handleProviderInstanceRemovedEvent(ctx context.Co
 		return fmt.Errorf("failed to unmarshal payload: %w", err)
 	}
 
-	return im.svc.DeleteGitHubAppInstallation(ctx, payload.InstallationID)
+	newCtx, cancel := context.WithTimeout(ctx, 1*time.Minute)
+	defer cancel()
+
+	return im.svc.DeleteGitHubAppInstallation(newCtx, payload.InstallationID)
 }
 
 // InstallationInfoWrapper is a helper struct to gether information


### PR DESCRIPTION
# Summary

This change increases the timeout when deleting installations from 30 seconds to 1 minute.

## Change Type

- [X] Bug fix (resolves an issue without affecting existing features)
- [ ] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [ ] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

Manual tests.

# Review Checklist:

- [X] Reviewed my own code for quality and clarity.
- [ ] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [ ] Included tests that validate the fix or feature.
- [ ] Checked that related changes are merged.
