### PR TITLE
Handle users deleted through the Keycloak management API, as well as through the Keycloak UI

### DIFF
--- a/identity/config/stacklok.yaml
+++ b/identity/config/stacklok.yaml
@@ -21,6 +21,9 @@ eventsEnabled: true
 enabledEventTypes:
   - DELETE_ACCOUNT
 eventsExpiration: 604800
+adminEventsEnabled: true
+attributes:
+  adminEventsExpiration: 604800
 
 # From:
 # Add account deletion capability to stacklok realm (see https://www.keycloak.org/docs/latest/server_admin/#authentication-operations)

--- a/internal/controlplane/identity_events.go
+++ b/internal/controlplane/identity_events.go
@@ -36,7 +36,7 @@ import (
 )
 
 const (
-	eventFetchInterval     = "@daily"
+	eventFetchInterval     = "@hourly"
 	deleteAccountEventType = "DELETE_ACCOUNT"
 )
 

--- a/internal/controlplane/identity_events.go
+++ b/internal/controlplane/identity_events.go
@@ -22,6 +22,8 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"net/url"
+	"strings"
 	"time"
 
 	"github.com/robfig/cron/v3"
@@ -38,7 +40,7 @@ const (
 	deleteAccountEventType = "DELETE_ACCOUNT"
 )
 
