### PR TITLE
Include the name of the package for which we couldn't find a fix

### DIFF
--- a/internal/engine/eval/vulncheck/report.go
+++ b/internal/engine/eval/vulncheck/report.go
@@ -58,7 +58,7 @@ const (
 	Minder analyzed this PR and found it does not add any new vulnerable dependencies.
 	`
 	reviewBodyDismissCommentText = "Previous Minder review was dismissed because the PR was updated"
-	vulnFoundWithNoPatch         = "Vulnerability found, but no patched version exists yet."
+	vulnFoundWithNoPatchFmt      = "Vulnerability found in `%s`, but no patched version exists yet."
 	pkgRepoInfoNotFound          = "Vulnerability found, but package not found in the package database."
 	pkgRepoLookupError           = "Error looking up package in the package database."
 )

--- a/internal/engine/eval/vulncheck/review.go
+++ b/internal/engine/eval/vulncheck/review.go
@@ -205,12 +205,11 @@ func (ra *reviewPrHandler) trackVulnerableDep(
 		body = pkgRepoInfoNotFound
 	case patch.GetFormatterMeta().pkgRegistryLookupError == nil:
 		if !patch.HasPatchedVersion() {
-			body = vulnFoundWithNoPatch
+			body = fmt.Sprintf(vulnFoundWithNoPatchFmt, dep.Dep.Name)
 		} else {
 			comment := patch.IndentedString(location.leadingWhitespace, location.line, dep.Dep)
 			body = reviewBodyWithSuggestion(comment)
 			lineTo = len(strings.Split(comment, "\n")) - 1
-
 		}
 	default:
 		body = pkgRepoLookupError

--- a/internal/engine/eval/vulncheck/review_test.go
+++ b/internal/engine/eval/vulncheck/review_test.go
@@ -358,7 +358,7 @@ func TestReviewPrHandlerVulnerabilitiesWithNoPatchVersion(t *testing.T) {
 	require.NoError(t, err)
 	require.NotEmpty(t, expStatusBody)
 
-	expCommentBody := vulnFoundWithNoPatch
+	expCommentBody := fmt.Sprintf(vulnFoundWithNoPatchFmt, dep.Dep.Name)
 
 	mockClient.EXPECT().
 		CreateReview(gomock.Any(), pr.RepoOwner, pr.RepoName, int(pr.Number), &github.PullRequestReviewRequest{
@@ -466,6 +466,8 @@ func TestReviewPrHandlerVulnerabilitiesDismissReview(t *testing.T) {
 			Message: github.String(reviewBodyDismissCommentText),
 		})
 
+	expCommentBody := fmt.Sprintf(vulnFoundWithNoPatchFmt, dep.Dep.Name)
+
 	mockClient.EXPECT().
 		CreateReview(gomock.Any(), pr.RepoOwner, pr.RepoName, int(pr.Number), &github.PullRequestReviewRequest{
 			CommitID: github.String(commitSHA),
@@ -474,7 +476,7 @@ func TestReviewPrHandlerVulnerabilitiesDismissReview(t *testing.T) {
 				{
 					Path: github.String(dep.File.Name),
 					Line: github.Int(1),
-					Body: github.String(vulnFoundWithNoPatch),
+					Body: github.String(expCommentBody),
 				},
 			}}).Return(
 		&github.PullRequestReview{


### PR DESCRIPTION
# Summary

When replying to a single line, github always prepends the context "before"
the line unless replying with a suggestion. This gets confusing when replying
to a line deeper in a diff especially the last line as we can't pinpoint a
single line to reply to.

To improve the UX a little bit, we include the package name with the
package we are replying to so that the user can tie the comment better
to the actual line.

Pair-Programmed-With: Michelangelo Mori <mmori@stacklok.com>

Fixes: #4529 

## Change Type

- [x] Bug fix (resolves an issue without affecting existing features)
- [ ] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [ ] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

manual

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [ ] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [ ] Included tests that validate the fix or feature.
- [ ] Checked that related changes are merged.
