### PR TITLE
Remove reconciling of artifacts during repo reconciliation

### DIFF
--- a/internal/reconcilers/entity_delete_test.go
+++ b/internal/reconcilers/entity_delete_test.go
@@ -181,7 +181,6 @@ func setUp(t *testing.T, tt testCase, ctrl *gomock.Controller) *Reconciler {
 		nil, // crypto.Engine not used in these tests
 		nil, // manager.ProviderManager not used in these tests
 		repoService,
-		nil, // propertyService.PropertiesService not used in these tests
 	)
 	require.NoError(t, err)
 

--- a/internal/reconcilers/reconcilers.go
+++ b/internal/reconcilers/reconcilers.go
@@ -19,7 +19,6 @@ package reconcilers
 import (
 	"github.com/stacklok/minder/internal/crypto"
 	"github.com/stacklok/minder/internal/db"
-	propSvc "github.com/stacklok/minder/internal/entities/properties/service"
 	"github.com/stacklok/minder/internal/events"
 	"github.com/stacklok/minder/internal/providers/manager"
 	"github.com/stacklok/minder/internal/repositories"
@@ -32,7 +31,6 @@ type Reconciler struct {
 	crypteng        crypto.Engine
 	providerManager manager.ProviderManager
 	repos           repositories.RepositoryService
-	propService     propSvc.PropertiesService
 }
 
 // NewReconciler creates a new reconciler object
@@ -42,7 +40,6 @@ func NewReconciler(
 	cryptoEngine crypto.Engine,
 	providerManager manager.ProviderManager,
 	repositoryService repositories.RepositoryService,
-	propService propSvc.PropertiesService,
 ) (*Reconciler, error) {
 	return &Reconciler{
 		store:           store,
@@ -50,7 +47,6 @@ func NewReconciler(
 		crypteng:        cryptoEngine,
 		providerManager: providerManager,
 		repos:           repositoryService,
-		propService:     propService,
 	}, nil
 }
 

--- a/internal/reconcilers/repository.go
+++ b/internal/reconcilers/repository.go
@@ -16,29 +16,18 @@ package reconcilers
 
 import (
 	"context"
-	"database/sql"
 	"encoding/json"
-	"errors"
 	"fmt"
-	"strings"
 
 	"github.com/ThreeDotsLabs/watermill/message"
 	"github.com/go-playground/validator/v10"
 	"github.com/google/uuid"
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
-	"google.golang.org/protobuf/types/known/timestamppb"
 
-	"github.com/stacklok/minder/internal/db"
-	"github.com/stacklok/minder/internal/engine/entities"
 	entityMessage "github.com/stacklok/minder/internal/entities/handlers/message"
-	"github.com/stacklok/minder/internal/entities/properties"
 	"github.com/stacklok/minder/internal/events"
-	"github.com/stacklok/minder/internal/providers/github"
 	"github.com/stacklok/minder/internal/reconcilers/messages"
-	"github.com/stacklok/minder/internal/verifier/verifyif"
-	pb "github.com/stacklok/minder/pkg/api/protobuf/go/minder/v1"
-	v1 "github.com/stacklok/minder/pkg/providers/v1"
 )
 
 // handleRepoReconcilerEvent handles events coming from the reconciler topic
@@ -62,13 +51,13 @@ func (r *Reconciler) handleRepoReconcilerEvent(msg *message.Message) error {
 
 	ctx := msg.Context()
 	log.Printf("handling reconciler event for project %s and repository %s", evt.Project.String(), evt.EntityID.String())
-	return r.handleArtifactsReconcilerEvent(ctx, &evt)
+	return r.handleRepositoryReconcilerEvent(ctx, &evt)
 }
 
 // HandleArtifactsReconcilerEvent recreates the artifacts belonging to
 // an specific repository
 // nolint: gocyclo
-func (r *Reconciler) handleArtifactsReconcilerEvent(ctx context.Context, evt *messages.RepoReconcilerEvent) error {
+func (r *Reconciler) handleRepositoryReconcilerEvent(ctx context.Context, evt *messages.RepoReconcilerEvent) error {
 	entRefresh := entityMessage.NewEntityRefreshAndDoMessage().
 		WithEntityID(evt.EntityID)
 
@@ -91,147 +80,5 @@ func (r *Reconciler) handleArtifactsReconcilerEvent(ctx context.Context, evt *me
 		return fmt.Errorf("error publishing message: %w", err)
 	}
 
-	// the code below this line will be refactored in a follow-up PR
-	ewp, err := r.propService.EntityWithPropertiesByID(ctx, evt.EntityID, nil)
-	if err != nil {
-		// database might be down, so we retry
-		log.Printf("error retrieving entity with properties: %v", err)
-		return nil
-	}
-
-	repoID, err := ewp.Properties.GetProperty(properties.PropertyUpstreamID).AsInt64()
-	if err != nil {
-		log.Printf("error getting property upstreamID: %v", err)
-		// no point in retrying, so we just return nil
-		return nil
-	}
-
-	// first retrieve data for the repository
-	repository, err := r.store.GetRepositoryByRepoID(ctx, repoID)
-	if errors.Is(err, sql.ErrNoRows) {
-		zerolog.Ctx(ctx).Debug().Err(err).
-			Int64("repositoryUpstreamID", repoID).
-			Msg("repository not found")
-		return nil
-	}
-	if err != nil {
-		// database might be down, so we retry
-		return fmt.Errorf("error retrieving repository %d in project %s: %w", repoID, evt.Project, err)
-	}
-
-	providerID := repository.ProviderID
-
-	p, err := r.providerManager.InstantiateFromID(ctx, providerID)
-	if err != nil {
-		return fmt.Errorf("error instantiating provider: %w", err)
-	}
-
-	cli, err := v1.As[v1.GitHub](p)
-	if err != nil {
-		// Keeping this behaviour to match the existing logic
-		// This reconciler logic needs to be split between GitHub-specific
-		// and generic parts.
-		log.Printf("provider %s is not supported for artifacts reconciler", providerID)
-		return nil
-	}
-
-	// todo: add another type of artifacts
-	artifacts, err := cli.ListPackagesByRepository(ctx, repository.RepoOwner, string(verifyif.ArtifactTypeContainer),
-		int64(repository.RepoID), 1, 100)
-	if err != nil {
-		if errors.Is(err, github.ErrNotFound) {
-			// we do not return error since it's a valid use case for a repository to not have artifacts
-			log.Printf("error retrieving artifacts for RepoID %d: %v", repository.RepoID, err)
-			return nil
-		} else if errors.Is(err, github.ErrNoPackageListingClient) {
-			// not a hard error, just misconfiguration or the user doesn't want to put a token
-			// into the provider config
-			zerolog.Ctx(ctx).Info().
-				Str("provider", providerID.String()).
-				Msg("No package listing client available for provider")
-			return nil
-		}
-		return err
-	}
-
-	for _, artifact := range artifacts {
-		// store information if we do not have it
-		typeLower := strings.ToLower(artifact.GetPackageType())
-		var newArtifactID uuid.UUID
-		pbArtifact, err := db.WithTransaction(r.store, func(tx db.ExtendQuerier) (*pb.Artifact, error) {
-			newArtifact, err := tx.UpsertArtifact(ctx,
-				db.UpsertArtifactParams{
-					RepositoryID: uuid.NullUUID{
-						UUID:  repository.ID,
-						Valid: true,
-					},
-					ArtifactName:       artifact.GetName(),
-					ArtifactType:       typeLower,
-					ArtifactVisibility: artifact.GetVisibility(),
-					ProjectID:          evt.Project,
-					ProviderName:       repository.Provider,
-					ProviderID:         providerID,
-				})
-
-			if err != nil {
-				return nil, err
-			}
-
-			newArtifactID = newArtifact.ID
-
-			// name is provider specific and should be based on properties.
-			// In github's case it's lowercase owner / artifact name
-			// TODO: Replace with a provider call to get
-			// a name based on properties.
-			var prefix string
-			if artifact.GetOwner().GetLogin() != "" {
-				prefix = artifact.GetOwner().GetLogin() + "/"
-			}
-
-			artName := prefix + artifact.GetName()
-
-			_, err = tx.CreateOrEnsureEntityByID(ctx, db.CreateOrEnsureEntityByIDParams{
-				ID:         newArtifact.ID,
-				EntityType: db.EntitiesArtifact,
-				Name:       artName,
-				ProjectID:  evt.Project,
-				ProviderID: providerID,
-				OriginatedFrom: uuid.NullUUID{
-					UUID:  repository.ID,
-					Valid: true,
-				},
-			})
-			if err != nil {
-				return nil, err
-			}
-
-			// publish event for artifact
-			return &pb.Artifact{
-				ArtifactPk: newArtifact.ID.String(),
-				Owner:      *artifact.GetOwner().Login,
-				Name:       artifact.GetName(),
-				Type:       artifact.GetPackageType(),
-				Visibility: artifact.GetVisibility(),
-				Repository: repository.RepoName,
-				Versions:   nil, // explicitly nil, will be filled by the ingester
-				CreatedAt:  timestamppb.New(artifact.GetCreatedAt().Time),
-			}, nil
-		})
-		if err != nil {
-			// just log error and continue
-			log.Printf("error storing artifact: %v", err)
-			continue
-		}
-		err = entities.NewEntityInfoWrapper().
-			WithProviderID(providerID).
-			WithArtifact(pbArtifact).
-			WithProjectID(evt.Project).
-			WithArtifactID(newArtifactID).
-			WithRepositoryID(repository.ID).
-			Publish(r.evt)
-		if err != nil {
-			return fmt.Errorf("error publishing message: %w", err)
-		}
-	}
 	return nil
 }

--- a/internal/reconcilers/run_profile_test.go
+++ b/internal/reconcilers/run_profile_test.go
@@ -92,7 +92,7 @@ func Test_handleProfileInitEvent(t *testing.T) {
 			stubEventer := &stubeventer.StubEventer{}
 			mockStore := scenario.setupDbMocks()(ctrl)
 
-			reconciler, err := NewReconciler(mockStore, stubEventer, nil, nil, nil, nil)
+			reconciler, err := NewReconciler(mockStore, stubEventer, nil, nil, nil)
 			require.NoError(t, err)
 			require.NotNil(t, reconciler)
 

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -253,7 +253,7 @@ func AllInOneServerService(
 	evt.ConsumeEvents(handler)
 
 	// Register the reconciler to handle entity events
-	rec, err := reconcilers.NewReconciler(store, evt, cryptoEngine, providerManager, repos, propSvc)
+	rec, err := reconcilers.NewReconciler(store, evt, cryptoEngine, providerManager, repos)
 	if err != nil {
 		return fmt.Errorf("unable to create reconciler: %w", err)
 	}


### PR DESCRIPTION
# Summary

The GitHub API doesn't allow us to list packages for repos, only for
organizations. We tried to work around that by listing packages for the
org and then filtering by the repository attribute, but this does not scale well.

Moreover, we agreed that going forward we'd like to register and enroll
packages in a similar way that we do register and enroll repositories.

Fixes: #4618


## Change Type

- [x] Bug fix (resolves an issue without affecting existing features)
- [ ] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [ ] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

just made sure that repo register works.

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [ ] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [ ] Included tests that validate the fix or feature.
- [ ] Checked that related changes are merged.
