### PR TITLE
Add a new ProtoMessageConverter provider interface to convert entities to typed protobuf messages

### DIFF
--- a/cmd/dev/app/rule_type/rttst.go
+++ b/cmd/dev/app/rule_type/rttst.go
@@ -378,7 +378,7 @@ func entityWithPropertiesToEntityInfoWrapper(ewp *entModels.EntityWithProperties
 	case minderv1.Entity_ENTITY_ARTIFACTS:
 		ent, err = properties.ArtifactV1FromProperties(ewp.Properties)
 	case minderv1.Entity_ENTITY_PULL_REQUESTS:
-		ent = properties.PullRequestV1FromProperties(ewp.Properties)
+		ent, err = properties.PullRequestV1FromProperties(ewp.Properties)
 	}
 	if err != nil {
 		return nil, fmt.Errorf("error converting properties to entity: %w", err)

--- a/internal/controlplane/handlers_githubwebhooks_test.go
+++ b/internal/controlplane/handlers_githubwebhooks_test.go
@@ -106,6 +106,30 @@ func withSuccessRetrieveAllProperties(entity v1.Entity, retPropsMap map[string]a
 	}
 }
 
+func withSuccessPullProto() func(mck propSvcMock) {
+	return func(mock propSvcMock) {
+		mock.EXPECT().
+			EntityWithPropertiesAsProto(gomock.Any(), gomock.Any(), gomock.Any()).
+			Return(&v1.PullRequest{}, nil)
+	}
+}
+
+func withSuccessArtifactProto() func(mck propSvcMock) {
+	return func(mock propSvcMock) {
+		mock.EXPECT().
+			EntityWithPropertiesAsProto(gomock.Any(), gomock.Any(), gomock.Any()).
+			Return(&v1.Artifact{}, nil)
+	}
+}
+
+func withSuccessRepoProto() func(mck propSvcMock) {
+	return func(mock propSvcMock) {
+		mock.EXPECT().
+			EntityWithPropertiesAsProto(gomock.Any(), gomock.Any(), gomock.Any()).
+			Return(&v1.Repository{}, nil)
+	}
+}
+
 type repoSvcMock = *mock_repos.MockRepositoryService
 type repoSvcMockBuilder = func(*gomock.Controller) repoSvcMock
 
@@ -679,6 +703,7 @@ func (s *UnitTestSuite) TestHandleGitHubWebHook() {
 					ghprop.ArtifactPropertyName:      "package-name",
 					ghprop.ArtifactPropertyCreatedAt: "2024-05-22T07:35:16Z",
 				}),
+				withSuccessArtifactProto(),
 			),
 			ghMocks: []func(hubMock gf.GitHubMock){
 				gf.WithSuccessfulGetEntityName("login/package-name"),
@@ -750,6 +775,7 @@ func (s *UnitTestSuite) TestHandleGitHubWebHook() {
 					ghprop.ArtifactPropertyName:      "demo-repo-go-debug",
 					ghprop.ArtifactPropertyCreatedAt: "2024-05-22T07:35:16Z",
 				}),
+				withSuccessArtifactProto(),
 			),
 			ghMocks: []func(hubMock gf.GitHubMock){
 				gf.WithSuccessfulGetEntityName("stacklok/minder"),
@@ -1322,6 +1348,9 @@ func (s *UnitTestSuite) TestHandleGitHubWebHook() {
 					"https://github.com/stacklok/minder",
 				),
 			},
