### PR TITLE
Allow customizing AckDeadline to allow for long-running sets of retries

### DIFF
--- a/internal/config/server/events.go
+++ b/internal/config/server/events.go
@@ -15,7 +15,11 @@
 
 package server
 
-import "github.com/stacklok/minder/internal/config"
+import (
+	"time"
+
+	"github.com/stacklok/minder/internal/config"
+)
 
 // EventConfig is the configuration for minder's eventing system.
 type EventConfig struct {
@@ -50,6 +54,10 @@ type SQLEventConfig struct {
 	// InitSchema is whether or not to initialize the schema
 	InitSchema bool                  `mapstructure:"init_schema" default:"true"`
 	Connection config.DatabaseConfig `mapstructure:"connection" default:"{\"dbname\":\"watermill\"}"`
+	// AckDeadline is the deadline (in seconds) before timing out and re-attempting
+	// a message delivery.  Note that setting this too short can cause messages to
+	// be retried even they should be marked as "poison".
+	AckDeadline time.Duration `mapstructure:"ack_deadline" default:"300s"`
 }
 
 // AggregatorConfig is the configuration for the event aggregator middleware

--- a/internal/events/sql/postgres.go
+++ b/internal/events/sql/postgres.go
@@ -56,6 +56,7 @@ func BuildPostgreSQLDriver(
 			SchemaAdapter:    watermillsql.DefaultPostgreSQLSchema{},
 			OffsetsAdapter:   watermillsql.DefaultPostgreSQLOffsetsAdapter{},
 			InitializeSchema: true,
+			AckDeadline:      &cfg.SQLPubSub.AckDeadline,
 		},
 		watermill.NewStdLogger(false, false),
 	)


### PR DESCRIPTION
# Summary

It turns out that Watermill SQL maintains an internal timeout on message delivery, and retries messages which take longer than the timeout.  On one hand, this feels like good infrastructure practice, but it interferes with related Watermill middleware for retries and handling poison messages.  One example of this is `AckDeadline`:

> AckDeadline is the time to wait for acking a message.
> If message is not acked within this time, it will be nacked and re-delivered.
>
> When messages are read in bulk, this time is calculated for each message separately.
>
> If you want to disable ack deadline, set it to 0.
> Warning: when ack deadline is disabled, messages which are not acked may block PostgreSQL subscriber from reading new messages
> due to not increasing `pg_snapshot_xmin(pg_current_snapshot())` value.
>
> Must be non-negative. Nil value defaults to 30s.

Fixes #4483

## Change Type

***Mark the type of change your PR introduces:***

- [x] Bug fix (resolves an issue without affecting existing features)
- [ ] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [ ] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

Manual testing with https://github.com/eleftherias/msg-queue-repro.git to find the issue and controlling setting, and then starting Minder to check that the new setting was accepted.  I did not build a unit test with a timeout to verify this setting, but did test manually in the reproduction repo.

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [x] Added comments to complex or tricky code sections.
- [x] Updated any affected documentation.
- [ ] Included tests that validate the fix or feature.
- [x] Checked that related changes are merged.
