### PR TITLE
Add feature flag for improved evaluation details.

### DIFF
--- a/internal/engine/eval/homoglyphs/application/homoglyphs_service.go
+++ b/internal/engine/eval/homoglyphs/application/homoglyphs_service.go
@@ -25,6 +25,7 @@ import (
 	"github.com/stacklok/minder/internal/engine/eval/homoglyphs/communication"
 	"github.com/stacklok/minder/internal/engine/eval/homoglyphs/domain"
 	engif "github.com/stacklok/minder/internal/engine/interfaces"
+	eoptions "github.com/stacklok/minder/internal/engine/options"
 	pbinternal "github.com/stacklok/minder/internal/proto"
 	pb "github.com/stacklok/minder/pkg/api/protobuf/go/minder/v1"
 	provifv1 "github.com/stacklok/minder/pkg/providers/v1"
@@ -43,6 +44,7 @@ func NewHomoglyphsEvaluator(
 	ctx context.Context,
 	reh *pb.RuleType_Definition_Eval_Homoglyphs,
 	ghClient provifv1.GitHub,
+	opts ...eoptions.Option,
 ) (engif.Evaluator, error) {
 	if ghClient == nil {
 		return nil, fmt.Errorf("provider builder is nil")
@@ -53,9 +55,9 @@ func NewHomoglyphsEvaluator(
 
 	switch reh.Type {
 	case invisibleCharacters:
-		return NewInvisibleCharactersEvaluator(ghClient)
+		return NewInvisibleCharactersEvaluator(ctx, ghClient, opts...)
 	case mixedScript:
-		return NewMixedScriptEvaluator(ctx, ghClient)
+		return NewMixedScriptEvaluator(ctx, ghClient, opts...)
 	default:
 		return nil, fmt.Errorf("unsupported homoglyphs type: %s", reh.Type)
 	}

--- a/internal/engine/eval/homoglyphs/application/invisible_characters_eval.go
+++ b/internal/engine/eval/homoglyphs/application/invisible_characters_eval.go
@@ -21,6 +21,7 @@ import (
 	"github.com/stacklok/minder/internal/engine/eval/homoglyphs/communication"
 	"github.com/stacklok/minder/internal/engine/eval/homoglyphs/domain"
 	engif "github.com/stacklok/minder/internal/engine/interfaces"
+	eoptions "github.com/stacklok/minder/internal/engine/options"
 	provifv1 "github.com/stacklok/minder/pkg/providers/v1"
 )
 
@@ -31,11 +32,23 @@ type InvisibleCharactersEvaluator struct {
 }
 
 // NewInvisibleCharactersEvaluator creates a new invisible characters evaluator
-func NewInvisibleCharactersEvaluator(ghClient provifv1.GitHub) (*InvisibleCharactersEvaluator, error) {
-	return &InvisibleCharactersEvaluator{
+func NewInvisibleCharactersEvaluator(
+	_ context.Context,
+	ghClient provifv1.GitHub,
+	opts ...eoptions.Option,
+) (*InvisibleCharactersEvaluator, error) {
+	evaluator := &InvisibleCharactersEvaluator{
 		processor:     domain.NewInvisibleCharactersProcessor(),
 		reviewHandler: communication.NewGhReviewPrHandler(ghClient),
-	}, nil
+	}
+
+	for _, opt := range opts {
+		if err := opt(evaluator); err != nil {
+			return nil, err
+		}
+	}
+
+	return evaluator, nil
 }
 
 // Eval evaluates the invisible characters rule type

--- a/internal/engine/eval/jq/jq.go
+++ b/internal/engine/eval/jq/jq.go
@@ -25,6 +25,7 @@ import (
 
 	evalerrors "github.com/stacklok/minder/internal/engine/errors"
 	engif "github.com/stacklok/minder/internal/engine/interfaces"
+	eoptions "github.com/stacklok/minder/internal/engine/options"
 	"github.com/stacklok/minder/internal/util"
 	pb "github.com/stacklok/minder/pkg/api/protobuf/go/minder/v1"
 )
@@ -35,7 +36,10 @@ type Evaluator struct {
 }
 
 // NewJQEvaluator creates a new JQ rule data evaluator
-func NewJQEvaluator(assertions []*pb.RuleType_Definition_Eval_JQComparison) (*Evaluator, error) {
+func NewJQEvaluator(
+	assertions []*pb.RuleType_Definition_Eval_JQComparison,
+	opts ...eoptions.Option,
+) (*Evaluator, error) {
 	if len(assertions) == 0 {
 		return nil, fmt.Errorf("missing jq assertions")
 	}
@@ -61,9 +65,17 @@ func NewJQEvaluator(assertions []*pb.RuleType_Definition_Eval_JQComparison) (*Ev
 		}
 	}
 
-	return &Evaluator{
+	evaluator := &Evaluator{
 		assertions: assertions,
-	}, nil
+	}
+
+	for _, opt := range opts {
+		if err := opt(evaluator); err != nil {
+			return nil, err
+		}
+	}
+
+	return evaluator, nil
 }
 
 // Eval calls the jq library to evaluate the rule

--- a/internal/engine/eval/vulncheck/vulncheck.go
+++ b/internal/engine/eval/vulncheck/vulncheck.go
@@ -22,11 +22,14 @@ import (
 	"strings"
 
 	"github.com/hashicorp/go-version"
+	"github.com/open-feature/go-sdk/openfeature"
 	"github.com/rs/zerolog"
 
 	evalerrors "github.com/stacklok/minder/internal/engine/errors"
 	"github.com/stacklok/minder/internal/engine/eval/templates"
 	engif "github.com/stacklok/minder/internal/engine/interfaces"
+	eoptions "github.com/stacklok/minder/internal/engine/options"
+	"github.com/stacklok/minder/internal/flags"
 	pbinternal "github.com/stacklok/minder/internal/proto"
 	provifv1 "github.com/stacklok/minder/pkg/providers/v1"
 )
@@ -38,18 +41,39 @@ const (
 
 // Evaluator is the vulncheck evaluator
 type Evaluator struct {
-	cli provifv1.GitHub
+	cli          provifv1.GitHub
+	featureFlags openfeature.IClient
+}
+
+var _ eoptions.SupportsFlags = (*Evaluator)(nil)
+
+// SetFlagsClient sets the `openfeature` client in the underlying
+// `Evaluator` struct.
+func (e *Evaluator) SetFlagsClient(client openfeature.IClient) error {
+	e.featureFlags = client
+	return nil
 }
 
 // NewVulncheckEvaluator creates a new vulncheck evaluator
-func NewVulncheckEvaluator(ghcli provifv1.GitHub) (*Evaluator, error) {
+func NewVulncheckEvaluator(
+	ghcli provifv1.GitHub,
+	opts ...eoptions.Option,
+) (*Evaluator, error) {
 	if ghcli == nil {
 		return nil, fmt.Errorf("provider builder is nil")
 	}
 
-	return &Evaluator{
+	evaluator := &Evaluator{
 		cli: ghcli,
-	}, nil
+	}
+
+	for _, opt := range opts {
+		if err := opt(evaluator); err != nil {
+			return nil, err
+		}
+	}
+
+	return evaluator, nil
 }
 
 // Eval implements the Evaluator interface.
@@ -60,9 +84,16 @@ func (e *Evaluator) Eval(ctx context.Context, pol map[string]any, res *engif.Res
 	}
 
 	if len(vulnerablePackages) > 0 {
-		return evalerrors.NewDetailedErrEvaluationFailed(
-			templates.VulncheckTemplate,
-			map[string]any{"packages": vulnerablePackages},
+		if e.featureFlags != nil && flags.Bool(ctx, e.featureFlags, flags.ImprovedEvalDetails) {
+			return evalerrors.NewDetailedErrEvaluationFailed(
+				templates.VulncheckTemplate,
+				map[string]any{"packages": vulnerablePackages},
+				"vulnerable packages: %s",
+				strings.Join(vulnerablePackages, ","),
+			)
+		}
+
+		return evalerrors.NewErrEvaluationFailed(
 			"vulnerable packages: %s",
 			strings.Join(vulnerablePackages, ","),
 		)

--- a/internal/engine/eval/vulncheck/vulncheck.go
+++ b/internal/engine/eval/vulncheck/vulncheck.go
@@ -84,7 +84,7 @@ func (e *Evaluator) Eval(ctx context.Context, pol map[string]any, res *engif.Res
 	}
 
 	if len(vulnerablePackages) > 0 {
-		if e.featureFlags != nil && flags.Bool(ctx, e.featureFlags, flags.ImprovedEvalDetails) {
+		if e.featureFlags != nil && flags.Bool(ctx, e.featureFlags, flags.VulnCheckErrorTemplate) {
 			return evalerrors.NewDetailedErrEvaluationFailed(
 				templates.VulncheckTemplate,
 				map[string]any{"packages": vulnerablePackages},

--- a/internal/engine/executor.go
+++ b/internal/engine/executor.go
@@ -31,6 +31,7 @@ import (
 	evalerrors "github.com/stacklok/minder/internal/engine/errors"
 	"github.com/stacklok/minder/internal/engine/ingestcache"
 	engif "github.com/stacklok/minder/internal/engine/interfaces"
+	eoptions "github.com/stacklok/minder/internal/engine/options"
 	"github.com/stacklok/minder/internal/engine/rtengine"
 	"github.com/stacklok/minder/internal/engine/selectors"
 	"github.com/stacklok/minder/internal/entities/properties/service"
@@ -128,6 +129,7 @@ func (e *executor) EvalEntityEvent(ctx context.Context, inf *entities.EntityInfo
 		inf.ProjectID,
 		provider,
 		ingestCache,
+		eoptions.WithFlagsClient(e.featureFlags),
 	)
 	if err != nil {
 		return fmt.Errorf("unable to fetch rule type instances for project: %w", err)

--- a/internal/engine/options/options.go
+++ b/internal/engine/options/options.go
@@ -1,0 +1,46 @@
+// Copyright 2024 Stacklok, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package options provides necessary interfaces and implementations
+// for implementing evaluator configuration options.
+package options
+
+import (
+	"github.com/open-feature/go-sdk/openfeature"
+
+	"github.com/stacklok/minder/internal/engine/interfaces"
+)
+
+// SupportsFlags interface advertises the fact that the implementer
+// can use an `openfeature` client to check for flags being set.
+type SupportsFlags interface {
+	SetFlagsClient(client openfeature.IClient) error
+}
+
+// Option is a function that takes an evaluator and does some
+// unspecified operation to it, returning an error in case of failure.
+type Option func(interfaces.Evaluator) error
+
+// WithFlagsClient provides the evaluation engine with an
+// `openfeature` client. In case the given evaluator dows not support
+// feature flags, WithFlagsClient silently ignores the error.
+func WithFlagsClient(client openfeature.IClient) Option {
+	return func(e interfaces.Evaluator) error {
+		inner, ok := e.(SupportsFlags)
+		if !ok {
+			return nil
+		}
+		return inner.SetFlagsClient(client)
+	}
+}

--- a/internal/engine/rtengine/cache.go
+++ b/internal/engine/rtengine/cache.go
@@ -86,10 +86,7 @@ func NewRuleEngineCache(
 	return &ruleEngineCache{engines: engines, opts: opts}, nil
 }
 
-func (r *ruleEngineCache) GetRuleEngine(
-	ctx context.Context,
-	ruleTypeID uuid.UUID,
-) (*RuleTypeEngine, error) {
+func (r *ruleEngineCache) GetRuleEngine(ctx context.Context, ruleTypeID uuid.UUID) (*RuleTypeEngine, error) {
 	if ruleTypeEngine, ok := r.engines[ruleTypeID]; ok {
 		return ruleTypeEngine, nil
 	}

--- a/internal/engine/rtengine/engine.go
+++ b/internal/engine/rtengine/engine.go
@@ -29,6 +29,7 @@ import (
 	"github.com/stacklok/minder/internal/engine/ingestcache"
 	"github.com/stacklok/minder/internal/engine/ingester"
 	engif "github.com/stacklok/minder/internal/engine/interfaces"
+	eoptions "github.com/stacklok/minder/internal/engine/options"
 	"github.com/stacklok/minder/internal/profiles"
 	minderv1 "github.com/stacklok/minder/pkg/api/protobuf/go/minder/v1"
 	provinfv1 "github.com/stacklok/minder/pkg/providers/v1"
@@ -77,6 +78,7 @@ func NewRuleTypeEngine(
 	ctx context.Context,
 	ruletype *minderv1.RuleType,
 	provider provinfv1.Provider,
+	opts ...eoptions.Option,
 ) (*RuleTypeEngine, error) {
 	rval, err := profiles.NewRuleValidator(ruletype)
 	if err != nil {
@@ -88,7 +90,7 @@ func NewRuleTypeEngine(
 		return nil, fmt.Errorf("cannot create rule data ingest: %w", err)
 	}
 
-	evaluator, err := eval.NewRuleEvaluator(ctx, ruletype, provider)
+	evaluator, err := eval.NewRuleEvaluator(ctx, ruletype, provider, opts...)
 	if err != nil {
 		return nil, fmt.Errorf("cannot create rule evaluator: %w", err)
 	}

--- a/internal/flags/constants.go
+++ b/internal/flags/constants.go
@@ -18,10 +18,11 @@ package flags
 const (
 	// UserManagement enables user management, i.e. invitations, role assignments, etc.
 	UserManagement Experiment = "user_management"
-	// EvalHistory enables logging of evaluation history in the new tables.
-	EvalHistory Experiment = "eval_history"
 	// DockerHubProvider enables the DockerHub provider.
 	DockerHubProvider Experiment = "dockerhub_provider"
 	// GitLabProvider enables the GitLab provider.
 	GitLabProvider Experiment = "gitlab_provider"
+	// ImprovedEvalDetails enables improved evaluation details
+	// messages.
+	ImprovedEvalDetails Experiment = "improved_eval_details"
 )

--- a/internal/flags/constants.go
+++ b/internal/flags/constants.go
@@ -22,7 +22,7 @@ const (
 	DockerHubProvider Experiment = "dockerhub_provider"
 	// GitLabProvider enables the GitLab provider.
 	GitLabProvider Experiment = "gitlab_provider"
-	// ImprovedEvalDetails enables improved evaluation details
-	// messages.
-	ImprovedEvalDetails Experiment = "improved_eval_details"
+	// VulnCheckErrorTemplate enables improved evaluation details
+	// messages in the vulncheck rule.
+	VulnCheckErrorTemplate Experiment = "vulncheck_error_template"
 )


### PR DESCRIPTION
# Summary

This change adds feature flag `vulncheck_error_template`, which is currently used by the `vulncheck` evaluator to determine whether to produce "legacy" message format (i.e. comma separated list of package names) or markdown (i.e. unordered list of package names).

Additionally, this change adds support for options when creating new evaluation engines, making them easier to extend and possibly test.

The change is backwards compatible.

## Change Type

- [ ] Bug fix (resolves an issue without affecting existing features)
- [ ] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [X] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

Manual tests.

# Review Checklist:

- [X] Reviewed my own code for quality and clarity.
- [X] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [ ] Included tests that validate the fix or feature.
- [X] Checked that related changes are merged.
