### PR TITLE
Simplify the entity_add handlers in preparation for using the NewGetEntityAndDeleteHandler"

### DIFF
--- a/internal/controlplane/handlers_entities.go
+++ b/internal/controlplane/handlers_entities.go
@@ -124,7 +124,7 @@ func createEntityMessage(
 	event := messages.NewMinderEvent().
 		WithProjectID(projectID).
 		WithProviderID(providerID).
-		WithEntityType("repository").
+		WithEntityType(pb.Entity_ENTITY_REPOSITORIES).
 		WithAttribute("repoName", repoName).
 		WithAttribute("repoOwner", repoOwner)
 

--- a/internal/controlplane/handlers_githubwebhooks.go
+++ b/internal/controlplane/handlers_githubwebhooks.go
@@ -885,8 +885,7 @@ func (s *Server) processRelevantRepositoryEvent(
 			WithProjectID(repoEntity.Entity.ProjectID).
 			WithProviderID(repoEntity.Entity.ProviderID).
 			WithEntityType("repository").
-			WithEntityID(repoEntity.Entity.ID).
-			WithAttribute("repoID", repoEntity.Entity.ID.String())
+			WithEntityID(repoEntity.Entity.ID)
 
 		return &processingResult{
 			topic:   events.TopicQueueReconcileEntityDelete,
@@ -1196,8 +1195,7 @@ func (s *Server) repositoryRemoved(
 		WithProjectID(repoEnt.Entity.ProjectID).
 		WithProviderID(repoEnt.Entity.ProviderID).
 		WithEntityType("repository").
-		WithEntityID(repoEnt.Entity.ID).
-		WithAttribute("repoID", repoEnt.Entity.ID.String())
+		WithEntityID(repoEnt.Entity.ID)
 
 	return &processingResult{
 		topic:   events.TopicQueueReconcileEntityDelete,

--- a/internal/controlplane/handlers_githubwebhooks.go
+++ b/internal/controlplane/handlers_githubwebhooks.go
@@ -884,7 +884,7 @@ func (s *Server) processRelevantRepositoryEvent(
 		repoEvent := messages.NewMinderEvent().
 			WithProjectID(repoEntity.Entity.ProjectID).
 			WithProviderID(repoEntity.Entity.ProviderID).
-			WithEntityType("repository").
+			WithEntityType(pb.Entity_ENTITY_REPOSITORIES).
 			WithEntityID(repoEntity.Entity.ID)
 
 		return &processingResult{
@@ -1194,7 +1194,7 @@ func (s *Server) repositoryRemoved(
 	event := messages.NewMinderEvent().
 		WithProjectID(repoEnt.Entity.ProjectID).
 		WithProviderID(repoEnt.Entity.ProviderID).
-		WithEntityType("repository").
+		WithEntityType(pb.Entity_ENTITY_REPOSITORIES).
 		WithEntityID(repoEnt.Entity.ID)
 
 	return &processingResult{
@@ -1215,7 +1215,7 @@ func (_ *Server) repositoryAdded(
 	event := messages.NewMinderEvent().
 		WithProjectID(installation.ProjectID.UUID).
 		WithProviderID(installation.ProviderID.UUID).
-		WithEntityType("repository").
+		WithEntityType(pb.Entity_ENTITY_REPOSITORIES).
 		WithAttribute("repoName", repo.GetName()).
 		WithAttribute("repoOwner", repo.GetOwner())
 

--- a/internal/controlplane/handlers_githubwebhooks.go
+++ b/internal/controlplane/handlers_githubwebhooks.go
@@ -1212,12 +1212,19 @@ func (_ *Server) repositoryAdded(
 		return nil, errors.New("invalid repository name")
 	}
 
+	addRepoProps, err := properties.NewProperties(map[string]any{
+		properties.PropertyUpstreamID: properties.NumericalValueToUpstreamID(repo.GetID()),
+		properties.PropertyName:       repo.GetFullName(),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("error creating repository properties: %w", err)
+	}
+
 	event := messages.NewMinderEvent().
 		WithProjectID(installation.ProjectID.UUID).
 		WithProviderID(installation.ProviderID.UUID).
 		WithEntityType(pb.Entity_ENTITY_REPOSITORIES).
-		WithAttribute("repoName", repo.GetName()).
-		WithAttribute("repoOwner", repo.GetOwner())
+		WithProperties(addRepoProps)
 
 	return &processingResult{
 		topic:   events.TopicQueueReconcileEntityAdd,

--- a/internal/controlplane/handlers_githubwebhooks_test.go
+++ b/internal/controlplane/handlers_githubwebhooks_test.go
@@ -410,7 +410,6 @@ func (s *UnitTestSuite) TestHandleWebHookRepository() {
 	require.NoError(t, validator.New().Struct(&inner))
 	require.Equal(t, providerID, inner.ProviderID)
 	require.Equal(t, projectID, inner.ProjectID)
-	require.Equal(t, repositoryID.String(), inner.Entity["repoID"])
 	require.Equal(t, nil, inner.Entity["repoName"])  // optional
 	require.Equal(t, nil, inner.Entity["repoOwner"]) // optional
 
@@ -1228,7 +1227,6 @@ func (s *UnitTestSuite) TestHandleGitHubWebHook() {
 				require.NoError(t, validator.New().Struct(&evt))
 				require.Equal(t, providerID, evt.ProviderID)
 				require.Equal(t, projectID, evt.ProjectID)
-				require.Equal(t, repositoryID.String(), evt.Entity["repoID"])
 				require.Equal(t, nil, evt.Entity["repoName"])  // optional
 				require.Equal(t, nil, evt.Entity["repoOwner"]) // optional
 			},
@@ -1280,7 +1278,6 @@ func (s *UnitTestSuite) TestHandleGitHubWebHook() {
 				require.NoError(t, validator.New().Struct(&evt))
 				require.Equal(t, providerID, evt.ProviderID)
 				require.Equal(t, projectID, evt.ProjectID)
-				require.Equal(t, repositoryID.String(), evt.Entity["repoID"])
 				require.Equal(t, nil, evt.Entity["repoName"])  // optional
 				require.Equal(t, nil, evt.Entity["repoOwner"]) // optional
 			},
@@ -1654,7 +1651,6 @@ func (s *UnitTestSuite) TestHandleGitHubWebHook() {
 				require.NoError(t, validator.New().Struct(&evt))
 				require.Equal(t, providerID, evt.ProviderID)
 				require.Equal(t, projectID, evt.ProjectID)
-				require.Equal(t, repositoryID.String(), evt.Entity["repoID"])
 				require.Equal(t, nil, evt.Entity["repoName"])  // optional
 				require.Equal(t, nil, evt.Entity["repoOwner"]) // optional
 			},
@@ -1705,7 +1701,6 @@ func (s *UnitTestSuite) TestHandleGitHubWebHook() {
 				require.NoError(t, validator.New().Struct(&evt))
 				require.Equal(t, providerID, evt.ProviderID)
 				require.Equal(t, projectID, evt.ProjectID)
-				require.Equal(t, repositoryID.String(), evt.Entity["repoID"])
 				require.Equal(t, nil, evt.Entity["repoName"])  // optional
 				require.Equal(t, nil, evt.Entity["repoOwner"]) // optional
 			},
@@ -1960,7 +1955,6 @@ func (s *UnitTestSuite) TestHandleGitHubWebHook() {
 				require.NoError(t, validator.New().Struct(&evt))
 				require.Equal(t, providerID, evt.ProviderID)
 				require.Equal(t, projectID, evt.ProjectID)
-				require.Equal(t, repositoryID.String(), evt.Entity["repoID"])
 				require.Equal(t, nil, evt.Entity["repoName"])  // optional
 				require.Equal(t, nil, evt.Entity["repoOwner"]) // optional
 			},
@@ -3642,7 +3636,6 @@ func (s *UnitTestSuite) TestHandleGitHubAppWebHook() {
 				require.NoError(t, err)
 				require.Equal(t, providerID, evt.ProviderID)
 				require.Equal(t, projectID, evt.ProjectID)
-				require.Equal(t, repositoryID.String(), evt.Entity["repoID"])
 
 				received = withTimeout(ch, timeout)
 				require.NotNilf(t, received, "no event received after waiting %s", timeout)
@@ -3654,7 +3647,6 @@ func (s *UnitTestSuite) TestHandleGitHubAppWebHook() {
 				require.NoError(t, err)
 				require.Equal(t, providerID, evt.ProviderID)
 				require.Equal(t, projectID, evt.ProjectID)
-				require.Equal(t, repositoryID.String(), evt.Entity["repoID"])
 			},
 		},
 

--- a/internal/controlplane/handlers_githubwebhooks_test.go
+++ b/internal/controlplane/handlers_githubwebhooks_test.go
@@ -410,8 +410,6 @@ func (s *UnitTestSuite) TestHandleWebHookRepository() {
 	require.NoError(t, validator.New().Struct(&inner))
 	require.Equal(t, providerID, inner.ProviderID)
 	require.Equal(t, projectID, inner.ProjectID)
-	require.Equal(t, nil, inner.Entity["repoName"])  // optional
-	require.Equal(t, nil, inner.Entity["repoOwner"]) // optional
 
 	// test that if no secret matches we get back a 400
 	req, err = http.NewRequest("POST", ts.URL, bytes.NewBuffer(packageJson))
@@ -1227,8 +1225,6 @@ func (s *UnitTestSuite) TestHandleGitHubWebHook() {
 				require.NoError(t, validator.New().Struct(&evt))
 				require.Equal(t, providerID, evt.ProviderID)
 				require.Equal(t, projectID, evt.ProjectID)
-				require.Equal(t, nil, evt.Entity["repoName"])  // optional
-				require.Equal(t, nil, evt.Entity["repoOwner"]) // optional
 			},
 		},
 		{
@@ -1278,8 +1274,6 @@ func (s *UnitTestSuite) TestHandleGitHubWebHook() {
 				require.NoError(t, validator.New().Struct(&evt))
 				require.Equal(t, providerID, evt.ProviderID)
 				require.Equal(t, projectID, evt.ProjectID)
-				require.Equal(t, nil, evt.Entity["repoName"])  // optional
-				require.Equal(t, nil, evt.Entity["repoOwner"]) // optional
 			},
 		},
 		{
@@ -1651,8 +1645,6 @@ func (s *UnitTestSuite) TestHandleGitHubWebHook() {
 				require.NoError(t, validator.New().Struct(&evt))
 				require.Equal(t, providerID, evt.ProviderID)
 				require.Equal(t, projectID, evt.ProjectID)
-				require.Equal(t, nil, evt.Entity["repoName"])  // optional
-				require.Equal(t, nil, evt.Entity["repoOwner"]) // optional
 			},
 		},
 		{
@@ -1701,8 +1693,6 @@ func (s *UnitTestSuite) TestHandleGitHubWebHook() {
 				require.NoError(t, validator.New().Struct(&evt))
 				require.Equal(t, providerID, evt.ProviderID)
 				require.Equal(t, projectID, evt.ProjectID)
-				require.Equal(t, nil, evt.Entity["repoName"])  // optional
-				require.Equal(t, nil, evt.Entity["repoOwner"]) // optional
 			},
 		},
 		{
@@ -1955,8 +1945,6 @@ func (s *UnitTestSuite) TestHandleGitHubWebHook() {
 				require.NoError(t, validator.New().Struct(&evt))
 				require.Equal(t, providerID, evt.ProviderID)
 				require.Equal(t, projectID, evt.ProjectID)
-				require.Equal(t, nil, evt.Entity["repoName"])  // optional
-				require.Equal(t, nil, evt.Entity["repoOwner"]) // optional
 			},
 		},
 		{
@@ -3484,6 +3472,8 @@ func (s *UnitTestSuite) TestHandleGitHubAppWebHook() {
 				require.NoError(t, err)
 				require.Equal(t, providerID, evt.ProviderID)
 				require.Equal(t, projectID, evt.ProjectID)
+				require.Equal(t, v1.Entity_ENTITY_REPOSITORIES, evt.EntityType)
+				require.Equal(t, "stacklok/minder", evt.Properties[properties.PropertyName])
 
 				received = withTimeout(ch, timeout)
 				require.NotNilf(t, received, "no event received after waiting %s", timeout)
@@ -3636,6 +3626,8 @@ func (s *UnitTestSuite) TestHandleGitHubAppWebHook() {
 				require.NoError(t, err)
 				require.Equal(t, providerID, evt.ProviderID)
 				require.Equal(t, projectID, evt.ProjectID)
+				require.Equal(t, v1.Entity_ENTITY_REPOSITORIES, evt.EntityType)
+				require.Equal(t, repositoryID, evt.EntityID)
 
 				received = withTimeout(ch, timeout)
 				require.NotNilf(t, received, "no event received after waiting %s", timeout)

--- a/internal/entities/handlers/strategies/message/minder_entity.go
+++ b/internal/entities/handlers/strategies/message/minder_entity.go
@@ -41,7 +41,7 @@ func (_ *toMinderEntityStrategy) CreateMessage(_ context.Context, ewp *models.En
 	entEvent := messages.NewMinderEvent().
 		WithProjectID(ewp.Entity.ProjectID).
 		WithProviderID(ewp.Entity.ProviderID).
-		WithEntityType(ewp.Entity.Type.String()).
+		WithEntityType(ewp.Entity.Type).
 		WithEntityID(ewp.Entity.ID)
 
 	err := entEvent.ToMessage(m)

--- a/internal/reconcilers/entity_add.go
+++ b/internal/reconcilers/entity_add.go
@@ -27,6 +27,7 @@ import (
 	"github.com/stacklok/minder/internal/entities/properties"
 	"github.com/stacklok/minder/internal/logger"
 	"github.com/stacklok/minder/internal/reconcilers/messages"
+	pb "github.com/stacklok/minder/pkg/api/protobuf/go/minder/v1"
 )
 
 // handleEntityAddEvent handles the entity add event.
@@ -49,6 +50,11 @@ func (r *Reconciler) handleEntityAddEvent(msg *message.Message) error {
 		// We don't return the event since there's no use
 		// retrying it if it's invalid.
 		l.Error().Err(err).Msg("error validating event")
+		return nil
+	}
+
+	if event.EntityType != pb.Entity_ENTITY_REPOSITORIES {
+		l.Error().Str("entity_type", event.EntityType.String()).Msg("entity type not supported")
 		return nil
 	}
 

--- a/internal/reconcilers/entity_add_test.go
+++ b/internal/reconcilers/entity_add_test.go
@@ -25,15 +25,22 @@ import (
 
 	df "github.com/stacklok/minder/database/mock/fixtures"
 	db "github.com/stacklok/minder/internal/db"
+	"github.com/stacklok/minder/internal/entities/properties"
 	"github.com/stacklok/minder/internal/reconcilers/messages"
 	rf "github.com/stacklok/minder/internal/repositories/mock/fixtures"
 	pb "github.com/stacklok/minder/pkg/api/protobuf/go/minder/v1"
 )
 
 var (
-	repoOwner = "stacklok"
-	repoName  = "minder"
+	repoFullName = "stacklok/minder"
 )
+
+func repoProperties() *properties.Properties {
+	props, _ := properties.NewProperties(map[string]any{
+		properties.PropertyName: repoFullName,
+	})
+	return props
+}
 
 func TestHandleEntityAdd(t *testing.T) {
 	t.Parallel()
@@ -64,8 +71,7 @@ func TestHandleEntityAdd(t *testing.T) {
 					WithProviderID(providerID).
 					WithProjectID(projectID).
 					WithEntityType(pb.Entity_ENTITY_REPOSITORIES).
-					WithAttribute("repoName", repoName).
-					WithAttribute("repoOwner", repoOwner).
+					WithProperties(repoProperties()).
 					ToMessage(m)
 				require.NoError(t, err, "invalid message")
 				return m
@@ -86,8 +92,7 @@ func TestHandleEntityAdd(t *testing.T) {
 					WithProviderID(providerID).
 					WithProjectID(projectID).
 					WithEntityType(pb.Entity_ENTITY_REPOSITORIES).
-					WithAttribute("repoName", repoName).
-					WithAttribute("repoOwner", repoOwner).
+					WithProperties(repoProperties()).
 					ToMessage(m)
 				require.NoError(t, err, "invalid message")
 				return m
@@ -119,8 +124,7 @@ func TestHandleEntityAdd(t *testing.T) {
 					WithProviderID(providerID).
 					WithProjectID(projectID).
 					WithEntityType(pb.Entity_ENTITY_REPOSITORIES).
-					WithAttribute("repoName", repoName).
-					WithAttribute("repoOwner", repoOwner).
+					WithProperties(repoProperties()).
 					ToMessage(m)
 				require.NoError(t, err, "invalid message")
 				return m

--- a/internal/reconcilers/entity_add_test.go
+++ b/internal/reconcilers/entity_add_test.go
@@ -63,7 +63,7 @@ func TestHandleEntityAdd(t *testing.T) {
 				err := messages.NewMinderEvent().
 					WithProviderID(providerID).
 					WithProjectID(projectID).
-					WithEntityType("repository").
+					WithEntityType(pb.Entity_ENTITY_REPOSITORIES).
 					WithAttribute("repoName", repoName).
 					WithAttribute("repoOwner", repoOwner).
 					ToMessage(m)
@@ -85,7 +85,7 @@ func TestHandleEntityAdd(t *testing.T) {
 				err := messages.NewMinderEvent().
 					WithProviderID(providerID).
 					WithProjectID(projectID).
-					WithEntityType("repository").
+					WithEntityType(pb.Entity_ENTITY_REPOSITORIES).
 					WithAttribute("repoName", repoName).
 					WithAttribute("repoOwner", repoOwner).
 					ToMessage(m)
@@ -118,7 +118,7 @@ func TestHandleEntityAdd(t *testing.T) {
 				err := messages.NewMinderEvent().
 					WithProviderID(providerID).
 					WithProjectID(projectID).
-					WithEntityType("repository").
+					WithEntityType(pb.Entity_ENTITY_REPOSITORIES).
 					WithAttribute("repoName", repoName).
 					WithAttribute("repoOwner", repoOwner).
 					ToMessage(m)

--- a/internal/reconcilers/entity_delete.go
+++ b/internal/reconcilers/entity_delete.go
@@ -26,6 +26,7 @@ import (
 
 	minderlogger "github.com/stacklok/minder/internal/logger"
 	"github.com/stacklok/minder/internal/reconcilers/messages"
+	pb "github.com/stacklok/minder/pkg/api/protobuf/go/minder/v1"
 )
 
 //nolint:exhaustive
@@ -44,6 +45,11 @@ func (r *Reconciler) handleEntityDeleteEvent(msg *message.Message) error {
 		// We don't return the event since there's no use
 		// retrying it if it's invalid.
 		l.Error().Err(err).Msg("error validating event")
+		return nil
+	}
+
+	if event.EntityType != pb.Entity_ENTITY_REPOSITORIES {
+		l.Error().Str("entity_type", event.EntityType.String()).Msg("entity type not supported")
 		return nil
 	}
 

--- a/internal/reconcilers/entity_delete_test.go
+++ b/internal/reconcilers/entity_delete_test.go
@@ -69,8 +69,8 @@ func TestHandleEntityDelete(t *testing.T) {
 					WithProviderID(providerID).
 					WithProjectID(projectID).
 					WithEntityType(pb.Entity_ENTITY_REPOSITORIES).
-					WithEntityID(repositoryID).
-					WithAttribute("repoID", repositoryID.String())
+					WithEntityID(repositoryID)
+
 				err := eiw.ToMessage(m)
 				require.NoError(t, err, "invalid message")
 				return m
@@ -91,8 +91,8 @@ func TestHandleEntityDelete(t *testing.T) {
 					WithProviderID(providerID).
 					WithProjectID(projectID).
 					WithEntityType(pb.Entity_ENTITY_REPOSITORIES).
-					WithEntityID(repositoryID).
-					WithAttribute("repoID", repositoryID.String())
+					WithEntityID(repositoryID)
+
 				err := eiw.ToMessage(m)
 				require.NoError(t, err, "invalid message")
 				return m
@@ -114,8 +114,8 @@ func TestHandleEntityDelete(t *testing.T) {
 					WithProviderID(providerID).
 					WithProjectID(projectID).
 					WithEntityType(pb.Entity_ENTITY_REPOSITORIES).
-					WithEntityID(repositoryID).
-					WithAttribute("repoID", repositoryID.String())
+					WithEntityID(repositoryID)
+
 				err := eiw.ToMessage(m)
 				require.NoError(t, err, "invalid message")
 				return m

--- a/internal/reconcilers/entity_delete_test.go
+++ b/internal/reconcilers/entity_delete_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/stacklok/minder/internal/reconcilers/messages"
 	mockrepo "github.com/stacklok/minder/internal/repositories/mock"
 	rf "github.com/stacklok/minder/internal/repositories/mock/fixtures"
+	pb "github.com/stacklok/minder/pkg/api/protobuf/go/minder/v1"
 )
 
 var (
@@ -67,7 +68,7 @@ func TestHandleEntityDelete(t *testing.T) {
 				eiw := messages.NewMinderEvent().
 					WithProviderID(providerID).
 					WithProjectID(projectID).
-					WithEntityType("repository").
+					WithEntityType(pb.Entity_ENTITY_REPOSITORIES).
 					WithEntityID(repositoryID).
 					WithAttribute("repoID", repositoryID.String())
 				err := eiw.ToMessage(m)
@@ -89,7 +90,7 @@ func TestHandleEntityDelete(t *testing.T) {
 				eiw := messages.NewMinderEvent().
 					WithProviderID(providerID).
 					WithProjectID(projectID).
-					WithEntityType("repository").
+					WithEntityType(pb.Entity_ENTITY_REPOSITORIES).
 					WithEntityID(repositoryID).
 					WithAttribute("repoID", repositoryID.String())
 				err := eiw.ToMessage(m)
@@ -112,7 +113,7 @@ func TestHandleEntityDelete(t *testing.T) {
 				eiw := messages.NewMinderEvent().
 					WithProviderID(providerID).
 					WithProjectID(projectID).
-					WithEntityType("repository").
+					WithEntityType(pb.Entity_ENTITY_REPOSITORIES).
 					WithEntityID(repositoryID).
 					WithAttribute("repoID", repositoryID.String())
 				err := eiw.ToMessage(m)

--- a/internal/reconcilers/messages/messages.go
+++ b/internal/reconcilers/messages/messages.go
@@ -22,6 +22,8 @@ import (
 
 	"github.com/ThreeDotsLabs/watermill/message"
 	"github.com/google/uuid"
+
+	minderv1 "github.com/stacklok/minder/pkg/api/protobuf/go/minder/v1"
 )
 
 // RepoReconcilerEvent is an event that is sent to the reconciler topic
@@ -67,10 +69,10 @@ type CoreContext struct {
 // This struct is meant to be used with providers that can push events
 // to Minder, or with providers that Minder can poll.
 type MinderEvent struct {
-	ProviderID uuid.UUID `json:"provider_id" validate:"required"`
-	ProjectID  uuid.UUID `json:"project_id" validate:"required"`
-	EntityType string    `json:"entity_type" validate:"required"`
-	EntityID   uuid.UUID `json:"entity_id"`
+	ProviderID uuid.UUID       `json:"provider_id" validate:"required"`
+	ProjectID  uuid.UUID       `json:"project_id" validate:"required"`
+	EntityType minderv1.Entity `json:"entity_type" validate:"required"`
+	EntityID   uuid.UUID       `json:"entity_id"`
 	// TODO: This should really be using actual property keys
 	Entity map[string]any `json:"entity" validate:"required"`
 }
@@ -108,7 +110,7 @@ func (e *MinderEvent) WithEntityID(entityID uuid.UUID) *MinderEvent {
 
 // WithEntityType sets the type of the entity. Type of the entity must
 // be meaningful to the Provider.
-func (e *MinderEvent) WithEntityType(entityType string) *MinderEvent {
+func (e *MinderEvent) WithEntityType(entityType minderv1.Entity) *MinderEvent {
 	e.EntityType = entityType
 	return e
 }
@@ -126,7 +128,6 @@ func (e *MinderEvent) ToMessage(msg *message.Message) error {
 	msg.Payload = payload
 	msg.Metadata.Set("providerID", e.ProviderID.String())
 	msg.Metadata.Set("projectID", e.ProjectID.String())
-	msg.Metadata.Set("entityType", e.EntityType)
 
 	return nil
 }

--- a/internal/reconcilers/messages/messages.go
+++ b/internal/reconcilers/messages/messages.go
@@ -23,6 +23,7 @@ import (
 	"github.com/ThreeDotsLabs/watermill/message"
 	"github.com/google/uuid"
 
+	"github.com/stacklok/minder/internal/entities/properties"
 	minderv1 "github.com/stacklok/minder/pkg/api/protobuf/go/minder/v1"
 )
 
@@ -73,14 +74,13 @@ type MinderEvent struct {
 	ProjectID  uuid.UUID       `json:"project_id" validate:"required"`
 	EntityType minderv1.Entity `json:"entity_type" validate:"required"`
 	EntityID   uuid.UUID       `json:"entity_id"`
-	// TODO: This should really be using actual property keys
-	Entity map[string]any `json:"entity" validate:"required"`
+	Properties map[string]any  `json:"entity" validate:"required"`
 }
 
 // NewMinderEvent creates a new entity added event.
 func NewMinderEvent() *MinderEvent {
 	return &MinderEvent{
-		Entity: map[string]any{},
+		Properties: map[string]any{},
 	}
 }
 
@@ -96,9 +96,9 @@ func (e *MinderEvent) WithProjectID(projectID uuid.UUID) *MinderEvent {
 	return e
 }
 
-// WithAttribute sets attributes of the entity for a MinderEvent.
-func (e *MinderEvent) WithAttribute(key string, val any) *MinderEvent {
-	e.Entity[key] = val
+// WithProperties adds properties to MinderEvent.
+func (e *MinderEvent) WithProperties(props *properties.Properties) *MinderEvent {
+	e.Properties = props.ToProtoStruct().AsMap()
 	return e
 }
 


### PR DESCRIPTION

# Summary

As a follow-up to this PR, I want to use the NewGetEntityAndDeleteHandler for handling repo deletions
and in general I want to get rid of calls to `fetchRepo()`. This is a prep PR that makes the
`MinderEvent` messages more generic and let them work with properties.

- **Remove unused setters of repoID attribute for entity reconciliation** - This just simplifies the code
- **Use minderv1.Entity instead of a string and check the entity type for repos** - Using just strings is error prone. We might need to revisit this as we make entities completely pluggable, but we're not there yet and I don't like to add strings comparison. At the same time I want to only run the entity_add handler on repositories.
- **Use generic properties instead of repoName/repoOwner when adding entities** - The handler required the use of repoName/repoOwner that were eventually converted to `properties.PropertyName` before being sent off. Let's just use properties all the way down.

Related: #4682

## Change Type

- [ ] Bug fix (resolves an issue without affecting existing features)
- [ ] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [x] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

adding/removing repos, registering all repos

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [ ] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [x] Included tests that validate the fix or feature.
- [ ] Checked that related changes are merged.
