### PR TITLE
Remove database use from handleRelevantRepositoryEvent

### DIFF
--- a/internal/entities/handlers/handler.go
+++ b/internal/entities/handlers/handler.go
@@ -158,6 +158,10 @@ func (b *handleEntityAndDoBase) forwardEntityCheck(
 	return true, nil
 }
 
+// matchPropertiesCheck checks if the properties of the entity match the properties in the message.
+// this is different from the hint check, which is a check to see if the entity comes from where we expect
+// it to come from. A concrete example is receiving a "meta" event on a webhook we don't manage, in that case
+// we'd want to match on the webhook ID and only proceed if it matches with the webhook ID minder tracks.
 func (_ *handleEntityAndDoBase) matchPropertiesCheck(
 	entMsg *message.HandleEntityAndDoMessage,
 	ewp *models.EntityWithProperties) error {

--- a/internal/entities/handlers/message/message.go
+++ b/internal/entities/handlers/message/message.go
@@ -43,9 +43,15 @@ type EntityHint struct {
 
 // HandleEntityAndDoMessage is a message that is sent to the entity handler to refresh an entity and perform an action.
 type HandleEntityAndDoMessage struct {
-	Entity     TypedProps     `json:"entity"`
-	Originator TypedProps     `json:"owner"`
-	Hint       EntityHint     `json:"hint"`
+	Entity     TypedProps `json:"entity"`
+	Originator TypedProps `json:"owner"`
+	// Hint is used to help the entity handler find the entity upstream
+	// using the property service. A typical use case is to use the provider
+	// in the hint and an upstream ID in the Entity.GetByProps attribute
+	Hint EntityHint `json:"hint"`
+	// MatchProps is used to match the properties of the found entity. One
+	// use-case is to include the hook ID in the MatchProps to match against
+	// the entity's hook ID to avoid forwading the message to the wrong entity.
 	MatchProps map[string]any `json:"match_props"`
 }
 

--- a/internal/entities/handlers/message/message.go
+++ b/internal/entities/handlers/message/message.go
@@ -43,9 +43,10 @@ type EntityHint struct {
 
 // HandleEntityAndDoMessage is a message that is sent to the entity handler to refresh an entity and perform an action.
 type HandleEntityAndDoMessage struct {
-	Entity     TypedProps `json:"entity"`
-	Originator TypedProps `json:"owner"`
-	Hint       EntityHint `json:"hint"`
+	Entity     TypedProps     `json:"entity"`
+	Originator TypedProps     `json:"owner"`
+	Hint       EntityHint     `json:"hint"`
+	MatchProps map[string]any `json:"match_props"`
 }
 
 // NewEntityRefreshAndDoMessage creates a new HandleEntityAndDoMessage struct.
@@ -114,4 +115,11 @@ func (e *HandleEntityAndDoMessage) ToMessage(msg *message.Message) error {
 
 	msg.Payload = payloadBytes
 	return nil
+}
+
+// WithMatchProps sets the properties that must match the properties from the found entity
+// in order to perform the action.
+func (e *HandleEntityAndDoMessage) WithMatchProps(matchProps *properties.Properties) *HandleEntityAndDoMessage {
+	e.MatchProps = matchProps.ToProtoStruct().AsMap()
+	return e
 }

--- a/internal/entities/properties/properties.go
+++ b/internal/entities/properties/properties.go
@@ -25,6 +25,7 @@ import (
 	"github.com/puzpuzpuz/xsync/v3"
 	"github.com/rs/zerolog"
 	"golang.org/x/exp/constraints"
+	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/structpb"
 )
 
@@ -220,6 +221,19 @@ func (p *Property) RawValue() any {
 		return nil
 	}
 	return p.value.AsInterface()
+}
+
+// Equal checks if two Properties are equal
+func (p *Property) Equal(other *Property) bool {
+	if p == nil && other == nil {
+		return true
+	}
+
+	if p == nil || other == nil {
+		return false
+	}
+
+	return proto.Equal(p.value, other.value)
 }
 
 // Properties struct that holds the properties map and provides access to Property values

--- a/internal/entities/properties/properties_test.go
+++ b/internal/entities/properties/properties_test.go
@@ -909,3 +909,147 @@ func TestProperties_Len(t *testing.T) {
 		})
 	}
 }
