### PR TITLE
gitlab: don't use deprecated token database column

### DIFF
--- a/internal/providers/gitlab/manager/manager.go
+++ b/internal/providers/gitlab/manager/manager.go
@@ -142,17 +142,13 @@ func (m *providerClassManager) getProviderCredentials(
 		return nil, fmt.Errorf("error getting credential: %w", err)
 	}
 
-	// TODO: get rid of this once we migrate all secrets to use the new structure
-	var encryptedData crypto.EncryptedData
-	if encToken.EncryptedAccessToken.Valid {
-		encryptedData, err = crypto.DeserializeEncryptedData(encToken.EncryptedAccessToken.RawMessage)
-		if err != nil {
-			return nil, err
-		}
-	} else if encToken.EncryptedToken.Valid {
-		encryptedData = crypto.NewBackwardsCompatibleEncryptedData(encToken.EncryptedToken.String)
-	} else {
+	if !encToken.EncryptedAccessToken.Valid {
 		return nil, fmt.Errorf("no secret found for provider %s", encToken.Provider)
+	}
+
+	encryptedData, err := crypto.DeserializeEncryptedData(encToken.EncryptedAccessToken.RawMessage)
+	if err != nil {
+		return nil, err
 	}
 	decryptedToken, err := m.crypteng.DecryptOAuthToken(encryptedData)
 	if err != nil {


### PR DESCRIPTION
# Summary

This uses the "encrypted access token" column which we should have fully
migrated to by now. We don't need the fallback code at all in this case.

## Change Type

***Mark the type of change your PR introduces:***

- [ ] Bug fix (resolves an issue without affecting existing features)
- [ ] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [x] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

***Outline how the changes were tested, including steps to reproduce and any relevant configurations. 
Attach screenshots if helpful.***

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [ ] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [ ] Included tests that validate the fix or feature.
- [ ] Checked that related changes are merged.
