### PR TITLE
Fix data race in internal/entities/handlers/handler_test.go

### DIFF
--- a/internal/entities/handlers/handler_test.go
+++ b/internal/entities/handlers/handler_test.go
@@ -53,7 +53,7 @@ var (
 	repoName = "testorg/testrepo"
 	pullName = "testorg/testrepo/789"
 
-	repoEwp = &models.EntityWithProperties{
+	repoEwp = models.EntityWithProperties{
 		Entity: models.EntityInstance{
 			ID:         repoID,
 			Type:       minderv1.Entity_ENTITY_REPOSITORIES,
@@ -71,7 +71,7 @@ var (
 		properties.RepoPropertyIsFork:    false,
 	}
 
-	pullRequestEwp = &models.EntityWithProperties{
+	pullRequestEwp = models.EntityWithProperties{
 		Entity: models.EntityInstance{
 			ID:         pullRequestID,
 			Type:       minderv1.Entity_ENTITY_PULL_REQUESTS,
@@ -116,14 +116,14 @@ func withSuccessfulGetEntityName(name string) func(providerMock) {
 	}
 }
 
-func buildEwp(t *testing.T, ewp *models.EntityWithProperties, propMap map[string]any) *models.EntityWithProperties {
+func buildEwp(t *testing.T, ewp models.EntityWithProperties, propMap map[string]any) *models.EntityWithProperties {
 	t.Helper()
 
 	entProps, err := properties.NewProperties(propMap)
 	require.NoError(t, err)
 	ewp.Properties = entProps
 
-	return ewp
+	return &ewp
 }
 
 func checkRepoMessage(t *testing.T, msg *watermill.Message) {
@@ -245,7 +245,7 @@ func TestRefreshEntityAndDoHandler_HandleRefreshEntityAndEval(t *testing.T) {
 			providerHint:     "github",
 			setupPropSvcMocks: func() fixtures.MockPropertyServiceBuilder {
 				return fixtures.NewMockPropertiesService(
-					fixtures.WithSuccessfulEntityByUpstreamHint(repoEwp, githubHint),
+					fixtures.WithSuccessfulEntityByUpstreamHint(&repoEwp, githubHint),
 					fixtures.WithFailedRetrieveAllPropertiesForEntity(service.ErrEntityNotFound),
 				)
 			},
@@ -261,7 +261,7 @@ func TestRefreshEntityAndDoHandler_HandleRefreshEntityAndEval(t *testing.T) {
 			lookupType:       minderv1.Entity_ENTITY_REPOSITORIES,
 			setupPropSvcMocks: func() fixtures.MockPropertyServiceBuilder {
 				return fixtures.NewMockPropertiesService(
-					fixtures.WithSuccessfulEntityByUpstreamHint(repoEwp, githubHint),
+					fixtures.WithSuccessfulEntityByUpstreamHint(&repoEwp, githubHint),
 					fixtures.WithSuccessfulRetrieveAllPropertiesForEntity(),
 					fixtures.WithFailedEntityWithPropertiesAsProto(errors.New("fart")),
 				)


### PR DESCRIPTION
# Summary

We were passing around a pointer-to-data to a bunch of different tests, each of which did their own setup on the pointed-to data while declaring that they were `t.Parallel()`.

Everybody gets their own copy of the data!

```
WARNING: DATA RACE
  Write at 0x000002a873d8 by goroutine 15:
    github.com/stacklok/minder/internal/entities/handlers.buildEwp()
        /home/runner/work/minder/minder/internal/entities/handlers/handler_test.go:124 +0x7e
    github.com/stacklok/minder/internal/entities/handlers.TestRefreshEntityAndDoHandler_HandleRefreshEntityAndEval.func1()
        /home/runner/work/minder/minder/internal/entities/handlers/handler_test.go:210 +0x6f
    github.com/stacklok/minder/internal/entities/handlers.TestRefreshEntityAndDoHandler_HandleRefreshEntityAndEval.func7()
        /home/runner/work/minder/minder/internal/entities/handlers/handler_test.go:379 +0x558
    testing.tRunner()
        /opt/hostedtoolcache/go/1.23.1/x64/src/testing/testing.go:1690 +0x226
    testing.(*T).Run.gowrap1()
        /opt/hostedtoolcache/go/1.23.1/x64/src/testing/testing.go:1743 +0x44
  
  Previous write at 0x000002a873d8 by goroutine 19:
    github.com/stacklok/minder/internal/entities/handlers.buildEwp()
        /home/runner/work/minder/minder/internal/entities/handlers/handler_test.go:124 +0x7e
    github.com/stacklok/minder/internal/entities/handlers.TestRefreshEntityAndDoHandler_HandleRefreshEntityAndEval.func5()
        /home/runner/work/minder/minder/internal/entities/handlers/handler_test.go:292 +0xfd
    github.com/stacklok/minder/internal/entities/handlers.TestRefreshEntityAndDoHandler_HandleRefreshEntityAndEval.func7()
        /home/runner/work/minder/minder/internal/entities/handlers/handler_test.go:379 +0x558
    testing.tRunner()
        /opt/hostedtoolcache/go/1.23.1/x64/src/testing/testing.go:1690 +0x226
    testing.(*T).Run.gowrap1()
        /opt/hostedtoolcache/go/1.23.1/x64/src/testing/testing.go:1743 +0x44
```

## Change Type

***Mark the type of change your PR introduces:***

- [ ] Bug fix (resolves an issue without affecting existing features)
- [ ] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [x] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

`go test -count 50 -race ./internal/entities/handlers`

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [x] Added comments to complex or tricky code sections.
- [x] Updated any affected documentation.
- [x] Included tests that validate the fix or feature.
- [x] Checked that related changes are merged.
