### PR TITLE
Don't fail on deregistering a repo on repo delete

### DIFF
--- a/internal/repositories/service.go
+++ b/internal/repositories/service.go
@@ -534,7 +534,9 @@ func (r *repositoryService) deleteRepository(
 
 	err = client.DeregisterEntity(ctx, pb.Entity_ENTITY_REPOSITORIES, repo.Properties)
 	if err != nil {
-		return fmt.Errorf("error deleting webhook: %w", err)
+		zerolog.Ctx(ctx).Error().
+			Dict("properties", repo.Properties.ToLogDict()).
+			Err(err).Msg("error deregistering repo")
 	}
 
 	_, err = db.WithTransaction(r.store, func(t db.ExtendQuerier) (*pb.Repository, error) {

--- a/internal/repositories/service_test.go
+++ b/internal/repositories/service_test.go
@@ -210,15 +210,14 @@ func TestRepositoryService_DeleteRepository(t *testing.T) {
 			ExpectedError: "error instantiating provider",
 		},
 		{
-			Name:         "DeleteByName fails when entity cannot be deregistered",
+			Name:         "DeleteByName still works when entity cannot be deregistered",
 			DeleteType:   ByName,
-			DBSetup:      newDBMock(withSuccessfulGetByName),
+			DBSetup:      newDBMock(withSuccessfulGetByName, withSuccessfulDelete),
 			ServiceSetup: newPropSvcMock(withSuccessfulEntityWithProps),
 			ProviderManagerSetup: func(p provinfv1.Provider) pf.ProviderManagerMockBuilder {
 				return pf.NewProviderManagerMock(pf.WithSuccessfulInstantiateFromID(p))
 			},
 			ProviderSetup: newProviderMock(withFailedDeregister),
-			ExpectedError: "error deleting webhook",
 		},
 		{
 			Name:         "DeleteByName by ID fails when repo cannot be deleted from DB",
@@ -264,15 +263,14 @@ func TestRepositoryService_DeleteRepository(t *testing.T) {
 			ExpectedError: "error instantiating provider",
 		},
 		{
-			Name:         "DeleteByID fails when entity cannot be deregistered",
+			Name:         "DeleteByID works when entity cannot be deregistered",
 			DeleteType:   ByID,
-			DBSetup:      newDBMock(),
+			DBSetup:      newDBMock(withSuccessfulDelete),
 			ServiceSetup: newPropSvcMock(withSuccessfulEntityWithProps),
 			ProviderManagerSetup: func(p provinfv1.Provider) pf.ProviderManagerMockBuilder {
 				return pf.NewProviderManagerMock(pf.WithSuccessfulInstantiateFromID(p))
 			},
 			ProviderSetup: newProviderMock(withFailedDeregister),
-			ExpectedError: "error deleting webhook",
 		},
 		{
 			Name:         "DeleteByID by ID fails when repo cannot be deleted from DB",


### PR DESCRIPTION
# Summary

this may be a transcient error, so let's not fail and allow minder to
delete it.

This may result in a dangling webhook registration in github. Which is
not too problematic since Minder detects and is able to overwrite them.

Fixes: #3518

## Change Type

***Mark the type of change your PR introduces:***

- [x] Bug fix (resolves an issue without affecting existing features)
- [ ] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [ ] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

***Outline how the changes were tested, including steps to reproduce and any relevant configurations. 
Attach screenshots if helpful.***

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [ ] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [ ] Included tests that validate the fix or feature.
- [ ] Checked that related changes are merged.
