### PR TITLE
GitHub: don't try to use OAuth token for github-app provider

### DIFF
--- a/internal/controlplane/handlers_providers_test.go
+++ b/internal/controlplane/handlers_providers_test.go
@@ -546,8 +546,8 @@ func TestDeleteProvider(t *testing.T) {
 		},
 		ID:         providerID,
 		Version:    provinfv1.V1,
-		Definition: json.RawMessage(`{"github-app": {}}`),
-		Class:      db.ProviderClassGithubApp,
+		Definition: json.RawMessage(`{"github": {}}`),
+		Class:      db.ProviderClassGithub,
 	}, nil)
 	mockStore.EXPECT().
 		GetAccessTokenByProjectID(gomock.Any(), gomock.Any()).
@@ -671,8 +671,8 @@ func TestDeleteProviderByID(t *testing.T) {
 			db.ProviderTypeGithub,
 		},
 		Version:    provinfv1.V1,
-		Definition: json.RawMessage(`{"github-app": {}}`),
-		Class:      db.ProviderClassGithubApp,
+		Definition: json.RawMessage(`{"github": {}}`),
+		Class:      db.ProviderClassGithub,
 	}, nil)
 	mockStore.EXPECT().DeleteProvider(gomock.Any(), db.DeleteProviderParams{
 		ID:        providerID,


### PR DESCRIPTION
# Summary

This separates the providers a little further by always assuming that if
the github app provider class is used, you should only check for the
github app credentials (which require an installation ID).

This will thus reduce the number of database calls we do when
instantiating the provider, since Minder will now do the right thing.

## Change Type

***Mark the type of change your PR introduces:***

- [ ] Bug fix (resolves an issue without affecting existing features)
- [ ] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [x] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

***Outline how the changes were tested, including steps to reproduce and any relevant configurations. 
Attach screenshots if helpful.***

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [ ] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [ ] Included tests that validate the fix or feature.
- [ ] Checked that related changes are merged.
