### PR TITLE
Do not reply that a package has an unfixed vulnerability when in fact it is malicious

### DIFF
--- a/internal/engine/eval/vulncheck/report.go
+++ b/internal/engine/eval/vulncheck/report.go
@@ -81,6 +81,21 @@ const (
 )
 
 const (
+	maliciousVulnFoundTemplate = `Malicious vulnerability found for dependency <tt>{{.Name}}</tt>:
+
+| ID | Summary | Details |
+|----|---------|---------|
+{{- range .Vulns}}
+| [{{.ID}}](https://osv.dev/vulnerability/{{.ID}}) | {{.Summary}} | {{.Details}} |
+{{- end}}
+
+Please review and remove this dependency immediately.`
+
+	maliciousVulnFoundFallbackFmt = `Malicious vulnerability found for dependency %s.
+Please review and remove this dependency immediately.", dep.Dep.Name)`
+)
+
+const (
 	tableVulnerabilitiesHeaderName = "vulnerabilitiesTableHeader"
 	tableVulnerabilitiesHeader     = `<h3>Summary of vulnerabilities found</h3>
 Minder found the following vulnerabilities in this PR:


### PR DESCRIPTION
# Summary

Malicious packages that have a vulnerability entry `MAL-` are in fact
malicious. Our OSV evaluator handled the `MAL-` vulnerabilities the same
as all the others which meant that it would just reply with "A
vulnerability was found, but no fixed version exists yet".

A malicious package is unlikely to not be malicious again, so let's put
a sterner warning including a link to the vulnerability into the reply.

Fixes: #4528

## Change Type

- [x] Bug fix (resolves an issue without affecting existing features)
- [ ] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [ ] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

manually, see e.g. https://github.com/jakubtestorg/bad-python/pull/266

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [ ] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [ ] Included tests that validate the fix or feature.
- [ ] Checked that related changes are merged.
