### PR TITLE
properties service: Don't fail if multiple entries are found

### DIFF
--- a/internal/entities/properties/service/helpers.go
+++ b/internal/entities/properties/service/helpers.go
@@ -232,7 +232,7 @@ func matchEntityWithHint(
 				continue
 			} else if errors.Is(err, ErrMultipleEntities) {
 				l.Error().Msg("multiple entities matched")
-				return nil, ErrMultipleEntities
+				continue
 			}
 			return nil, fmt.Errorf("failed to match entity by hint: %w", err)
 		}


### PR DESCRIPTION
# Summary

the `matchEntityWithHint` attempts to look for an entity using
identifying properties. For PRs, the upstream ID is not sufficient since
it's an integer that will clash with other PRs. In this case, we should
instead continue the search and search by name which is more unique.

## Change Type

***Mark the type of change your PR introduces:***

- [x] Bug fix (resolves an issue without affecting existing features)
- [ ] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [ ] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

***Outline how the changes were tested, including steps to reproduce and any relevant configurations. 
Attach screenshots if helpful.***

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [ ] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [ ] Included tests that validate the fix or feature.
- [ ] Checked that related changes are merged.
