### PR TITLE
Fix missing slash in github webhook path

### DIFF
--- a/internal/controlplane/server.go
+++ b/internal/controlplane/server.go
@@ -367,7 +367,7 @@ func (s *Server) StartHTTPServer(ctx context.Context) error {
 	}
 
 	// This requires explicit middleware. CORS is not required here.
-	mux.Handle("/api/v1/webhook/github", otelmw(withMiddleware(s.HandleGitHubWebHook())))
+	mux.Handle("/api/v1/webhook/github/", otelmw(withMiddleware(s.HandleGitHubWebHook())))
 	mux.Handle("/api/v1/ghapp/", otelmw(withMiddleware(s.HandleGitHubAppWebhook())))
 	mux.Handle("/api/v1/gh-marketplace/", otelmw(withMiddleware(s.NoopWebhookHandler())))
 	mux.Handle("/static/", fs)


### PR DESCRIPTION
The slash was missing and is the reason we were getting:

```
2024/09/13 11:30:01 ERROR: Failed to extract ServerMetadata from context
```

Signed-off-by: Juan Antonio Osorio <ozz@stacklok.com>

# Summary

***Provide a brief overview of the changes and the issue being addressed. 
Explain the rationale and any background necessary for understanding the changes. 
List dependencies required by this change, if any.***

Fixes #(related issue)

## Change Type

***Mark the type of change your PR introduces:***

- [x] Bug fix (resolves an issue without affecting existing features)
- [ ] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [ ] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

***Outline how the changes were tested, including steps to reproduce and any relevant configurations. 
Attach screenshots if helpful.***

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [ ] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [ ] Included tests that validate the fix or feature.
- [ ] Checked that related changes are merged.
