### PR TITLE
Drop the use of fetchRepo and its RefreshRepositoryByUpstreamID when deleting a repository

### DIFF
--- a/internal/entities/handlers/handler_test.go
+++ b/internal/entities/handlers/handler_test.go
@@ -16,6 +16,7 @@
 package handlers
 
 import (
+	"encoding/json"
 	"errors"
 	"testing"
 
@@ -42,6 +43,7 @@ import (
 	"github.com/stacklok/minder/internal/providers/manager"
 	mock_manager "github.com/stacklok/minder/internal/providers/manager/mock"
 	provManFixtures "github.com/stacklok/minder/internal/providers/manager/mock/fixtures"
+	"github.com/stacklok/minder/internal/reconcilers/messages"
 	minderv1 "github.com/stacklok/minder/pkg/api/protobuf/go/minder/v1"
 	provifv1 "github.com/stacklok/minder/pkg/providers/v1"
 )
@@ -153,6 +155,17 @@ func buildEwp(t *testing.T, ewp models.EntityWithProperties, propMap map[string]
 	return &ewp
 }
 
+func checkRepoEntityMessage(t *testing.T, msg *watermill.Message) {
+	t.Helper()
+
+	var event messages.MinderEvent
+
+	err := json.Unmarshal(msg.Payload, &event)
+	require.NoError(t, err)
+	require.Equal(t, minderv1.Entity_ENTITY_REPOSITORIES, event.EntityType)
+	require.Equal(t, repoID, event.EntityID)
+}
+
 func checkRepoMessage(t *testing.T, msg *watermill.Message) {
 	t.Helper()
 
@@ -221,6 +234,15 @@ func removeOriginatingEntityHandlerBuilder(
 	provMgr manager.ProviderManager,
 ) events.Consumer {
 	return NewRemoveOriginatingEntityHandler(evt, store, propSvc, provMgr)
+}
+
+func getAndDeleteEntityHandlerBuilder(
+	evt events.Publisher,
+	store db.Store,
+	propSvc service.PropertiesService,
+	_ manager.ProviderManager,
+) events.Consumer {
+	return NewGetEntityAndDeleteHandler(evt, store, propSvc)
 }
 
 func TestRefreshEntityAndDoHandler_HandleRefreshEntityAndEval(t *testing.T) {
@@ -592,6 +614,58 @@ func TestRefreshEntityAndDoHandler_HandleRefreshEntityAndEval(t *testing.T) {
 				return provManFixtures.NewProviderManagerMock(
 					provManFixtures.WithSuccessfulInstantiateFromID(prov),
 				)
+			},
+			expectedPublish: false,
+		},
+		{
+			name:             "NewGetEntityAndDeleteHandler: happy path publishes",
+			handlerBuilderFn: getAndDeleteEntityHandlerBuilder,
+			messageBuilder: func() *message.HandleEntityAndDoMessage {
+				getByProps, _ := properties.NewProperties(map[string]any{
+					properties.PropertyUpstreamID: "123",
+				})
+
+				return message.NewEntityRefreshAndDoMessage().
+					WithEntity(minderv1.Entity_ENTITY_REPOSITORIES, getByProps).
+					WithProviderImplementsHint("github")
+			},
+			setupPropSvcMocks: func() fixtures.MockPropertyServiceBuilder {
+				repoPropsEwp := buildEwp(t, repoEwp, repoPropMap)
+
+				return fixtures.NewMockPropertiesService(
+					fixtures.WithSuccessfulEntityByUpstreamHint(repoPropsEwp, githubHint),
+				)
+			},
+			mockStoreFunc: df.NewMockStore(),
+			providerSetup: newProviderMock(),
+			providerManagerSetup: func(_ provifv1.Provider) provManFixtures.ProviderManagerMockBuilder {
+				return provManFixtures.NewProviderManagerMock()
+			},
+			expectedPublish: true,
+			checkWmMsg:      checkRepoEntityMessage,
+			topic:           events.TopicQueueReconcileEntityDelete,
+		},
+		{
+			name:             "NewGetEntityAndDeleteHandler: failure to get entity does not publish",
+			handlerBuilderFn: getAndDeleteEntityHandlerBuilder,
+			messageBuilder: func() *message.HandleEntityAndDoMessage {
+				getByProps, _ := properties.NewProperties(map[string]any{
+					properties.PropertyUpstreamID: "123",
+				})
+
+				return message.NewEntityRefreshAndDoMessage().
+					WithEntity(minderv1.Entity_ENTITY_REPOSITORIES, getByProps).
+					WithProviderImplementsHint("github")
+			},
+			setupPropSvcMocks: func() fixtures.MockPropertyServiceBuilder {
+				return fixtures.NewMockPropertiesService(
+					fixtures.WithFailedEntityByUpstreamHint(service.ErrEntityNotFound),
+				)
+			},
+			mockStoreFunc: df.NewMockStore(),
+			providerSetup: newProviderMock(),
+			providerManagerSetup: func(_ provifv1.Provider) provManFixtures.ProviderManagerMockBuilder {
+				return provManFixtures.NewProviderManagerMock()
 			},
 			expectedPublish: false,
 		},

--- a/internal/reconcilers/entity_delete.go
+++ b/internal/reconcilers/entity_delete.go
@@ -15,7 +15,6 @@
 package reconcilers
 
 import (
-	"database/sql"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -24,6 +23,7 @@ import (
 	"github.com/go-playground/validator/v10"
 	"github.com/rs/zerolog"
 
+	"github.com/stacklok/minder/internal/entities/properties/service"
 	minderlogger "github.com/stacklok/minder/internal/logger"
 	"github.com/stacklok/minder/internal/reconcilers/messages"
 	pb "github.com/stacklok/minder/pkg/api/protobuf/go/minder/v1"
@@ -67,7 +67,7 @@ func (r *Reconciler) handleEntityDeleteEvent(msg *message.Message) error {
 	// Remove the entry in the DB. There's no need to clean any webhook we created for this repository, as GitHub
 	// will automatically remove them when the repository is deleted.
 	err := r.repos.DeleteByID(ctx, event.EntityID, event.ProjectID)
-	if errors.Is(err, sql.ErrNoRows) {
+	if errors.Is(err, service.ErrEntityNotFound) {
 		zerolog.Ctx(ctx).Debug().Err(err).
 			Str("entity UUID", event.EntityID.String()).
 			Msg("repository not found")

--- a/internal/reconcilers/entity_delete_test.go
+++ b/internal/reconcilers/entity_delete_test.go
@@ -16,7 +16,6 @@ package reconcilers
 
 import (
 	"context"
-	"database/sql"
 	"errors"
 	"testing"
 
@@ -28,6 +27,7 @@ import (
 	mockdb "github.com/stacklok/minder/database/mock"
 	df "github.com/stacklok/minder/database/mock/fixtures"
 	serverconfig "github.com/stacklok/minder/internal/config/server"
+	"github.com/stacklok/minder/internal/entities/properties/service"
 	"github.com/stacklok/minder/internal/events"
 	"github.com/stacklok/minder/internal/reconcilers/messages"
 	mockrepo "github.com/stacklok/minder/internal/repositories/mock"
@@ -81,7 +81,7 @@ func TestHandleEntityDelete(t *testing.T) {
 			mockStoreFunc: nil,
 			mockReposFunc: rf.NewRepoService(
 				rf.WithFailedDeleteByID(
-					sql.ErrNoRows,
+					service.ErrEntityNotFound,
 				),
 			),
 			messageFunc: func(t *testing.T) *message.Message {
@@ -151,6 +151,8 @@ func TestHandleEntityDelete(t *testing.T) {
 			// then
 			if tt.err {
 				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
 			}
 		})
 	}

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -276,6 +276,9 @@ func AllInOneServerService(
 	delOriginatingEntity := handlers.NewRemoveOriginatingEntityHandler(evt, store, propSvc, providerManager)
 	evt.ConsumeEvents(delOriginatingEntity)
 
+	getAndDeleteEntity := handlers.NewGetEntityAndDeleteHandler(evt, store, propSvc)
+	evt.ConsumeEvents(getAndDeleteEntity)
+
 	// Register the email manager to handle email invitations
 	var mailClient events.Consumer
 	if cfg.Email.AWSSES.Region != "" && cfg.Email.AWSSES.Sender != "" {


### PR DESCRIPTION

# Summary

- **Add test coverage for NewGetEntityAndDeleteHandler** - Before we enable this handler, let's add tests
- **Special case service.ErrEntityNotFound, not sql.ErrNoRows** - Since we switched to using entities, deleting a non-existent repository returns `service.ErrEntityNotFound`, not `sql.ErrNoRows`. Ignoring the wrong error code caused us to retry the message needlessly.
- **Drop the use of fetchRepo and its RefreshRepositoryByUpstreamID when deleting a repository** - This removes one more usage of the old handler and one more database access from the webhook handler.

Fixes: #4682

## Change Type

- [x] Bug fix (resolves an issue without affecting existing features)
- [ ] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [x] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

by adding and deleting repos and enrolling all repos

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [ ] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [x] Included tests that validate the fix or feature.
- [ ] Checked that related changes are merged.
