### PR TITLE
Remove RefreshRepositoryByUpstreamID from the repo reconciler

### DIFF
--- a/internal/controlplane/handlers_reconciliationtasks.go
+++ b/internal/controlplane/handlers_reconciliationtasks.go
@@ -95,7 +95,7 @@ func getRepositoryReconciliationMessage(ctx context.Context, store db.Store,
 	logger.BusinessRecord(ctx).Project = repo.ProjectID
 	logger.BusinessRecord(ctx).Repository = repo.ID
 
-	msg, err := reconcilers.NewRepoReconcilerMessage(repo.ProviderID, repo.RepoID, repo.ProjectID)
+	msg, err := reconcilers.NewRepoReconcilerMessage(repo.ProviderID, repo.ID, repo.ProjectID)
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "error getting reconciler message: %v", err)
 	}

--- a/internal/entities/handlers/handler.go
+++ b/internal/entities/handlers/handler.go
@@ -109,6 +109,27 @@ func (b *handleEntityAndDoBase) handleRefreshEntityAndDo(msg *watermill.Message)
 	return nil
 }
 
+// NewRefreshByIDAndEvaluateHandler creates a new handler that refreshes an entity and evaluates it.
+func NewRefreshByIDAndEvaluateHandler(
+	evt events.Publisher,
+	store db.Store,
+	propSvc propertyService.PropertiesService,
+	provMgr manager.ProviderManager,
+	handlerMiddleware ...watermill.HandlerMiddleware,
+) events.Consumer {
+	return &handleEntityAndDoBase{
+		evt: evt,
+
+		refreshEntity: entStrategies.NewRefreshEntityByIDStrategy(propSvc, provMgr, store),
+		createMessage: msgStrategies.NewToEntityInfoWrapper(store, propSvc, provMgr),
+
+		handlerName:        events.TopicQueueRefreshEntityByIDAndEvaluate,
+		forwardHandlerName: events.TopicQueueEntityEvaluate,
+
+		handlerMiddleware: handlerMiddleware,
+	}
+}
+
 // NewRefreshEntityAndEvaluateHandler creates a new handler that refreshes an entity and evaluates it.
 func NewRefreshEntityAndEvaluateHandler(
 	evt events.Publisher,

--- a/internal/entities/handlers/handler_test.go
+++ b/internal/entities/handlers/handler_test.go
@@ -369,7 +369,7 @@ func TestRefreshEntityAndDoHandler_HandleRefreshEntityAndEval(t *testing.T) {
 			if tt.ownerPropMap != nil {
 				ownerProps, err := properties.NewProperties(tt.ownerPropMap)
 				require.NoError(t, err)
-				entityMsg = entityMsg.WithOwner(tt.ownerType, ownerProps)
+				entityMsg = entityMsg.WithOriginator(tt.ownerType, ownerProps)
 			}
 
 			handlerMsg := watermill.NewMessage(uuid.New().String(), nil)

--- a/internal/entities/handlers/message/message.go
+++ b/internal/entities/handlers/message/message.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 
 	"github.com/ThreeDotsLabs/watermill/message"
+	"github.com/google/uuid"
 
 	"github.com/stacklok/minder/internal/entities/properties"
 	v1 "github.com/stacklok/minder/pkg/api/protobuf/go/minder/v1"
@@ -30,6 +31,7 @@ import (
 // it is used for either the entity or the owner entity.
 type TypedProps struct {
 	Type       v1.Entity      `json:"type"`
+	EntityID   uuid.UUID      `json:"entity_id"`
 	GetByProps map[string]any `json:"get_by_props"`
 }
 
@@ -68,6 +70,12 @@ func (e *HandleEntityAndDoMessage) WithOriginator(
 		Type:       originatorType,
 		GetByProps: originatorProps.ToProtoStruct().AsMap(),
 	}
+	return e
+}
+
+// WithEntityID sets the entity ID for the entity that will be used when looking up the entity.
+func (e *HandleEntityAndDoMessage) WithEntityID(entityID uuid.UUID) *HandleEntityAndDoMessage {
+	e.Entity.EntityID = entityID
 	return e
 }
 

--- a/internal/entities/handlers/message/message.go
+++ b/internal/entities/handlers/message/message.go
@@ -60,11 +60,13 @@ func (e *HandleEntityAndDoMessage) WithEntity(entType v1.Entity, getByProps *pro
 	return e
 }
 
-// WithOwner sets the owner entity and its properties.
-func (e *HandleEntityAndDoMessage) WithOwner(ownerType v1.Entity, ownerProps *properties.Properties) *HandleEntityAndDoMessage {
+// WithOriginator sets the owner entity and its properties.
+func (e *HandleEntityAndDoMessage) WithOriginator(
+	originatorType v1.Entity, originatorProps *properties.Properties,
+) *HandleEntityAndDoMessage {
 	e.Originator = TypedProps{
-		Type:       ownerType,
-		GetByProps: ownerProps.ToProtoStruct().AsMap(),
+		Type:       originatorType,
+		GetByProps: originatorProps.ToProtoStruct().AsMap(),
 	}
 	return e
 }

--- a/internal/entities/handlers/message/message_test.go
+++ b/internal/entities/handlers/message/message_test.go
@@ -94,7 +94,7 @@ func TestEntityRefreshAndDoMessageRoundTrip(t *testing.T) {
 			if sc.ownerProps != nil {
 				ownerProps, err := properties.NewProperties(sc.ownerProps)
 				require.NoError(t, err)
-				original.WithOwner(sc.ownerType, ownerProps)
+				original.WithOriginator(sc.ownerType, ownerProps)
 			}
 
 			handlerMsg := message.NewMessage(uuid.New().String(), nil)

--- a/internal/entities/properties/service/mock/fixtures/fixtures.go
+++ b/internal/entities/properties/service/mock/fixtures/fixtures.go
@@ -70,6 +70,16 @@ func WithFailedEntityByUpstreamHint(
 	}
 }
 
+func WithSuccessfulEntityWithPropertiesByID(
+	entityID uuid.UUID,
+	ewp *models.EntityWithProperties,
+) MockPropertyServiceOption {
+	return func(mockPropSvc *mockSvc.MockPropertiesService) {
+		mockPropSvc.EXPECT().EntityWithPropertiesByID(gomock.Any(), entityID, gomock.Any()).
+			Return(ewp, nil)
+	}
+}
+
 func WithSuccessfulRetrieveAllPropertiesForEntity() MockPropertyServiceOption {
 	return func(mockPropSvc *mockSvc.MockPropertiesService) {
 		mockPropSvc.EXPECT().

--- a/internal/entities/properties/service/mock/fixtures/fixtures.go
+++ b/internal/entities/properties/service/mock/fixtures/fixtures.go
@@ -135,3 +135,13 @@ func WithSuccessfulRetrieveAllProperties(
 			Return(retProps, nil)
 	}
 }
+
+func WithFailedGetEntityWithPropertiesByID(
+	err error,
+) MockPropertyServiceOption {
+	return func(mockPropSvc *mockSvc.MockPropertiesService) {
+		mockPropSvc.EXPECT().
+			EntityWithPropertiesByID(gomock.Any(), gomock.Any(), gomock.Any()).
+			Return(nil, err)
+	}
+}

--- a/internal/events/constants.go
+++ b/internal/events/constants.go
@@ -42,6 +42,8 @@ const (
 	TopicQueueOriginatingEntityDelete = "originating.entity.delete.event"
 	// TopicQueueGetEntityAndDelete retrieves an entity from the database and schedules it for deletion
 	TopicQueueGetEntityAndDelete = "get.entity.delete.event"
+	// TopicQueueRefreshEntityByIDAndEvaluate makes sure that entity properties are up-to-date and schedules an evaluation
+	TopicQueueRefreshEntityByIDAndEvaluate = "refresh.entity.by.id.evaluate.event"
 	// TopicQueueRefreshEntityAndEvaluate makes sure that entity properties are up-to-date and schedules an evaluation
 	TopicQueueRefreshEntityAndEvaluate = "refresh.entity.evaluate.event"
 	// TopicQueueEntityEvaluate is the topic for entity evaluation events from webhooks

--- a/internal/reconcilers/entity_delete_test.go
+++ b/internal/reconcilers/entity_delete_test.go
@@ -180,6 +180,7 @@ func setUp(t *testing.T, tt testCase, ctrl *gomock.Controller) *Reconciler {
 		nil, // crypto.Engine not used in these tests
 		nil, // manager.ProviderManager not used in these tests
 		repoService,
+		nil, // propertyService.PropertiesService not used in these tests
 	)
 	require.NoError(t, err)
 

--- a/internal/reconcilers/messages/messages.go
+++ b/internal/reconcilers/messages/messages.go
@@ -28,15 +28,18 @@ import (
 type RepoReconcilerEvent struct {
 	// Project is the project that the event is relevant to
 	Project uuid.UUID `json:"project"`
-	// Repository is the repository to be reconciled
-	Repository int64 `json:"repository" validate:"gte=0"`
+	// Provider is the provider that the event is relevant to
+	Provider uuid.UUID `json:"provider"`
+	// EntityID is the entity id of the repository to be reconciled
+	EntityID uuid.UUID `json:"entity_id"`
 }
 
 // NewRepoReconcilerMessage creates a new repos init event
-func NewRepoReconcilerMessage(providerID uuid.UUID, repoID int64, projectID uuid.UUID) (*message.Message, error) {
+func NewRepoReconcilerMessage(providerID uuid.UUID, entityID uuid.UUID, projectID uuid.UUID) (*message.Message, error) {
 	evt := &RepoReconcilerEvent{
-		Repository: repoID,
-		Project:    projectID,
+		Project:  projectID,
+		Provider: providerID,
+		EntityID: entityID,
 	}
 
 	evtStr, err := json.Marshal(evt)
@@ -45,7 +48,6 @@ func NewRepoReconcilerMessage(providerID uuid.UUID, repoID int64, projectID uuid
 	}
 
 	msg := message.NewMessage(uuid.New().String(), evtStr)
-	msg.Metadata.Set("provider_id", providerID.String())
 	return msg, nil
 }
 

--- a/internal/reconcilers/reconcilers.go
+++ b/internal/reconcilers/reconcilers.go
@@ -19,6 +19,7 @@ package reconcilers
 import (
 	"github.com/stacklok/minder/internal/crypto"
 	"github.com/stacklok/minder/internal/db"
+	propSvc "github.com/stacklok/minder/internal/entities/properties/service"
 	"github.com/stacklok/minder/internal/events"
 	"github.com/stacklok/minder/internal/providers/manager"
 	"github.com/stacklok/minder/internal/repositories"
@@ -31,6 +32,7 @@ type Reconciler struct {
 	crypteng        crypto.Engine
 	providerManager manager.ProviderManager
 	repos           repositories.RepositoryService
+	propService     propSvc.PropertiesService
 }
 
 // NewReconciler creates a new reconciler object
@@ -40,6 +42,7 @@ func NewReconciler(
 	cryptoEngine crypto.Engine,
 	providerManager manager.ProviderManager,
 	repositoryService repositories.RepositoryService,
+	propService propSvc.PropertiesService,
 ) (*Reconciler, error) {
 	return &Reconciler{
 		store:           store,
@@ -47,6 +50,7 @@ func NewReconciler(
 		crypteng:        cryptoEngine,
 		providerManager: providerManager,
 		repos:           repositoryService,
+		propService:     propService,
 	}, nil
 }
 

--- a/internal/reconcilers/repository.go
+++ b/internal/reconcilers/repository.go
@@ -45,7 +45,10 @@ import (
 func (r *Reconciler) handleRepoReconcilerEvent(msg *message.Message) error {
 	var evt messages.RepoReconcilerEvent
 	if err := json.Unmarshal(msg.Payload, &evt); err != nil {
-		return fmt.Errorf("error unmarshalling payload: %w", err)
+		// We don't return the event since there's no use
+		// retrying it if it's invalid.
+		log.Printf("error unmarshalling event: %v", err)
+		return nil
 	}
 
 	// validate event

--- a/internal/reconcilers/repository.go
+++ b/internal/reconcilers/repository.go
@@ -31,9 +31,11 @@ import (
 
 	"github.com/stacklok/minder/internal/db"
 	"github.com/stacklok/minder/internal/engine/entities"
+	entityMessage "github.com/stacklok/minder/internal/entities/handlers/message"
+	"github.com/stacklok/minder/internal/entities/properties"
+	"github.com/stacklok/minder/internal/events"
 	"github.com/stacklok/minder/internal/providers/github"
 	"github.com/stacklok/minder/internal/reconcilers/messages"
-	"github.com/stacklok/minder/internal/repositories"
 	"github.com/stacklok/minder/internal/verifier/verifyif"
 	pb "github.com/stacklok/minder/pkg/api/protobuf/go/minder/v1"
 	v1 "github.com/stacklok/minder/pkg/providers/v1"
@@ -56,7 +58,7 @@ func (r *Reconciler) handleRepoReconcilerEvent(msg *message.Message) error {
 	}
 
 	ctx := msg.Context()
-	log.Printf("handling reconciler event for project %s and repository %d", evt.Project.String(), evt.Repository)
+	log.Printf("handling reconciler event for project %s and repository %s", evt.Project.String(), evt.EntityID.String())
 	return r.handleArtifactsReconcilerEvent(ctx, &evt)
 }
 
@@ -64,30 +66,49 @@ func (r *Reconciler) handleRepoReconcilerEvent(msg *message.Message) error {
 // an specific repository
 // nolint: gocyclo
 func (r *Reconciler) handleArtifactsReconcilerEvent(ctx context.Context, evt *messages.RepoReconcilerEvent) error {
+	entRefresh := entityMessage.NewEntityRefreshAndDoMessage().
+		WithEntityID(evt.EntityID)
+
+	m := message.NewMessage(uuid.New().String(), nil)
+	if err := entRefresh.ToMessage(m); err != nil {
+		return fmt.Errorf("error creating message: %w", err)
+	}
+
+	m.SetContext(ctx)
+	if err := r.evt.Publish(events.TopicQueueRefreshEntityByIDAndEvaluate, m); err != nil {
+		return fmt.Errorf("error publishing message: %w", err)
+	}
+
+	// the code below this line will be refactored in a follow-up PR
+	ewp, err := r.propService.EntityWithPropertiesByID(ctx, evt.EntityID, nil)
+	if err != nil {
+		log.Printf("error retrieving entity with properties: %v", err)
+		return nil
+	}
+
+	repoID, err := ewp.Properties.GetProperty(properties.PropertyUpstreamID).AsInt64()
+	if err != nil {
+		log.Printf("error getting property upstreamID: %v", err)
+		return nil
+	}
+
 	// first retrieve data for the repository
-	repository, err := r.store.GetRepositoryByRepoID(ctx, evt.Repository)
+	repository, err := r.store.GetRepositoryByRepoID(ctx, repoID)
 	if errors.Is(err, sql.ErrNoRows) {
 		zerolog.Ctx(ctx).Debug().Err(err).
-			Int64("repositoryUpstreamID", evt.Repository).
+			Int64("repositoryUpstreamID", repoID).
 			Msg("repository not found")
 		return nil
 	}
 	if err != nil {
-		return fmt.Errorf("error retrieving repository %d in project %s: %w", evt.Repository, evt.Project, err)
+		return fmt.Errorf("error retrieving repository %d in project %s: %w", repoID, evt.Project, err)
 	}
 
 	providerID := repository.ProviderID
+
 	p, err := r.providerManager.InstantiateFromID(ctx, providerID)
 	if err != nil {
 		return fmt.Errorf("error instantiating provider: %w", err)
-	}
-
-	_, err = r.repos.RefreshRepositoryByUpstreamID(ctx, repository.RepoID)
-	if errors.Is(err, v1.ErrEntityNotFound) || errors.Is(err, repositories.ErrRepoNotFound) {
-		zerolog.Ctx(ctx).Debug().Err(err).Str("repository", repository.ID.String()).Msg("repository not found")
-	} else if err != nil {
-		zerolog.Ctx(ctx).Debug().Err(err).Str("repository", repository.ID.String()).Msg("error refreshing repository")
-		return fmt.Errorf("error refreshing repository: %w", err)
 	}
 
 	cli, err := v1.As[v1.GitHub](p)
@@ -97,19 +118,6 @@ func (r *Reconciler) handleArtifactsReconcilerEvent(ctx context.Context, evt *me
 		// and generic parts.
 		log.Printf("provider %s is not supported for artifacts reconciler", providerID)
 		return nil
-	}
-
-	// evaluate profile for repo
-	repo := repositories.PBRepositoryFromDB(repository)
-
-	err = entities.NewEntityInfoWrapper().
-		WithProviderID(providerID).
-		WithRepository(repo).
-		WithProjectID(evt.Project).
-		WithRepositoryID(repository.ID).
-		Publish(r.evt)
-	if err != nil {
-		return fmt.Errorf("error publishing message: %w", err)
 	}
 
 	// todo: add another type of artifacts

--- a/internal/reconcilers/repository_test.go
+++ b/internal/reconcilers/repository_test.go
@@ -42,6 +42,7 @@ func Test_handleRepoReconcilerEvent(t *testing.T) {
 		setupPropSvcMocks func() fixtures.MockPropertyServiceBuilder
 		expectedPublish   bool
 		expectedErr       bool
+		entityID          uuid.UUID
 		topic             string
 	}{
 		{
@@ -54,7 +55,17 @@ func Test_handleRepoReconcilerEvent(t *testing.T) {
 				)
 			},
 			topic:           events.TopicQueueRefreshEntityByIDAndEvaluate,
+			entityID:        testRepoID,
 			expectedPublish: true,
+			expectedErr:     false,
+		},
+		{
+			name: "event with no upstream ID",
+			setupPropSvcMocks: func() fixtures.MockPropertyServiceBuilder {
+				return fixtures.NewMockPropertiesService()
+			},
+			entityID:        uuid.Nil,
+			expectedPublish: false,
 			expectedErr:     false,
 		},
 	}
@@ -66,7 +77,7 @@ func Test_handleRepoReconcilerEvent(t *testing.T) {
 			ctrl := gomock.NewController(t)
 			defer ctrl.Finish()
 
-			msg, err := messages.NewRepoReconcilerMessage(testProviderID, testRepoID, testProjectID)
+			msg, err := messages.NewRepoReconcilerMessage(testProviderID, scenario.entityID, testProjectID)
 			require.NoError(t, err)
 			require.NotNil(t, msg)
 

--- a/internal/reconcilers/repository_test.go
+++ b/internal/reconcilers/repository_test.go
@@ -1,0 +1,95 @@
+// Copyright 2023 Stacklok, Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package reconcilers
+
+import (
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+
+	propSvc "github.com/stacklok/minder/internal/entities/properties/service"
+	"github.com/stacklok/minder/internal/entities/properties/service/mock/fixtures"
+	"github.com/stacklok/minder/internal/events"
+	stubeventer "github.com/stacklok/minder/internal/events/stubs"
+	"github.com/stacklok/minder/internal/reconcilers/messages"
+)
+
+var (
+	testProviderID = uuid.New()
+	testProjectID  = uuid.New()
+	testRepoID     = uuid.New()
+)
+
+func Test_handleRepoReconcilerEvent(t *testing.T) {
+	t.Parallel()
+
+	scenarios := []struct {
+		name              string
+		setupPropSvcMocks func() fixtures.MockPropertyServiceBuilder
+		expectedPublish   bool
+		expectedErr       bool
+		topic             string
+	}{
+		{
+			name: "valid event",
+			setupPropSvcMocks: func() fixtures.MockPropertyServiceBuilder {
+				// this just shortcuts the function at the point we will refactor
+				// soon
+				return fixtures.NewMockPropertiesService(
+					fixtures.WithFailedGetEntityWithPropertiesByID(propSvc.ErrEntityNotFound),
+				)
+			},
+			topic:           events.TopicQueueRefreshEntityByIDAndEvaluate,
+			expectedPublish: true,
+			expectedErr:     false,
+		},
+	}
+
+	for _, scenario := range scenarios {
+		t.Run(scenario.name, func(t *testing.T) {
+			t.Parallel()
+
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			msg, err := messages.NewRepoReconcilerMessage(testProviderID, testRepoID, testProjectID)
+			require.NoError(t, err)
+			require.NotNil(t, msg)
+
+			stubEventer := &stubeventer.StubEventer{}
+			mockPropSvc := scenario.setupPropSvcMocks()(ctrl)
+
+			reconciler, err := NewReconciler(nil, stubEventer, nil, nil, nil, mockPropSvc)
+			require.NoError(t, err)
+			require.NotNil(t, reconciler)
+
+			err = reconciler.handleRepoReconcilerEvent(msg)
+			if scenario.expectedErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+
+			if scenario.expectedPublish {
+				require.Equal(t, 1, len(stubEventer.Sent))
+				require.Contains(t, stubEventer.Topics, scenario.topic)
+			} else {
+				require.Equal(t, 0, len(stubEventer.Sent))
+			}
+		})
+	}
+}

--- a/internal/reminder/messages/messages.go
+++ b/internal/reminder/messages/messages.go
@@ -23,22 +23,22 @@ import (
 	"github.com/google/uuid"
 )
 
-// RepoReminderEvent is an event that is published by the reminder service to trigger repo reconciliation
-type RepoReminderEvent struct {
+// EntityReminderEvent is an event that is published by the reminder service to trigger repo reconciliation
+type EntityReminderEvent struct {
 	// Project is the project that the event is relevant to
 	Project uuid.UUID `json:"project"`
 	// ProviderID is the provider of the repository
 	ProviderID uuid.UUID `json:"provider"`
-	// RepositoryID is id of the repository to be reconciled
-	RepositoryID int64 `json:"repository"`
+	// EntityID is the entity id of the repository to be reconciled
+	EntityID uuid.UUID `json:"entity_id"`
 }
 
-// NewRepoReminderMessage creates a new repo reminder message
-func NewRepoReminderMessage(providerId uuid.UUID, repoID int64, projectID uuid.UUID) (*message.Message, error) {
-	evt := &RepoReminderEvent{
-		Project:      projectID,
-		ProviderID:   providerId,
-		RepositoryID: repoID,
+// NewEntityReminderMessage creates a new repo reminder message
+func NewEntityReminderMessage(providerId uuid.UUID, entityID uuid.UUID, projectID uuid.UUID) (*message.Message, error) {
+	evt := &EntityReminderEvent{
+		Project:    projectID,
+		ProviderID: providerId,
+		EntityID:   entityID,
 	}
 
 	evtStr, err := json.Marshal(evt)
@@ -50,9 +50,9 @@ func NewRepoReminderMessage(providerId uuid.UUID, repoID int64, projectID uuid.U
 	return msg, nil
 }
 
-// RepoReminderEventFromMessage creates a new repo reminder event from a message
-func RepoReminderEventFromMessage(msg *message.Message) (*RepoReminderEvent, error) {
-	var evt RepoReminderEvent
+// EntityReminderEventFromMessage creates a new repo reminder event from a message
+func EntityReminderEventFromMessage(msg *message.Message) (*EntityReminderEvent, error) {
+	var evt EntityReminderEvent
 	if err := json.Unmarshal(msg.Payload, &evt); err != nil {
 		return nil, fmt.Errorf("error unmarshalling payload: %w", err)
 	}

--- a/internal/reminder/reminder.go
+++ b/internal/reminder/reminder.go
@@ -266,8 +266,8 @@ func createReminderMessages(ctx context.Context, repos []db.Repository) ([]*mess
 
 	messages := make([]*message.Message, 0, len(repos))
 	for _, repo := range repos {
-		repoReconcileMessage, err := remindermessages.NewRepoReminderMessage(
-			repo.ProviderID, repo.RepoID, repo.ProjectID,
+		repoReconcileMessage, err := remindermessages.NewEntityReminderMessage(
+			repo.ProviderID, repo.ID, repo.ProjectID,
 		)
 		if err != nil {
 			return nil, fmt.Errorf("error creating reminder message: %w", err)

--- a/internal/reminderprocessor/reminder_processor.go
+++ b/internal/reminderprocessor/reminder_processor.go
@@ -43,14 +43,14 @@ func (rp *ReminderProcessor) Register(r events.Registrar) {
 }
 
 func (rp *ReminderProcessor) reminderMessageHandler(msg *message.Message) error {
-	evt, err := remindermessages.RepoReminderEventFromMessage(msg)
+	evt, err := remindermessages.EntityReminderEventFromMessage(msg)
 	if err != nil {
 		return fmt.Errorf("error unmarshalling reminder event: %w", err)
 	}
 
 	log.Info().Msgf("Received reminder event: %v", evt)
 
-	repoReconcileMsg, err := reconcilermessages.NewRepoReconcilerMessage(evt.ProviderID, evt.RepositoryID, evt.Project)
+	repoReconcileMsg, err := reconcilermessages.NewRepoReconcilerMessage(evt.ProviderID, evt.EntityID, evt.Project)
 	if err != nil {
 		return fmt.Errorf("error creating repo reconcile event: %w", err)
 	}

--- a/internal/repositories/service.go
+++ b/internal/repositories/service.go
@@ -214,7 +214,7 @@ func (r *repositoryService) CreateRepository(
 	}
 
 	// publish a reconciling event for the registered repositories
-	if err = r.pushReconcilerEvent(pbRepo, projectID, provider.ID); err != nil {
+	if err = r.pushReconcilerEvent(dbID, projectID, provider.ID); err != nil {
 		return nil, err
 	}
 
@@ -562,10 +562,10 @@ func (r *repositoryService) deleteRepository(
 	return nil
 }
 
-func (r *repositoryService) pushReconcilerEvent(pbRepo *pb.Repository, projectID uuid.UUID, providerID uuid.UUID) error {
-	log.Printf("publishing register event for repository: %s/%s", pbRepo.Owner, pbRepo.Name)
+func (r *repositoryService) pushReconcilerEvent(entityID uuid.UUID, projectID uuid.UUID, providerID uuid.UUID) error {
+	log.Printf("publishing register event for repository: %s", entityID.String())
 
-	msg, err := reconcilers.NewRepoReconcilerMessage(providerID, pbRepo.RepoId, projectID)
+	msg, err := reconcilers.NewRepoReconcilerMessage(providerID, entityID, projectID)
 	if err != nil {
 		return fmt.Errorf("error creating reconciler event: %v", err)
 	}

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -253,7 +253,7 @@ func AllInOneServerService(
 	evt.ConsumeEvents(handler)
 
 	// Register the reconciler to handle entity events
-	rec, err := reconcilers.NewReconciler(store, evt, cryptoEngine, providerManager, repos)
+	rec, err := reconcilers.NewReconciler(store, evt, cryptoEngine, providerManager, repos, propSvc)
 	if err != nil {
 		return fmt.Errorf("unable to create reconciler: %w", err)
 	}
@@ -266,6 +266,9 @@ func AllInOneServerService(
 	// Register the entity refresh manager to handle entity refresh events
 	refresh := handlers.NewRefreshEntityAndEvaluateHandler(evt, store, propSvc, providerManager)
 	evt.ConsumeEvents(refresh)
+
+	refreshById := handlers.NewRefreshByIDAndEvaluateHandler(evt, store, propSvc, providerManager)
+	evt.ConsumeEvents(refreshById)
 
 	// Register the email manager to handle email invitations
 	var mailClient events.Consumer


### PR DESCRIPTION
# Summary

- **Rename WithOwner to WithOriginator** - We renamed Owner to Originator in the new refresh-and-do handlers, but forgot to rename the method that sets that attribute.
- **Add a new Get-By-ID-Refresh-And-Do handler** - Since we have the entity ID available, we don't need to refresh by upstream ID, but by entity ID. To do that, we add a new handler that does just that.
- **Use NewEntityRefreshAndDoMessage instead of calling RefreshRepositoryByUpstreamID in reconcilers** - Gets rid of the RefreshRepositoryByUpstreamID request that we are tryign to phase out in favour of the generic new handlers. This will also allow the reconcile handler to be useful for the github reconciler.
- **Handle messages with no entityID** - since we changed the format of the reconcile message, we check if the field we added is set and if not, just drop the message.

Fixes #4595

## Change Type

- [ ] Bug fix (resolves an issue without affecting existing features)
- [ ] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [x] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

unit tests + manual

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [x] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [x] Included tests that validate the fix or feature.
- [ ] Checked that related changes are merged.