+
+func Test_Equal(t *testing.T) {
+	t.Parallel()
+
+	scenarios := []struct {
+		name  string
+		a     any
+		b     any
+		equal bool
+	}{
+		{
+			name:  "equal string",
+			a:     "test",
+			b:     "test",
+			equal: true,
+		},
+		{
+			name:  "different string",
+			a:     "test",
+			b:     "test2",
+			equal: false,
+		},
+		{
+			name:  "equal int64",
+			a:     int64(42),
+			b:     int64(42),
+			equal: true,
+		},
+		{
+			name:  "different int64",
+			a:     int64(42),
+			b:     int64(43),
+			equal: false,
+		},
+		{
+			name:  "equal uint64",
+			a:     uint64(42),
+			b:     uint64(42),
+			equal: true,
+		},
+		{
+			name:  "different uint64",
+			a:     uint64(42),
+			b:     uint64(43),
+			equal: false,
+		},
+		{
+			name:  "equal bool",
+			a:     true,
+			b:     true,
+			equal: true,
+		},
+		{
+			name:  "different bool",
+			a:     true,
+			b:     false,
+			equal: false,
+		},
+		{
+			name:  "equal float64",
+			a:     3.14,
+			b:     3.14,
+			equal: true,
+		},
+		{
+			name:  "different float64",
+			a:     3.14,
+			b:     3.15,
+			equal: false,
+		},
+		{
+			name:  "equal map",
+			a:     map[string]any{"test": "value"},
+			b:     map[string]any{"test": "value"},
+			equal: true,
+		},
+		{
+			name:  "different map",
+			a:     map[string]any{"test": "value"},
+			b:     map[string]any{"test": "value2"},
+			equal: false,
+		},
+		{
+			name:  "equal nil",
+			a:     nil,
+			b:     nil,
+			equal: true,
+		},
+		{
+			name:  "different nil",
+			a:     nil,
+			b:     "test",
+			equal: false,
+		},
+		{
+			name:  "different types",
+			a:     "test",
+			b:     42,
+			equal: false,
+		},
+	}
+
+	for _, s := range scenarios {
+		t.Run(s.name, func(t *testing.T) {
+			t.Parallel()
+
+			p1, err := NewProperty(s.a)
+			require.NoError(t, err)
+			p2, err := NewProperty(s.b)
+			require.NoError(t, err)
+
+			assert.Equal(t, s.equal, p1.Equal(p2))
+		})
+	}
+}
+
+func TestProperties_Equal_Nils(t *testing.T) {
+	t.Parallel()
+
+	t.Run("both nil", func(t *testing.T) {
+		t.Parallel()
+
+		var p1, p2 *Property
+		assert.True(t, p1.Equal(p2))
+	})
+
+	t.Run("nil parameter", func(t *testing.T) {
+		t.Parallel()
+
+		p1, err := NewProperty("test")
+		require.NoError(t, err)
+		var p2 *Property
+		assert.False(t, p1.Equal(p2))
+	})
+
+	t.Run("nil receiver", func(t *testing.T) {
+		t.Parallel()
+
+		var p1 *Property
+		p2, err := NewProperty("test")
+		require.NoError(t, err)
+		assert.False(t, p1.Equal(p2))
+	})
+}


### PR DESCRIPTION
# Summary

- **Add Property.Equal** - Comparing properties will be useful to check if a matching property is a subset of the retrieved properties.
- **Add WithMatchProps to the HandleEntityAndDoMessage** - We'll match the received entity on these properties
- **Don't forward entity if it doesn't match message.MatchProps** - After receiving an entity, check if the `message.MatchProps` map is set.  If yes, make sure that it is a subset of the properties of the entity just received. If it is not, drop the message.  This will allow us to restrict forwarding the message by properties set by the caller.
- **Use the handler forwarding to evaluate repository/meta messages** - Instead of fetching the repo directly in the handler and forwarding to a handler, create a NewEntityRefreshAndDoMessage message and offload the entity processing to minder-core.  This removes the last piece of the github webhook that was directly touching the database with the exception of looking up the github app installation.

Fixes: #4703

## Change Type

- [ ] Bug fix (resolves an issue without affecting existing features)
- [ ] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [x] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

mostly unit tests + adding and removing repos

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [ ] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [x] Included tests that validate the fix or feature.
- [ ] Checked that related changes are merged.
