### PR TITLE
Add "options" to properties service calls

### DIFF
--- a/internal/controlplane/handlers_evalstatus.go
+++ b/internal/controlplane/handlers_evalstatus.go
@@ -597,7 +597,8 @@ func (s *Server) buildRuleEvaluationStatusFromDBEvaluation(
 			Msg("error converting severity will use defaults")
 	}
 
-	err = s.props.RetrieveAllPropertiesForEntity(ctx, efp, s.providerManager, s.store)
+	err = s.props.RetrieveAllPropertiesForEntity(ctx, efp, s.providerManager,
+		propSvc.ReadBuilder().WithStoreOrTransaction(s.store).TolerateStaleData())
 	if err != nil {
 		return nil, fmt.Errorf("error fetching properties for entity: %s: %w", efp.Entity.ID.String(), err)
 	}

--- a/internal/controlplane/handlers_githubwebhooks.go
+++ b/internal/controlplane/handlers_githubwebhooks.go
@@ -42,6 +42,7 @@ import (
 	"github.com/stacklok/minder/internal/engine/entities"
 	"github.com/stacklok/minder/internal/entities/models"
 	"github.com/stacklok/minder/internal/entities/properties"
+	"github.com/stacklok/minder/internal/entities/properties/service"
 	"github.com/stacklok/minder/internal/events"
 	"github.com/stacklok/minder/internal/projects/features"
 	"github.com/stacklok/minder/internal/providers/github/clients"
@@ -730,7 +731,9 @@ func (s *Server) processPackageEvent(
 		refreshedPkgProperties, err = s.props.RetrieveAllProperties(
 			ctx, provider,
 			repoEnt.Entity.ProjectID, repoEnt.Entity.ProviderID,
-			pkgLookupProps, pb.Entity_ENTITY_ARTIFACTS, tx)
+			pkgLookupProps, pb.Entity_ENTITY_ARTIFACTS,
+			service.ReadBuilder().WithStoreOrTransaction(tx))
+
 		if err != nil {
 			return nil, fmt.Errorf("error retrieving properties: %w", err)
 		}
@@ -776,7 +779,8 @@ func (s *Server) processPackageEvent(
 		refreshedPkgProperties, err = s.props.RetrieveAllProperties(
 			ctx, provider,
 			ent.ProjectID, ent.ProviderID,
-			refreshedPkgProperties, pb.Entity_ENTITY_ARTIFACTS, tx)
+			refreshedPkgProperties, pb.Entity_ENTITY_ARTIFACTS,
+			service.ReadBuilder().WithStoreOrTransaction(tx))
 		if err != nil {
 			return nil, fmt.Errorf("error retrieving properties: %w", err)
 		}
@@ -1613,7 +1617,9 @@ func (s *Server) updatePullRequestInfoFromProvider(
 
 	prProps, err := s.props.RetrieveAllProperties(ctx, provider,
 		repoEnt.Entity.ProjectID, repoEnt.Entity.ProviderID,
-		lookupProperties, pb.Entity_ENTITY_PULL_REQUESTS, qtx)
+		lookupProperties, pb.Entity_ENTITY_PULL_REQUESTS,
+		service.ReadBuilder().WithStoreOrTransaction(qtx))
+
 	if err != nil {
 		return nil, fmt.Errorf("error retrieving properties: %w", err)
 	}

--- a/internal/controlplane/handlers_profile.go
+++ b/internal/controlplane/handlers_profile.go
@@ -461,7 +461,8 @@ func (s *Server) getRuleEvalStatus(
 		return nil, fmt.Errorf("error fetching entity for properties: %w", err)
 	}
 
-	err = s.props.RetrieveAllPropertiesForEntity(ctx, efp, s.providerManager, s.store)
+	err = s.props.RetrieveAllPropertiesForEntity(ctx, efp, s.providerManager,
+		propSvc.ReadBuilder().WithStoreOrTransaction(s.store).TolerateStaleData())
 	if err != nil {
 		return nil, fmt.Errorf("error fetching properties for entity: %w", err)
 	}

--- a/internal/engine/executor.go
+++ b/internal/engine/executor.go
@@ -235,7 +235,8 @@ func (e *executor) profileEvalStatus(
 	}
 
 	// get the entity with properties by the entity UUID
-	ewp, err := e.propService.EntityWithProperties(ctx, entityID, e.querier)
+	ewp, err := e.propService.EntityWithProperties(ctx, entityID,
+		service.CallBuilder().WithStoreOrTransaction(e.querier))
 	if err != nil {
 		return fmt.Errorf("error getting entity with properties: %w", err)
 	}

--- a/internal/entities/properties/service/mock/service.go
+++ b/internal/entities/properties/service/mock/service.go
@@ -14,9 +14,9 @@ import (
 	reflect "reflect"
 
 	uuid "github.com/google/uuid"
-	db "github.com/stacklok/minder/internal/db"
 	models "github.com/stacklok/minder/internal/entities/models"
 	properties "github.com/stacklok/minder/internal/entities/properties"
+	service "github.com/stacklok/minder/internal/entities/properties/service"
 	manager "github.com/stacklok/minder/internal/providers/manager"
 	v1 "github.com/stacklok/minder/pkg/api/protobuf/go/minder/v1"
 	v10 "github.com/stacklok/minder/pkg/providers/v1"
@@ -47,102 +47,102 @@ func (m *MockPropertiesService) EXPECT() *MockPropertiesServiceMockRecorder {
 }
 
 // EntityWithProperties mocks base method.
-func (m *MockPropertiesService) EntityWithProperties(ctx context.Context, entityID uuid.UUID, qtx db.ExtendQuerier) (*models.EntityWithProperties, error) {
+func (m *MockPropertiesService) EntityWithProperties(ctx context.Context, entityID uuid.UUID, opts *service.CallOptions) (*models.EntityWithProperties, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "EntityWithProperties", ctx, entityID, qtx)
+	ret := m.ctrl.Call(m, "EntityWithProperties", ctx, entityID, opts)
 	ret0, _ := ret[0].(*models.EntityWithProperties)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // EntityWithProperties indicates an expected call of EntityWithProperties.
-func (mr *MockPropertiesServiceMockRecorder) EntityWithProperties(ctx, entityID, qtx any) *gomock.Call {
+func (mr *MockPropertiesServiceMockRecorder) EntityWithProperties(ctx, entityID, opts any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EntityWithProperties", reflect.TypeOf((*MockPropertiesService)(nil).EntityWithProperties), ctx, entityID, qtx)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EntityWithProperties", reflect.TypeOf((*MockPropertiesService)(nil).EntityWithProperties), ctx, entityID, opts)
 }
 
 // ReplaceAllProperties mocks base method.
-func (m *MockPropertiesService) ReplaceAllProperties(ctx context.Context, entityID uuid.UUID, props *properties.Properties, qtx db.ExtendQuerier) error {
+func (m *MockPropertiesService) ReplaceAllProperties(ctx context.Context, entityID uuid.UUID, props *properties.Properties, opts *service.CallOptions) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ReplaceAllProperties", ctx, entityID, props, qtx)
+	ret := m.ctrl.Call(m, "ReplaceAllProperties", ctx, entityID, props, opts)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // ReplaceAllProperties indicates an expected call of ReplaceAllProperties.
-func (mr *MockPropertiesServiceMockRecorder) ReplaceAllProperties(ctx, entityID, props, qtx any) *gomock.Call {
+func (mr *MockPropertiesServiceMockRecorder) ReplaceAllProperties(ctx, entityID, props, opts any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReplaceAllProperties", reflect.TypeOf((*MockPropertiesService)(nil).ReplaceAllProperties), ctx, entityID, props, qtx)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReplaceAllProperties", reflect.TypeOf((*MockPropertiesService)(nil).ReplaceAllProperties), ctx, entityID, props, opts)
 }
 
 // ReplaceProperty mocks base method.
-func (m *MockPropertiesService) ReplaceProperty(ctx context.Context, entityID uuid.UUID, key string, prop *properties.Property, qtx db.ExtendQuerier) error {
+func (m *MockPropertiesService) ReplaceProperty(ctx context.Context, entityID uuid.UUID, key string, prop *properties.Property, opts *service.CallOptions) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ReplaceProperty", ctx, entityID, key, prop, qtx)
+	ret := m.ctrl.Call(m, "ReplaceProperty", ctx, entityID, key, prop, opts)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // ReplaceProperty indicates an expected call of ReplaceProperty.
-func (mr *MockPropertiesServiceMockRecorder) ReplaceProperty(ctx, entityID, key, prop, qtx any) *gomock.Call {
+func (mr *MockPropertiesServiceMockRecorder) ReplaceProperty(ctx, entityID, key, prop, opts any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReplaceProperty", reflect.TypeOf((*MockPropertiesService)(nil).ReplaceProperty), ctx, entityID, key, prop, qtx)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReplaceProperty", reflect.TypeOf((*MockPropertiesService)(nil).ReplaceProperty), ctx, entityID, key, prop, opts)
 }
 
 // RetrieveAllProperties mocks base method.
-func (m *MockPropertiesService) RetrieveAllProperties(ctx context.Context, provider v10.Provider, projectId, providerID uuid.UUID, lookupProperties *properties.Properties, entType v1.Entity, qtx db.ExtendQuerier) (*properties.Properties, error) {
+func (m *MockPropertiesService) RetrieveAllProperties(ctx context.Context, provider v10.Provider, projectId, providerID uuid.UUID, lookupProperties *properties.Properties, entType v1.Entity, opts *service.ReadOptions) (*properties.Properties, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "RetrieveAllProperties", ctx, provider, projectId, providerID, lookupProperties, entType, qtx)
+	ret := m.ctrl.Call(m, "RetrieveAllProperties", ctx, provider, projectId, providerID, lookupProperties, entType, opts)
 	ret0, _ := ret[0].(*properties.Properties)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // RetrieveAllProperties indicates an expected call of RetrieveAllProperties.
-func (mr *MockPropertiesServiceMockRecorder) RetrieveAllProperties(ctx, provider, projectId, providerID, lookupProperties, entType, qtx any) *gomock.Call {
+func (mr *MockPropertiesServiceMockRecorder) RetrieveAllProperties(ctx, provider, projectId, providerID, lookupProperties, entType, opts any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RetrieveAllProperties", reflect.TypeOf((*MockPropertiesService)(nil).RetrieveAllProperties), ctx, provider, projectId, providerID, lookupProperties, entType, qtx)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RetrieveAllProperties", reflect.TypeOf((*MockPropertiesService)(nil).RetrieveAllProperties), ctx, provider, projectId, providerID, lookupProperties, entType, opts)
 }
 
 // RetrieveAllPropertiesForEntity mocks base method.
-func (m *MockPropertiesService) RetrieveAllPropertiesForEntity(ctx context.Context, efp *models.EntityWithProperties, provMan manager.ProviderManager, qtx db.ExtendQuerier) error {
+func (m *MockPropertiesService) RetrieveAllPropertiesForEntity(ctx context.Context, efp *models.EntityWithProperties, provMan manager.ProviderManager, opts *service.ReadOptions) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "RetrieveAllPropertiesForEntity", ctx, efp, provMan, qtx)
+	ret := m.ctrl.Call(m, "RetrieveAllPropertiesForEntity", ctx, efp, provMan, opts)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // RetrieveAllPropertiesForEntity indicates an expected call of RetrieveAllPropertiesForEntity.
-func (mr *MockPropertiesServiceMockRecorder) RetrieveAllPropertiesForEntity(ctx, efp, provMan, qtx any) *gomock.Call {
+func (mr *MockPropertiesServiceMockRecorder) RetrieveAllPropertiesForEntity(ctx, efp, provMan, opts any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RetrieveAllPropertiesForEntity", reflect.TypeOf((*MockPropertiesService)(nil).RetrieveAllPropertiesForEntity), ctx, efp, provMan, qtx)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RetrieveAllPropertiesForEntity", reflect.TypeOf((*MockPropertiesService)(nil).RetrieveAllPropertiesForEntity), ctx, efp, provMan, opts)
 }
 
 // RetrieveProperty mocks base method.
-func (m *MockPropertiesService) RetrieveProperty(ctx context.Context, provider v10.Provider, projectId, providerID uuid.UUID, lookupProperties *properties.Properties, entType v1.Entity, key string) (*properties.Property, error) {
+func (m *MockPropertiesService) RetrieveProperty(ctx context.Context, provider v10.Provider, projectId, providerID uuid.UUID, lookupProperties *properties.Properties, entType v1.Entity, key string, opts *service.ReadOptions) (*properties.Property, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "RetrieveProperty", ctx, provider, projectId, providerID, lookupProperties, entType, key)
+	ret := m.ctrl.Call(m, "RetrieveProperty", ctx, provider, projectId, providerID, lookupProperties, entType, key, opts)
 	ret0, _ := ret[0].(*properties.Property)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // RetrieveProperty indicates an expected call of RetrieveProperty.
-func (mr *MockPropertiesServiceMockRecorder) RetrieveProperty(ctx, provider, projectId, providerID, lookupProperties, entType, key any) *gomock.Call {
+func (mr *MockPropertiesServiceMockRecorder) RetrieveProperty(ctx, provider, projectId, providerID, lookupProperties, entType, key, opts any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RetrieveProperty", reflect.TypeOf((*MockPropertiesService)(nil).RetrieveProperty), ctx, provider, projectId, providerID, lookupProperties, entType, key)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RetrieveProperty", reflect.TypeOf((*MockPropertiesService)(nil).RetrieveProperty), ctx, provider, projectId, providerID, lookupProperties, entType, key, opts)
 }
 
 // SaveAllProperties mocks base method.
-func (m *MockPropertiesService) SaveAllProperties(ctx context.Context, entityID uuid.UUID, props *properties.Properties, qtx db.ExtendQuerier) error {
+func (m *MockPropertiesService) SaveAllProperties(ctx context.Context, entityID uuid.UUID, props *properties.Properties, opts *service.CallOptions) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SaveAllProperties", ctx, entityID, props, qtx)
+	ret := m.ctrl.Call(m, "SaveAllProperties", ctx, entityID, props, opts)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // SaveAllProperties indicates an expected call of SaveAllProperties.
-func (mr *MockPropertiesServiceMockRecorder) SaveAllProperties(ctx, entityID, props, qtx any) *gomock.Call {
+func (mr *MockPropertiesServiceMockRecorder) SaveAllProperties(ctx, entityID, props, opts any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SaveAllProperties", reflect.TypeOf((*MockPropertiesService)(nil).SaveAllProperties), ctx, entityID, props, qtx)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SaveAllProperties", reflect.TypeOf((*MockPropertiesService)(nil).SaveAllProperties), ctx, entityID, props, opts)
 }

--- a/internal/entities/properties/service/options.go
+++ b/internal/entities/properties/service/options.go
@@ -1,0 +1,113 @@
+//
+// Copyright 2024 Stacklok, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package service
+
+import "github.com/stacklok/minder/internal/db"
+
+// CallOptions is a struct that contains the options for a service call
+// Since most calls will need to interact with the database, the ExtendQuerier is included
+// to ensure we can pass in a transaction if needed.
+type CallOptions struct {
+	storeOrTransaction db.ExtendQuerier
+}
+
+// CallBuilder is a function that returns a new CallOptions struct
+func CallBuilder() *CallOptions {
+	return &CallOptions{}
+}
+
+// WithStoreOrTransaction is a function that sets the StoreOrTransaction field in the CallOptions struct
+func (psco *CallOptions) WithStoreOrTransaction(storeOrTransaction db.ExtendQuerier) *CallOptions {
+	if psco == nil {
+		return nil
+	}
+	psco.storeOrTransaction = storeOrTransaction
+	return psco
+}
+
+func (psco *CallOptions) getStoreOrTransaction() db.ExtendQuerier {
+	if psco == nil {
+		return nil
+	}
+	return psco.storeOrTransaction
+}
+
+// ReadOptions is a struct that contains the options for a read service call
+// This extends the PropertiesServiceCallOptions struct and adds a TolerateStaleData field.
+// This field is used to determine if the service call can return stale data or not.
+// This is useful for read calls that can tolerate stale data.
+type ReadOptions struct {
+	*CallOptions
+	tolerateStaleData bool
+}
+
+// ReadBuilder is a function that returns a new ReadOptions struct
+func ReadBuilder() *ReadOptions {
+	return &ReadOptions{}
+}
+
+// TolerateStaleData is a function that sets the TolerateStaleData field in the ReadOptions struct
+func (psco *ReadOptions) TolerateStaleData() *ReadOptions {
+	if psco == nil {
+		return nil
+	}
+	psco.tolerateStaleData = true
+	return psco
+}
+
+// WithStoreOrTransaction is a function that sets the StoreOrTransaction field in the ReadOptions struct
+func (psco *ReadOptions) WithStoreOrTransaction(storeOrTransaction db.ExtendQuerier) *ReadOptions {
+	if psco == nil {
+		return nil
+	}
+	if psco.CallOptions == nil {
+		psco.CallOptions = CallBuilder()
+	}
+	psco.CallOptions = psco.CallOptions.WithStoreOrTransaction(storeOrTransaction)
+	return psco
+}
+
+func (psco *ReadOptions) canTolerateStaleData() bool {
+	if psco == nil {
+		return false
+	}
+	return psco.tolerateStaleData
+}
+
+func (psco *ReadOptions) getStoreOrTransaction() db.ExtendQuerier {
+	if psco == nil || psco.CallOptions == nil {
+		return nil
+	}
+	return psco.CallOptions.getStoreOrTransaction()
+}
+
+func (psco *ReadOptions) getPropertiesServiceCallOptions() *CallOptions {
+	if psco == nil {
+		return nil
+	}
+	return psco.CallOptions
+}
+
+type getStoreOrTransaction interface {
+	getStoreOrTransaction() db.ExtendQuerier
+}
+
+func (ps *propertiesService) getStoreOrTransaction(opts getStoreOrTransaction) db.ExtendQuerier {
+	if opts != nil && opts.getStoreOrTransaction() != nil {
+		return opts.getStoreOrTransaction()
+	}
+	return ps.store
+}

--- a/internal/entities/properties/service/service_test.go
+++ b/internal/entities/properties/service/service_test.go
@@ -248,7 +248,8 @@ func TestPropertiesService_SaveProperty(t *testing.T) {
 			}
 
 			err = tctx.testQueries.WithTransactionErr(func(qtx db.ExtendQuerier) error {
-				return propSvc.ReplaceProperty(ctx, ent.ID, tt.key, prop, qtx)
+				return propSvc.ReplaceProperty(ctx, ent.ID, tt.key, prop,
+					CallBuilder().WithStoreOrTransaction(qtx))
 			})
 			require.NoError(t, err)
 
@@ -397,7 +398,8 @@ func TestPropertiesService_SaveAllProperties(t *testing.T) {
 			require.NoError(t, err)
 
 			err = tctx.testQueries.WithTransactionErr(func(qtx db.ExtendQuerier) error {
-				return propSvc.ReplaceAllProperties(ctx, ent.ID, props, qtx)
+				return propSvc.ReplaceAllProperties(ctx, ent.ID, props,
+					CallBuilder().WithStoreOrTransaction(qtx))
 			})
 			require.NoError(t, err)
 
@@ -587,7 +589,8 @@ func TestPropertiesService_RetrieveProperty(t *testing.T) {
 			getByProps, err := properties.NewProperties(propSearch)
 			require.NoError(t, err)
 
-			gotProps, err := propSvc.RetrieveProperty(ctx, githubMock, tctx.dbProj.ID, tctx.ghAppProvider.ID, getByProps, tt.params.entType, tt.propName)
+			gotProps, err := propSvc.RetrieveProperty(
+				ctx, githubMock, tctx.dbProj.ID, tctx.ghAppProvider.ID, getByProps, tt.params.entType, tt.propName, nil)
 
 			if tt.expectErr != "" {
 				require.Contains(t, err.Error(), tt.expectErr)
@@ -803,7 +806,9 @@ func TestPropertiesService_RetrieveAllProperties(t *testing.T) {
 			getByProps, err := properties.NewProperties(tt.lookupProps)
 			require.NoError(t, err)
 
-			gotProps, err := propSvc.RetrieveAllProperties(ctx, githubMock, tctx.dbProj.ID, tctx.ghAppProvider.ID, getByProps, tt.params.entType, tctx.testQueries)
+			gotProps, err := propSvc.RetrieveAllProperties(
+				ctx, githubMock, tctx.dbProj.ID, tctx.ghAppProvider.ID, getByProps, tt.params.entType,
+				ReadBuilder().WithStoreOrTransaction(tctx.testQueries))
 
 			if tt.expectErr != "" {
 				require.Contains(t, err.Error(), tt.expectErr)

--- a/internal/history/service.go
+++ b/internal/history/service.go
@@ -218,12 +218,14 @@ func (ehs *evaluationHistoryService) ListEvaluationHistory(
 
 	data := make([]*OneEvalHistoryAndEntity, 0, len(rows))
 	for _, row := range rows {
-		efp, err := propsvc.EntityWithProperties(ctx, row.EntityID, qtx)
+		efp, err := propsvc.EntityWithProperties(ctx, row.EntityID,
+			propertiessvc.CallBuilder().WithStoreOrTransaction(qtx))
 		if err != nil {
 			return nil, fmt.Errorf("error fetching entity for properties: %w", err)
 		}
 
-		err = propsvc.RetrieveAllPropertiesForEntity(ctx, efp, ehs.providerManager, qtx)
+		err = propsvc.RetrieveAllPropertiesForEntity(ctx, efp, ehs.providerManager,
+			propertiessvc.ReadBuilder().WithStoreOrTransaction(qtx).TolerateStaleData())
 		if err != nil {
 			return nil, fmt.Errorf("error fetching properties for entity: %w", err)
 		}


### PR DESCRIPTION
# Summary

Instead of passing the db store and other optional values as
explicit paramters, this introduces options to the properties service.
This allows us to start building queries in a more dynamic way.

The querier is passed always now as an option.

Disregarding stale data was introduced as an option, and it was also
used in the places it's needed, that is, in GET calls.

## Change Type

***Mark the type of change your PR introduces:***

- [ ] Bug fix (resolves an issue without affecting existing features)
- [x] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [ ] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

***Outline how the changes were tested, including steps to reproduce and any relevant configurations. 
Attach screenshots if helpful.***

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [ ] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [ ] Included tests that validate the fix or feature.
- [ ] Checked that related changes are merged.
