### PR TITLE
Fixed wrong indentation of HTML in PR comments.

### DIFF
--- a/internal/engine/eval/trusty/actions.go
+++ b/internal/engine/eval/trusty/actions.go
@@ -94,7 +94,7 @@ Archived packages are no longer updated or maintained. This can lead to security
   | Number of git tags or releases | {{ .Provenance.Historical.NumTags }}
   | Versions matched to tags or releases | {{ .Provenance.Historical.MatchedVersions }} |
 
-  {{- end -}}
+  {{- end }}
   {{ if .Provenance.Sigstore }}
 
   __This package has been digitally signed using sigtore.__
@@ -105,8 +105,8 @@ Archived packages are no longer updated or maintained. This can lead to security
   | Cerificate Issuer | {{ .Provenance.Sigstore.Issuer }} |
   | GitHub action workflow | {{ .Provenance.Sigstore.Workflow }} |
   | Rekor (public ledger) entry | {{ .Provenance.Sigstore.RekorURI }} |
-  {{- end -}}
-  </details>
+  {{- end }}
+</details>
 {{- end -}}
 {{ if .Alternatives }}
 <details>


### PR DESCRIPTION
# Summary

Some trailing `</details>` tag in trusty PR comments were misplaced because they were missing a `\n` before them, causing the dependency list to be a tree instead.

## Change Type

- [ ] Bug fix (resolves an issue without affecting existing features)
- [ ] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [X] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

Manual tests.

# Review Checklist:

- [X] Reviewed my own code for quality and clarity.
- [ ] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [ ] Included tests that validate the fix or feature.
- [X] Checked that related changes are merged.
