### PR TITLE
Add `ReregisterEntity` to provider interface

### DIFF
--- a/internal/providers/dockerhub/dockerhub.go
+++ b/internal/providers/dockerhub/dockerhub.go
@@ -218,3 +218,11 @@ func (_ *dockerHubImageLister) DeregisterEntity(
 	// TODO: implement
 	return nil
 }
+
+// ReregisterEntity implements the Provider interface
+func (_ *dockerHubImageLister) ReregisterEntity(
+	_ context.Context, _ minderv1.Entity, _ *properties.Properties,
+) error {
+	// TODO: implement
+	return nil
+}

--- a/internal/providers/github/entities.go
+++ b/internal/providers/github/entities.go
@@ -108,17 +108,7 @@ func (c *GitHub) RegisterEntity(
 	}
 	ping := c.webhookConfig.ExternalPingURL
 
-	jsonCT := "json"
-	newHook := &github.Hook{
-		Config: &github.HookConfig{
-			URL:         ptr.Ptr(webhookURL.String()),
-			ContentType: &jsonCT,
-			Secret:      &secret,
-		},
-		PingURL: &ping,
-		Events:  targetedEvents,
-	}
-
+	newHook := getGitHubWebhook(webhookURL.String(), ping, secret)
 	webhook, err := c.CreateHook(ctx, repoOwner, repoName, newHook)
 	if err != nil {
 		return nil, fmt.Errorf("error creating hook: %w", err)
@@ -168,6 +158,57 @@ func (c *GitHub) DeregisterEntity(ctx context.Context, entityType minderv1.Entit
 	err := c.DeleteHook(ctx, repoOwner, repoName, hookID)
 	if err != nil {
 		return fmt.Errorf("error deleting hook: %w", err)
+	}
+
+	return nil
+}
+
+// ReregisterEntity implements the Provider interface
+func (c *GitHub) ReregisterEntity(
+	ctx context.Context, entityType minderv1.Entity, props *properties.Properties,
+) error {
+	// We only need explicit registration steps for repositories
+	// The rest of the entities are originated from them.
+	if entityType != minderv1.Entity_ENTITY_REPOSITORIES {
+		return nil
+	}
+
+	repoNameP := props.GetProperty(ghprop.RepoPropertyName)
+	if repoNameP == nil {
+		return errors.New("repo name property not found")
+	}
+
+	repoOwnerP := props.GetProperty(ghprop.RepoPropertyOwner)
+	if repoOwnerP == nil {
+		return errors.New("repo owner property not found")
+	}
+
+	hookIDP := props.GetProperty(ghprop.RepoPropertyHookId)
+	if hookIDP == nil {
+		return errors.New("hook ID property not found")
+	}
+
+	hookURL := props.GetProperty(ghprop.RepoPropertyHookUrl)
+	if hookURL == nil {
+		return errors.New("hook URL property not found")
+	}
+
+	ping := c.webhookConfig.ExternalPingURL
+
+	secret, err := c.webhookConfig.GetWebhookSecret()
+	if err != nil {
+		return fmt.Errorf("error getting webhook secret for github provider: %w", err)
+	}
+
+	repoName := repoNameP.GetString()
+	repoOwner := repoOwnerP.GetString()
+	hookID := hookIDP.GetInt64()
+
+	hook := getGitHubWebhook(hookURL.GetString(), ping, secret)
+	_, err = c.EditHook(ctx, repoOwner, repoName, hookID, hook)
+	if err != nil {
+		zerolog.Ctx(ctx).Error().Err(err).Msg("unable to update hook")
+		return fmt.Errorf("unable to update hook: %w", err)
 	}
 
 	return nil
@@ -240,4 +281,16 @@ func ensureGitHubPathInWebhook(u *url.URL) (*url.URL, error) {
 	}
 
 	return u.JoinPath("github"), nil
+}
+
+func getGitHubWebhook(webhookURL, pingURL, secret string) *github.Hook {
+	return &github.Hook{
+		Config: &github.HookConfig{
+			URL:         ptr.Ptr(webhookURL),
+			ContentType: ptr.Ptr("json"),
+			Secret:      &secret,
+		},
+		PingURL: ptr.Ptr(pingURL),
+		Events:  targetedEvents,
+	}
 }

--- a/internal/providers/github/ghcr/ghcr.go
+++ b/internal/providers/github/ghcr/ghcr.go
@@ -177,3 +177,10 @@ func (_ *ImageLister) DeregisterEntity(_ context.Context, _ minderv1.Entity, _ *
 	// TODO: implement
 	return nil
 }
+
+// ReregisterEntity implements the Provider interface
+func (_ *ImageLister) ReregisterEntity(
+	_ context.Context, _ minderv1.Entity, _ *properties.Properties,
+) error {
+	return nil
+}

--- a/internal/providers/github/mock/github.go
+++ b/internal/providers/github/mock/github.go
@@ -137,6 +137,20 @@ func (mr *MockProviderMockRecorder) RegisterEntity(ctx, entType, props any) *gom
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RegisterEntity", reflect.TypeOf((*MockProvider)(nil).RegisterEntity), ctx, entType, props)
 }
 
