### PR TITLE
Add missing extension to docs links

### DIFF
--- a/docs/docs/understand/rule_evaluation.md
+++ b/docs/docs/understand/rule_evaluation.md
@@ -28,11 +28,11 @@ To view the rule evaluations, run [`minder history list`](../ref/cli/minder_hist
 
 The _status_ of a rule evaluation describes the outcome of executing the rule against an entity. Possible statuses are:
 
-* **Success**: the entity was evaluated and is in compliance with the rule. For example, given the [`secret_scanning`](../ref/rules/secret_scanning) rule, this means that secret scanning is enabled on the repository being evaluated.
-* **Failure**: the entity was evaluated and is _not_ in compliance with the rule. For example, given the [`secret_scanning`](../ref/rules/secret_scanning) rule, this means that secret scanning is _not_ enabled on the repository being evaluated.
+* **Success**: the entity was evaluated and is in compliance with the rule. For example, given the [`secret_scanning`](../ref/rules/secret_scanning.md) rule, this means that secret scanning is enabled on the repository being evaluated.
+* **Failure**: the entity was evaluated and is _not_ in compliance with the rule. For example, given the [`secret_scanning`](../ref/rules/secret_scanning.md) rule, this means that secret scanning is _not_ enabled on the repository being evaluated.
 * **Error**: the rule could not be evaluated for some reason. For example, the server being evaluated was not online or could not be contacted.
 * **Pending**: the rule has not yet been evaluated. Once evaluated, it will move into a state that represents the evaluation.
-* **Skipped**: the rule is not configured for the entity. For example, given the [`secret_scanning`](../ref/rules/secret_scanning) rule, it can be configured to skip private repositories.
+* **Skipped**: the rule is not configured for the entity. For example, given the [`secret_scanning`](../ref/rules/secret_scanning.md) rule, it can be configured to skip private repositories.
 
 ### Alert status
 


### PR DESCRIPTION
# Summary

The new rule evaluations page added in #4481 has three links to the secret_scanning rule page that are missing the .md extension. These worked in the minder-docs.stacklok.dev build but caused the Docusaurus build to fail on a broken link error for the cloud docs overlay.

## Change Type

- [ ] Bug fix (resolves an issue without affecting existing features)
- [ ] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [x] Documentation (updates or additions to documentation)
- [ ] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

Confirmed links are working via local preview.

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [ ] Added comments to complex or tricky code sections.
- [x] Updated any affected documentation.
- [ ] Included tests that validate the fix or feature.
- [ ] Checked that related changes are merged.
