### PR TITLE
Use generic refresh and message forwarding to evaluator for profile init

### DIFF
--- a/database/mock/fixtures/store.go
+++ b/database/mock/fixtures/store.go
@@ -22,6 +22,7 @@ package fixtures
 import (
 	"database/sql"
 	"encoding/json"
+	"slices"
 
 	"github.com/google/uuid"
 	"go.uber.org/mock/gomock"
@@ -219,5 +220,42 @@ func WithSuccessfullGetEntityByID(
 		mockStore.EXPECT().
 			GetEntityByID(gomock.Any(), expID).
 			Return(entity, nil)
+	}
+}
+
+func WithSuccessfulGetEntitiesByProjectHierarchy(
+	entities []db.EntityInstance,
+	expectedProjectIDs []uuid.UUID,
+) func(*mockdb.MockStore) {
+	isSubset := func(actualAny any) bool {
+		actual, ok := actualAny.([]uuid.UUID)
+		if !ok {
+			return false
+		}
+
+		for _, e := range expectedProjectIDs {
+			if !slices.Contains(actual, e) {
+				return false
+			}
+		}
+		return true
+	}
+
+	return func(mockStore *mockdb.MockStore) {
+		mockStore.EXPECT().
+			GetEntitiesByProjectHierarchy(
+				gomock.Any(),
+				gomock.Cond(isSubset)).
+			Return(entities, nil)
+	}
+}
+
+func WithFailedGetEntitiesByProjectHierarchy(
+	err error,
+) func(*mockdb.MockStore) {
+	return func(mockStore *mockdb.MockStore) {
+		mockStore.EXPECT().
+			GetEntitiesByProjectHierarchy(gomock.Any(), gomock.Any()).
+			Return(nil, err)
 	}
 }

--- a/database/mock/store.go
+++ b/database/mock/store.go
@@ -924,6 +924,21 @@ func (mr *MockStoreMockRecorder) GetChildrenProjects(arg0, arg1 any) *gomock.Cal
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetChildrenProjects", reflect.TypeOf((*MockStore)(nil).GetChildrenProjects), arg0, arg1)
 }
 
