### PR TITLE
Do not forward messages for archived and/or private repos

### DIFF
--- a/internal/entities/handlers/strategies/message/entity_info_wrapper.go
+++ b/internal/entities/handlers/strategies/message/entity_info_wrapper.go
@@ -53,6 +53,10 @@ func NewToEntityInfoWrapper(
 func (c *toEntityInfoWrapper) CreateMessage(
 	ctx context.Context, ewp *models.EntityWithProperties,
 ) (*message.Message, error) {
+	if ewp == nil {
+		return nil, fmt.Errorf("entity with properties is nil")
+	}
+
 	pbEnt, err := c.propSvc.EntityWithPropertiesAsProto(ctx, ewp, c.provMgr)
 	if err != nil {
 		return nil, fmt.Errorf("error converting entity to protobuf: %w", err)

--- a/internal/entities/handlers/strategies/message/minder_entity.go
+++ b/internal/entities/handlers/strategies/message/minder_entity.go
@@ -36,6 +36,10 @@ func NewToMinderEntity() strategies.MessageCreateStrategy {
 }
 
 func (_ *toMinderEntityStrategy) CreateMessage(_ context.Context, ewp *models.EntityWithProperties) (*watermill.Message, error) {
+	if ewp == nil {
+		return nil, fmt.Errorf("entity with properties is nil")
+	}
+
 	m := watermill.NewMessage(uuid.New().String(), nil)
 
 	entEvent := messages.NewMinderEvent().


### PR DESCRIPTION
# Summary

Since the github webhook handler won't have access to the properties and
the properties will be refreshed and read later on, we'd lose the
ability to not evaluate messages from private or archived repositories.

We do check for the private and archived flags at repo registration, but
since a repo can go private or be archived later, this is not enough.

Let's check for these properties after retrieving the entity and before
forwarding it on.

Fixes: #4666

## Change Type

- [x] Bug fix (resolves an issue without affecting existing features)
- [ ] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [ ] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

I created a public repo then made it private.

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [ ] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [x] Included tests that validate the fix or feature.
- [ ] Checked that related changes are merged.