-// AccountEvent is an event returned by the identity provider
+// AccountEvent is an event returned by Keycloak for user events
 type AccountEvent struct {
 	Time     int64  `json:"time"`
 	Type     string `json:"type"`
@@ -102,6 +104,80 @@ func HandleEvents(
 			err := DeleteUser(ctx, store, authzClient, projectDeleter, event.UserId)
 			if err != nil {
 				zerolog.Ctx(ctx).Error().Msgf("events chron: error deleting user account: %v", err)
+			}
+		}
+	}
+}
+
+// AdminEvent is an event returned by Keycloak for admin events -- note the completely different structure
+type AdminEvent struct {
+	Time          int64  `json:"time"`
+	RealmId       string `json:"realmId"`
+	OperationType string `json:"operationType"`
+	ResourceType  string `json:"resourceType"`
+	ResourcePath  string `json:"resourcePath"`
+}
+
+// SubscribeToAdminEvents starts a cron job that periodicalyl fetches admin events from Keycloak.
+// Users who are deleted through the Keycloak API show up as admin events, not normal identity events.
+func SubscribeToAdminEvents(
+	ctx context.Context,
+	store db.Store,
+	authzClient authz.Client,
+	cfg *serverconfig.Config,
+	projectDeleter projects.ProjectDeleter,
+) error {
+	c := cron.New()
+	_, err := c.AddFunc(eventFetchInterval, func() {
+		HandleAdminEvents(ctx, store, authzClient, cfg, projectDeleter)
+	})
+	if err != nil {
+		return err
+	}
+	c.Start()
+	return nil
+}
+
+// HandleAdminEvents deletes users where the deletion occurred through the Keycloak API.
+func HandleAdminEvents(
+	ctx context.Context,
+	store db.Store,
+	authzClient authz.Client,
+	cfg *serverconfig.Config,
+	projectDeleter projects.ProjectDeleter,
+) {
+	d := time.Now().Add(time.Duration(10) * time.Minute)
+	ctx, cancel := context.WithDeadline(ctx, d)
+	defer cancel()
+
+	query := url.Values{
+		"operationTypes": []string{"DELETE"},
+		"resourceTypes":  []string{"USER"},
+	}
+	resp, err := cfg.Identity.Server.Do(ctx, "GET", "admin/realms/stacklok/admin-events", query, nil)
+	if err != nil {
+		zerolog.Ctx(ctx).Error().Msgf("events cron: error getting admin events: %v", err)
+		return
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		zerolog.Ctx(ctx).Error().Msgf("events cron: unexpected status code when fetching admin events: %d", resp.StatusCode)
+		return
+	}
+
+	var events []AdminEvent
+	err = json.NewDecoder(resp.Body).Decode(&events)
+	if err != nil {
+		zerolog.Ctx(ctx).Error().Msgf("events cron: error decoding admin events: %v", err)
+		return
+	}
+	for _, event := range events {
+		if event.OperationType == "DELETE" && event.ResourceType == "USER" {
+			userId := strings.TrimPrefix(event.ResourcePath, "users/")
+			err := DeleteUser(ctx, store, authzClient, projectDeleter, userId)
+			if err != nil {
+				zerolog.Ctx(ctx).Error().Msgf("events cron: error deleting user account from admin event: %v", err)
 			}
 		}
 	}

--- a/internal/controlplane/identity_events_test.go
+++ b/internal/controlplane/identity_events_test.go
@@ -98,7 +98,6 @@ func TestHandleEvents(t *testing.T) {
 	HandleEvents(context.Background(), mockStore, authzClient, &c, deleter)
 }
 
-
 func TestHandleAdminEvents(t *testing.T) {
 	t.Parallel()
 

--- a/internal/controlplane/identity_events_test.go
+++ b/internal/controlplane/identity_events_test.go
@@ -98,6 +98,65 @@ func TestHandleEvents(t *testing.T) {
 	HandleEvents(context.Background(), mockStore, authzClient, &c, deleter)
 }
 
+
+func TestHandleAdminEvents(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/realms/stacklok/protocol/openid-connect/token":
+			tokenHandler(t, w)
+		case "/admin/realms/stacklok/admin-events":
+			adminEventHandler(t, w)
+		default:
+			t.Fatalf("Unexpected call to mock server endpoint %s", r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockStore := mockdb.NewMockStore(ctrl)
+
+	tx := sql.Tx{}
+	mockStore.EXPECT().BeginTransaction().Return(&tx, nil)
+	mockStore.EXPECT().GetQuerierWithTransaction(gomock.Any()).Return(mockStore)
+	mockStore.EXPECT().
+		GetUserBySubject(gomock.Any(), "existingUserId").
+		Return(db.User{
+			IdentitySubject: "existingUserId",
+		}, nil)
+	mockStore.EXPECT().
+		DeleteUser(gomock.Any(), gomock.Any()).
+		Return(nil)
+	mockStore.EXPECT().Commit(gomock.Any())
+	// we expect rollback to be called even if there is no error (through defer), in that case it will be a no-op
+	mockStore.EXPECT().Rollback(gomock.Any())
+
+	mockStore.EXPECT().BeginTransaction().Return(&tx, nil)
+	mockStore.EXPECT().GetQuerierWithTransaction(gomock.Any()).Return(mockStore)
+	mockStore.EXPECT().
+		GetUserBySubject(gomock.Any(), "alreadyDeletedUserId").
+		Return(db.User{}, sql.ErrNoRows)
+	mockStore.EXPECT().Commit(gomock.Any())
+	mockStore.EXPECT().Rollback(gomock.Any())
+
+	c := serverconfig.Config{
+		Identity: serverconfig.IdentityConfigWrapper{
+			Server: serverconfig.IdentityConfig{
+				IssuerUrl:    server.URL,
+				ClientId:     "client-id",
+				ClientSecret: "client-secret",
+			},
+		},
+	}
+	authzClient := &mock.NoopClient{Authorized: true}
+	mockProviderManager := mockmanager.NewMockProviderManager(ctrl)
+	deleter := projects.NewProjectDeleter(authzClient, mockProviderManager)
+	HandleAdminEvents(context.Background(), mockStore, authzClient, &c, deleter)
+}
+
 func TestDeleteUserOneProject(t *testing.T) {
 	t.Parallel()
 
@@ -280,6 +339,31 @@ func eventHandler(t *testing.T, w http.ResponseWriter) {
 			RealmId:  "realmId",
 			ClientId: "clientId",
 			UserId:   "alreadyDeletedUserId",
+		},
+	}
+	w.WriteHeader(http.StatusOK)
+	err := json.NewEncoder(w).Encode(data)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func adminEventHandler(t *testing.T, w http.ResponseWriter) {
+	t.Helper()
+	data := []AdminEvent{
+		{
+			Time:          1697030342912,
+			RealmId:       "realmId",
+			OperationType: "DELETE",
+			ResourceType:  "USER",
+			ResourcePath:  "users/existingUserId",
+		},
+		{
+			Time:          1697030342844,
+			RealmId:       "realmId",
+			OperationType: "DELETE",
+			ResourceType:  "USER",
+			ResourcePath:  "users/alreadyDeletedUserId",
 		},
 	}
 	w.WriteHeader(http.StatusOK)

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -209,6 +209,10 @@ func AllInOneServerService(
 	if err != nil {
 		return fmt.Errorf("unable to subscribe to identity server events: %w", err)
 	}
+	err = controlplane.SubscribeToAdminEvents(ctx, store, authzClient, cfg, projectDeleter)
+	if err != nil {
+		return fmt.Errorf("unable to subscribe to account events: %w", err)
+	}
 
 	aggr := eea.NewEEA(store, evt, &cfg.Events.Aggregator)
 


### PR DESCRIPTION
# Summary

It turns out that users deleted through the Keycloak API don't show up in the "User Events" queue, but instead show up in a different "admin events" queue.  We should handle those deletions as well.

Fixes https://github.com/stacklok/minder-stories/issues/29

## Change Type

***Mark the type of change your PR introduces:***

- [x] Bug fix (resolves an issue without affecting existing features)
- [ ] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [ ] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

Manual testing and added a unit test.  Note that the code generally follows the same form as user events, but with a different schema and different URL endpoint.  I did not make a lot of effort to de-duplicate the two codepaths.

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [x] Added comments to complex or tricky code sections.
- [x] Updated any affected documentation.
- [x] Included tests that validate the fix or feature.
- [x] Checked that related changes are merged.