+			mockPropsBld: newPropSvcMock(
+				withSuccessRepoProto(),
+			),
 			mockRepoBld: newRepoSvcMock(
 				withSuccessRepoById(
 					models.EntityInstance{
@@ -1370,6 +1399,9 @@ func (s *UnitTestSuite) TestHandleGitHubWebHook() {
 					"https://github.com/stacklok/minder",
 				),
 			},
+			mockPropsBld: newPropSvcMock(
+				withSuccessRepoProto(),
+			),
 			mockRepoBld: newRepoSvcMock(
 				withSuccessRepoById(
 					models.EntityInstance{
@@ -1418,6 +1450,9 @@ func (s *UnitTestSuite) TestHandleGitHubWebHook() {
 					"https://github.com/stacklok/minder",
 				),
 			},
+			mockPropsBld: newPropSvcMock(
+				withSuccessRepoProto(),
+			),
 			mockRepoBld: newRepoSvcMock(
 				withSuccessRepoById(
 					models.EntityInstance{
@@ -1466,6 +1501,9 @@ func (s *UnitTestSuite) TestHandleGitHubWebHook() {
 					"https://github.com/stacklok/minder",
 				),
 			},
+			mockPropsBld: newPropSvcMock(
+				withSuccessRepoProto(),
+			),
 			mockRepoBld: newRepoSvcMock(
 				withSuccessRepoById(
 					models.EntityInstance{
@@ -1513,6 +1551,9 @@ func (s *UnitTestSuite) TestHandleGitHubWebHook() {
 					"https://github.com/stacklok/minder",
 				),
 			},
+			mockPropsBld: newPropSvcMock(
+				withSuccessRepoProto(),
+			),
 			mockRepoBld: newRepoSvcMock(
 				withSuccessRepoById(
 					models.EntityInstance{
@@ -1561,6 +1602,9 @@ func (s *UnitTestSuite) TestHandleGitHubWebHook() {
 					"https://github.com/stacklok/minder",
 				),
 			},
+			mockPropsBld: newPropSvcMock(
+				withSuccessRepoProto(),
+			),
 			mockRepoBld: newRepoSvcMock(
 				withSuccessRepoById(
 					models.EntityInstance{
@@ -1608,6 +1652,9 @@ func (s *UnitTestSuite) TestHandleGitHubWebHook() {
 					"https://github.com/stacklok/minder",
 				),
 			},
+			mockPropsBld: newPropSvcMock(
+				withSuccessRepoProto(),
+			),
 			mockRepoBld: newRepoSvcMock(
 				withSuccessRepoById(
 					models.EntityInstance{
@@ -1656,6 +1703,9 @@ func (s *UnitTestSuite) TestHandleGitHubWebHook() {
 					"https://github.com/stacklok/minder",
 				),
 			},
+			mockPropsBld: newPropSvcMock(
+				withSuccessRepoProto(),
+			),
 			mockRepoBld: newRepoSvcMock(
 				withSuccessRepoById(
 					models.EntityInstance{
@@ -1704,6 +1754,9 @@ func (s *UnitTestSuite) TestHandleGitHubWebHook() {
 					"https://github.com/stacklok/minder",
 				),
 			},
+			mockPropsBld: newPropSvcMock(
+				withSuccessRepoProto(),
+			),
 			mockRepoBld: newRepoSvcMock(
 				withSuccessRepoById(
 					models.EntityInstance{
@@ -1854,6 +1907,9 @@ func (s *UnitTestSuite) TestHandleGitHubWebHook() {
 					"https://github.com/stacklok/minder",
 				),
 			},
+			mockPropsBld: newPropSvcMock(
+				withSuccessRepoProto(),
+			),
 			mockRepoBld: newRepoSvcMock(
 				withSuccessRepoById(
 					models.EntityInstance{
@@ -1902,6 +1958,9 @@ func (s *UnitTestSuite) TestHandleGitHubWebHook() {
 					"https://github.com/stacklok/minder",
 				),
 			},
+			mockPropsBld: newPropSvcMock(
+				withSuccessRepoProto(),
+			),
 			mockRepoBld: newRepoSvcMock(
 				withSuccessRepoById(
 					models.EntityInstance{
@@ -1950,6 +2009,9 @@ func (s *UnitTestSuite) TestHandleGitHubWebHook() {
 					"https://github.com/stacklok/minder",
 				),
 			},
+			mockPropsBld: newPropSvcMock(
+				withSuccessRepoProto(),
+			),
 			mockRepoBld: newRepoSvcMock(
 				withSuccessRepoById(
 					models.EntityInstance{
@@ -1998,6 +2060,9 @@ func (s *UnitTestSuite) TestHandleGitHubWebHook() {
 					"https://github.com/stacklok/minder",
 				),
 			},
+			mockPropsBld: newPropSvcMock(
+				withSuccessRepoProto(),
+			),
 			mockRepoBld: newRepoSvcMock(
 				withSuccessRepoById(
 					models.EntityInstance{
@@ -2097,6 +2162,9 @@ func (s *UnitTestSuite) TestHandleGitHubWebHook() {
 					"https://github.com/stacklok/minder",
 				),
 			},
+			mockPropsBld: newPropSvcMock(
+				withSuccessRepoProto(),
+			),
 			mockRepoBld: newRepoSvcMock(
 				withSuccessRepoById(
 					models.EntityInstance{
@@ -2184,6 +2252,9 @@ func (s *UnitTestSuite) TestHandleGitHubWebHook() {
 					Private:  github.Bool(true),
 				},
 			},
+			mockPropsBld: newPropSvcMock(
+				withSuccessRepoProto(),
+			),
 			mockRepoBld: newRepoSvcMock(
 				withSuccessRepoById(
 					models.EntityInstance{
@@ -2232,6 +2303,9 @@ func (s *UnitTestSuite) TestHandleGitHubWebHook() {
 					"https://github.com/stacklok/minder",
 				),
 			},
+			mockPropsBld: newPropSvcMock(
+				withSuccessRepoProto(),
+			),
 			mockRepoBld: newRepoSvcMock(
 				withSuccessRepoById(
 					models.EntityInstance{
@@ -2280,6 +2354,9 @@ func (s *UnitTestSuite) TestHandleGitHubWebHook() {
 					"https://github.com/stacklok/minder",
 				),
 			},
+			mockPropsBld: newPropSvcMock(
+				withSuccessRepoProto(),
+			),
 			mockRepoBld: newRepoSvcMock(
 				withSuccessRepoById(
 					models.EntityInstance{
@@ -2328,6 +2405,9 @@ func (s *UnitTestSuite) TestHandleGitHubWebHook() {
 					"https://github.com/stacklok/minder",
 				),
 			},
+			mockPropsBld: newPropSvcMock(
+				withSuccessRepoProto(),
+			),
 			mockRepoBld: newRepoSvcMock(
 				withSuccessRepoById(
 					models.EntityInstance{
@@ -2376,6 +2456,9 @@ func (s *UnitTestSuite) TestHandleGitHubWebHook() {
 					"https://github.com/stacklok/minder",
 				),
 			},
+			mockPropsBld: newPropSvcMock(
+				withSuccessRepoProto(),
+			),
 			mockRepoBld: newRepoSvcMock(
 				withSuccessRepoById(
 					models.EntityInstance{
@@ -2424,6 +2507,9 @@ func (s *UnitTestSuite) TestHandleGitHubWebHook() {
 					"https://github.com/stacklok/minder",
 				),
 			},
+			mockPropsBld: newPropSvcMock(
+				withSuccessRepoProto(),
+			),
 			mockRepoBld: newRepoSvcMock(
 				withSuccessRepoById(
 					models.EntityInstance{
@@ -2472,6 +2558,9 @@ func (s *UnitTestSuite) TestHandleGitHubWebHook() {
 					"https://github.com/stacklok/minder",
 				),
 			},
+			mockPropsBld: newPropSvcMock(
+				withSuccessRepoProto(),
+			),
 			mockRepoBld: newRepoSvcMock(
 				withSuccessRepoById(
 					models.EntityInstance{
@@ -2519,6 +2608,9 @@ func (s *UnitTestSuite) TestHandleGitHubWebHook() {
 					"https://github.com/stacklok/minder",
 				),
 			},
+			mockPropsBld: newPropSvcMock(
+				withSuccessRepoProto(),
+			),
 			mockRepoBld: newRepoSvcMock(
 				withSuccessRepoById(
 					models.EntityInstance{
@@ -2567,6 +2659,9 @@ func (s *UnitTestSuite) TestHandleGitHubWebHook() {
 					"https://github.com/stacklok/minder",
 				),
 			},
+			mockPropsBld: newPropSvcMock(
+				withSuccessRepoProto(),
+			),
 			mockRepoBld: newRepoSvcMock(
 				withSuccessRepoById(
 					models.EntityInstance{
@@ -2615,6 +2710,9 @@ func (s *UnitTestSuite) TestHandleGitHubWebHook() {
 					"https://github.com/stacklok/minder",
 				),
 			},
+			mockPropsBld: newPropSvcMock(
+				withSuccessRepoProto(),
+			),
 			mockRepoBld: newRepoSvcMock(
 				withSuccessRepoById(
 					models.EntityInstance{
@@ -2663,6 +2761,9 @@ func (s *UnitTestSuite) TestHandleGitHubWebHook() {
 					"https://github.com/stacklok/minder",
 				),
 			},
+			mockPropsBld: newPropSvcMock(
+				withSuccessRepoProto(),
+			),
 			mockRepoBld: newRepoSvcMock(
 				withSuccessRepoById(
 					models.EntityInstance{
@@ -2711,6 +2812,9 @@ func (s *UnitTestSuite) TestHandleGitHubWebHook() {
 					"https://github.com/stacklok/minder",
 				),
 			},
+			mockPropsBld: newPropSvcMock(
+				withSuccessRepoProto(),
+			),
 			mockRepoBld: newRepoSvcMock(
 				withSuccessRepoById(
 					models.EntityInstance{
@@ -2759,6 +2863,9 @@ func (s *UnitTestSuite) TestHandleGitHubWebHook() {
 					"https://github.com/stacklok/minder",
 				),
 			},
+			mockPropsBld: newPropSvcMock(
+				withSuccessRepoProto(),
+			),
 			mockRepoBld: newRepoSvcMock(
 				withSuccessRepoById(
 					models.EntityInstance{
@@ -2807,6 +2914,9 @@ func (s *UnitTestSuite) TestHandleGitHubWebHook() {
 					"https://github.com/stacklok/minder",
 				),
 			},
+			mockPropsBld: newPropSvcMock(
+				withSuccessRepoProto(),
+			),
 			mockRepoBld: newRepoSvcMock(
 				withSuccessRepoById(
 					models.EntityInstance{
@@ -2855,6 +2965,9 @@ func (s *UnitTestSuite) TestHandleGitHubWebHook() {
 					"https://github.com/stacklok/minder",
 				),
 			},
+			mockPropsBld: newPropSvcMock(
+				withSuccessRepoProto(),
+			),
 			mockRepoBld: newRepoSvcMock(
 				withSuccessRepoById(
 					models.EntityInstance{
@@ -2903,6 +3016,9 @@ func (s *UnitTestSuite) TestHandleGitHubWebHook() {
 					"https://github.com/stacklok/minder",
 				),
 			},
+			mockPropsBld: newPropSvcMock(
+				withSuccessRepoProto(),
+			),
 			mockRepoBld: newRepoSvcMock(
 				withSuccessRepoById(
 					models.EntityInstance{
@@ -2951,6 +3067,9 @@ func (s *UnitTestSuite) TestHandleGitHubWebHook() {
 					"https://github.com/stacklok/minder",
 				),
 			},
+			mockPropsBld: newPropSvcMock(
+				withSuccessRepoProto(),
+			),
 			mockRepoBld: newRepoSvcMock(
 				withSuccessRepoById(
 					models.EntityInstance{
@@ -2998,6 +3117,9 @@ func (s *UnitTestSuite) TestHandleGitHubWebHook() {
 					"https://github.com/stacklok/minder",
 				),
 			},
+			mockPropsBld: newPropSvcMock(
+				withSuccessRepoProto(),
+			),
 			mockRepoBld: newRepoSvcMock(
 				withSuccessRepoById(
 					models.EntityInstance{
@@ -3045,6 +3167,9 @@ func (s *UnitTestSuite) TestHandleGitHubWebHook() {
 					"https://github.com/stacklok/minder",
 				),
 			},
+			mockPropsBld: newPropSvcMock(
+				withSuccessRepoProto(),
+			),
 			mockRepoBld: newRepoSvcMock(
 				withSuccessRepoById(
 					models.EntityInstance{
@@ -3103,6 +3228,9 @@ func (s *UnitTestSuite) TestHandleGitHubWebHook() {
 					HTMLURL:  github.String("https://github.com/stacklok/minder"),
 				},
 			},
+			mockPropsBld: newPropSvcMock(
+				withSuccessRepoProto(),
+			),
 			mockRepoBld: newRepoSvcMock(
 				withSuccessRepoById(
 					models.EntityInstance{
@@ -3143,6 +3271,9 @@ func (s *UnitTestSuite) TestHandleGitHubWebHook() {
 			event: "push",
 			// https://pkg.go.dev/github.com/google/go-github/v62@v62.0.0/github#PushEvent
 			rawPayload: []byte(rawPushEvent),
+			mockPropsBld: newPropSvcMock(
+				withSuccessRepoProto(),
+			),
 			mockRepoBld: newRepoSvcMock(
 				withSuccessRepoById(
 					models.EntityInstance{
@@ -3192,6 +3323,9 @@ func (s *UnitTestSuite) TestHandleGitHubWebHook() {
 					"https://github.com/stacklok/minder",
 				),
 			},
+			mockPropsBld: newPropSvcMock(
+				withSuccessRepoProto(),
+			),
 			mockRepoBld: newRepoSvcMock(
 				withSuccessRepoById(
 					models.EntityInstance{
@@ -3227,6 +3361,9 @@ func (s *UnitTestSuite) TestHandleGitHubWebHook() {
 					"https://github.com/stacklok/minder",
 				),
 			},
+			mockPropsBld: newPropSvcMock(
+				withSuccessRepoProto(),
+			),
 			mockRepoBld: newRepoSvcMock(
 				withSuccessRepoById(
 					models.EntityInstance{
@@ -3255,6 +3392,9 @@ func (s *UnitTestSuite) TestHandleGitHubWebHook() {
 			// https://docs.github.com/en/webhooks/webhook-events-and-payloads#branch_protection_configuration
 			event:      "branch_protection_configuration",
 			rawPayload: []byte(rawBranchProtectionConfigurationDisabledEvent),
+			mockPropsBld: newPropSvcMock(
+				withSuccessRepoProto(),
+			),
 			mockRepoBld: newRepoSvcMock(
 				withSuccessRepoById(
 					models.EntityInstance{
@@ -3301,6 +3441,9 @@ func (s *UnitTestSuite) TestHandleGitHubWebHook() {
 					"https://github.com/stacklok/minder",
 				),
 			},
+			mockPropsBld: newPropSvcMock(
+				withSuccessRepoProto(),
+			),
 			mockRepoBld: newRepoSvcMock(
 				withSuccessRepoById(
 					models.EntityInstance{
@@ -3347,6 +3490,9 @@ func (s *UnitTestSuite) TestHandleGitHubWebHook() {
 					"https://github.com/stacklok/minder",
 				),
 			},
+			mockPropsBld: newPropSvcMock(
+				withSuccessRepoProto(),
+			),
 			mockRepoBld: newRepoSvcMock(
 				withSuccessRepoById(
 					models.EntityInstance{
@@ -3412,6 +3558,9 @@ func (s *UnitTestSuite) TestHandleGitHubWebHook() {
 						ghprop.RepoPropertyId:             int64(12345),
 					}),
 			),
+			mockPropsBld: newPropSvcMock(
+				withSuccessRepoProto(),
+			),
 			topic:      events.TopicQueueEntityEvaluate,
 			statusCode: http.StatusOK,
 			queued: func(t *testing.T, event string, ch <-chan *message.Message) {
@@ -3439,6 +3588,9 @@ func (s *UnitTestSuite) TestHandleGitHubWebHook() {
 					"https://github.com/stacklok/minder",
 				),
 			},
+			mockPropsBld: newPropSvcMock(
+				withSuccessRepoProto(),
+			),
 			mockRepoBld: newRepoSvcMock(
 				withSuccessRepoById(
 					models.EntityInstance{
@@ -3485,6 +3637,9 @@ func (s *UnitTestSuite) TestHandleGitHubWebHook() {
 					"https://github.com/stacklok/minder",
 				),
 			},
+			mockPropsBld: newPropSvcMock(
+				withSuccessRepoProto(),
+			),
 			mockRepoBld: newRepoSvcMock(
 				withSuccessRepoById(
 					models.EntityInstance{
@@ -3531,6 +3686,9 @@ func (s *UnitTestSuite) TestHandleGitHubWebHook() {
 					"https://github.com/stacklok/minder",
 				),
 			},
+			mockPropsBld: newPropSvcMock(
+				withSuccessRepoProto(),
+			),
 			mockRepoBld: newRepoSvcMock(
 				withSuccessRepoById(
 					models.EntityInstance{
@@ -3594,6 +3752,7 @@ func (s *UnitTestSuite) TestHandleGitHubWebHook() {
 			},
 			mockPropsBld: newPropSvcMock(
 				withSuccessRetrieveAllProperties(v1.Entity_ENTITY_PULL_REQUESTS, nil),
+				withSuccessPullProto(),
 			),
 			mockRepoBld: newRepoSvcMock(
 				withSuccessRepoById(
@@ -3665,6 +3824,7 @@ func (s *UnitTestSuite) TestHandleGitHubWebHook() {
 			},
 			mockPropsBld: newPropSvcMock(
 				withSuccessRetrieveAllProperties(v1.Entity_ENTITY_PULL_REQUESTS, nil),
+				withSuccessPullProto(),
 			),
 			mockRepoBld: newRepoSvcMock(
 				withSuccessRepoById(
@@ -3736,6 +3896,7 @@ func (s *UnitTestSuite) TestHandleGitHubWebHook() {
 			},
 			mockPropsBld: newPropSvcMock(
 				withSuccessRetrieveAllProperties(v1.Entity_ENTITY_PULL_REQUESTS, nil),
+				withSuccessPullProto(),
 			),
 			mockRepoBld: newRepoSvcMock(
 				withSuccessRepoById(

--- a/internal/entities/properties/service/mock/service.go
+++ b/internal/entities/properties/service/mock/service.go
@@ -21,6 +21,7 @@ import (
 	v1 "github.com/stacklok/minder/pkg/api/protobuf/go/minder/v1"
 	v10 "github.com/stacklok/minder/pkg/providers/v1"
 	gomock "go.uber.org/mock/gomock"
+	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 )
 
 // MockPropertiesService is a mock of PropertiesService interface.
@@ -59,6 +60,21 @@ func (m *MockPropertiesService) EntityWithProperties(ctx context.Context, entity
 func (mr *MockPropertiesServiceMockRecorder) EntityWithProperties(ctx, entityID, opts any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EntityWithProperties", reflect.TypeOf((*MockPropertiesService)(nil).EntityWithProperties), ctx, entityID, opts)
+}
+
+// EntityWithPropertiesAsProto mocks base method.
+func (m *MockPropertiesService) EntityWithPropertiesAsProto(ctx context.Context, ewp *models.EntityWithProperties, provMgr manager.ProviderManager) (protoreflect.ProtoMessage, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "EntityWithPropertiesAsProto", ctx, ewp, provMgr)
+	ret0, _ := ret[0].(protoreflect.ProtoMessage)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// EntityWithPropertiesAsProto indicates an expected call of EntityWithPropertiesAsProto.
+func (mr *MockPropertiesServiceMockRecorder) EntityWithPropertiesAsProto(ctx, ewp, provMgr any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EntityWithPropertiesAsProto", reflect.TypeOf((*MockPropertiesService)(nil).EntityWithPropertiesAsProto), ctx, ewp, provMgr)
 }
 
 // ReplaceAllProperties mocks base method.

--- a/internal/providers/github/mock/github.go
+++ b/internal/providers/github/mock/github.go
@@ -23,6 +23,7 @@ import (
 	v10 "github.com/stacklok/minder/pkg/api/protobuf/go/minder/v1"
 	v11 "github.com/stacklok/minder/pkg/providers/v1"
 	gomock "go.uber.org/mock/gomock"
+	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 )
 
 // MockProvider is a mock of Provider interface.
@@ -288,6 +289,146 @@ func (m *MockGit) SupportsEntity(entType v10.Entity) bool {
 func (mr *MockGitMockRecorder) SupportsEntity(entType any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SupportsEntity", reflect.TypeOf((*MockGit)(nil).SupportsEntity), entType)
+}
+
+// MockProtoMessageConverter is a mock of ProtoMessageConverter interface.
+type MockProtoMessageConverter struct {
+	ctrl     *gomock.Controller
+	recorder *MockProtoMessageConverterMockRecorder
+}
+
+// MockProtoMessageConverterMockRecorder is the mock recorder for MockProtoMessageConverter.
+type MockProtoMessageConverterMockRecorder struct {
+	mock *MockProtoMessageConverter
+}
+
+// NewMockProtoMessageConverter creates a new mock instance.
+func NewMockProtoMessageConverter(ctrl *gomock.Controller) *MockProtoMessageConverter {
+	mock := &MockProtoMessageConverter{ctrl: ctrl}
+	mock.recorder = &MockProtoMessageConverterMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MockProtoMessageConverter) EXPECT() *MockProtoMessageConverterMockRecorder {
+	return m.recorder
+}
+
+// CanImplement mocks base method.
+func (m *MockProtoMessageConverter) CanImplement(trait v10.ProviderType) bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CanImplement", trait)
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// CanImplement indicates an expected call of CanImplement.
+func (mr *MockProtoMessageConverterMockRecorder) CanImplement(trait any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CanImplement", reflect.TypeOf((*MockProtoMessageConverter)(nil).CanImplement), trait)
+}
+
+// DeregisterEntity mocks base method.
+func (m *MockProtoMessageConverter) DeregisterEntity(ctx context.Context, entType v10.Entity, props *properties.Properties) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeregisterEntity", ctx, entType, props)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DeregisterEntity indicates an expected call of DeregisterEntity.
+func (mr *MockProtoMessageConverterMockRecorder) DeregisterEntity(ctx, entType, props any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeregisterEntity", reflect.TypeOf((*MockProtoMessageConverter)(nil).DeregisterEntity), ctx, entType, props)
+}
+
+// FetchAllProperties mocks base method.
+func (m *MockProtoMessageConverter) FetchAllProperties(ctx context.Context, getByProps *properties.Properties, entType v10.Entity, cachedProps *properties.Properties) (*properties.Properties, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "FetchAllProperties", ctx, getByProps, entType, cachedProps)
+	ret0, _ := ret[0].(*properties.Properties)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// FetchAllProperties indicates an expected call of FetchAllProperties.
+func (mr *MockProtoMessageConverterMockRecorder) FetchAllProperties(ctx, getByProps, entType, cachedProps any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FetchAllProperties", reflect.TypeOf((*MockProtoMessageConverter)(nil).FetchAllProperties), ctx, getByProps, entType, cachedProps)
+}
+
+// FetchProperty mocks base method.
+func (m *MockProtoMessageConverter) FetchProperty(ctx context.Context, getByProps *properties.Properties, entType v10.Entity, key string) (*properties.Property, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "FetchProperty", ctx, getByProps, entType, key)
+	ret0, _ := ret[0].(*properties.Property)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// FetchProperty indicates an expected call of FetchProperty.
+func (mr *MockProtoMessageConverterMockRecorder) FetchProperty(ctx, getByProps, entType, key any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FetchProperty", reflect.TypeOf((*MockProtoMessageConverter)(nil).FetchProperty), ctx, getByProps, entType, key)
+}
+
+// GetEntityName mocks base method.
+func (m *MockProtoMessageConverter) GetEntityName(entType v10.Entity, props *properties.Properties) (string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetEntityName", entType, props)
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetEntityName indicates an expected call of GetEntityName.
+func (mr *MockProtoMessageConverterMockRecorder) GetEntityName(entType, props any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetEntityName", reflect.TypeOf((*MockProtoMessageConverter)(nil).GetEntityName), entType, props)
+}
+
+// PropertiesToProtoMessage mocks base method.
+func (m *MockProtoMessageConverter) PropertiesToProtoMessage(entType v10.Entity, props *properties.Properties) (protoreflect.ProtoMessage, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "PropertiesToProtoMessage", entType, props)
+	ret0, _ := ret[0].(protoreflect.ProtoMessage)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// PropertiesToProtoMessage indicates an expected call of PropertiesToProtoMessage.
+func (mr *MockProtoMessageConverterMockRecorder) PropertiesToProtoMessage(entType, props any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PropertiesToProtoMessage", reflect.TypeOf((*MockProtoMessageConverter)(nil).PropertiesToProtoMessage), entType, props)
+}
+
+// RegisterEntity mocks base method.
+func (m *MockProtoMessageConverter) RegisterEntity(ctx context.Context, entType v10.Entity, props *properties.Properties) (*properties.Properties, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "RegisterEntity", ctx, entType, props)
+	ret0, _ := ret[0].(*properties.Properties)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// RegisterEntity indicates an expected call of RegisterEntity.
+func (mr *MockProtoMessageConverterMockRecorder) RegisterEntity(ctx, entType, props any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RegisterEntity", reflect.TypeOf((*MockProtoMessageConverter)(nil).RegisterEntity), ctx, entType, props)
+}
+
+// SupportsEntity mocks base method.
+func (m *MockProtoMessageConverter) SupportsEntity(entType v10.Entity) bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SupportsEntity", entType)
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// SupportsEntity indicates an expected call of SupportsEntity.
+func (mr *MockProtoMessageConverterMockRecorder) SupportsEntity(entType any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SupportsEntity", reflect.TypeOf((*MockProtoMessageConverter)(nil).SupportsEntity), entType)
 }
 
 // MockREST is a mock of REST interface.

--- a/internal/providers/github/properties/pull_request.go
+++ b/internal/providers/github/properties/pull_request.go
@@ -173,7 +173,7 @@ func getPrWrapperAttrsFromProps(props *properties.Properties) (string, string, i
 }
 
 // PullRequestV1FromProperties creates a PullRequestV1 from a properties object
-func PullRequestV1FromProperties(props *properties.Properties) *minderv1.PullRequest {
+func PullRequestV1FromProperties(props *properties.Properties) (*minderv1.PullRequest, error) {
 	return &minderv1.PullRequest{
 		Url:       props.GetProperty(PullPropertyURL).GetString(),
 		CommitSha: props.GetProperty(PullPropertySha).GetString(),
@@ -182,5 +182,5 @@ func PullRequestV1FromProperties(props *properties.Properties) *minderv1.PullReq
 		RepoName:  props.GetProperty(PullPropertyRepoName).GetString(),
 		AuthorId:  props.GetProperty(PullPropertyAuthorID).GetInt64(),
 		Action:    props.GetProperty(PullPropertyAction).GetString(),
-	}
+	}, nil
 }

--- a/pkg/providers/v1/providers.go
+++ b/pkg/providers/v1/providers.go
@@ -30,6 +30,7 @@ import (
 	"github.com/google/go-containerregistry/pkg/authn"
 	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-github/v63/github"
+	"google.golang.org/protobuf/reflect/protoreflect"
 
 	"github.com/stacklok/minder/internal/entities/properties"
 	minderv1 "github.com/stacklok/minder/pkg/api/protobuf/go/minder/v1"
@@ -88,6 +89,15 @@ type Git interface {
 
 	// Clone clones a git repository
 	Clone(ctx context.Context, url string, branch string) (*git.Repository, error)
+}
+
+// ProtoMessageConverter is the interface for converting properties to a proto message
+// this is temporary until we can get rid of the typed proto messages in EntityInfoWrapper
+// and the engine. That's also why we just didn't add the method to the generic Provider
+// interface.
+type ProtoMessageConverter interface {
+	Provider
+	PropertiesToProtoMessage(entType minderv1.Entity, props *properties.Properties) (protoreflect.ProtoMessage, error)
 }
 
 // REST is the trait interface for interacting with an REST API.


### PR DESCRIPTION

# Summary

This will help us get rid of database and/or property calls in the
webhook handler.

Related: #4327

## Change Type

- [ ] Bug fix (resolves an issue without affecting existing features)
- [ ] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [x] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

make test

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [ ] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [x] Included tests that validate the fix or feature.
- [ ] Checked that related changes are merged.
