### PR TITLE
Disable the NATS tests temporarily again

### DIFF
--- a/internal/events/nats/natschannel_test.go
+++ b/internal/events/nats/natschannel_test.go
@@ -32,6 +32,8 @@ import (
 )
 
 func TestNatsChannel(t *testing.T) {
+	t.Skip("Skipping test that is failing in CI") // https://github.com/stacklok/minder/issues/4542
+
 	t.Parallel()
 	server := natsserver.RunRandClientPortServer()
 	if err := server.EnableJetStream(nil); err != nil {


### PR DESCRIPTION
# Summary

While introducing the NATS driver is a gret idea and will allow us to
scale better, the tests are still a bit flaky and require us to
reschedule our CI tests quite often.

Let's disable them temporarily

Related: #4542

## Change Type

- [ ] Bug fix (resolves an issue without affecting existing features)
- [ ] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [x] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

N/A

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [ ] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [ ] Included tests that validate the fix or feature.
- [ ] Checked that related changes are merged.
