### PR TITLE
Add general webhook registration mechanism

### DIFF
--- a/internal/providers/dockerhub/webhook.go
+++ b/internal/providers/dockerhub/webhook.go
@@ -1,0 +1,24 @@
+// Copyright 2024 Stacklok, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dockerhub
+
+import "net/http"
+
+// GetWebhookHandler implements the ProviderManager interface
+// Note that this is where the whole webhook handler is defined and
+// will live.
+func (_ *providerClassManager) GetWebhookHandler() http.Handler {
+	return nil
+}

--- a/internal/providers/github/manager/webhook.go
+++ b/internal/providers/github/manager/webhook.go
@@ -1,0 +1,24 @@
+// Copyright 2024 Stacklok, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package manager
+
+import "net/http"
+
+// GetWebhookHandler implements the ProviderManager interface
+// Note that this is where the whole webhook handler is defined and
+// will live.
+func (_ *githubProviderManager) GetWebhookHandler() http.Handler {
+	return nil
+}

--- a/internal/providers/gitlab/manager/webhook.go
+++ b/internal/providers/gitlab/manager/webhook.go
@@ -1,0 +1,24 @@
+// Copyright 2024 Stacklok, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package manager
+
+import "net/http"
+
+// GetWebhookHandler implements the ProviderManager interface
+// Note that this is where the whole webhook handler is defined and
+// will live.
+func (_ *providerClassManager) GetWebhookHandler() http.Handler {
+	return nil
+}

--- a/internal/providers/manager/mock/auth_manager.go
+++ b/internal/providers/manager/mock/auth_manager.go
@@ -12,6 +12,7 @@ package mock_manager
 import (
 	context "context"
 	json "encoding/json"
+	http "net/http"
 	reflect "reflect"
 
 	db "github.com/stacklok/minder/internal/db"
@@ -165,6 +166,20 @@ func (m *MockproviderClassOAuthManager) GetSupportedClasses() []db.ProviderClass
 func (mr *MockproviderClassOAuthManagerMockRecorder) GetSupportedClasses() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSupportedClasses", reflect.TypeOf((*MockproviderClassOAuthManager)(nil).GetSupportedClasses))
+}
+
+// GetWebhookHandler mocks base method.
+func (m *MockproviderClassOAuthManager) GetWebhookHandler() http.Handler {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetWebhookHandler")
+	ret0, _ := ret[0].(http.Handler)
+	return ret0
+}
+
+// GetWebhookHandler indicates an expected call of GetWebhookHandler.
+func (mr *MockproviderClassOAuthManagerMockRecorder) GetWebhookHandler() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetWebhookHandler", reflect.TypeOf((*MockproviderClassOAuthManager)(nil).GetWebhookHandler))
 }
 
 // MarshallConfig mocks base method.

--- a/internal/providers/manager/mock/manager.go
+++ b/internal/providers/manager/mock/manager.go
@@ -12,6 +12,8 @@ package mock_manager
 import (
 	context "context"
 	json "encoding/json"
+	iter "iter"
+	http "net/http"
 	reflect "reflect"
 
 	uuid "github.com/google/uuid"
@@ -133,6 +135,20 @@ func (mr *MockProviderManagerMockRecorder) InstantiateFromNameProject(ctx, name,
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InstantiateFromNameProject", reflect.TypeOf((*MockProviderManager)(nil).InstantiateFromNameProject), ctx, name, projectID)
 }
 
+// IterateWebhookHandlers mocks base method.
+func (m *MockProviderManager) IterateWebhookHandlers() iter.Seq2[string, http.Handler] {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "IterateWebhookHandlers")
+	ret0, _ := ret[0].(iter.Seq2[string, http.Handler])
+	return ret0
+}
+
+// IterateWebhookHandlers indicates an expected call of IterateWebhookHandlers.
+func (mr *MockProviderManagerMockRecorder) IterateWebhookHandlers() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IterateWebhookHandlers", reflect.TypeOf((*MockProviderManager)(nil).IterateWebhookHandlers))
+}
+
 // PatchProviderConfig mocks base method.
 func (m *MockProviderManager) PatchProviderConfig(ctx context.Context, providerName string, projectID uuid.UUID, configPatch map[string]any) error {
 	m.ctrl.T.Helper()
@@ -211,6 +227,20 @@ func (m *MockProviderClassManager) GetSupportedClasses() []db.ProviderClass {
 func (mr *MockProviderClassManagerMockRecorder) GetSupportedClasses() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSupportedClasses", reflect.TypeOf((*MockProviderClassManager)(nil).GetSupportedClasses))
+}
+
+// GetWebhookHandler mocks base method.
+func (m *MockProviderClassManager) GetWebhookHandler() http.Handler {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetWebhookHandler")
+	ret0, _ := ret[0].(http.Handler)
+	return ret0
+}
+
+// GetWebhookHandler indicates an expected call of GetWebhookHandler.
+func (mr *MockProviderClassManagerMockRecorder) GetWebhookHandler() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetWebhookHandler", reflect.TypeOf((*MockProviderClassManager)(nil).GetWebhookHandler))
 }
 
 // MarshallConfig mocks base method.


### PR DESCRIPTION
# Summary

This adds per provider class paths so each provider class will bring
it's own webhook handling. GitHub is a slightly special case... so we
handle it separately for now.

Note that this will require folks changing their configuration to remove
`github` as a suffix on deployments. If nothing is changed, this should
be a no-op as it does not re-append `github` in the path.

Related-To: #4329

## Change Type

***Mark the type of change your PR introduces:***

- [ ] Bug fix (resolves an issue without affecting existing features)
- [x] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [ ] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

***Outline how the changes were tested, including steps to reproduce and any relevant configurations. 
Attach screenshots if helpful.***

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [ ] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [ ] Included tests that validate the fix or feature.
- [ ] Checked that related changes are merged.
