### PR TITLE
Pass correct logger to watermill.

### DIFF
--- a/internal/events/eventer.go
+++ b/internal/events/eventer.go
@@ -153,7 +153,7 @@ func instantiateDriver(
 	switch driver {
 	case GoChannelDriver:
 		zerolog.Ctx(ctx).Info().Msg("Using go-channel driver")
-		return gochannel.BuildGoChannelDriver(cfg)
+		return gochannel.BuildGoChannelDriver(ctx, cfg)
 	case SQLDriver:
 		zerolog.Ctx(ctx).Info().Msg("Using SQL driver")
 		return eventersql.BuildPostgreSQLDriver(ctx, cfg)

--- a/internal/events/gochannel/gochannel.go
+++ b/internal/events/gochannel/gochannel.go
@@ -17,19 +17,28 @@
 package gochannel
 
 import (
+	"context"
+
 	"github.com/ThreeDotsLabs/watermill/message"
 	"github.com/ThreeDotsLabs/watermill/pubsub/gochannel"
+	"github.com/alexdrl/zerowater"
+	"github.com/rs/zerolog"
 
 	serverconfig "github.com/stacklok/minder/internal/config/server"
 	"github.com/stacklok/minder/internal/events/common"
 )
 
 // BuildGoChannelDriver creates a gochannel driver for the eventer
-func BuildGoChannelDriver(cfg *serverconfig.EventConfig) (message.Publisher, message.Subscriber, common.DriverCloser, error) {
+func BuildGoChannelDriver(
+	ctx context.Context,
+	cfg *serverconfig.EventConfig,
+) (message.Publisher, message.Subscriber, common.DriverCloser, error) {
+	logger := zerowater.NewZerologLoggerAdapter(zerolog.Ctx(ctx).With().Logger())
+
 	pubsub := gochannel.NewGoChannel(gochannel.Config{
 		OutputChannelBuffer: cfg.GoChannel.BufferSize,
 		Persistent:          cfg.GoChannel.PersistEvents,
-	}, nil)
+	}, logger)
 
 	return pubsub, pubsub, func() {}, nil
 }

--- a/internal/events/sql/postgres.go
+++ b/internal/events/sql/postgres.go
@@ -20,9 +20,10 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/ThreeDotsLabs/watermill"
 	watermillsql "github.com/ThreeDotsLabs/watermill-sql/v3/pkg/sql"
 	"github.com/ThreeDotsLabs/watermill/message"
+	"github.com/alexdrl/zerowater"
+	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
 
 	serverconfig "github.com/stacklok/minder/internal/config/server"
@@ -38,13 +39,15 @@ func BuildPostgreSQLDriver(
 		return nil, nil, nil, fmt.Errorf("unable to connect to events database: %w", err)
 	}
 
+	logger := zerowater.NewZerologLoggerAdapter(zerolog.Ctx(ctx).With().Logger())
+
 	publisher, err := watermillsql.NewPublisher(
 		db,
 		watermillsql.PublisherConfig{
 			SchemaAdapter:        watermillsql.DefaultPostgreSQLSchema{},
 			AutoInitializeSchema: true,
 		},
-		watermill.NewStdLogger(false, false),
+		logger,
 	)
 	if err != nil {
 		return nil, nil, nil, fmt.Errorf("failed to create SQL publisher: %w", err)
@@ -58,7 +61,7 @@ func BuildPostgreSQLDriver(
 			InitializeSchema: true,
 			AckDeadline:      &cfg.SQLPubSub.AckDeadline,
 		},
-		watermill.NewStdLogger(false, false),
+		logger,
 	)
 	if err != nil {
 		return nil, nil, nil, fmt.Errorf("failed to create SQL subscriber: %w", err)


### PR DESCRIPTION
# Summary

In a couple cases, watermill was provided with its default logger which outputs unstructured strings.

This change configures `sql` and `go-channel` watermill drivers with a wrapped zerolog instance.

## Change Type

- [ ] Bug fix (resolves an issue without affecting existing features)
- [ ] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [X] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

Manual tests.

# Review Checklist:

- [X] Reviewed my own code for quality and clarity.
- [ ] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [ ] Included tests that validate the fix or feature.
- [X] Checked that related changes are merged.
