### PR TITLE
Add template support to evaluation details.

### DIFF
--- a/internal/engine/errors/errors_test.go
+++ b/internal/engine/errors/errors_test.go
@@ -1,0 +1,147 @@
+// Copyright 2024 Stacklok, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package errors
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/stacklok/minder/internal/engine/eval/templates"
+)
+
+func TestLegacyEvaluationDetailRendering(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		msg     string
+		args    []any
+		error   string
+		details string
+	}{
+		{
+			name:    "legacy",
+			msg:     "format: %s",
+			args:    []any{"this is the message"},
+			error:   "evaluation failure: format: this is the message",
+			details: "format: this is the message",
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := NewErrEvaluationFailed(
+				tt.msg,
+				tt.args...,
+			)
+
+			require.Equal(t, tt.error, err.Error())
+			evalErr, ok := err.(*EvaluationError)
+			require.True(t, ok)
+			require.Equal(t, tt.details, evalErr.Msg)
+		})
+	}
+}
+
+func TestEvaluationDetailRendering(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		msg     string
+		msgArgs []any
+		tmpl    string
+		args    any
+		error   string
+		details string
+	}{
+		{
+			name:    "legacy",
+			msg:     "this is the message",
+			tmpl:    "",
+			args:    nil,
+			error:   "evaluation failure: this is the message",
+			details: "this is the message",
+		},
+		{
+			name:    "empty template",
+			msg:     "this is the message",
+			tmpl:    "",
+			args:    nil,
+			error:   "evaluation failure: this is the message",
+			details: "this is the message",
+		},
+		{
+			name:    "simple template",
+			msg:     "this is the message",
+			tmpl:    "fancy template with {{ . }}",
+			args:    "fancy message",
+			error:   "evaluation failure: this is the message",
+			details: "fancy template with fancy message",
+		},
+		{
+			name:    "complex template",
+			msg:     "this is the message",
+			tmpl:    "fancy template with {{ range $idx, $val := . }}{{ if $idx }}, {{ end }}{{ . }}{{ end }}",
+			args:    []any{"many", "many", "many messages"},
+			error:   "evaluation failure: this is the message",
+			details: "fancy template with many, many, many messages",
+		},
+		{
+			name:    "enforced limit",
+			msg:     "this is the message",
+			tmpl:    "fancy template with {{ . }}",
+			args:    strings.Repeat("A", 1025),
+			error:   "evaluation failure: this is the message",
+			details: "evaluation failure: this is the message",
+		},
+		// vulncheck template
+		{
+			name:    "vulncheck template",
+			msg:     "this is the message",
+			tmpl:    templates.VulncheckTemplate,
+			args:    map[string]any{"packages": []string{"boto3", "urllib3", "python-oauth2"}},
+			error:   "evaluation failure: this is the message",
+			details: "Vulnerable packages found:\n* `boto3`\n* `urllib3`\n* `python-oauth2`\n",
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := NewDetailedErrEvaluationFailed(
+				tt.tmpl,
+				tt.args,
+				tt.msg,
+				tt.msgArgs...,
+			)
+
+			require.Equal(t, tt.error, err.Error())
+			evalErr, ok := err.(*EvaluationError)
+			require.True(t, ok)
+			require.Equal(t, tt.details, evalErr.Details())
+			require.LessOrEqual(t, len(evalErr.Details()), 1024)
+		})
+	}
+}

--- a/internal/engine/eval/templates/templates.go
+++ b/internal/engine/eval/templates/templates.go
@@ -1,0 +1,27 @@
+// Copyright 2024 Stacklok, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package templates contains template strings for evaluation details.
+package templates
+
+import (
+	// This comment makes the linter happy.
+	_ "embed"
+)
+
+// VulncheckTemplate is the template for evaluation details of the
+// `vulncheck` evaluation engine.
+//
+//go:embed vulncheckTemplate.tmpl
+var VulncheckTemplate string

--- a/internal/engine/eval/templates/vulncheckTemplate.tmpl
+++ b/internal/engine/eval/templates/vulncheckTemplate.tmpl
@@ -1,0 +1,4 @@
+Vulnerable packages found:
+{{- range .packages }}
+* `{{- . -}}`
+{{- end }}

--- a/internal/engine/eval/vulncheck/vulncheck.go
+++ b/internal/engine/eval/vulncheck/vulncheck.go
@@ -25,6 +25,7 @@ import (
 	"github.com/rs/zerolog"
 
 	evalerrors "github.com/stacklok/minder/internal/engine/errors"
+	"github.com/stacklok/minder/internal/engine/eval/templates"
 	engif "github.com/stacklok/minder/internal/engine/interfaces"
 	pbinternal "github.com/stacklok/minder/internal/proto"
 	provifv1 "github.com/stacklok/minder/pkg/providers/v1"
@@ -59,7 +60,12 @@ func (e *Evaluator) Eval(ctx context.Context, pol map[string]any, res *engif.Res
 	}
 
 	if len(vulnerablePackages) > 0 {
-		return evalerrors.NewErrEvaluationFailed("vulnerable packages: %s", strings.Join(vulnerablePackages, ","))
+		return evalerrors.NewDetailedErrEvaluationFailed(
+			templates.VulncheckTemplate,
+			vulnerablePackages,
+			"vulnerable packages: %s",
+			strings.Join(vulnerablePackages, ","),
+		)
 	}
 
 	return nil

--- a/internal/engine/eval/vulncheck/vulncheck_test.go
+++ b/internal/engine/eval/vulncheck/vulncheck_test.go
@@ -1,0 +1,68 @@
+// Copyright 2024 Stacklok, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package vulncheck
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	evalerrors "github.com/stacklok/minder/internal/engine/errors"
+	"github.com/stacklok/minder/internal/engine/eval/templates"
+)
+
+func TestEvaluationDetailRendering(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		msg     string
+		msgArgs []any
+		tmpl    string
+		args    any
+		error   string
+		details string
+	}{
+		// vulncheck template
+		{
+			name:    "vulncheck template",
+			msg:     "this is the message",
+			tmpl:    templates.VulncheckTemplate,
+			args:    map[string]any{"packages": []string{"boto3", "urllib3", "python-oauth2"}},
+			error:   "evaluation failure: this is the message",
+			details: "Vulnerable packages found:\n* `boto3`\n* `urllib3`\n* `python-oauth2`\n",
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := evalerrors.NewDetailedErrEvaluationFailed(
+				tt.tmpl,
+				tt.args,
+				tt.msg,
+				tt.msgArgs...,
+			)
+
+			require.Equal(t, tt.error, err.Error())
+			evalErr, ok := err.(*evalerrors.EvaluationError)
+			require.True(t, ok)
+			require.Equal(t, tt.details, evalErr.Details())
+		})
+	}
+}


### PR DESCRIPTION
# Summary

This change extends error type available for use in evaluation engines with support for go templates. This error type supports rendering complex templates along with the usual string rendering. Despite the type itself being the same, a new constructor was added to avoid a bigger refactoring. Ideally, the old constructor should be deprecated and all places returning an `ErrEvaluationFailed` error should use the new one instead.

Templates are internal to Minder and cannot be customized by the end user. Also, template engine choice was arbitrary and can be changed at any time.

Fixes #4525
Fixes #4526

## Change Type

- [ ] Bug fix (resolves an issue without affecting existing features)
- [X] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [X] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

Unit tests.

# Review Checklist:

- [X] Reviewed my own code for quality and clarity.
- [ ] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [ ] Included tests that validate the fix or feature.
- [X] Checked that related changes are merged.
