### PR TITLE
Add a method to retrieve an entity by upstream ID with a hint

### DIFF
--- a/internal/controlplane/handlers_evalstatus.go
+++ b/internal/controlplane/handlers_evalstatus.go
@@ -393,7 +393,7 @@ func (s *Server) sortEntitiesEvaluationStatus(
 				continue
 			}
 
-			efp, err := s.props.EntityWithProperties(ctx, e.EntityID, nil)
+			efp, err := s.props.EntityWithPropertiesByID(ctx, e.EntityID, nil)
 			if err != nil {
 				if errors.Is(err, propSvc.ErrEntityNotFound) {
 					// If the entity is not found, log and skip

--- a/internal/controlplane/handlers_profile.go
+++ b/internal/controlplane/handlers_profile.go
@@ -456,7 +456,7 @@ func (s *Server) getRuleEvalStatus(
 
 	// the caller just ignores allt the errors anyway, so we don't start a transaction as the integrity issues
 	// would not be discovered anyway
-	efp, err := s.props.EntityWithProperties(ctx, dbRuleEvalStat.EntityID, nil)
+	efp, err := s.props.EntityWithPropertiesByID(ctx, dbRuleEvalStat.EntityID, nil)
 	if err != nil {
 		return nil, fmt.Errorf("error fetching entity for properties: %w", err)
 	}

--- a/internal/controlplane/handlers_providers_test.go
+++ b/internal/controlplane/handlers_providers_test.go
@@ -528,7 +528,7 @@ func TestDeleteProvider(t *testing.T) {
 
 	mockprops := propSvc.NewMockPropertiesService(ctrl)
 	mockprops.EXPECT().
-		EntityWithProperties(gomock.Any(), gomock.Any(), nil).
+		EntityWithPropertiesByID(gomock.Any(), gomock.Any(), nil).
 		Return(models.NewEntityWithPropertiesFromInstance(
 			models.EntityInstance{}, nil), nil)
 
@@ -649,7 +649,7 @@ func TestDeleteProviderByID(t *testing.T) {
 
 	mockprops := propSvc.NewMockPropertiesService(ctrl)
 	mockprops.EXPECT().
-		EntityWithProperties(gomock.Any(), gomock.Any(), nil).
+		EntityWithPropertiesByID(gomock.Any(), gomock.Any(), nil).
 		Return(models.NewEntityWithPropertiesFromInstance(
 			models.EntityInstance{}, nil), nil)
 

--- a/internal/engine/executor.go
+++ b/internal/engine/executor.go
@@ -235,7 +235,7 @@ func (e *executor) profileEvalStatus(
 	}
 
 	// get the entity with properties by the entity UUID
-	ewp, err := e.propService.EntityWithProperties(ctx, entityID,
+	ewp, err := e.propService.EntityWithPropertiesByID(ctx, entityID,
 		service.CallBuilder().WithStoreOrTransaction(e.querier))
 	if err != nil {
 		return fmt.Errorf("error getting entity with properties: %w", err)

--- a/internal/engine/executor_test.go
+++ b/internal/engine/executor_test.go
@@ -325,7 +325,7 @@ default allow = true`,
 
 	mockPropSvc := mockprops.NewMockPropertiesService(ctrl)
 	mockPropSvc.EXPECT().
-		EntityWithProperties(gomock.Any(), repositoryID, gomock.Any()).
+		EntityWithPropertiesByID(gomock.Any(), repositoryID, gomock.Any()).
 		Return(&models.EntityWithProperties{
 			Entity: models.EntityInstance{
 				ID:         repositoryID,

--- a/internal/entities/properties/service/helpers.go
+++ b/internal/entities/properties/service/helpers.go
@@ -20,6 +20,7 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"slices"
 	"time"
 
 	"github.com/google/uuid"
@@ -143,35 +144,173 @@ func getEntityIdByName(
 	return ent.ID, nil
 }
 
-func getEntityIdByUpstreamID(
-	ctx context.Context, projectId uuid.UUID,
+func getAllByProperty(
+	ctx context.Context,
+	propName string,
+	propVal any,
+	entType minderv1.Entity,
+	projectID uuid.UUID,
 	providerID uuid.UUID,
-	upstreamID string, entType minderv1.Entity,
 	qtx db.ExtendQuerier,
-) (uuid.UUID, error) {
+) ([]db.EntityInstance, error) {
+	l := zerolog.Ctx(ctx).With().Any(propName, propVal).Logger()
+
 	ents, err := qtx.GetTypedEntitiesByPropertyV1(
 		ctx,
 		entities.EntityTypeToDB(entType),
-		properties.PropertyUpstreamID,
-		upstreamID,
+		propName,
+		propVal,
 		db.GetTypedEntitiesOptions{
-			ProjectID:  projectId,
+			ProjectID:  projectID,
 			ProviderID: providerID,
 		})
 	if errors.Is(err, sql.ErrNoRows) {
-		return uuid.Nil, ErrEntityNotFound
+		return nil, ErrEntityNotFound
 	} else if err != nil {
-		return uuid.Nil, fmt.Errorf("error fetching entities by property: %w", err)
+		return nil, fmt.Errorf("error fetching entities by property: %w", err)
+	}
+
+	if len(ents) == 0 {
+		l.Debug().Msg("no entity found")
+		return nil, ErrEntityNotFound
+	}
+
+	return ents, nil
+}
+
+func getEntityIdByUpstreamID(
+	ctx context.Context,
+	projectID uuid.UUID, providerID uuid.UUID,
+	upstreamID string, entType minderv1.Entity,
+	qtx db.ExtendQuerier,
+) (uuid.UUID, error) {
+	ents, err := getAllByProperty(ctx, properties.PropertyUpstreamID, upstreamID, entType, projectID, providerID, qtx)
+	if err != nil {
+		return uuid.Nil, err
 	}
 
 	if len(ents) > 1 {
 		return uuid.Nil, ErrMultipleEntities
-	} else if len(ents) == 1 {
-		return ents[0].ID, nil
 	}
 
-	// no entity found
-	return uuid.Nil, ErrEntityNotFound
+	return ents[0].ID, nil
+}
+
+func matchEntityWithHint(
+	ctx context.Context,
+	props *properties.Properties,
+	entType minderv1.Entity,
+	hint *ByUpstreamHint,
+	l zerolog.Logger,
+	qtx db.ExtendQuerier,
+) (*db.EntityInstance, error) {
+	if !hint.isSet() {
+		return nil, fmt.Errorf("at least one of projectID, providerID or providerImplements must be set in hint")
+	}
+
+	var ents []db.EntityInstance
+	var err error
+
+	lookupOrder := []string{properties.PropertyUpstreamID, properties.PropertyName}
+	for _, loopupProp := range lookupOrder {
+		prop := props.GetProperty(loopupProp)
+		if prop == nil {
+			continue
+		}
+
+		l.Debug().Str("lookupProp", loopupProp).Msg("fetching by property")
+		ents, err = getAllByProperty(ctx,
+			loopupProp, prop.RawValue(), entType,
+			// we search across all projects and providers. This is expected because the lookup properties only
+			// contain upstream properties and the get-with-hint methods are only to be used by callers who don't
+			// know the project or provider ID and only have an upstream webhook payload.
+			uuid.Nil, uuid.Nil,
+			qtx)
+		if errors.Is(err, ErrEntityNotFound) {
+			l.Debug().Str("lookupProp", loopupProp).Msg("no entity found")
+			continue
+		} else if err != nil {
+			return nil, fmt.Errorf("failed to get entities by upstream ID: %w", err)
+		}
+
+		match, err := findMatchByUpstreamHint(ctx, ents, hint, qtx)
+		if err != nil {
+			if errors.Is(err, ErrEntityNotFound) {
+				l.Error().Msg("no entity matched")
+				continue
+			} else if errors.Is(err, ErrMultipleEntities) {
+				l.Error().Msg("multiple entities matched")
+				return nil, ErrMultipleEntities
+			}
+			return nil, fmt.Errorf("failed to match entity by hint: %w", err)
+		}
+		return match, nil
+	}
+
+	return nil, ErrEntityNotFound
+}
+
+func findMatchByUpstreamHint(
+	ctx context.Context, ents []db.EntityInstance, hint *ByUpstreamHint, qtx db.ExtendQuerier,
+) (*db.EntityInstance, error) {
+	var match *db.EntityInstance
+	for _, ent := range ents {
+		var thisMatch *db.EntityInstance
+		zerolog.Ctx(ctx).Debug().Msgf("matching entity %s", ent.ID.String())
+		if dbEntMatchesUpstreamHint(ctx, ent, hint, qtx) {
+			zerolog.Ctx(ctx).Debug().Msgf("entity %s matched by hint", ent.ID.String())
+			thisMatch = &ent
+		}
+
+		if thisMatch != nil {
+			if match != nil {
+				zerolog.Ctx(ctx).Error().Msg("multiple entities matched")
+				return nil, ErrMultipleEntities
+			}
+			match = thisMatch
+		}
+	}
+
+	if match == nil {
+		zerolog.Ctx(ctx).Debug().Msg("no entity matched")
+		return nil, ErrEntityNotFound
+	}
+
+	return match, nil
+}
+
+func dbEntMatchesUpstreamHint(ctx context.Context, ent db.EntityInstance, hint *ByUpstreamHint, qtx db.ExtendQuerier) bool {
+	logger := zerolog.Ctx(ctx)
+
+	if hint.ProviderImplements.Valid || hint.ProviderClass.Valid {
+		dbProv, err := qtx.GetProviderByID(ctx, ent.ProviderID)
+		if err != nil {
+			logger.Error().
+				Str("providerID", ent.ProviderID.String()).
+				Err(err).
+				Msg("error getting provider by ID")
+			return false
+		}
+
+		if hint.ProviderClass.Valid && dbProv.Class != hint.ProviderClass.ProviderClass {
+			logger.Debug().
+				Str("ProviderID", ent.ProviderID.String()).
+				Str("providerClass", string(dbProv.Class)).
+				Str("hintProviderClass", string(hint.ProviderClass.ProviderClass)).
+				Msg("provider class does not match hint")
+			return false
+		}
+
+		if hint.ProviderImplements.Valid && !slices.Contains(dbProv.Implements, hint.ProviderImplements.ProviderType) {
+			logger.Debug().
+				Str("ProviderID", ent.ProviderID.String()).
+				Str("providerType", string(hint.ProviderImplements.ProviderType)).
+				Msg("provider does not implement hint")
+			return false
+		}
+	}
+
+	return true
 }
 
 func (ps *propertiesService) areDatabasePropertiesValid(

--- a/internal/entities/properties/service/mock/service.go
+++ b/internal/entities/properties/service/mock/service.go
@@ -47,6 +47,21 @@ func (m *MockPropertiesService) EXPECT() *MockPropertiesServiceMockRecorder {
 	return m.recorder
 }
 
+// EntityWithPropertiesAsProto mocks base method.
+func (m *MockPropertiesService) EntityWithPropertiesAsProto(ctx context.Context, ewp *models.EntityWithProperties, provMgr manager.ProviderManager) (protoreflect.ProtoMessage, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "EntityWithPropertiesAsProto", ctx, ewp, provMgr)
+	ret0, _ := ret[0].(protoreflect.ProtoMessage)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// EntityWithPropertiesAsProto indicates an expected call of EntityWithPropertiesAsProto.
+func (mr *MockPropertiesServiceMockRecorder) EntityWithPropertiesAsProto(ctx, ewp, provMgr any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EntityWithPropertiesAsProto", reflect.TypeOf((*MockPropertiesService)(nil).EntityWithPropertiesAsProto), ctx, ewp, provMgr)
+}
+
 // EntityWithPropertiesByID mocks base method.
 func (m *MockPropertiesService) EntityWithPropertiesByID(ctx context.Context, entityID uuid.UUID, opts *service.CallOptions) (*models.EntityWithProperties, error) {
 	m.ctrl.T.Helper()
@@ -62,19 +77,19 @@ func (mr *MockPropertiesServiceMockRecorder) EntityWithPropertiesByID(ctx, entit
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EntityWithPropertiesByID", reflect.TypeOf((*MockPropertiesService)(nil).EntityWithPropertiesByID), ctx, entityID, opts)
 }
 
-// EntityWithPropertiesAsProto mocks base method.
-func (m *MockPropertiesService) EntityWithPropertiesAsProto(ctx context.Context, ewp *models.EntityWithProperties, provMgr manager.ProviderManager) (protoreflect.ProtoMessage, error) {
+// EntityWithPropertiesByUpstreamHint mocks base method.
+func (m *MockPropertiesService) EntityWithPropertiesByUpstreamHint(ctx context.Context, entType v1.Entity, getByProps *properties.Properties, hint service.ByUpstreamHint, opts *service.CallOptions) (*models.EntityWithProperties, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "EntityWithPropertiesAsProto", ctx, ewp, provMgr)
-	ret0, _ := ret[0].(protoreflect.ProtoMessage)
+	ret := m.ctrl.Call(m, "EntityWithPropertiesByUpstreamHint", ctx, entType, getByProps, hint, opts)
+	ret0, _ := ret[0].(*models.EntityWithProperties)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// EntityWithPropertiesAsProto indicates an expected call of EntityWithPropertiesAsProto.
-func (mr *MockPropertiesServiceMockRecorder) EntityWithPropertiesAsProto(ctx, ewp, provMgr any) *gomock.Call {
+// EntityWithPropertiesByUpstreamHint indicates an expected call of EntityWithPropertiesByUpstreamHint.
+func (mr *MockPropertiesServiceMockRecorder) EntityWithPropertiesByUpstreamHint(ctx, entType, getByProps, hint, opts any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EntityWithPropertiesAsProto", reflect.TypeOf((*MockPropertiesService)(nil).EntityWithPropertiesAsProto), ctx, ewp, provMgr)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EntityWithPropertiesByUpstreamHint", reflect.TypeOf((*MockPropertiesService)(nil).EntityWithPropertiesByUpstreamHint), ctx, entType, getByProps, hint, opts)
 }
 
 // ReplaceAllProperties mocks base method.

--- a/internal/entities/properties/service/mock/service.go
+++ b/internal/entities/properties/service/mock/service.go
@@ -47,19 +47,19 @@ func (m *MockPropertiesService) EXPECT() *MockPropertiesServiceMockRecorder {
 	return m.recorder
 }
 
-// EntityWithProperties mocks base method.
-func (m *MockPropertiesService) EntityWithProperties(ctx context.Context, entityID uuid.UUID, opts *service.CallOptions) (*models.EntityWithProperties, error) {
+// EntityWithPropertiesByID mocks base method.
+func (m *MockPropertiesService) EntityWithPropertiesByID(ctx context.Context, entityID uuid.UUID, opts *service.CallOptions) (*models.EntityWithProperties, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "EntityWithProperties", ctx, entityID, opts)
+	ret := m.ctrl.Call(m, "EntityWithPropertiesByID", ctx, entityID, opts)
 	ret0, _ := ret[0].(*models.EntityWithProperties)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// EntityWithProperties indicates an expected call of EntityWithProperties.
-func (mr *MockPropertiesServiceMockRecorder) EntityWithProperties(ctx, entityID, opts any) *gomock.Call {
+// EntityWithPropertiesByID indicates an expected call of EntityWithPropertiesByID.
+func (mr *MockPropertiesServiceMockRecorder) EntityWithPropertiesByID(ctx, entityID, opts any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EntityWithProperties", reflect.TypeOf((*MockPropertiesService)(nil).EntityWithProperties), ctx, entityID, opts)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EntityWithPropertiesByID", reflect.TypeOf((*MockPropertiesService)(nil).EntityWithPropertiesByID), ctx, entityID, opts)
 }
 
 // EntityWithPropertiesAsProto mocks base method.

--- a/internal/entities/properties/service/service.go
+++ b/internal/entities/properties/service/service.go
@@ -60,8 +60,8 @@ type PropertiesService interface {
 	EntityWithPropertiesAsProto(
 		ctx context.Context, ewp *models.EntityWithProperties, provMgr manager.ProviderManager,
 	) (protoreflect.ProtoMessage, error)
-	// EntityWithProperties Fetches an Entity by ID and Project in order to refresh the properties
-	EntityWithProperties(
+	// EntityWithPropertiesByID Fetches an Entity by ID and Project in order to refresh the properties
+	EntityWithPropertiesByID(
 		ctx context.Context, entityID uuid.UUID, opts *CallOptions,
 	) (*models.EntityWithProperties, error)
 	// RetrieveAllProperties fetches all properties for an entity
@@ -290,7 +290,7 @@ func (ps *propertiesService) ReplaceProperty(
 	return err
 }
 
-func (ps *propertiesService) EntityWithProperties(
+func (ps *propertiesService) EntityWithPropertiesByID(
 	ctx context.Context, entityID uuid.UUID,
 	opts *CallOptions,
 ) (*models.EntityWithProperties, error) {

--- a/internal/entities/properties/service/service.go
+++ b/internal/entities/properties/service/service.go
@@ -64,6 +64,16 @@ type PropertiesService interface {
 	EntityWithPropertiesByID(
 		ctx context.Context, entityID uuid.UUID, opts *CallOptions,
 	) (*models.EntityWithProperties, error)
+	// EntityWithPropertiesByUpstreamHint fetches an entity by upstream properties
+	// and returns the entity with its properties. It is expected that the caller
+	// does NOT know the project or provider ID. Whatever hints it may have
+	// are to be passed to the hint parameter which will be used in case multiple
+	// entries with the same ID are found.
+	EntityWithPropertiesByUpstreamHint(
+		ctx context.Context,
+		entType minderv1.Entity, getByProps *properties.Properties,
+		hint ByUpstreamHint, opts *CallOptions,
+	) (*models.EntityWithProperties, error)
 	// RetrieveAllProperties fetches all properties for an entity
 	// given a project, provider, and identifying properties.
 	// If the entity has properties in the database, it will return those
@@ -290,28 +300,14 @@ func (ps *propertiesService) ReplaceProperty(
 	return err
 }
 
-func (ps *propertiesService) EntityWithPropertiesByID(
-	ctx context.Context, entityID uuid.UUID,
+func (ps *propertiesService) getEntityWithProperties(
+	ctx context.Context,
+	ent db.EntityInstance,
 	opts *CallOptions,
 ) (*models.EntityWithProperties, error) {
 	q := ps.getStoreOrTransaction(opts)
 
-	zerolog.Ctx(ctx).Debug().Str("entityID", entityID.String()).Msg("fetching entity with properties")
-	ent, err := q.GetEntityByID(ctx, entityID)
-	if errors.Is(err, sql.ErrNoRows) {
-		return nil, ErrEntityNotFound
-	} else if err != nil {
-		return nil, fmt.Errorf("error getting entity: %w", err)
-	}
-	zerolog.Ctx(ctx).Debug().
-		Str("projectID", ent.ProjectID.String()).
-		Str("providerID", ent.ProviderID.String()).
-		Str("entityType", string(ent.EntityType)).
-		Str("entityName", ent.Name).
-		Str("entityID", ent.ID.String()).
-		Msg("entity found")
-
-	dbProps, err := q.GetAllPropertiesForEntity(ctx, entityID)
+	dbProps, err := q.GetAllPropertiesForEntity(ctx, ent.ID)
 	if errors.Is(err, sql.ErrNoRows) {
 		return nil, fmt.Errorf("failed to get properties for entity: %w", ErrEntityNotFound)
 	} else if err != nil {
@@ -335,6 +331,75 @@ func (ps *propertiesService) EntityWithPropertiesByID(
 	}
 
 	return models.NewEntityWithProperties(ent, props), nil
+}
+
+func (ps *propertiesService) EntityWithPropertiesByID(
+	ctx context.Context, entityID uuid.UUID,
+	opts *CallOptions,
+) (*models.EntityWithProperties, error) {
+	q := ps.getStoreOrTransaction(opts)
+
+	zerolog.Ctx(ctx).Debug().Str("entityID", entityID.String()).Msg("fetching entity with properties")
+	ent, err := q.GetEntityByID(ctx, entityID)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, ErrEntityNotFound
+	} else if err != nil {
+		return nil, fmt.Errorf("error getting entity: %w", err)
+	}
+
+	return ps.getEntityWithProperties(ctx, ent, opts)
+}
+
+// ByUpstreamHint is a hint to help find an entity by upstream ID
+// API-wise it should only be exposed in those methods of the service layer
+// that do not know the project or provider ID and are searching for an entity
+// based on upstream properties only.
+// The hint
+type ByUpstreamHint struct {
+	// ProviderImplements is the provider type to search by
+	ProviderImplements db.NullProviderType
+	ProviderClass      db.NullProviderClass
+}
+
+// ToLogDict converts the hint to a log dictionary for use by zerolog
+func (hint *ByUpstreamHint) ToLogDict() *zerolog.Event {
+	dict := zerolog.Dict().
+		Interface("ProviderImplements", hint.ProviderImplements)
+
+	return dict
+}
+
+func (hint *ByUpstreamHint) isSet() bool {
+	return hint.ProviderImplements.Valid || hint.ProviderClass.Valid
+}
+
+func (ps *propertiesService) EntityWithPropertiesByUpstreamHint(
+	ctx context.Context,
+	entType minderv1.Entity,
+	getByProps *properties.Properties,
+	hint ByUpstreamHint,
+	opts *CallOptions,
+) (*models.EntityWithProperties, error) {
+	q := ps.getStoreOrTransaction(opts)
+
+	l := zerolog.Ctx(ctx).With().
+		Dict("getByProps", getByProps.ToLogDict()).
+		Dict("hint", hint.ToLogDict()).
+		Logger()
+
+	l.Debug().Msg("fetching entity with properties by upstream hint")
+
+	ent, err := matchEntityWithHint(ctx, getByProps, entType, &hint, l, q)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get entity ID: %w", err)
+	}
+
+	ewp, err := ps.getEntityWithProperties(ctx, *ent, opts)
+	if err != nil {
+		return nil, err
+	}
+
+	return ewp, nil
 }
 
 // EntityWithPropertiesAsProto converts the entity with properties to a protobuf message

--- a/internal/entities/properties/service/service_test.go
+++ b/internal/entities/properties/service/service_test.go
@@ -904,7 +904,7 @@ func TestPropertiesService_EntityWithProperties(t *testing.T) {
 				Return(tt.dbPropsBuilder(tt.entityID), nil)
 
 			ps := NewPropertiesService(mockDB)
-			result, err := ps.EntityWithProperties(ctx, tt.entityID, nil)
+			result, err := ps.EntityWithPropertiesByID(ctx, tt.entityID, nil)
 			require.NoError(t, err)
 			require.NotNil(t, result)
 			require.Equal(t, result.Entity.ID, tt.entityID)

--- a/internal/history/service.go
+++ b/internal/history/service.go
@@ -218,7 +218,7 @@ func (ehs *evaluationHistoryService) ListEvaluationHistory(
 
 	data := make([]*OneEvalHistoryAndEntity, 0, len(rows))
 	for _, row := range rows {
-		efp, err := propsvc.EntityWithProperties(ctx, row.EntityID,
+		efp, err := propsvc.EntityWithPropertiesByID(ctx, row.EntityID,
 			propertiessvc.CallBuilder().WithStoreOrTransaction(qtx))
 		if err != nil {
 			return nil, fmt.Errorf("error fetching entity for properties: %w", err)

--- a/internal/history/service_test.go
+++ b/internal/history/service_test.go
@@ -836,12 +836,12 @@ func TestListEvaluationHistory(t *testing.T) {
 			pm := pmMock.NewMockProviderManager(ctrl)
 			propsSvc := propsSvcMock.NewMockPropertiesService(ctrl)
 			for _, efp := range tt.efp {
-				propsSvc.EXPECT().EntityWithProperties(ctx, gomock.Any(), gomock.Any()).
+				propsSvc.EXPECT().EntityWithPropertiesByID(ctx, gomock.Any(), gomock.Any()).
 					Return(efp, tt.entityForPropertiesError)
 			}
 
 			if tt.entityForPropertiesError != nil && len(tt.efp) == 0 {
-				propsSvc.EXPECT().EntityWithProperties(ctx, gomock.Any(), gomock.Any()).
+				propsSvc.EXPECT().EntityWithPropertiesByID(ctx, gomock.Any(), gomock.Any()).
 					Return(nil, tt.entityForPropertiesError).AnyTimes()
 			}
 			propsSvc.EXPECT().RetrieveAllPropertiesForEntity(ctx, gomock.Any(), gomock.Any(), gomock.Any()).

--- a/internal/providers/github/manager/manager.go
+++ b/internal/providers/github/manager/manager.go
@@ -177,7 +177,7 @@ func (g *githubProviderManager) Delete(ctx context.Context, config *db.Provider)
 		}
 
 		for _, ent := range entities {
-			ewp, err := g.propsSvc.EntityWithProperties(ctx, ent.ID, nil)
+			ewp, err := g.propsSvc.EntityWithPropertiesByID(ctx, ent.ID, nil)
 			if err != nil {
 				zerolog.Ctx(ctx).Error().Err(err).
 					Str("provider_id", config.ID.String()).

--- a/internal/repositories/service.go
+++ b/internal/repositories/service.go
@@ -257,7 +257,7 @@ func (r *repositoryService) ListRepositories(
 
 	ents = make([]*models.EntityWithProperties, 0, len(repoEnts))
 	for _, ent := range repoEnts {
-		ewp, err := r.propSvc.EntityWithProperties(ctx, ent.ID,
+		ewp, err := r.propSvc.EntityWithPropertiesByID(ctx, ent.ID,
 			service.CallBuilder().WithStoreOrTransaction(qtx))
 		if err != nil {
 			return nil, fmt.Errorf("error fetching properties for repository: %w", err)
@@ -315,7 +315,7 @@ func (r *repositoryService) DeleteByID(ctx context.Context, repositoryID uuid.UU
 	logger.BusinessRecord(ctx).Project = projectID
 	logger.BusinessRecord(ctx).Repository = repositoryID
 
-	ent, err := r.propSvc.EntityWithProperties(ctx, repositoryID, nil)
+	ent, err := r.propSvc.EntityWithPropertiesByID(ctx, repositoryID, nil)
 	if err != nil {
 		return fmt.Errorf("error fetching repository: %w", err)
 	}
@@ -355,7 +355,7 @@ func (r *repositoryService) DeleteByName(
 
 	logger.BusinessRecord(ctx).Repository = repo.ID
 
-	ent, err := r.propSvc.EntityWithProperties(ctx, repo.ID, nil)
+	ent, err := r.propSvc.EntityWithPropertiesByID(ctx, repo.ID, nil)
 	if err != nil {
 		return fmt.Errorf("error fetching repository: %w", err)
 	}

--- a/internal/repositories/service_test.go
+++ b/internal/repositories/service_test.go
@@ -712,7 +712,7 @@ func withSuccessfulPropFetch(prop *properties.Properties) func(svcMock propSvcMo
 
 func withSuccessfulEntityWithProps(mock propSvcMock) {
 	mock.EXPECT().
-		EntityWithProperties(gomock.Any(), gomock.Any(), gomock.Any()).
+		EntityWithPropertiesByID(gomock.Any(), gomock.Any(), gomock.Any()).
 		Return(models.NewEntityWithPropertiesFromInstance(models.EntityInstance{
 			ID:         dbRepo.ID,
 			ProjectID:  projectID,
@@ -722,7 +722,7 @@ func withSuccessfulEntityWithProps(mock propSvcMock) {
 
 func withFailedEntityWithProps(mock propSvcMock) {
 	mock.EXPECT().
-		EntityWithProperties(gomock.Any(), gomock.Any(), gomock.Any()).
+		EntityWithPropertiesByID(gomock.Any(), gomock.Any(), gomock.Any()).
 		Return(nil, errDefault)
 }
 


### PR DESCRIPTION
# Summary

When processing a webhook payload, we typically only have the
information from the webhook payload available which is to say
information about the upstream entity. We even don't know exactly which
provider and which project are we handling.

We used to sort of wing it in the github webhook handler and were just
searching by upstream ID as if it was globally unique, but that no
longer works with the introduction of multiple providers where several
entities might have the same upstream ID, just in different providers.

To handle that, we add a new method to the properties service that
searches by upstream ID with a hint. At the moment, the interface
supports providerID, projectID and provider implements as a hint.

The immediate use is that the github provider will search by the
upstream ID with the hint set to ProviderTypeGithub as that's
implemented both by the app and OAuth github providers.

If any attribute of the hint is set, then the entity's attribute must
match the hint, otherwise the entity is filtered out. Additionally, once
the entity is found, the hint might contain a property with a value that
must match. The use-case there would be deleting entities where we want
to ensure that we are deleting an entity with an appropriate upstream
hook ID.

If no entities match the hints or if multiple entities match a hint, an
error is returned.

Related: #4327

## Change Type

- [ ] Bug fix (resolves an issue without affecting existing features)
- [x] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [ ] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

as part of a larger branch + unit tests

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [x] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [x] Included tests that validate the fix or feature.
- [ ] Checked that related changes are merged.
