### PR TITLE
Clean up test providers and move `EntityToProtoMessage` as top-level interface function

### DIFF
--- a/internal/entities/properties/service/service.go
+++ b/internal/entities/properties/service/service.go
@@ -411,11 +411,5 @@ func (_ *propertiesService) EntityWithPropertiesAsProto(
 		return nil, fmt.Errorf("error instantiating provider %s: %w", ewp.Entity.ProviderID.String(), err)
 	}
 
-	converter, err := provifv1.As[provifv1.ProtoMessageConverter](prov)
-	if err != nil {
-		return nil, fmt.Errorf("provider %s doesn't implement ProtoMessageConverter: %w",
-			ewp.Entity.ProviderID.String(), err)
-	}
-
-	return converter.PropertiesToProtoMessage(ewp.Entity.Type, ewp.Properties)
+	return prov.PropertiesToProtoMessage(ewp.Entity.Type, ewp.Properties)
 }

--- a/internal/providers/dockerhub/dockerhub.go
+++ b/internal/providers/dockerhub/dockerhub.go
@@ -25,6 +25,7 @@ import (
 	"path"
 
 	"golang.org/x/oauth2"
+	"google.golang.org/protobuf/reflect/protoreflect"
 
 	"github.com/stacklok/minder/internal/db"
 	"github.com/stacklok/minder/internal/entities/properties"
@@ -225,4 +226,11 @@ func (_ *dockerHubImageLister) ReregisterEntity(
 ) error {
 	// TODO: implement
 	return nil
+}
+
+// PropertiesToProtoMessage implements the Provider interface
+func (_ *dockerHubImageLister) PropertiesToProtoMessage(
+	_ minderv1.Entity, _ *properties.Properties) (protoreflect.ProtoMessage, error) {
+	// TODO: Implement
+	return nil, nil
 }

--- a/internal/providers/github/ghcr/ghcr.go
+++ b/internal/providers/github/ghcr/ghcr.go
@@ -25,6 +25,7 @@ import (
 	"github.com/google/go-github/v63/github"
 	"golang.org/x/oauth2"
 	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/reflect/protoreflect"
 
 	"github.com/stacklok/minder/internal/entities/properties"
 	"github.com/stacklok/minder/internal/verifier/verifyif"
@@ -183,4 +184,10 @@ func (_ *ImageLister) ReregisterEntity(
 	_ context.Context, _ minderv1.Entity, _ *properties.Properties,
 ) error {
 	return nil
+}
+
+// PropertiesToProtoMessage implements the Provider interface
+func (_ *ImageLister) PropertiesToProtoMessage(_ minderv1.Entity, _ *properties.Properties) (protoreflect.ProtoMessage, error) {
+	// TODO: Implement
+	return nil, nil
 }

--- a/internal/providers/github/mock/github.go
+++ b/internal/providers/github/mock/github.go
@@ -122,6 +122,21 @@ func (mr *MockProviderMockRecorder) GetEntityName(entType, props any) *gomock.Ca
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetEntityName", reflect.TypeOf((*MockProvider)(nil).GetEntityName), entType, props)
 }
 
+// PropertiesToProtoMessage mocks base method.
+func (m *MockProvider) PropertiesToProtoMessage(entType v10.Entity, props *properties.Properties) (protoreflect.ProtoMessage, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "PropertiesToProtoMessage", entType, props)
+	ret0, _ := ret[0].(protoreflect.ProtoMessage)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// PropertiesToProtoMessage indicates an expected call of PropertiesToProtoMessage.
+func (mr *MockProviderMockRecorder) PropertiesToProtoMessage(entType, props any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PropertiesToProtoMessage", reflect.TypeOf((*MockProvider)(nil).PropertiesToProtoMessage), entType, props)
+}
+
 // RegisterEntity mocks base method.
 func (m *MockProvider) RegisterEntity(ctx context.Context, entType v10.Entity, props *properties.Properties) (*properties.Properties, error) {
 	m.ctrl.T.Helper()
@@ -276,6 +291,21 @@ func (mr *MockGitMockRecorder) GetEntityName(entType, props any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetEntityName", reflect.TypeOf((*MockGit)(nil).GetEntityName), entType, props)
 }
 
+// PropertiesToProtoMessage mocks base method.
+func (m *MockGit) PropertiesToProtoMessage(entType v10.Entity, props *properties.Properties) (protoreflect.ProtoMessage, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "PropertiesToProtoMessage", entType, props)
+	ret0, _ := ret[0].(protoreflect.ProtoMessage)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// PropertiesToProtoMessage indicates an expected call of PropertiesToProtoMessage.
+func (mr *MockGitMockRecorder) PropertiesToProtoMessage(entType, props any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PropertiesToProtoMessage", reflect.TypeOf((*MockGit)(nil).PropertiesToProtoMessage), entType, props)
+}
+
 // RegisterEntity mocks base method.
 func (m *MockGit) RegisterEntity(ctx context.Context, entType v10.Entity, props *properties.Properties) (*properties.Properties, error) {
 	m.ctrl.T.Helper()
@@ -317,160 +347,6 @@ func (m *MockGit) SupportsEntity(entType v10.Entity) bool {
 func (mr *MockGitMockRecorder) SupportsEntity(entType any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SupportsEntity", reflect.TypeOf((*MockGit)(nil).SupportsEntity), entType)
-}
-
-// MockProtoMessageConverter is a mock of ProtoMessageConverter interface.
-type MockProtoMessageConverter struct {
-	ctrl     *gomock.Controller
-	recorder *MockProtoMessageConverterMockRecorder
-}
-
-// MockProtoMessageConverterMockRecorder is the mock recorder for MockProtoMessageConverter.
-type MockProtoMessageConverterMockRecorder struct {
-	mock *MockProtoMessageConverter
-}
-
-// NewMockProtoMessageConverter creates a new mock instance.
-func NewMockProtoMessageConverter(ctrl *gomock.Controller) *MockProtoMessageConverter {
-	mock := &MockProtoMessageConverter{ctrl: ctrl}
-	mock.recorder = &MockProtoMessageConverterMockRecorder{mock}
-	return mock
-}
-
-// EXPECT returns an object that allows the caller to indicate expected use.
-func (m *MockProtoMessageConverter) EXPECT() *MockProtoMessageConverterMockRecorder {
-	return m.recorder
-}
-
-// CanImplement mocks base method.
-func (m *MockProtoMessageConverter) CanImplement(trait v10.ProviderType) bool {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CanImplement", trait)
-	ret0, _ := ret[0].(bool)
-	return ret0
-}
-
-// CanImplement indicates an expected call of CanImplement.
-func (mr *MockProtoMessageConverterMockRecorder) CanImplement(trait any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CanImplement", reflect.TypeOf((*MockProtoMessageConverter)(nil).CanImplement), trait)
-}
-
-// DeregisterEntity mocks base method.
-func (m *MockProtoMessageConverter) DeregisterEntity(ctx context.Context, entType v10.Entity, props *properties.Properties) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DeregisterEntity", ctx, entType, props)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// DeregisterEntity indicates an expected call of DeregisterEntity.
-func (mr *MockProtoMessageConverterMockRecorder) DeregisterEntity(ctx, entType, props any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeregisterEntity", reflect.TypeOf((*MockProtoMessageConverter)(nil).DeregisterEntity), ctx, entType, props)
-}
-
-// FetchAllProperties mocks base method.
-func (m *MockProtoMessageConverter) FetchAllProperties(ctx context.Context, getByProps *properties.Properties, entType v10.Entity, cachedProps *properties.Properties) (*properties.Properties, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "FetchAllProperties", ctx, getByProps, entType, cachedProps)
-	ret0, _ := ret[0].(*properties.Properties)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// FetchAllProperties indicates an expected call of FetchAllProperties.
-func (mr *MockProtoMessageConverterMockRecorder) FetchAllProperties(ctx, getByProps, entType, cachedProps any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FetchAllProperties", reflect.TypeOf((*MockProtoMessageConverter)(nil).FetchAllProperties), ctx, getByProps, entType, cachedProps)
-}
-
-// FetchProperty mocks base method.
-func (m *MockProtoMessageConverter) FetchProperty(ctx context.Context, getByProps *properties.Properties, entType v10.Entity, key string) (*properties.Property, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "FetchProperty", ctx, getByProps, entType, key)
-	ret0, _ := ret[0].(*properties.Property)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// FetchProperty indicates an expected call of FetchProperty.
-func (mr *MockProtoMessageConverterMockRecorder) FetchProperty(ctx, getByProps, entType, key any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FetchProperty", reflect.TypeOf((*MockProtoMessageConverter)(nil).FetchProperty), ctx, getByProps, entType, key)
-}
-
-// GetEntityName mocks base method.
-func (m *MockProtoMessageConverter) GetEntityName(entType v10.Entity, props *properties.Properties) (string, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetEntityName", entType, props)
-	ret0, _ := ret[0].(string)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetEntityName indicates an expected call of GetEntityName.
-func (mr *MockProtoMessageConverterMockRecorder) GetEntityName(entType, props any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetEntityName", reflect.TypeOf((*MockProtoMessageConverter)(nil).GetEntityName), entType, props)
-}
-
-// PropertiesToProtoMessage mocks base method.
-func (m *MockProtoMessageConverter) PropertiesToProtoMessage(entType v10.Entity, props *properties.Properties) (protoreflect.ProtoMessage, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "PropertiesToProtoMessage", entType, props)
-	ret0, _ := ret[0].(protoreflect.ProtoMessage)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// PropertiesToProtoMessage indicates an expected call of PropertiesToProtoMessage.
-func (mr *MockProtoMessageConverterMockRecorder) PropertiesToProtoMessage(entType, props any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PropertiesToProtoMessage", reflect.TypeOf((*MockProtoMessageConverter)(nil).PropertiesToProtoMessage), entType, props)
-}
-
-// RegisterEntity mocks base method.
-func (m *MockProtoMessageConverter) RegisterEntity(ctx context.Context, entType v10.Entity, props *properties.Properties) (*properties.Properties, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "RegisterEntity", ctx, entType, props)
-	ret0, _ := ret[0].(*properties.Properties)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// RegisterEntity indicates an expected call of RegisterEntity.
-func (mr *MockProtoMessageConverterMockRecorder) RegisterEntity(ctx, entType, props any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RegisterEntity", reflect.TypeOf((*MockProtoMessageConverter)(nil).RegisterEntity), ctx, entType, props)
-}
-
-// ReregisterEntity mocks base method.
-func (m *MockProtoMessageConverter) ReregisterEntity(ctx context.Context, entType v10.Entity, props *properties.Properties) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ReregisterEntity", ctx, entType, props)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// ReregisterEntity indicates an expected call of ReregisterEntity.
-func (mr *MockProtoMessageConverterMockRecorder) ReregisterEntity(ctx, entType, props any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReregisterEntity", reflect.TypeOf((*MockProtoMessageConverter)(nil).ReregisterEntity), ctx, entType, props)
-}
-
-// SupportsEntity mocks base method.
-func (m *MockProtoMessageConverter) SupportsEntity(entType v10.Entity) bool {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SupportsEntity", entType)
-	ret0, _ := ret[0].(bool)
-	return ret0
-}
-
-// SupportsEntity indicates an expected call of SupportsEntity.
-func (mr *MockProtoMessageConverterMockRecorder) SupportsEntity(entType any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SupportsEntity", reflect.TypeOf((*MockProtoMessageConverter)(nil).SupportsEntity), entType)
 }
 
 // MockREST is a mock of REST interface.
@@ -611,6 +487,21 @@ func (m *MockREST) NewRequest(method, url string, body any) (*http.Request, erro
 func (mr *MockRESTMockRecorder) NewRequest(method, url, body any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewRequest", reflect.TypeOf((*MockREST)(nil).NewRequest), method, url, body)
+}
+
+// PropertiesToProtoMessage mocks base method.
+func (m *MockREST) PropertiesToProtoMessage(entType v10.Entity, props *properties.Properties) (protoreflect.ProtoMessage, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "PropertiesToProtoMessage", entType, props)
+	ret0, _ := ret[0].(protoreflect.ProtoMessage)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// PropertiesToProtoMessage indicates an expected call of PropertiesToProtoMessage.
+func (mr *MockRESTMockRecorder) PropertiesToProtoMessage(entType, props any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PropertiesToProtoMessage", reflect.TypeOf((*MockREST)(nil).PropertiesToProtoMessage), entType, props)
 }
 
 // RegisterEntity mocks base method.
@@ -765,6 +656,21 @@ func (m *MockRepoLister) ListAllRepositories(arg0 context.Context) ([]*v10.Repos
 func (mr *MockRepoListerMockRecorder) ListAllRepositories(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListAllRepositories", reflect.TypeOf((*MockRepoLister)(nil).ListAllRepositories), arg0)
+}
+
+// PropertiesToProtoMessage mocks base method.
+func (m *MockRepoLister) PropertiesToProtoMessage(entType v10.Entity, props *properties.Properties) (protoreflect.ProtoMessage, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "PropertiesToProtoMessage", entType, props)
+	ret0, _ := ret[0].(protoreflect.ProtoMessage)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// PropertiesToProtoMessage indicates an expected call of PropertiesToProtoMessage.
+func (mr *MockRepoListerMockRecorder) PropertiesToProtoMessage(entType, props any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PropertiesToProtoMessage", reflect.TypeOf((*MockRepoLister)(nil).PropertiesToProtoMessage), entType, props)
 }
 
 // RegisterEntity mocks base method.
@@ -1515,6 +1421,21 @@ func (mr *MockGitHubMockRecorder) NewRequest(method, url, body any) *gomock.Call
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewRequest", reflect.TypeOf((*MockGitHub)(nil).NewRequest), method, url, body)
 }
 
+// PropertiesToProtoMessage mocks base method.
+func (m *MockGitHub) PropertiesToProtoMessage(entType v10.Entity, props *properties.Properties) (protoreflect.ProtoMessage, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "PropertiesToProtoMessage", entType, props)
+	ret0, _ := ret[0].(protoreflect.ProtoMessage)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// PropertiesToProtoMessage indicates an expected call of PropertiesToProtoMessage.
+func (mr *MockGitHubMockRecorder) PropertiesToProtoMessage(entType, props any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PropertiesToProtoMessage", reflect.TypeOf((*MockGitHub)(nil).PropertiesToProtoMessage), entType, props)
+}
+
 // RegisterEntity mocks base method.
 func (m *MockGitHub) RegisterEntity(ctx context.Context, entType v10.Entity, props *properties.Properties) (*properties.Properties, error) {
 	m.ctrl.T.Helper()
@@ -1771,6 +1692,21 @@ func (mr *MockImageListerMockRecorder) ListImages(ctx any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListImages", reflect.TypeOf((*MockImageLister)(nil).ListImages), ctx)
 }
 
+// PropertiesToProtoMessage mocks base method.
+func (m *MockImageLister) PropertiesToProtoMessage(entType v10.Entity, props *properties.Properties) (protoreflect.ProtoMessage, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "PropertiesToProtoMessage", entType, props)
+	ret0, _ := ret[0].(protoreflect.ProtoMessage)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// PropertiesToProtoMessage indicates an expected call of PropertiesToProtoMessage.
+func (mr *MockImageListerMockRecorder) PropertiesToProtoMessage(entType, props any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PropertiesToProtoMessage", reflect.TypeOf((*MockImageLister)(nil).PropertiesToProtoMessage), entType, props)
+}
+
 // RegisterEntity mocks base method.
 func (m *MockImageLister) RegisterEntity(ctx context.Context, entType v10.Entity, props *properties.Properties) (*properties.Properties, error) {
 	m.ctrl.T.Helper()
@@ -2012,6 +1948,21 @@ func (m *MockOCI) ListTags(ctx context.Context, name string) ([]string, error) {
 func (mr *MockOCIMockRecorder) ListTags(ctx, name any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListTags", reflect.TypeOf((*MockOCI)(nil).ListTags), ctx, name)
+}
+
+// PropertiesToProtoMessage mocks base method.
+func (m *MockOCI) PropertiesToProtoMessage(entType v10.Entity, props *properties.Properties) (protoreflect.ProtoMessage, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "PropertiesToProtoMessage", entType, props)
+	ret0, _ := ret[0].(protoreflect.ProtoMessage)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// PropertiesToProtoMessage indicates an expected call of PropertiesToProtoMessage.
+func (mr *MockOCIMockRecorder) PropertiesToProtoMessage(entType, props any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PropertiesToProtoMessage", reflect.TypeOf((*MockOCI)(nil).PropertiesToProtoMessage), entType, props)
 }
 
 // RegisterEntity mocks base method.

--- a/internal/providers/noop/noop.go
+++ b/internal/providers/noop/noop.go
@@ -1,0 +1,78 @@
+// Copyright 2024 Stacklok, Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package noop provides a no-op provider implementation.
+package noop
+
+import (
+	"context"
+
+	"google.golang.org/protobuf/reflect/protoreflect"
+
+	"github.com/stacklok/minder/internal/entities/properties"
+	minderv1 "github.com/stacklok/minder/pkg/api/protobuf/go/minder/v1"
+)
+
+// Provider is a no-op provider implementation
+// This is useful for testing.
+type Provider struct{}
+
+// CanImplement implements the Provider interface
+func (*Provider) CanImplement(_ minderv1.ProviderType) bool {
+	return false
+}
+
+// FetchAllProperties implements the Provider interface
+func (*Provider) FetchAllProperties(
+	_ context.Context, _ *properties.Properties, _ minderv1.Entity, _ *properties.Properties,
+) (*properties.Properties, error) {
+	return nil, nil
+}
+
+// FetchProperty Implements the Provider interface
+func (*Provider) FetchProperty(
+	_ context.Context, _ *properties.Properties, _ minderv1.Entity, _ string) (*properties.Property, error) {
+	return nil, nil
+}
+
+// GetEntityName implements the Provider interface
+func (*Provider) GetEntityName(_ minderv1.Entity, _ *properties.Properties) (string, error) {
+	return "", nil
+}
+
+// SupportsEntity implements the Provider interface
+func (*Provider) SupportsEntity(_ minderv1.Entity) bool {
+	return false
+}
+
+// RegisterEntity implements the Provider interface
+func (*Provider) RegisterEntity(
+	_ context.Context, _ minderv1.Entity, _ *properties.Properties) (*properties.Properties, error) {
+	return nil, nil
+}
+
+// DeregisterEntity implements the Provider interface
+func (*Provider) DeregisterEntity(_ context.Context, _ minderv1.Entity, _ *properties.Properties) error {
+	return nil
+}
+
+// ReregisterEntity implements the Provider interface
+func (*Provider) ReregisterEntity(_ context.Context, _ minderv1.Entity, _ *properties.Properties) error {
+	return nil
+}
+
+// PropertiesToProtoMessage implements the Provider interface
+func (*Provider) PropertiesToProtoMessage(_ minderv1.Entity, _ *properties.Properties) (protoreflect.ProtoMessage, error) {
+	return nil, nil
+}

--- a/internal/providers/selectors/mock/interface.go
+++ b/internal/providers/selectors/mock/interface.go
@@ -18,6 +18,7 @@ import (
 	proto "github.com/stacklok/minder/internal/proto"
 	v1 "github.com/stacklok/minder/pkg/api/protobuf/go/minder/v1"
 	gomock "go.uber.org/mock/gomock"
+	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 )
 
 // MockRepoSelectorConverter is a mock of RepoSelectorConverter interface.
@@ -114,6 +115,21 @@ func (m *MockRepoSelectorConverter) GetEntityName(entType v1.Entity, props *prop
 func (mr *MockRepoSelectorConverterMockRecorder) GetEntityName(entType, props any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetEntityName", reflect.TypeOf((*MockRepoSelectorConverter)(nil).GetEntityName), entType, props)
+}
+
+// PropertiesToProtoMessage mocks base method.
+func (m *MockRepoSelectorConverter) PropertiesToProtoMessage(entType v1.Entity, props *properties.Properties) (protoreflect.ProtoMessage, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "PropertiesToProtoMessage", entType, props)
+	ret0, _ := ret[0].(protoreflect.ProtoMessage)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// PropertiesToProtoMessage indicates an expected call of PropertiesToProtoMessage.
+func (mr *MockRepoSelectorConverterMockRecorder) PropertiesToProtoMessage(entType, props any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PropertiesToProtoMessage", reflect.TypeOf((*MockRepoSelectorConverter)(nil).PropertiesToProtoMessage), entType, props)
 }
 
 // RegisterEntity mocks base method.
@@ -283,6 +299,21 @@ func (mr *MockArtifactSelectorConverterMockRecorder) GetEntityName(entType, prop
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetEntityName", reflect.TypeOf((*MockArtifactSelectorConverter)(nil).GetEntityName), entType, props)
 }
 
+// PropertiesToProtoMessage mocks base method.
+func (m *MockArtifactSelectorConverter) PropertiesToProtoMessage(entType v1.Entity, props *properties.Properties) (protoreflect.ProtoMessage, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "PropertiesToProtoMessage", entType, props)
+	ret0, _ := ret[0].(protoreflect.ProtoMessage)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// PropertiesToProtoMessage indicates an expected call of PropertiesToProtoMessage.
+func (mr *MockArtifactSelectorConverterMockRecorder) PropertiesToProtoMessage(entType, props any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PropertiesToProtoMessage", reflect.TypeOf((*MockArtifactSelectorConverter)(nil).PropertiesToProtoMessage), entType, props)
+}
+
 // RegisterEntity mocks base method.
 func (m *MockArtifactSelectorConverter) RegisterEntity(ctx context.Context, entType v1.Entity, props *properties.Properties) (*properties.Properties, error) {
 	m.ctrl.T.Helper()
@@ -420,6 +451,21 @@ func (m *MockPullRequestSelectorConverter) GetEntityName(entType v1.Entity, prop
 func (mr *MockPullRequestSelectorConverterMockRecorder) GetEntityName(entType, props any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetEntityName", reflect.TypeOf((*MockPullRequestSelectorConverter)(nil).GetEntityName), entType, props)
+}
+
+// PropertiesToProtoMessage mocks base method.
+func (m *MockPullRequestSelectorConverter) PropertiesToProtoMessage(entType v1.Entity, props *properties.Properties) (protoreflect.ProtoMessage, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "PropertiesToProtoMessage", entType, props)
+	ret0, _ := ret[0].(protoreflect.ProtoMessage)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// PropertiesToProtoMessage indicates an expected call of PropertiesToProtoMessage.
+func (mr *MockPullRequestSelectorConverterMockRecorder) PropertiesToProtoMessage(entType, props any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PropertiesToProtoMessage", reflect.TypeOf((*MockPullRequestSelectorConverter)(nil).PropertiesToProtoMessage), entType, props)
 }
 
 // PullRequestToSelectorEntity mocks base method.

--- a/internal/providers/selectors/selector_entity_test.go
+++ b/internal/providers/selectors/selector_entity_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/stacklok/minder/internal/entities/properties"
 	internalpb "github.com/stacklok/minder/internal/proto"
 	ghprops "github.com/stacklok/minder/internal/providers/github/properties"
+	"github.com/stacklok/minder/internal/providers/noop"
 	minderv1 "github.com/stacklok/minder/pkg/api/protobuf/go/minder/v1"
 	provifv1 "github.com/stacklok/minder/pkg/providers/v1"
 )
@@ -108,6 +109,7 @@ func pullRequestToSelectorEntity(t *testing.T, name, class string, pullRequestEn
 }
 
 type fullProvider struct {
+	noop.Provider
 	name  string
 	class string
 	t     *testing.T
@@ -129,36 +131,6 @@ func (m *fullProvider) PullRequestToSelectorEntity(_ context.Context, pullReques
 	return pullRequestToSelectorEntity(m.t, m.name, m.class, pullRequestEntityWithProps)
 }
 
-func (_ *fullProvider) FetchAllProperties(
-	_ context.Context, _ *properties.Properties, _ minderv1.Entity, _ *properties.Properties,
-) (*properties.Properties, error) {
-	return nil, nil
-}
-
-func (_ *fullProvider) FetchProperty(_ context.Context, _ *properties.Properties, _ minderv1.Entity, _ string) (*properties.Property, error) {
-	return nil, nil
-}
-
-func (_ *fullProvider) GetEntityName(_ minderv1.Entity, _ *properties.Properties) (string, error) {
-	return "", nil
-}
-
-func (_ *fullProvider) SupportsEntity(_ minderv1.Entity) bool {
-	return false
-}
-
-func (_ *fullProvider) RegisterEntity(_ context.Context, _ minderv1.Entity, _ *properties.Properties) (*properties.Properties, error) {
-	return nil, nil
-}
-
-func (_ *fullProvider) DeregisterEntity(_ context.Context, _ minderv1.Entity, _ *properties.Properties) error {
-	return nil
-}
-
-func (_ *fullProvider) ReregisterEntity(_ context.Context, _ minderv1.Entity, _ *properties.Properties) error {
-	return nil
-}
-
 func newMockProvider(t *testing.T, name, class string) *fullProvider {
 	t.Helper()
 
@@ -170,6 +142,7 @@ func newMockProvider(t *testing.T, name, class string) *fullProvider {
 }
 
 type repoOnlyProvider struct {
+	noop.Provider
 	name  string
 	class string
 	t     *testing.T
@@ -187,36 +160,6 @@ func newRepoOnlyProvider(t *testing.T, name, class string) *repoOnlyProvider {
 
 func (_ *repoOnlyProvider) CanImplement(_ minderv1.ProviderType) bool {
 	return true
-}
-
-func (_ *repoOnlyProvider) FetchAllProperties(
-	_ context.Context, _ *properties.Properties, _ minderv1.Entity, _ *properties.Properties,
-) (*properties.Properties, error) {
-	return nil, nil
-}
-
-func (_ *repoOnlyProvider) FetchProperty(_ context.Context, _ *properties.Properties, _ minderv1.Entity, _ string) (*properties.Property, error) {
-	return nil, nil
-}
-
-func (_ *repoOnlyProvider) GetEntityName(_ minderv1.Entity, _ *properties.Properties) (string, error) {
-	return "", nil
-}
-
-func (_ *repoOnlyProvider) SupportsEntity(minderv1.Entity) bool {
-	return false
-}
-
-func (_ *repoOnlyProvider) RegisterEntity(_ context.Context, _ minderv1.Entity, _ *properties.Properties) (*properties.Properties, error) {
-	return nil, nil
-}
-
-func (_ *repoOnlyProvider) DeregisterEntity(_ context.Context, _ minderv1.Entity, _ *properties.Properties) error {
-	return nil
-}
-
-func (_ *repoOnlyProvider) ReregisterEntity(_ context.Context, _ minderv1.Entity, _ *properties.Properties) error {
-	return nil
 }
 
 func (m *repoOnlyProvider) RepoToSelectorEntity(_ context.Context, repoEntWithProps *models.EntityWithProperties) *internalpb.SelectorEntity {

--- a/internal/providers/testproviders/git.go
+++ b/internal/providers/testproviders/git.go
@@ -15,10 +15,8 @@
 package testproviders
 
 import (
-	"context"
-
-	"github.com/stacklok/minder/internal/entities/properties"
 	"github.com/stacklok/minder/internal/providers/git"
+	"github.com/stacklok/minder/internal/providers/noop"
 	minderv1 "github.com/stacklok/minder/pkg/api/protobuf/go/minder/v1"
 	provifv1 "github.com/stacklok/minder/pkg/providers/v1"
 )
@@ -26,6 +24,7 @@ import (
 // GitProvider is a test implementation of the Git provider
 // interface
 type GitProvider struct {
+	noop.Provider
 	*git.Git
 }
 
@@ -42,50 +41,4 @@ var _ provifv1.Provider = (*GitProvider)(nil)
 // CanImplement implements the Provider interface
 func (_ *GitProvider) CanImplement(trait minderv1.ProviderType) bool {
 	return trait == minderv1.ProviderType_PROVIDER_TYPE_GIT
-}
-
-// FetchAllProperties implements the Provider interface
-func (_ *GitProvider) FetchAllProperties(
-	_ context.Context, _ *properties.Properties, _ minderv1.Entity, _ *properties.Properties,
-) (*properties.Properties, error) {
-	return nil, nil
-}
-
-// FetchProperty implements the Provider interface
-func (_ *GitProvider) FetchProperty(
-	_ context.Context, _ *properties.Properties, _ minderv1.Entity, _ string) (*properties.Property, error) {
-	return nil, nil
-}
-
-// GetEntityName implements the Provider interface
-func (_ *GitProvider) GetEntityName(_ minderv1.Entity, _ *properties.Properties) (string, error) {
-	return "", nil
-}
-
-// SupportsEntity implements the Provider interface
-func (_ *GitProvider) SupportsEntity(_ minderv1.Entity) bool {
-	// TODO: implement
-	return false
-}
-
-// RegisterEntity implements the Provider interface
-func (_ *GitProvider) RegisterEntity(
-	_ context.Context, _ minderv1.Entity, _ *properties.Properties,
-) (*properties.Properties, error) {
-	// TODO: implement
-	return nil, nil
-}
-
-// DeregisterEntity implements the Provider interface
-func (_ *GitProvider) DeregisterEntity(_ context.Context, _ minderv1.Entity, _ *properties.Properties) error {
-	// TODO: implement
-	return nil
-}
-
-// ReregisterEntity implements the Provider interface
-func (_ *GitProvider) ReregisterEntity(
-	_ context.Context, _ minderv1.Entity, _ *properties.Properties,
-) error {
-	// TODO: implement
-	return nil
 }

--- a/internal/providers/testproviders/rest.go
+++ b/internal/providers/testproviders/rest.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/stacklok/minder/internal/entities/properties"
 	"github.com/stacklok/minder/internal/providers/http"
+	"github.com/stacklok/minder/internal/providers/noop"
 	"github.com/stacklok/minder/internal/providers/telemetry"
 	minderv1 "github.com/stacklok/minder/pkg/api/protobuf/go/minder/v1"
 	provifv1 "github.com/stacklok/minder/pkg/providers/v1"
@@ -27,6 +28,7 @@ import (
 // RESTProvider is a test implementation of the REST provider
 // interface
 type RESTProvider struct {
+	noop.Provider
 	*http.REST
 }
 

--- a/pkg/providers/v1/providers.go
+++ b/pkg/providers/v1/providers.go
@@ -86,6 +86,12 @@ type Provider interface {
 	// updating the webhook URL or secret for a particular repository or artifact. This is useful
 	// for secret rotation.
 	ReregisterEntity(ctx context.Context, entType minderv1.Entity, props *properties.Properties) error
+
+	// PropertiesToProtoMessage is the interface for converting properties to a proto message
+	// this is temporary until we can get rid of the typed proto messages in EntityInfoWrapper
+	// and the engine. That's also why we just didn't add the method to the generic Provider
+	// interface.
+	PropertiesToProtoMessage(entType minderv1.Entity, props *properties.Properties) (protoreflect.ProtoMessage, error)
 }
 
 // Git is the interface for git providers
@@ -94,15 +100,6 @@ type Git interface {
 
 	// Clone clones a git repository
 	Clone(ctx context.Context, url string, branch string) (*git.Repository, error)
-}
-
-// ProtoMessageConverter is the interface for converting properties to a proto message
-// this is temporary until we can get rid of the typed proto messages in EntityInfoWrapper
-// and the engine. That's also why we just didn't add the method to the generic Provider
-// interface.
-type ProtoMessageConverter interface {
-	Provider
-	PropertiesToProtoMessage(entType minderv1.Entity, props *properties.Properties) (protoreflect.ProtoMessage, error)
 }
 
 // REST is the trait interface for interacting with an REST API.


### PR DESCRIPTION
# Summary

We were doing a lot of repetition in our test providers, so this
implemented a `noop` provider that fills in the signature as needed.

This also moved the `EntityToProtoMessage` function to be a top-level
provider function in the interface. While this is temporary, it's useful
to know this needs to be defined while we move everything to the general
protobuf interface.

## Change Type

***Mark the type of change your PR introduces:***

- [ ] Bug fix (resolves an issue without affecting existing features)
- [ ] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [x] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

***Outline how the changes were tested, including steps to reproduce and any relevant configurations. 
Attach screenshots if helpful.***

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [ ] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [ ] Included tests that validate the fix or feature.
- [ ] Checked that related changes are merged.