+// ReregisterEntity mocks base method.
+func (m *MockProvider) ReregisterEntity(ctx context.Context, entType v10.Entity, props *properties.Properties) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ReregisterEntity", ctx, entType, props)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// ReregisterEntity indicates an expected call of ReregisterEntity.
+func (mr *MockProviderMockRecorder) ReregisterEntity(ctx, entType, props any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReregisterEntity", reflect.TypeOf((*MockProvider)(nil).ReregisterEntity), ctx, entType, props)
+}
+
 // SupportsEntity mocks base method.
 func (m *MockProvider) SupportsEntity(entType v10.Entity) bool {
 	m.ctrl.T.Helper()
@@ -277,6 +291,20 @@ func (mr *MockGitMockRecorder) RegisterEntity(ctx, entType, props any) *gomock.C
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RegisterEntity", reflect.TypeOf((*MockGit)(nil).RegisterEntity), ctx, entType, props)
 }
 
+// ReregisterEntity mocks base method.
+func (m *MockGit) ReregisterEntity(ctx context.Context, entType v10.Entity, props *properties.Properties) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ReregisterEntity", ctx, entType, props)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// ReregisterEntity indicates an expected call of ReregisterEntity.
+func (mr *MockGitMockRecorder) ReregisterEntity(ctx, entType, props any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReregisterEntity", reflect.TypeOf((*MockGit)(nil).ReregisterEntity), ctx, entType, props)
+}
+
 // SupportsEntity mocks base method.
 func (m *MockGit) SupportsEntity(entType v10.Entity) bool {
 	m.ctrl.T.Helper()
@@ -415,6 +443,20 @@ func (m *MockProtoMessageConverter) RegisterEntity(ctx context.Context, entType 
 func (mr *MockProtoMessageConverterMockRecorder) RegisterEntity(ctx, entType, props any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RegisterEntity", reflect.TypeOf((*MockProtoMessageConverter)(nil).RegisterEntity), ctx, entType, props)
+}
+
+// ReregisterEntity mocks base method.
+func (m *MockProtoMessageConverter) ReregisterEntity(ctx context.Context, entType v10.Entity, props *properties.Properties) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ReregisterEntity", ctx, entType, props)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// ReregisterEntity indicates an expected call of ReregisterEntity.
+func (mr *MockProtoMessageConverterMockRecorder) ReregisterEntity(ctx, entType, props any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReregisterEntity", reflect.TypeOf((*MockProtoMessageConverter)(nil).ReregisterEntity), ctx, entType, props)
 }
 
 // SupportsEntity mocks base method.
@@ -586,6 +628,20 @@ func (mr *MockRESTMockRecorder) RegisterEntity(ctx, entType, props any) *gomock.
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RegisterEntity", reflect.TypeOf((*MockREST)(nil).RegisterEntity), ctx, entType, props)
 }
 
+// ReregisterEntity mocks base method.
+func (m *MockREST) ReregisterEntity(ctx context.Context, entType v10.Entity, props *properties.Properties) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ReregisterEntity", ctx, entType, props)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// ReregisterEntity indicates an expected call of ReregisterEntity.
+func (mr *MockRESTMockRecorder) ReregisterEntity(ctx, entType, props any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReregisterEntity", reflect.TypeOf((*MockREST)(nil).ReregisterEntity), ctx, entType, props)
+}
+
 // SupportsEntity mocks base method.
 func (m *MockREST) SupportsEntity(entType v10.Entity) bool {
 	m.ctrl.T.Helper()
@@ -724,6 +780,20 @@ func (m *MockRepoLister) RegisterEntity(ctx context.Context, entType v10.Entity,
 func (mr *MockRepoListerMockRecorder) RegisterEntity(ctx, entType, props any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RegisterEntity", reflect.TypeOf((*MockRepoLister)(nil).RegisterEntity), ctx, entType, props)
+}
+
+// ReregisterEntity mocks base method.
+func (m *MockRepoLister) ReregisterEntity(ctx context.Context, entType v10.Entity, props *properties.Properties) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ReregisterEntity", ctx, entType, props)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// ReregisterEntity indicates an expected call of ReregisterEntity.
+func (mr *MockRepoListerMockRecorder) ReregisterEntity(ctx, entType, props any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReregisterEntity", reflect.TypeOf((*MockRepoLister)(nil).ReregisterEntity), ctx, entType, props)
 }
 
 // SupportsEntity mocks base method.
@@ -1460,6 +1530,20 @@ func (mr *MockGitHubMockRecorder) RegisterEntity(ctx, entType, props any) *gomoc
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RegisterEntity", reflect.TypeOf((*MockGitHub)(nil).RegisterEntity), ctx, entType, props)
 }
 
+// ReregisterEntity mocks base method.
+func (m *MockGitHub) ReregisterEntity(ctx context.Context, entType v10.Entity, props *properties.Properties) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ReregisterEntity", ctx, entType, props)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// ReregisterEntity indicates an expected call of ReregisterEntity.
+func (mr *MockGitHubMockRecorder) ReregisterEntity(ctx, entType, props any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReregisterEntity", reflect.TypeOf((*MockGitHub)(nil).ReregisterEntity), ctx, entType, props)
+}
+
 // SetCommitStatus mocks base method.
 func (m *MockGitHub) SetCommitStatus(arg0 context.Context, arg1, arg2, arg3 string, arg4 *github.RepoStatus) (*github.RepoStatus, error) {
 	m.ctrl.T.Helper()
@@ -1702,6 +1786,20 @@ func (mr *MockImageListerMockRecorder) RegisterEntity(ctx, entType, props any) *
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RegisterEntity", reflect.TypeOf((*MockImageLister)(nil).RegisterEntity), ctx, entType, props)
 }
 
+// ReregisterEntity mocks base method.
+func (m *MockImageLister) ReregisterEntity(ctx context.Context, entType v10.Entity, props *properties.Properties) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ReregisterEntity", ctx, entType, props)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// ReregisterEntity indicates an expected call of ReregisterEntity.
+func (mr *MockImageListerMockRecorder) ReregisterEntity(ctx, entType, props any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReregisterEntity", reflect.TypeOf((*MockImageLister)(nil).ReregisterEntity), ctx, entType, props)
+}
+
 // SupportsEntity mocks base method.
 func (m *MockImageLister) SupportsEntity(entType v10.Entity) bool {
 	m.ctrl.T.Helper()
@@ -1929,6 +2027,20 @@ func (m *MockOCI) RegisterEntity(ctx context.Context, entType v10.Entity, props 
 func (mr *MockOCIMockRecorder) RegisterEntity(ctx, entType, props any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RegisterEntity", reflect.TypeOf((*MockOCI)(nil).RegisterEntity), ctx, entType, props)
+}
+
+// ReregisterEntity mocks base method.
+func (m *MockOCI) ReregisterEntity(ctx context.Context, entType v10.Entity, props *properties.Properties) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ReregisterEntity", ctx, entType, props)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// ReregisterEntity indicates an expected call of ReregisterEntity.
+func (mr *MockOCIMockRecorder) ReregisterEntity(ctx, entType, props any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReregisterEntity", reflect.TypeOf((*MockOCI)(nil).ReregisterEntity), ctx, entType, props)
 }
 
 // SupportsEntity mocks base method.

--- a/internal/providers/selectors/mock/interface.go
+++ b/internal/providers/selectors/mock/interface.go
@@ -145,6 +145,20 @@ func (mr *MockRepoSelectorConverterMockRecorder) RepoToSelectorEntity(ctx, repoE
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RepoToSelectorEntity", reflect.TypeOf((*MockRepoSelectorConverter)(nil).RepoToSelectorEntity), ctx, repoEntWithProps)
 }
 
+// ReregisterEntity mocks base method.
+func (m *MockRepoSelectorConverter) ReregisterEntity(ctx context.Context, entType v1.Entity, props *properties.Properties) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ReregisterEntity", ctx, entType, props)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// ReregisterEntity indicates an expected call of ReregisterEntity.
+func (mr *MockRepoSelectorConverterMockRecorder) ReregisterEntity(ctx, entType, props any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReregisterEntity", reflect.TypeOf((*MockRepoSelectorConverter)(nil).ReregisterEntity), ctx, entType, props)
+}
+
 // SupportsEntity mocks base method.
 func (m *MockRepoSelectorConverter) SupportsEntity(entType v1.Entity) bool {
 	m.ctrl.T.Helper()
@@ -284,6 +298,20 @@ func (mr *MockArtifactSelectorConverterMockRecorder) RegisterEntity(ctx, entType
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RegisterEntity", reflect.TypeOf((*MockArtifactSelectorConverter)(nil).RegisterEntity), ctx, entType, props)
 }
 
+// ReregisterEntity mocks base method.
+func (m *MockArtifactSelectorConverter) ReregisterEntity(ctx context.Context, entType v1.Entity, props *properties.Properties) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ReregisterEntity", ctx, entType, props)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// ReregisterEntity indicates an expected call of ReregisterEntity.
+func (mr *MockArtifactSelectorConverterMockRecorder) ReregisterEntity(ctx, entType, props any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReregisterEntity", reflect.TypeOf((*MockArtifactSelectorConverter)(nil).ReregisterEntity), ctx, entType, props)
+}
+
 // SupportsEntity mocks base method.
 func (m *MockArtifactSelectorConverter) SupportsEntity(entType v1.Entity) bool {
 	m.ctrl.T.Helper()
@@ -421,6 +449,20 @@ func (m *MockPullRequestSelectorConverter) RegisterEntity(ctx context.Context, e
 func (mr *MockPullRequestSelectorConverterMockRecorder) RegisterEntity(ctx, entType, props any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RegisterEntity", reflect.TypeOf((*MockPullRequestSelectorConverter)(nil).RegisterEntity), ctx, entType, props)
+}
+
+// ReregisterEntity mocks base method.
+func (m *MockPullRequestSelectorConverter) ReregisterEntity(ctx context.Context, entType v1.Entity, props *properties.Properties) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ReregisterEntity", ctx, entType, props)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// ReregisterEntity indicates an expected call of ReregisterEntity.
+func (mr *MockPullRequestSelectorConverterMockRecorder) ReregisterEntity(ctx, entType, props any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReregisterEntity", reflect.TypeOf((*MockPullRequestSelectorConverter)(nil).ReregisterEntity), ctx, entType, props)
 }
 
 // SupportsEntity mocks base method.

--- a/internal/providers/selectors/selector_entity_test.go
+++ b/internal/providers/selectors/selector_entity_test.go
@@ -155,6 +155,10 @@ func (_ *fullProvider) DeregisterEntity(_ context.Context, _ minderv1.Entity, _ 
 	return nil
 }
 
+func (_ *fullProvider) ReregisterEntity(_ context.Context, _ minderv1.Entity, _ *properties.Properties) error {
+	return nil
+}
+
 func newMockProvider(t *testing.T, name, class string) *fullProvider {
 	t.Helper()
 
@@ -208,6 +212,10 @@ func (_ *repoOnlyProvider) RegisterEntity(_ context.Context, _ minderv1.Entity, 
 }
 
 func (_ *repoOnlyProvider) DeregisterEntity(_ context.Context, _ minderv1.Entity, _ *properties.Properties) error {
+	return nil
+}
+
+func (_ *repoOnlyProvider) ReregisterEntity(_ context.Context, _ minderv1.Entity, _ *properties.Properties) error {
 	return nil
 }
 

--- a/internal/providers/testproviders/git.go
+++ b/internal/providers/testproviders/git.go
@@ -81,3 +81,11 @@ func (_ *GitProvider) DeregisterEntity(_ context.Context, _ minderv1.Entity, _ *
 	// TODO: implement
 	return nil
 }
+
+// ReregisterEntity implements the Provider interface
+func (_ *GitProvider) ReregisterEntity(
+	_ context.Context, _ minderv1.Entity, _ *properties.Properties,
+) error {
+	// TODO: implement
+	return nil
+}

--- a/internal/providers/testproviders/rest.go
+++ b/internal/providers/testproviders/rest.go
@@ -90,3 +90,11 @@ func (_ *RESTProvider) DeregisterEntity(_ context.Context, _ minderv1.Entity, _ 
 	// TODO: implement
 	return nil
 }
+
+// ReregisterEntity implements the Provider interface
+func (_ *RESTProvider) ReregisterEntity(
+	_ context.Context, _ minderv1.Entity, _ *properties.Properties,
+) error {
+	// TODO: implement
+	return nil
+}

--- a/pkg/providers/v1/providers.go
+++ b/pkg/providers/v1/providers.go
@@ -81,6 +81,11 @@ type Provider interface {
 	// When implementing, try to make this idempotent. That is, if the entity is already deregistered,
 	// (e.g. a webhook is already deleted), then this should not return an error.
 	DeregisterEntity(ctx context.Context, entType minderv1.Entity, props *properties.Properties) error
+
+	// ReregisterEntity runs the necessary updates to the entity registration. This could be
+	// updating the webhook URL or secret for a particular repository or artifact. This is useful
+	// for secret rotation.
+	ReregisterEntity(ctx context.Context, entType minderv1.Entity, props *properties.Properties) error
 }
 
 // Git is the interface for git providers


### PR DESCRIPTION
# Summary

This adds an interface that's meant to re-register an entity. This is
useful when updating a certain part of the entity registration. The only
use-case we have right now is secret rotation. So this is what was
effectively implemented.

This merely implemented the functions for the GitLab and GitHub
providers. The webhook update sub-command will be updated to take it
into use in a subsequent patch.

## Change Type

***Mark the type of change your PR introduces:***

- [ ] Bug fix (resolves an issue without affecting existing features)
- [x] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [ ] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

***Outline how the changes were tested, including steps to reproduce and any relevant configurations. 
Attach screenshots if helpful.***

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [ ] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [ ] Included tests that validate the fix or feature.
- [ ] Checked that related changes are merged.