+// GetEntitiesByProjectHierarchy mocks base method.
+func (m *MockStore) GetEntitiesByProjectHierarchy(arg0 context.Context, arg1 []uuid.UUID) ([]db.EntityInstance, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetEntitiesByProjectHierarchy", arg0, arg1)
+	ret0, _ := ret[0].([]db.EntityInstance)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetEntitiesByProjectHierarchy indicates an expected call of GetEntitiesByProjectHierarchy.
+func (mr *MockStoreMockRecorder) GetEntitiesByProjectHierarchy(arg0, arg1 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetEntitiesByProjectHierarchy", reflect.TypeOf((*MockStore)(nil).GetEntitiesByProjectHierarchy), arg0, arg1)
+}
+
 // GetEntitiesByProvider mocks base method.
 func (m *MockStore) GetEntitiesByProvider(arg0 context.Context, arg1 uuid.UUID) ([]db.EntityInstance, error) {
 	m.ctrl.T.Helper()

--- a/database/query/entities.sql
+++ b/database/query/entities.sql
@@ -85,6 +85,12 @@ WHERE entity_instances.entity_type = $1
 SELECT * FROM entity_instances
 WHERE entity_instances.provider_id = $1;
 
+-- GetEntitiesByProjectHierarchy retrieves all entities for a project or hierarchy of projects.
+
+-- name: GetEntitiesByProjectHierarchy :many
+SELECT * FROM entity_instances
+WHERE entity_instances.project_id = ANY(sqlc.arg(projects)::uuid[]);
+
 -- name: GetProperty :one
 SELECT * FROM properties
 WHERE entity_id = $1 AND key = $2;

--- a/internal/db/querier.go
+++ b/internal/db/querier.go
@@ -86,6 +86,8 @@ type Querier interface {
 	GetArtifactByName(ctx context.Context, arg GetArtifactByNameParams) (Artifact, error)
 	GetBundle(ctx context.Context, arg GetBundleParams) (Bundle, error)
 	GetChildrenProjects(ctx context.Context, id uuid.UUID) ([]GetChildrenProjectsRow, error)
+	// GetEntitiesByProjectHierarchy retrieves all entities for a project or hierarchy of projects.
+	GetEntitiesByProjectHierarchy(ctx context.Context, projects []uuid.UUID) ([]EntityInstance, error)
 	// GetEntitiesByProvider retrieves all entities of a given provider.
 	// this is how one would get all repositories, artifacts, etc. for a given provider.
 	GetEntitiesByProvider(ctx context.Context, providerID uuid.UUID) ([]EntityInstance, error)

--- a/internal/reconcilers/run_profile.go
+++ b/internal/reconcilers/run_profile.go
@@ -16,7 +16,6 @@ package reconcilers
 
 import (
 	"context"
-	"database/sql"
 	"encoding/json"
 	"fmt"
 
@@ -24,12 +23,9 @@ import (
 	"github.com/go-playground/validator/v10"
 	"github.com/google/uuid"
 	"github.com/rs/zerolog"
-	"github.com/rs/zerolog/log"
 
-	"github.com/stacklok/minder/internal/artifacts"
-	"github.com/stacklok/minder/internal/db"
-	"github.com/stacklok/minder/internal/engine/entities"
-	"github.com/stacklok/minder/internal/repositories"
+	entityMessage "github.com/stacklok/minder/internal/entities/handlers/message"
+	"github.com/stacklok/minder/internal/events"
 )
 
 // ProfileInitEvent is an event that is sent to the reconciler topic
@@ -64,7 +60,8 @@ func (r *Reconciler) handleProfileInitEvent(msg *message.Message) error {
 
 	var evt ProfileInitEvent
 	if err := json.Unmarshal(msg.Payload, &evt); err != nil {
-		return fmt.Errorf("error unmarshalling payload: %w", err)
+		zerolog.Ctx(ctx).Error().Err(err).Msg("error unmarshalling event")
+		return nil
 	}
 
 	// validate event
@@ -73,7 +70,6 @@ func (r *Reconciler) handleProfileInitEvent(msg *message.Message) error {
 		// We don't return the event since there's no use
 		// retrying it if it's invalid.
 		zerolog.Ctx(ctx).Error().Err(err).Msg("error validating event")
-		log.Printf("error validating event: %v", err)
 		return nil
 	}
 
@@ -92,88 +88,30 @@ func (r *Reconciler) publishProfileInitEvents(
 	ctx context.Context,
 	projectID uuid.UUID,
 ) error {
-	dbrepos, err := r.store.ListRegisteredRepositoriesByProjectIDAndProvider(ctx,
-		db.ListRegisteredRepositoriesByProjectIDAndProviderParams{
-			Provider:  sql.NullString{Valid: false},
-			ProjectID: projectID,
-		})
+	ents, err := r.store.GetEntitiesByProjectHierarchy(ctx, []uuid.UUID{projectID})
 	if err != nil {
-		return fmt.Errorf("publishProfileInitEvents: error getting registered repos: %v", err)
+		// we retry in case the database is having a bad day
+		return fmt.Errorf("cannot get entities: %w", err)
 	}
 
-	for _, dbrepo := range dbrepos {
-		_, err := r.repos.RefreshRepositoryByUpstreamID(ctx, dbrepo.RepoID)
-		if err != nil {
-			zerolog.Ctx(ctx).Debug().Err(err).Str("repository", dbrepo.ID.String()).Msg("error refreshing repository")
-			continue
+	for _, ent := range ents {
+		entRefresh := entityMessage.NewEntityRefreshAndDoMessage().
+			WithEntityID(ent.ID)
+
+		m := message.NewMessage(uuid.New().String(), nil)
+		m.SetContext(ctx)
+
+		if err := entRefresh.ToMessage(m); err != nil {
+			zerolog.Ctx(ctx).Error().Err(err).Msg("error marshalling message")
+			// no point in retrying, so we return nil
+			return nil
 		}
 
-		// protobufs are our API, so we always execute on these instead of the DB directly.
-		repo := repositories.PBRepositoryFromDB(dbrepo)
-		err = entities.NewEntityInfoWrapper().
-			WithProviderID(dbrepo.ProviderID).
-			WithProjectID(projectID).
-			WithRepository(repo).
-			WithRepositoryID(dbrepo.ID).
-			Publish(r.evt)
-
-		// This is a non-fatal error, so we'll just log it
-		// and continue
-		if err != nil {
-			return fmt.Errorf("error publishing init event for repo %s: %v", dbrepo.ID, err)
+		if err := r.evt.Publish(events.TopicQueueRefreshEntityByIDAndEvaluate, m); err != nil {
+			// we retry in case watermill is having a bad day
+			return fmt.Errorf("error publishing message: %w", err)
 		}
 	}
 
-	// after we've initialized repository profiles, let's initialize artifacts
-	// TODO(jakub): this should be done in an iterator of sorts
-	for i := range dbrepos {
-		pdb := &dbrepos[i]
-		err := r.publishArtifactProfileInitEvents(ctx, projectID, pdb)
-		if err != nil {
-			return fmt.Errorf("publishProfileInitEvents: error publishing artifact events: %v", err)
-		}
-	}
-
-	return nil
-}
-
-func (r *Reconciler) publishArtifactProfileInitEvents(
-	ctx context.Context,
-	projectID uuid.UUID,
-	dbrepo *db.Repository,
-) error {
-	dbArtifacts, err := r.store.ListArtifactsByRepoID(ctx, uuid.NullUUID{
-		UUID:  dbrepo.ID,
-		Valid: true,
-	})
-	if err != nil {
-		return fmt.Errorf("error getting artifacts: %w", err)
-	}
-	if len(dbArtifacts) == 0 {
-		zerolog.Ctx(ctx).Debug().Str("repository", dbrepo.ID.String()).Msgf("no artifacts found, skipping")
-		return nil
-	}
-	for _, dbA := range dbArtifacts {
-		// Get the artifact with all its versions as a protobuf
-		_, pbArtifact, err := artifacts.GetArtifact(ctx, r.store, dbrepo.ProjectID, dbA.ID)
-		if err != nil {
-			return fmt.Errorf("error getting artifact versions: %w", err)
-		}
-
-		err = entities.NewEntityInfoWrapper().
-			WithProviderID(dbrepo.ProviderID).
-			WithProjectID(projectID).
-			WithArtifact(pbArtifact).
-			WithRepositoryID(dbrepo.ID).
-			WithArtifactID(dbA.ID).
-			Publish(r.evt)
-
-		// This is a non-fatal error, so we'll just log it
-		// and continue
-		if err != nil {
-			log.Printf("error publishing init event for repo %s: %v", dbrepo.ID, err)
-			continue
-		}
-	}
 	return nil
 }

--- a/internal/reconcilers/run_profile_test.go
+++ b/internal/reconcilers/run_profile_test.go
@@ -1,0 +1,112 @@
+// Copyright 2024 Stacklok, Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package reconcilers
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+
+	df "github.com/stacklok/minder/database/mock/fixtures"
+	"github.com/stacklok/minder/internal/db"
+	"github.com/stacklok/minder/internal/events"
+	stubeventer "github.com/stacklok/minder/internal/events/stubs"
+)
+
+var (
+	testReconcileProjectID = uuid.New()
+)
+
+func Test_handleProfileInitEvent(t *testing.T) {
+	t.Parallel()
+
+	scenarios := []struct {
+		name         string
+		setupDbMocks func() df.MockStoreBuilder
+		numPublish   int
+		expectedErr  bool
+	}{
+		{
+			name: "valid event",
+			setupDbMocks: func() df.MockStoreBuilder {
+				retEnts := []db.EntityInstance{
+					{
+						EntityType: db.EntitiesArtifact,
+						ID:         uuid.New(),
+					},
+					{
+						EntityType: db.EntitiesPullRequest,
+						ID:         uuid.New(),
+					},
+					{
+						EntityType: db.EntitiesRepository,
+						ID:         uuid.New(),
+					},
+				}
+				return df.NewMockStore(
+					df.WithSuccessfulGetEntitiesByProjectHierarchy(retEnts, []uuid.UUID{testReconcileProjectID}),
+				)
+			},
+			expectedErr: false,
+			numPublish:  3,
+		},
+		{
+			name: "error getting entities",
+			setupDbMocks: func() df.MockStoreBuilder {
+				return df.NewMockStore(
+					df.WithFailedGetEntitiesByProjectHierarchy(sql.ErrNoRows),
+				)
+			},
+			expectedErr: true,
+			numPublish:  0,
+		},
+	}
+
+	for _, scenario := range scenarios {
+		t.Run(scenario.name, func(t *testing.T) {
+			t.Parallel()
+
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			msg, err := NewProfileInitMessage(projectID)
+			require.NoError(t, err)
+			require.NotNil(t, msg)
+
+			stubEventer := &stubeventer.StubEventer{}
+			mockStore := scenario.setupDbMocks()(ctrl)
+
+			reconciler, err := NewReconciler(mockStore, stubEventer, nil, nil, nil, nil)
+			require.NoError(t, err)
+			require.NotNil(t, reconciler)
+
+			err = reconciler.publishProfileInitEvents(context.Background(), testReconcileProjectID)
+			if scenario.expectedErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+
+			require.Equal(t, scenario.numPublish, len(stubEventer.Sent))
+			if scenario.numPublish > 0 {
+				require.Contains(t, stubEventer.Topics, events.TopicQueueRefreshEntityByIDAndEvaluate)
+			}
+		})
+	}
+}


### PR DESCRIPTION

# Summary

- **Use generic message forwarding to initialize the profile instead of entity-specific database searches** - Because we were bound to entity-specific protobuf types and didn't have a good way of iterating over all entities, we used to enumerate all repos and then all artifacts just to marshall them and send off to the evaluator. With generic entities we can simply enumerate all entities and send them off for refresh and forwarding to the evaluator.

Fixes: #4621

## Change Type

- [ ] Bug fix (resolves an issue without affecting existing features)
- [ ] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [x] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

unit test + manually

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [ ] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [x] Included tests that validate the fix or feature.
- [ ] Checked that related changes are merged.
