### PR TITLE
Pass along transaction to RetrieveAllPropertiesForEntity

### DIFF
--- a/internal/entities/handlers/strategies/entity/refresh_by_upstream_props.go
+++ b/internal/entities/handlers/strategies/entity/refresh_by_upstream_props.go
@@ -59,7 +59,8 @@ func (r *refreshEntityByUpstreamIDStrategy) GetEntity(
 			return nil, fmt.Errorf("error getting entity: %w", err)
 		}
 
-		err = r.propSvc.RetrieveAllPropertiesForEntity(ctx, ewp, r.provMgr, propertyService.ReadBuilder())
+		err = r.propSvc.RetrieveAllPropertiesForEntity(ctx, ewp, r.provMgr,
+			propertyService.ReadBuilder().WithStoreOrTransaction(t))
 		if err != nil {
 			return nil, fmt.Errorf("error fetching entity: %w", err)
 		}


### PR DESCRIPTION

# Summary

When refreshing entity by upstream ID, we would have started a
transaction and passed the TX handle to the GetEntity call, but not to
the subsequent RetrieveAllPropertiesForEntity call.

## Change Type

- [x] Bug fix (resolves an issue without affecting existing features)
- [ ] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [ ] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

this is covered by unit test + smoke tests

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [ ] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [ ] Included tests that validate the fix or feature.
- [ ] Checked that related changes are merged.
