### PR TITLE
Make max number of idle connections configurable.

### DIFF
--- a/internal/config/common.go
+++ b/internal/config/common.go
@@ -34,12 +34,13 @@ import (
 
 // DatabaseConfig is the configuration for the database
 type DatabaseConfig struct {
-	Host     string `mapstructure:"dbhost" default:"localhost"`
-	Port     int    `mapstructure:"dbport" default:"5432"`
-	User     string `mapstructure:"dbuser" default:"postgres"`
-	Password string `mapstructure:"dbpass" default:"postgres"`
-	Name     string `mapstructure:"dbname" default:"minder"`
-	SSLMode  string `mapstructure:"sslmode" default:"disable"`
+	Host            string `mapstructure:"dbhost" default:"localhost"`
+	Port            int    `mapstructure:"dbport" default:"5432"`
+	User            string `mapstructure:"dbuser" default:"postgres"`
+	Password        string `mapstructure:"dbpass" default:"postgres"`
+	Name            string `mapstructure:"dbname" default:"minder"`
+	SSLMode         string `mapstructure:"sslmode" default:"disable"`
+	IdleConnections int    `mapstructure:"idle_connections" default:"0"`
 }
 
 // GetDBConnection returns a connection to the database
@@ -52,6 +53,10 @@ func (c *DatabaseConfig) GetDBConnection(ctx context.Context) (*sql.DB, string, 
 	conn, err := splunksql.Open("postgres", uri)
 	if err != nil {
 		return nil, "", err
+	}
+
+	if c.IdleConnections != 0 {
+		conn.SetMaxIdleConns(c.IdleConnections)
 	}
 
 	for i := 0; i < 8; i++ {


### PR DESCRIPTION
# Summary

This change allows setting the maximum number of idle connections via configuration file. This is useful since local testing showed that Minder `eventer` spends roughly ~25% of its time opening connections to Postgres.

## Change Type

- [ ] Bug fix (resolves an issue without affecting existing features)
- [ ] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [X] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

Checked via `pprof` and debugger.

# Review Checklist:

- [X] Reviewed my own code for quality and clarity.
- [ ] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [ ] Included tests that validate the fix or feature.
- [ ] Checked that related changes are merged.
