### PR TITLE
gitlab: Handle token refresh

### DIFF
--- a/internal/providers/gitlab/manager/manager_test.go
+++ b/internal/providers/gitlab/manager/manager_test.go
@@ -1,0 +1,75 @@
+// Copyright 2024 Stacklok, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package manager contains the GitLabProviderClassManager
+package manager
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"golang.org/x/oauth2"
+)
+
+func Test_tokenNeedsRefresh(t *testing.T) {
+	t.Parallel()
+
+	baseTime := time.Now()
+
+	tests := []struct {
+		name  string
+		token oauth2.Token
+		want  bool
+	}{
+		{
+			name:  "token is expired",
+			token: accessTokenWithExpiration(baseTime.Add(-1 * time.Minute)),
+			want:  true,
+		},
+		{
+			name:  "token is not expired and does not need refresh",
+			token: accessTokenWithExpiration(baseTime.Add(15 * time.Minute)),
+			want:  false,
+		},
+		{
+			name:  "token is not expired but needs refresh",
+			token: accessTokenWithExpiration(baseTime.Add(5 * time.Minute)),
+			want:  true,
+		},
+		{
+			name: "token is not valid",
+			token: oauth2.Token{
+				AccessToken: "",
+				Expiry:      baseTime.Add(15 * time.Minute),
+			},
+			want: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			needsRefresh := tokenNeedsRefresh(tt.token)
+			assert.Equal(t, tt.want, needsRefresh)
+		})
+	}
+}
+
+func accessTokenWithExpiration(exp time.Time) oauth2.Token {
+	return oauth2.Token{
+		AccessToken: "ozz-likes-beer",
+		Expiry:      exp,
+	}
+}


### PR DESCRIPTION
# Summary

Gitlab uses shorter lived tokens than github, this adds the logic to
handle a token refresh.

At the moment this is done within the gitlab provider manager. While
this works for now, we might want to determine whether we make this a
more general pattern, or keep handling this within each provider.

Closes: #4605

## Change Type

***Mark the type of change your PR introduces:***

- [ ] Bug fix (resolves an issue without affecting existing features)
- [x] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [ ] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

***Outline how the changes were tested, including steps to reproduce and any relevant configurations. 
Attach screenshots if helpful.***

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [ ] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [ ] Included tests that validate the fix or feature.
- [ ] Checked that related changes are merged.
