### PR TITLE
Query Keycloak for user deletions every 5 minutes

### DIFF
--- a/internal/controlplane/identity_events.go
+++ b/internal/controlplane/identity_events.go
@@ -36,7 +36,7 @@ import (
 )
 
 const (
-	eventFetchInterval     = "@hourly"
+	eventFetchInterval     = "@every 5m"
 	deleteAccountEventType = "DELETE_ACCOUNT"
 )
 
@@ -76,7 +76,7 @@ func HandleEvents(
 	cfg *serverconfig.Config,
 	projectDeleter projects.ProjectDeleter,
 ) {
-	d := time.Now().Add(time.Duration(10) * time.Minute)
+	d := time.Now().Add(time.Duration(5) * time.Minute)
 	ctx, cancel := context.WithDeadline(ctx, d)
 	defer cancel()
 


### PR DESCRIPTION

# Summary
Change the interval that we use to poll Keycloak for deletion events, from 1 hour to 5 minutes.
This way, if a user deletes their account elsewhere, they can re-create their account on Minder after at most 5 minutes.


Fixes #4614

## Change Type

***Mark the type of change your PR introduces:***

- [ ] Bug fix (resolves an issue without affecting existing features)
- [x] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [ ] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

***Outline how the changes were tested, including steps to reproduce and any relevant configurations. 
Attach screenshots if helpful.***

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [ ] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [ ] Included tests that validate the fix or feature.
- [ ] Checked that related changes are merged.
