### PR TITLE
Add github/pull_author_login as a property for PRs

### DIFF
--- a/docs/docs/how-to/profile_selectors.md
+++ b/docs/docs/how-to/profile_selectors.md
@@ -99,13 +99,14 @@ Selectors for repositories allow you to filter and manage repositories based on 
 
 ## Pull request properties set by the GitHub provider
 
-| Field                   | Description                             | Type   |
-|-------------------------|-----------------------------------------|--------|
-| `github/pull_url`       | The URL of the pull request             | string |
-| `github/pull_number`    | The number of the pull request          | string |
-| `github/pull_author_id` | The author of the pull request          | string |
-| `github/repo_name`      | The github repo name (e.g. `stacklok`). | string |
-| `github/repo_owner`     | The github repo owner (e.g. `minder`).  | string |
+| Field                      | Description                                        | Type   |
+|----------------------------|----------------------------------------------------|--------|
+| `github/pull_url`          | The URL of the pull request                        | string |
+| `github/pull_number`       | The number of the pull request                     | string |
+| `github/pull_author_id`    | The numerical ID of the author of the pull request | int    |
+| `github/pull_author_login` | The github login of the author of the pull request | string |
+| `github/repo_name`         | The github repo name (e.g. `stacklok`).            | string |
+| `github/repo_owner`        | The github repo owner (e.g. `minder`).             | string |
 
 ## Entity provider selectors
 

--- a/internal/providers/github/properties/pull_request.go
+++ b/internal/providers/github/properties/pull_request.go
@@ -44,6 +44,8 @@ const (
 	PullPropertyRepoName = "github/repo_name"
 	// PullPropertyAuthorID is the ID of the author of the pull request
 	PullPropertyAuthorID = "github/pull_author_id"
+	// PullPropertyAuthorLogin is the login of the author of the pull request
+	PullPropertyAuthorLogin = "github/pull_author_login"
 	// PullPropertyAction is an operational property that represents the action that was taken on the pull request
 	PullPropertyAction = "github/pull_action"
 )
@@ -61,6 +63,7 @@ var prPropertyDefinitions = []propertyOrigin{
 			PullPropertyRepoOwner,
 			PullPropertyRepoName,
 			PullPropertyAuthorID,
+			PullPropertyAuthorLogin,
 			PullPropertyAction,
 		},
 		wrapper: getPrWrapper,
@@ -152,11 +155,12 @@ func getPrWrapper(
 		// github-specific
 		PullPropertyURL: prReply.GetHTMLURL(),
 		// our proto representation uses int64 for the number but GH uses int
-		PullPropertyNumber:    int64(prReply.GetNumber()),
-		PullPropertySha:       prReply.GetHead().GetSHA(),
-		PullPropertyRepoOwner: owner,
-		PullPropertyRepoName:  name,
-		PullPropertyAuthorID:  prReply.GetUser().GetID(),
+		PullPropertyNumber:      int64(prReply.GetNumber()),
+		PullPropertySha:         prReply.GetHead().GetSHA(),
+		PullPropertyRepoOwner:   owner,
+		PullPropertyRepoName:    name,
+		PullPropertyAuthorID:    prReply.GetUser().GetID(),
+		PullPropertyAuthorLogin: prReply.GetUser().GetLogin(),
 	}
 
 	return prProps, nil


### PR DESCRIPTION
# Summary

This allows us to write selectors like:
```
selection:
  - entity: pull_request
    selector: pull_request.properties['github/pull_author_login'] != 'jhrozek'
    comment: "We trust Jakub. Don't check his PRs"
```

## Change Type

- [ ] Bug fix (resolves an issue without affecting existing features)
- [x] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [ ] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

manually 

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [ ] Added comments to complex or tricky code sections.
- [x] Updated any affected documentation.
- [ ] Included tests that validate the fix or feature.
- [ ] Checked that related changes are merged.
