### PR TITLE
Use appropriate logging functions were possible

### DIFF
--- a/cmd/cli/app/provider/provider_get.go
+++ b/cmd/cli/app/provider/provider_get.go
@@ -79,13 +79,13 @@ func GetProviderCommand(ctx context.Context, cmd *cobra.Command, _ []string, con
 		if err != nil {
 			return err
 		}
-		fmt.Println(out)
+		cmd.Println(out)
 	case app.YAML:
 		out, err := util.GetYamlFromProto(out.GetProvider())
 		if err != nil {
 			return err
 		}
-		fmt.Println(out)
+		cmd.Println(out)
 	case app.Table:
 		t := table.New(table.Simple, layouts.Default, []string{"Key", "Value"})
 		p := out.GetProvider()

--- a/cmd/cli/app/provider/provider_list.go
+++ b/cmd/cli/app/provider/provider_list.go
@@ -49,7 +49,7 @@ func init() {
 }
 
 // ListProviderCommand lists the providers available in a specific project
-func ListProviderCommand(ctx context.Context, _ *cobra.Command, _ []string, conn *grpc.ClientConn) error {
+func ListProviderCommand(ctx context.Context, cmd *cobra.Command, _ []string, conn *grpc.ClientConn) error {
 
 	client := minderv1.NewProvidersServiceClient(conn)
 
@@ -86,13 +86,13 @@ func ListProviderCommand(ctx context.Context, _ *cobra.Command, _ []string, conn
 		if err != nil {
 			return err
 		}
-		fmt.Println(out)
+		cmd.Println(out)
 	case app.YAML:
 		out, err := util.GetYamlFromProto(out)
 		if err != nil {
 			return err
 		}
-		fmt.Println(out)
+		cmd.Println(out)
 	case app.Table:
 		t := table.New(table.Simple, layouts.ProviderList, nil)
 		for _, v := range out.Providers {

--- a/cmd/cli/app/repo/repo_reconcile.go
+++ b/cmd/cli/app/repo/repo_reconcile.go
@@ -17,7 +17,6 @@ package repo
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -78,7 +77,7 @@ func reconcileCommand(ctx context.Context, cmd *cobra.Command, _ []string, conn 
 		return cli.MessageAndError("Error creating reconciliation task", err)
 	}
 
-	fmt.Println("Reconciliation task created")
+	cmd.Println("Reconciliation task created")
 	return nil
 }
 

--- a/cmd/cli/app/repo/repo_register.go
+++ b/cmd/cli/app/repo/repo_register.go
@@ -56,7 +56,7 @@ func RegisterCmd(ctx context.Context, cmd *cobra.Command, _ []string, conn *grpc
 
 	if registerAll {
 		if len(inputRepoList) > 0 {
-			fmt.Println("Cannot use --all and --name together")
+			cmd.Println("Cannot use --all and --name together")
 			return nil
 		}
 

--- a/cmd/dev/app/image/list.go
+++ b/cmd/dev/app/image/list.go
@@ -98,7 +98,7 @@ func runCmdList(cmd *cobra.Command, _ []string) error {
 
 	// print the containers
 	for _, container := range containers {
-		fmt.Println(container)
+		cmd.Println(container)
 	}
 
 	return nil

--- a/cmd/dev/app/image/list_tags.go
+++ b/cmd/dev/app/image/list_tags.go
@@ -81,7 +81,7 @@ func runCmdListTags(cmd *cobra.Command, _ []string) error {
 
 	// print the containers
 	for _, container := range containers {
-		fmt.Println(container)
+		cmd.Println(container)
 	}
 
 	return nil

--- a/cmd/server/app/history_purge.go
+++ b/cmd/server/app/history_purge.go
@@ -60,7 +60,7 @@ func historyPurgeCommand(cmd *cobra.Command, _ []string) error {
 	// We maintain up to 30 days of history, plus any record
 	// that's the latest for any entity/rule pair.
 	threshold := time.Now().UTC().AddDate(0, 0, -30)
-	fmt.Printf("Calculated threshold is %s", threshold)
+	cmd.Printf("Calculated threshold is %s", threshold)
 
 	if err := purgeLoop(ctx, store, threshold, batchSize, dryRun, cmd.Printf); err != nil {
 		cliErrorf(cmd, "failed purging evaluation log: %s", err)

--- a/cmd/server/app/history_purge_test.go
+++ b/cmd/server/app/history_purge_test.go
@@ -17,7 +17,6 @@ package app
 import (
 	"context"
 	"errors"
-	"fmt"
 	"testing"
 	"time"
 	"unsafe"
@@ -232,7 +231,7 @@ func TestPurgeLoop(t *testing.T) {
 				store = tt.dbSetup(ctrl)
 			}
 
-			err := purgeLoop(ctx, store, tt.threshold, tt.size, tt.dryRun, printf)
+			err := purgeLoop(ctx, store, tt.threshold, tt.size, tt.dryRun, t.Logf)
 			if tt.err {
 				require.Error(t, err)
 				return
@@ -240,10 +239,6 @@ func TestPurgeLoop(t *testing.T) {
 			require.NoError(t, err)
 		})
 	}
-}
-
-func printf(format string, a ...any) {
-	fmt.Printf(format, a...)
 }
 
 func TestDeleteEvaluationHistory(t *testing.T) {

--- a/internal/authz/mock/noop_authz.go
+++ b/internal/authz/mock/noop_authz.go
@@ -18,9 +18,9 @@ package mock
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/google/uuid"
+	"github.com/rs/zerolog"
 
 	"github.com/stacklok/minder/internal/authz"
 	minderv1 "github.com/stacklok/minder/pkg/api/protobuf/go/minder/v1"
@@ -36,8 +36,8 @@ type NoopClient struct {
 var _ authz.Client = &NoopClient{}
 
 // Check implements authz.Client
-func (n *NoopClient) Check(_ context.Context, action string, project uuid.UUID) error {
-	fmt.Printf("noop authz check (%t): %s %s\n", n.Authorized, action, project)
+func (n *NoopClient) Check(ctx context.Context, action string, project uuid.UUID) error {
+	zerolog.Ctx(ctx).Debug().Str("action", action).Str("project", project.String()).Msg("noop authz check")
 	if n.Authorized {
 		return nil
 	}

--- a/internal/controlplane/handlers_providers_test.go
+++ b/internal/controlplane/handlers_providers_test.go
@@ -258,6 +258,7 @@ func TestCreateProvider(t *testing.T) {
 			require.NoError(t, err)
 
 			fakeServer.mockStore.EXPECT().CreateProvider(gomock.Any(), partialCreateParamsMatcher{
+				t: t,
 				value: db.CreateProviderParams{
 					Name:       scenario.name,
 					ProjectID:  projectID,
@@ -466,6 +467,7 @@ func TestCreateProviderFailures(t *testing.T) {
 
 type partialCreateParamsMatcher struct {
 	value db.CreateProviderParams
+	t     *testing.T
 }
 
 func (p partialCreateParamsMatcher) configMatches(name string, gotBytes json.RawMessage) bool {
@@ -478,7 +480,7 @@ func (p partialCreateParamsMatcher) configMatches(name string, gotBytes json.Raw
 		return false
 	}
 	if !cmp.Equal(exp, got) {
-		fmt.Printf("config mismatch for %s: %s\n", name, cmp.Diff(gotBytes, p.value.Definition))
+		p.t.Logf("config mismatch for %s: %s\n", name, cmp.Diff(gotBytes, p.value.Definition))
 		return false
 	}
 	return true

--- a/internal/engine/eval/eval.go
+++ b/internal/engine/eval/eval.go
@@ -69,7 +69,7 @@ func NewRuleEvaluator(
 		if err != nil {
 			return nil, errors.New("provider does not implement git trait")
 		}
-		return application.NewHomoglyphsEvaluator(e.GetHomoglyphs(), client)
+		return application.NewHomoglyphsEvaluator(ctx, e.GetHomoglyphs(), client)
 	default:
 		return nil, fmt.Errorf("unsupported rule type engine: %s", ruletype.Def.Eval.Type)
 	}

--- a/internal/engine/eval/homoglyphs/application/homoglyphs_service.go
+++ b/internal/engine/eval/homoglyphs/application/homoglyphs_service.go
@@ -40,6 +40,7 @@ const (
 
 // NewHomoglyphsEvaluator creates a new homoglyphs evaluator
 func NewHomoglyphsEvaluator(
+	ctx context.Context,
 	reh *pb.RuleType_Definition_Eval_Homoglyphs,
 	ghClient provifv1.GitHub,
 ) (engif.Evaluator, error) {
@@ -54,7 +55,7 @@ func NewHomoglyphsEvaluator(
 	case invisibleCharacters:
 		return NewInvisibleCharactersEvaluator(ghClient)
 	case mixedScript:
-		return NewMixedScriptEvaluator(ghClient)
+		return NewMixedScriptEvaluator(ctx, ghClient)
 	default:
 		return nil, fmt.Errorf("unsupported homoglyphs type: %s", reh.Type)
 	}

--- a/internal/engine/eval/homoglyphs/application/mixed_scripts_eval.go
+++ b/internal/engine/eval/homoglyphs/application/mixed_scripts_eval.go
@@ -32,8 +32,8 @@ type MixedScriptsEvaluator struct {
 }
 
 // NewMixedScriptEvaluator creates a new mixed scripts evaluator
-func NewMixedScriptEvaluator(ghClient provifv1.GitHub) (*MixedScriptsEvaluator, error) {
-	msProcessor, err := domain.NewMixedScriptsProcessor()
+func NewMixedScriptEvaluator(ctx context.Context, ghClient provifv1.GitHub) (*MixedScriptsEvaluator, error) {
+	msProcessor, err := domain.NewMixedScriptsProcessor(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("could not create mixed scripts processor: %w", err)
 	}

--- a/internal/engine/eval/homoglyphs/domain/mixed_scripts_test.go
+++ b/internal/engine/eval/homoglyphs/domain/mixed_scripts_test.go
@@ -15,6 +15,7 @@
 package domain
 
 import (
+	"context"
 	"reflect"
 	"sort"
 	"testing"
@@ -96,7 +97,7 @@ func TestFindMixedScripts(t *testing.T) {
 func TestLoadScriptData(t *testing.T) {
 	t.Parallel()
 
-	gotMap, err := loadScriptData("resources/scripts.txt")
+	gotMap, err := loadScriptData(context.Background(), "resources/scripts.txt")
 	if err != nil {
 		t.Fatalf("loadScriptData returned an error: %v", err)
 	}

--- a/internal/engine/eval/vulncheck/vulncheck.go
+++ b/internal/engine/eval/vulncheck/vulncheck.go
@@ -22,6 +22,7 @@ import (
 	"strings"
 
 	"github.com/hashicorp/go-version"
+	"github.com/rs/zerolog"
 
 	evalerrors "github.com/stacklok/minder/internal/engine/errors"
 	engif "github.com/stacklok/minder/internal/engine/interfaces"
@@ -179,7 +180,10 @@ func (e *Evaluator) checkVulnerabilities(
 ) (bool, error) {
 	ecoConfig := cfg.getEcosystemConfig(dep.Dep.Ecosystem)
 	if ecoConfig == nil {
-		fmt.Printf("Skipping dependency %s because ecosystem %s is not configured\n", dep.Dep.Name, dep.Dep.Ecosystem)
+		zerolog.Ctx(ctx).Info().
+			Str("ecosystem", string(dep.Dep.Ecosystem)).
+			Str("dependency", dep.Dep.Name).
+			Msg("Skipping dependency because ecosystem is not configured")
 		return false, nil
 	}
 

--- a/internal/providers/credentials/github_installation_token_credential.go
+++ b/internal/providers/credentials/github_installation_token_credential.go
@@ -26,6 +26,7 @@ import (
 	githttp "github.com/go-git/go-git/v5/plumbing/transport/http"
 	"github.com/google/go-containerregistry/pkg/authn"
 	"github.com/google/go-github/v63/github"
+	"github.com/rs/zerolog"
 	"golang.org/x/oauth2"
 
 	provifv1 "github.com/stacklok/minder/pkg/providers/v1"
@@ -50,7 +51,11 @@ func NewGitHubInstallationTokenCredential(
 ) *GitHubInstallationTokenCredential {
 	token, err := generateInstallationAccessToken(ctx, appId, privateKey, endpoint, installationId)
 	if err != nil {
-		fmt.Printf("error generating installation access token: %v", err)
+		zerolog.Ctx(ctx).Error().Err(err).
+			Int64("installation_id", installationId).
+			Int64("app_id", appId).
+			Str("endpoint", endpoint).
+			Msg("error generating installation access token")
 	}
 	return &GitHubInstallationTokenCredential{
 		installationId: installationId,


### PR DESCRIPTION
# Summary

I noticed a lot of usages of `fmt.Printf` or `fmt.Println` throughout
the codebase. While this does the trick, it loses a lot of context that
we'd ideally have.

This switches to using logging functions that keep context and give us
extra data that's useful for debugging.

## Change Type

***Mark the type of change your PR introduces:***

- [x] Bug fix (resolves an issue without affecting existing features)
- [x] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [x] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

***Outline how the changes were tested, including steps to reproduce and any relevant configurations. 
Attach screenshots if helpful.***

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [ ] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [ ] Included tests that validate the fix or feature.
- [ ] Checked that related changes are merged.
