### PR TITLE
Store provider's refresh token and expiry if possible

### DIFF
--- a/internal/controlplane/handlers_oauth.go
+++ b/internal/controlplane/handlers_oauth.go
@@ -280,9 +280,12 @@ func (s *Server) processOAuthCallback(ctx context.Context, w http.ResponseWriter
 	}
 
 	ftoken := &oauth2.Token{
-		AccessToken:  token.AccessToken,
-		TokenType:    token.TokenType,
-		RefreshToken: "",
+		AccessToken: token.AccessToken,
+		TokenType:   token.TokenType,
+		// These might be empty and that's fine. We'll only
+		// use them if they're present.
+		RefreshToken: token.RefreshToken,
+		Expiry:       token.Expiry,
 	}
 
 	// encode token


### PR DESCRIPTION
# Summary

As of today, we only store the access token and use that for provider
authentication. This ensures we're also persisting the refresh token and
expiry so we could leverage these in case re-authentication is needed.

Note that re-authentication will be handled in a separate PR.

## Change Type

***Mark the type of change your PR introduces:***

- [ ] Bug fix (resolves an issue without affecting existing features)
- [x] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [ ] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [ ] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [ ] Included tests that validate the fix or feature.
- [ ] Checked that related changes are merged.
