### PR TITLE
Use encoding/csv to when parsing selector record

### DIFF
--- a/internal/db/profile_selector_scan.go
+++ b/internal/db/profile_selector_scan.go
@@ -39,6 +39,7 @@ func (s *ProfileSelector) Scan(value interface{}) error {
 
 	// Split the string by commas to get the individual field values
 	cr := csv.NewReader(strings.NewReader(str))
+	cr.LazyQuotes = true // Enable LazyQuotes to allow for uneven number of quotes
 	parts, err := cr.Read()
 	if err != nil {
 		return fmt.Errorf("failed to scan SelectorInfo: %v", err)

--- a/internal/db/profile_selector_scan.go
+++ b/internal/db/profile_selector_scan.go
@@ -15,6 +15,7 @@
 package db
 
 import (
+	"encoding/csv"
 	"fmt"
 	"strings"
 )
@@ -37,7 +38,11 @@ func (s *ProfileSelector) Scan(value interface{}) error {
 	str = strings.TrimSuffix(str, ")")
 
 	// Split the string by commas to get the individual field values
-	parts := strings.Split(str, ",")
+	cr := csv.NewReader(strings.NewReader(str))
+	parts, err := cr.Read()
+	if err != nil {
+		return fmt.Errorf("failed to scan SelectorInfo: %v", err)
+	}
 
 	// Assign the values to the struct fields
 	if len(parts) != 5 {

--- a/internal/db/profile_selector_scan_test.go
+++ b/internal/db/profile_selector_scan_test.go
@@ -22,6 +22,9 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+// TestScan tests the Scan method of the ProfileSelector struct
+// for more tests that exercise the retrieval of a profile with selectors that also happens to use Scan
+// see TestProfileListWithSelectors
 func TestScan(t *testing.T) {
 	t.Parallel()
 
@@ -58,6 +61,20 @@ func TestScan(t *testing.T) {
 					Entities: EntitiesRepository,
 				},
 				Selector: "repository.properties['github/primary_language'] in ['TypeScript', 'Go']",
+				Comment:  "comment1",
+			},
+		},
+		{
+			name:  "Comment includes uneven quotes",
+			input: []byte(fmt.Sprintf("(%s,%s,repository,\"repository.name == foo\",\"\"comment1\")", selectorId, profileId)),
+			expected: ProfileSelector{
+				ID:        selectorId,
+				ProfileID: profileId,
+				Entity: NullEntities{
+					Valid:    true,
+					Entities: EntitiesRepository,
+				},
+				Selector: "repository.name == foo",
 				Comment:  "comment1",
 			},
 		},

--- a/internal/db/profile_selector_scan_test.go
+++ b/internal/db/profile_selector_scan_test.go
@@ -47,6 +47,20 @@ func TestScan(t *testing.T) {
 				Comment:  "comment1",
 			},
 		},
+		{
+			name:  "Valid input with commas in the selector",
+			input: []byte(fmt.Sprintf("(%s,%s,repository,\"repository.properties['github/primary_language'] in ['TypeScript', 'Go']\",\"comment1\")", selectorId, profileId)),
+			expected: ProfileSelector{
+				ID:        selectorId,
+				ProfileID: profileId,
+				Entity: NullEntities{
+					Valid:    true,
+					Entities: EntitiesRepository,
+				},
+				Selector: "repository.properties['github/primary_language'] in ['TypeScript', 'Go']",
+				Comment:  "comment1",
+			},
+		},
 	}
 
 	for _, tc := range tc {

--- a/internal/db/profile_selector_scan_test.go
+++ b/internal/db/profile_selector_scan_test.go
@@ -38,7 +38,7 @@ func TestScan(t *testing.T) {
 	}{
 		{
 			name:  "Valid input with all fields",
-			input: []byte(fmt.Sprintf("(%s,%s,repository,\"entity.name == \"\"test/test\"\" && repository.is_fork != true\",\"comment1\")", selectorId, profileId)),
+			input: []byte(fmt.Sprintf(`(%s,%s,repository,"entity.name == ""test/test"" && repository.is_fork != true","comment1")`, selectorId, profileId)),
 			expected: ProfileSelector{
 				ID:        selectorId,
 				ProfileID: profileId,
@@ -52,7 +52,7 @@ func TestScan(t *testing.T) {
 		},
 		{
 			name:  "Valid input with commas in the selector",
-			input: []byte(fmt.Sprintf("(%s,%s,repository,\"repository.properties['github/primary_language'] in ['TypeScript', 'Go']\",\"comment1\")", selectorId, profileId)),
+			input: []byte(fmt.Sprintf(`(%s,%s,repository,"repository.properties['github/primary_language'] in ['TypeScript', 'Go']","comment1")`, selectorId, profileId)),
 			expected: ProfileSelector{
 				ID:        selectorId,
 				ProfileID: profileId,
@@ -66,7 +66,7 @@ func TestScan(t *testing.T) {
 		},
 		{
 			name:  "Comment includes uneven quotes",
-			input: []byte(fmt.Sprintf("(%s,%s,repository,\"repository.name == foo\",\"\"comment1\")", selectorId, profileId)),
+			input: []byte(fmt.Sprintf(`(%s,%s,repository,"repository.name == foo",""comment1")`, selectorId, profileId)),
 			expected: ProfileSelector{
 				ID:        selectorId,
 				ProfileID: profileId,


### PR DESCRIPTION
# Summary

`encoding/csv` allows us to handle selectors with commas in them which
our naive parser embarassingly didn't such as:
```
repository.properties['github/primary_language'] in ['TypeScript', 'Go']
```

Fixes: #4514

## Change Type

- [x] Bug fix (resolves an issue without affecting existing features)
- [ ] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [ ] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

unit test plus using that selector

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [ ] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [x] Included tests that validate the fix or feature.
- [ ] Checked that related changes are merged.
