### PR TITLE
Simplify the attributes sent to the entity_add handler

### DIFF
--- a/internal/controlplane/handlers_githubwebhooks.go
+++ b/internal/controlplane/handlers_githubwebhooks.go
@@ -1241,8 +1241,7 @@ func (_ *Server) repositoryAdded(
 		WithProjectID(installation.ProjectID.UUID).
 		WithProviderID(installation.ProviderID.UUID).
 		WithEntityType("repository").
-		WithAttribute("repoName", repo.GetName()).
-		WithAttribute("repoOwner", repo.GetOwner())
+		WithAttribute(properties.PropertyName, repo.GetFullName())
 
 	return &processingResult{
 		topic:   events.TopicQueueReconcileEntityAdd,

--- a/internal/controlplane/handlers_githubwebhooks.go
+++ b/internal/controlplane/handlers_githubwebhooks.go
@@ -885,8 +885,7 @@ func (s *Server) processRelevantRepositoryEvent(
 			WithProjectID(repoEntity.Entity.ProjectID).
 			WithProviderID(repoEntity.Entity.ProviderID).
 			WithEntityType("repository").
-			WithEntityID(repoEntity.Entity.ID).
-			WithAttribute("repoID", repoEntity.Entity.ID.String())
+			WithEntityID(repoEntity.Entity.ID)
 
 		return &processingResult{
 			topic:   events.TopicQueueReconcileEntityDelete,
@@ -1221,8 +1220,7 @@ func (s *Server) repositoryRemoved(
 		WithProjectID(repoEnt.Entity.ProjectID).
 		WithProviderID(repoEnt.Entity.ProviderID).
 		WithEntityType("repository").
-		WithEntityID(repoEnt.Entity.ID).
-		WithAttribute("repoID", repoEnt.Entity.ID.String())
+		WithEntityID(repoEnt.Entity.ID)
 
 	return &processingResult{
 		topic:   events.TopicQueueReconcileEntityDelete,

--- a/internal/controlplane/handlers_githubwebhooks_test.go
+++ b/internal/controlplane/handlers_githubwebhooks_test.go
@@ -418,7 +418,6 @@ func (s *UnitTestSuite) TestHandleWebHookRepository() {
 	require.NoError(t, validator.New().Struct(&inner))
 	require.Equal(t, providerID, inner.ProviderID)
 	require.Equal(t, projectID, inner.ProjectID)
-	require.Equal(t, repositoryID.String(), inner.Entity["repoID"])
 	require.Equal(t, nil, inner.Entity["repoName"])  // optional
 	require.Equal(t, nil, inner.Entity["repoOwner"]) // optional
 
@@ -1236,7 +1235,6 @@ func (s *UnitTestSuite) TestHandleGitHubWebHook() {
 				require.NoError(t, validator.New().Struct(&evt))
 				require.Equal(t, providerID, evt.ProviderID)
 				require.Equal(t, projectID, evt.ProjectID)
-				require.Equal(t, repositoryID.String(), evt.Entity["repoID"])
 				require.Equal(t, nil, evt.Entity["repoName"])  // optional
 				require.Equal(t, nil, evt.Entity["repoOwner"]) // optional
 			},
@@ -1288,7 +1286,6 @@ func (s *UnitTestSuite) TestHandleGitHubWebHook() {
 				require.NoError(t, validator.New().Struct(&evt))
 				require.Equal(t, providerID, evt.ProviderID)
 				require.Equal(t, projectID, evt.ProjectID)
-				require.Equal(t, repositoryID.String(), evt.Entity["repoID"])
 				require.Equal(t, nil, evt.Entity["repoName"])  // optional
 				require.Equal(t, nil, evt.Entity["repoOwner"]) // optional
 			},
@@ -1837,7 +1834,6 @@ func (s *UnitTestSuite) TestHandleGitHubWebHook() {
 				require.NoError(t, validator.New().Struct(&evt))
 				require.Equal(t, providerID, evt.ProviderID)
 				require.Equal(t, projectID, evt.ProjectID)
-				require.Equal(t, repositoryID.String(), evt.Entity["repoID"])
 				require.Equal(t, nil, evt.Entity["repoName"])  // optional
 				require.Equal(t, nil, evt.Entity["repoOwner"]) // optional
 			},
@@ -1888,7 +1884,6 @@ func (s *UnitTestSuite) TestHandleGitHubWebHook() {
 				require.NoError(t, validator.New().Struct(&evt))
 				require.Equal(t, providerID, evt.ProviderID)
 				require.Equal(t, projectID, evt.ProjectID)
-				require.Equal(t, repositoryID.String(), evt.Entity["repoID"])
 				require.Equal(t, nil, evt.Entity["repoName"])  // optional
 				require.Equal(t, nil, evt.Entity["repoOwner"]) // optional
 			},
@@ -2143,7 +2138,6 @@ func (s *UnitTestSuite) TestHandleGitHubWebHook() {
 				require.NoError(t, validator.New().Struct(&evt))
 				require.Equal(t, providerID, evt.ProviderID)
 				require.Equal(t, projectID, evt.ProjectID)
-				require.Equal(t, repositoryID.String(), evt.Entity["repoID"])
 				require.Equal(t, nil, evt.Entity["repoName"])  // optional
 				require.Equal(t, nil, evt.Entity["repoOwner"]) // optional
 			},
@@ -4675,7 +4669,6 @@ func (s *UnitTestSuite) TestHandleGitHubAppWebHook() {
 				require.NoError(t, err)
 				require.Equal(t, providerID, evt.ProviderID)
 				require.Equal(t, projectID, evt.ProjectID)
-				require.Equal(t, repositoryID.String(), evt.Entity["repoID"])
 
 				received = withTimeout(ch, timeout)
 				require.NotNilf(t, received, "no event received after waiting %s", timeout)
@@ -4687,7 +4680,6 @@ func (s *UnitTestSuite) TestHandleGitHubAppWebHook() {
 				require.NoError(t, err)
 				require.Equal(t, providerID, evt.ProviderID)
 				require.Equal(t, projectID, evt.ProjectID)
-				require.Equal(t, repositoryID.String(), evt.Entity["repoID"])
 			},
 		},
 

--- a/internal/controlplane/handlers_githubwebhooks_test.go
+++ b/internal/controlplane/handlers_githubwebhooks_test.go
@@ -4517,6 +4517,7 @@ func (s *UnitTestSuite) TestHandleGitHubAppWebHook() {
 				require.NoError(t, err)
 				require.Equal(t, providerID, evt.ProviderID)
 				require.Equal(t, projectID, evt.ProjectID)
+				require.Equal(t, "stacklok/minder", evt.Entity[properties.PropertyName])
 
 				received = withTimeout(ch, timeout)
 				require.NotNilf(t, received, "no event received after waiting %s", timeout)
@@ -4528,6 +4529,7 @@ func (s *UnitTestSuite) TestHandleGitHubAppWebHook() {
 				require.NoError(t, err)
 				require.Equal(t, providerID, evt.ProviderID)
 				require.Equal(t, projectID, evt.ProjectID)
+				require.Equal(t, "stacklok/trusty", evt.Entity[properties.PropertyName])
 			},
 		},
 		{

--- a/internal/reconcilers/entity_add_test.go
+++ b/internal/reconcilers/entity_add_test.go
@@ -25,14 +25,14 @@ import (
 
 	df "github.com/stacklok/minder/database/mock/fixtures"
 	db "github.com/stacklok/minder/internal/db"
+	"github.com/stacklok/minder/internal/entities/properties"
 	"github.com/stacklok/minder/internal/reconcilers/messages"
 	rf "github.com/stacklok/minder/internal/repositories/mock/fixtures"
 	pb "github.com/stacklok/minder/pkg/api/protobuf/go/minder/v1"
 )
 
 var (
-	repoOwner = "stacklok"
-	repoName  = "minder"
+	repoFullName = "stacklok/minder"
 )
 
 func TestHandleEntityAdd(t *testing.T) {
@@ -64,8 +64,7 @@ func TestHandleEntityAdd(t *testing.T) {
 					WithProviderID(providerID).
 					WithProjectID(projectID).
 					WithEntityType("repository").
-					WithAttribute("repoName", repoName).
-					WithAttribute("repoOwner", repoOwner).
+					WithAttribute(properties.PropertyName, repoFullName).
 					ToMessage(m)
 				require.NoError(t, err, "invalid message")
 				return m
@@ -86,8 +85,7 @@ func TestHandleEntityAdd(t *testing.T) {
 					WithProviderID(providerID).
 					WithProjectID(projectID).
 					WithEntityType("repository").
-					WithAttribute("repoName", repoName).
-					WithAttribute("repoOwner", repoOwner).
+					WithAttribute(properties.PropertyName, repoFullName).
 					ToMessage(m)
 				require.NoError(t, err, "invalid message")
 				return m
@@ -119,8 +117,7 @@ func TestHandleEntityAdd(t *testing.T) {
 					WithProviderID(providerID).
 					WithProjectID(projectID).
 					WithEntityType("repository").
-					WithAttribute("repoName", repoName).
-					WithAttribute("repoOwner", repoOwner).
+					WithAttribute(properties.PropertyName, repoFullName).
 					ToMessage(m)
 				require.NoError(t, err, "invalid message")
 				return m


### PR DESCRIPTION

# Summary

I have a rather large branch that works towards not using database access from
the webhook handler. These two patches were part of that branch and can be submitted separately.

The aim is to decrease the number of attributes we send to the handler as well
as make them more generic.

Related: #4327

## Change Type

- [ ] Bug fix (resolves an issue without affecting existing features)
- [ ] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [x] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

as part of a larger branch + unit tests

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [ ] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [x] Included tests that validate the fix or feature.
- [ ] Checked that related changes are merged.
