### PR TITLE
Gitlab: Add support for the `Release` entity

### DIFF
--- a/cmd/cli/app/profile/table_render.go
+++ b/cmd/cli/app/profile/table_render.go
@@ -71,6 +71,9 @@ func RenderProfileTable(p *minderv1.Profile, t table.Table) {
 
 	// pull request
 	renderProfileRow(minderv1.PullRequestEntity, p.PullRequest, t)
+
+	// release
+	renderProfileRow(minderv1.ReleaseEntity, p.Release, t)
 }
 
 func renderProfileRow(entType minderv1.EntityType, rs []*minderv1.Profile_Rule, t table.Table) {

--- a/go.mod
+++ b/go.mod
@@ -330,7 +330,7 @@ require (
 	go.uber.org/atomic v1.11.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	go.uber.org/zap v1.27.0 // indirect
-	golang.org/x/mod v0.21.0 // indirect
+	golang.org/x/mod v0.21.0
 	golang.org/x/net v0.29.0 // indirect
 	golang.org/x/sys v0.26.0 // indirect
 	golang.org/x/text v0.19.0 // indirect

--- a/internal/profiles/util.go
+++ b/internal/profiles/util.go
@@ -174,6 +174,10 @@ func TraverseAllRulesForPipeline(p *pb.Profile, fn func(*pb.Profile_Rule) error)
 		return fmt.Errorf("error traversing artifact rules: %w", err)
 	}
 
+	if err := TraverseRules(p.Release, fn); err != nil {
+		return fmt.Errorf("error traversing release rules: %w", err)
+	}
+
 	return nil
 }
 

--- a/internal/providers/gitlab/gitlab.go
+++ b/internal/providers/gitlab/gitlab.go
@@ -143,5 +143,6 @@ func (c *gitlabClient) GetCredential() provifv1.GitLabCredential {
 // SupportsEntity implements the Provider interface
 func (_ *gitlabClient) SupportsEntity(entType minderv1.Entity) bool {
 	return entType == minderv1.Entity_ENTITY_REPOSITORIES ||
-		entType == minderv1.Entity_ENTITY_PULL_REQUESTS
+		entType == minderv1.Entity_ENTITY_PULL_REQUESTS ||
+		entType == minderv1.Entity_ENTITY_RELEASE
 }

--- a/internal/providers/gitlab/manager/webhook.go
+++ b/internal/providers/gitlab/manager/webhook.go
@@ -92,6 +92,8 @@ func (m *providerClassManager) getWebhookEventDispatcher(
 		return m.handleTagPush
 	case gitlablib.EventTypeMergeRequest:
 		return m.handleMergeRequest
+	case gitlablib.EventTypeRelease:
+		return m.handleRelease
 	default:
 		return m.handleNoop
 	}

--- a/internal/providers/gitlab/manager/webhook_handlers_releases.go
+++ b/internal/providers/gitlab/manager/webhook_handlers_releases.go
@@ -1,0 +1,113 @@
+// Copyright 2024 Stacklok, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package manager
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/ThreeDotsLabs/watermill/message"
+	"github.com/google/uuid"
+	"github.com/rs/zerolog"
+	gitlablib "github.com/xanzy/go-gitlab"
+
+	entmsg "github.com/stacklok/minder/internal/entities/handlers/message"
+	"github.com/stacklok/minder/internal/entities/properties"
+	"github.com/stacklok/minder/internal/events"
+	"github.com/stacklok/minder/internal/providers/gitlab"
+	minderv1 "github.com/stacklok/minder/pkg/api/protobuf/go/minder/v1"
+)
+
+func (m *providerClassManager) handleRelease(l zerolog.Logger, r *http.Request) error {
+	l.Debug().Msg("handling release event")
+
+	releaseEvent := gitlablib.ReleaseEvent{}
+	if err := decodeJSONSafe(r.Body, &releaseEvent); err != nil {
+		return fmt.Errorf("error decoding release event: %w", err)
+	}
+
+	releaseID := releaseEvent.ID
+	if releaseID == 0 {
+		return fmt.Errorf("release event missing ID")
+	}
+
+	tag := releaseEvent.Tag
+	if tag == "" {
+		return fmt.Errorf("merge request event missing IID")
+	}
+
+	rawProjectID := releaseEvent.Project.ID
+	if rawProjectID == 0 {
+		return fmt.Errorf("merge request event missing project ID")
+	}
+
+	// TODO: Should we explicitly handle upcoming/historical releases?
+
+	switch {
+	case releaseEvent.Action == "create":
+		return m.publishReleaseMessage(releaseID, tag, rawProjectID,
+			events.TopicQueueOriginatingEntityAdd)
+	case releaseEvent.Action == "update":
+		return m.publishReleaseMessage(releaseID, tag, rawProjectID,
+			events.TopicQueueRefreshEntityAndEvaluate)
+	// We don't handle deletions this way. Instead, a user
+	// would delete the release entity directly.
+	default:
+		return nil
+	}
+}
+
+func (m *providerClassManager) publishReleaseMessage(
+	releaseID int, tag string, rawProjectID int, queueTopic string) error {
+	mrUpstreamID := gitlab.FormatPullRequestUpstreamID(releaseID)
+	mrProjectID := gitlab.FormatRepositoryUpstreamID(rawProjectID)
+
+	// Form identifying properties
+	identifyingProps, err := properties.NewProperties(map[string]any{
+		properties.PropertyUpstreamID: mrUpstreamID,
+		gitlab.ReleasePropertyTagName: tag,
+		gitlab.PullRequestProjectID:   mrProjectID,
+	})
+	if err != nil {
+		return fmt.Errorf("error creating identifying properties: %w", err)
+	}
+
+	repoIdentifyingProps, err := properties.NewProperties(map[string]any{
+		properties.PropertyUpstreamID: mrProjectID,
+	})
+	if err != nil {
+		return fmt.Errorf("error creating repo identifying properties: %w", err)
+	}
+
+	// Form message to publish
+	outm := entmsg.NewEntityRefreshAndDoMessage()
+	outm.WithEntity(minderv1.Entity_ENTITY_RELEASE, identifyingProps)
+	outm.WithOriginator(minderv1.Entity_ENTITY_REPOSITORIES, repoIdentifyingProps)
+	outm.WithProviderClassHint(gitlab.Class)
+
+	// Convert message for publishing
+	msgID := uuid.New().String()
+	msg := message.NewMessage(msgID, nil)
+	if err := outm.ToMessage(msg); err != nil {
+		return fmt.Errorf("error converting message to protobuf: %w", err)
+	}
+
+	// Publish message
+	if err := m.pub.Publish(queueTopic, msg); err != nil {
+		return fmt.Errorf("error publishing refresh and eval message: %w", err)
+	}
+
+	return nil
+}

--- a/internal/providers/gitlab/manager/webhook_handlers_releases.go
+++ b/internal/providers/gitlab/manager/webhook_handlers_releases.go
@@ -77,7 +77,7 @@ func (m *providerClassManager) publishReleaseMessage(
 	// Form identifying properties
 	identifyingProps, err := properties.NewProperties(map[string]any{
 		properties.PropertyUpstreamID: mrUpstreamID,
-		gitlab.ReleasePropertyTagName: tag,
+		gitlab.ReleasePropertyTag:     tag,
 		gitlab.PullRequestProjectID:   mrProjectID,
 	})
 	if err != nil {

--- a/internal/providers/gitlab/properties.go
+++ b/internal/providers/gitlab/properties.go
@@ -62,6 +62,17 @@ const (
 	PullRequestURL = "gitlab/merge_request_url"
 )
 
+// Release Properties
+const (
+	// ReleasePropertyProjectID represents the gitlab project ID
+	ReleasePropertyProjectID = "gitlab/project_id"
+	// ReleasePropertyTagName represents the gitlab release tag name.
+	// NOTE: This is used for release discovery, not for creating releases.
+	ReleasePropertyTagName = "gitlab/tag_name"
+	// ReleasePropertyBranch represents the gitlab release branch
+	ReleasePropertyBranch = "gitlab/branch"
+)
+
 // FetchAllProperties implements the provider interface
 func (c *gitlabClient) FetchAllProperties(
 	ctx context.Context, getByProps *properties.Properties, entType minderv1.Entity, _ *properties.Properties,
@@ -76,6 +87,8 @@ func (c *gitlabClient) FetchAllProperties(
 		return c.getPropertiesForRepo(ctx, getByProps)
 	case minderv1.Entity_ENTITY_PULL_REQUESTS:
 		return c.getPropertiesForPullRequest(ctx, getByProps)
+	case minderv1.Entity_ENTITY_RELEASE:
+		return c.getPropertiesForRelease(ctx, getByProps)
 	default:
 		return nil, fmt.Errorf("entity type %s not supported", entType)
 	}
@@ -104,6 +117,8 @@ func (c *gitlabClient) GetEntityName(entityType minderv1.Entity, props *properti
 		return getRepoNameFromProperties(props)
 	case minderv1.Entity_ENTITY_PULL_REQUESTS:
 		return getPullRequestNameFromProperties(props)
+	case minderv1.Entity_ENTITY_RELEASE:
+		return getReleaseNameFromProperties(props)
 	default:
 		return "", fmt.Errorf("entity type %s not supported", entityType)
 	}
@@ -123,6 +138,8 @@ func (c *gitlabClient) PropertiesToProtoMessage(
 		return repoV1FromProperties(props)
 	case minderv1.Entity_ENTITY_PULL_REQUESTS:
 		return pullRequestV1FromProperties(props)
+	case minderv1.Entity_ENTITY_RELEASE:
+		return releaseEntityV1FromProperties(props)
 	default:
 		return nil, fmt.Errorf("entity type %s not supported", entType)
 	}

--- a/internal/providers/gitlab/properties.go
+++ b/internal/providers/gitlab/properties.go
@@ -66,9 +66,9 @@ const (
 const (
 	// ReleasePropertyProjectID represents the gitlab project ID
 	ReleasePropertyProjectID = "gitlab/project_id"
-	// ReleasePropertyTagName represents the gitlab release tag name.
+	// ReleasePropertyTag represents the gitlab release tag name.
 	// NOTE: This is used for release discovery, not for creating releases.
-	ReleasePropertyTagName = "gitlab/tag_name"
+	ReleasePropertyTag = "gitlab/tag"
 	// ReleasePropertyBranch represents the gitlab release branch
 	ReleasePropertyBranch = "gitlab/branch"
 )

--- a/internal/providers/gitlab/release_properties.go
+++ b/internal/providers/gitlab/release_properties.go
@@ -1,0 +1,286 @@
+//
+// Copyright 2024 Stacklok, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gitlab
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/cenkalti/backoff/v4"
+	"github.com/rs/zerolog"
+	gitlablib "github.com/xanzy/go-gitlab"
+	"golang.org/x/mod/semver"
+
+	"github.com/stacklok/minder/internal/entities/properties"
+	minderv1 "github.com/stacklok/minder/pkg/api/protobuf/go/minder/v1"
+)
+
+// FormatReleaseUpstreamID returns the upstream ID for a gitlab release
+// This is done so we don't have to deal with conversions in the provider
+// when dealing with entities
+func FormatReleaseUpstreamID(id int) string {
+	return fmt.Sprintf("%d", id)
+}
+
+func (c *gitlabClient) getPropertiesForRelease(
+	ctx context.Context, getByProps *properties.Properties,
+) (*properties.Properties, error) {
+	uid, err := getByProps.GetProperty(properties.PropertyUpstreamID).AsString()
+	if err != nil {
+		return nil, fmt.Errorf("upstream ID not found or invalid: %w", err)
+	}
+
+	pid, err := getByProps.GetProperty(ReleasePropertyProjectID).AsString()
+	if err != nil {
+		return nil, fmt.Errorf("project ID not found or invalid: %w", err)
+	}
+
+	releaseTagName, err := getByProps.GetProperty(ReleasePropertyTagName).AsString()
+	if err != nil {
+		return nil, fmt.Errorf("tag name not found or invalid: %w", err)
+	}
+
+	releasePath, err := url.JoinPath("projects", pid, "releases", releaseTagName)
+	if err != nil {
+		return nil, fmt.Errorf("failed to join URL path for release using upstream ID: %w", err)
+	}
+
+	// NOTE: We're not using github.com/xanzy/go-gitlab to do the actual
+	// request here because of the way they form authentication for requests.
+	// It would be ideal to use it, so we should consider contributing and making
+	// that part more pluggable.
+	req, err := c.NewRequest(http.MethodGet, releasePath, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request for release using upstream ID: %w", err)
+	}
+
+	resp, err := c.Do(ctx, req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get release using upstream ID: %w", err)
+	}
+
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("failed to get release using upstream ID: %w", err)
+	}
+
+	release := &gitlablib.Release{}
+	if err := json.NewDecoder(resp.Body).Decode(release); err != nil {
+		return nil, fmt.Errorf("failed to decode response for release using upstream ID: %w", err)
+	}
+
+	proj, err := c.getGitLabProject(ctx, pid)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get project: %w", err)
+	}
+
+	// Get the commit refs for the release
+	refs, err := c.getCommitBranchRefs(ctx, pid, release.Commit.ID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get commit refs: %w", err)
+	}
+
+	if len(refs) == 0 {
+		return nil, fmt.Errorf("no commit refs found for release")
+	}
+
+	// try to guess the branch from the commit refs
+	branch := guessBranchFromCommitRefs(refs, release.TagName)
+
+	outProps, err := gitlabReleaseToProperties(uid, proj, branch)
+	if err != nil {
+		return nil, fmt.Errorf("failed to convert release to properties: %w", err)
+	}
+
+	return outProps, nil
+}
+
+func (c *gitlabClient) getCommitBranchRefs(
+	ctx context.Context, projID string, commitID string,
+) ([]*gitlablib.CommitRef, error) {
+	commitRefsPath, err := url.JoinPath("projects", projID, "repository", "commits", commitID, "refs")
+	if err != nil {
+		return nil, fmt.Errorf("failed to join URL path for commit refs: %w", err)
+	}
+
+	// append the type=branch query param
+	// It's safe to append this way since it's a constant string
+	// and we've already parsed the URL
+	commitRefsPath = fmt.Sprintf("%s?type=branch", commitRefsPath)
+
+	var resp *http.Response
+	err = backoff.RetryNotify(
+		func() error {
+			req, err := c.NewRequest(http.MethodGet, commitRefsPath, nil)
+			if err != nil {
+				return fmt.Errorf("failed to create request for commit refs: %w", err)
+			}
+
+			resp, err = c.Do(ctx, req)
+			if err != nil {
+				return fmt.Errorf("failed to get commit refs: %w", err)
+			}
+
+			if resp.StatusCode != http.StatusOK {
+				return fmt.Errorf("failed to get commit refs: HTTP Status %d", resp.StatusCode)
+			}
+
+			return nil
+		},
+		backoff.WithMaxRetries(backoff.NewExponentialBackOff(), 5),
+		func(err error, _ time.Duration) {
+			zerolog.Ctx(ctx).Debug().Err(err).Msg("failed to get commit refs, retrying")
+		})
+	if err != nil {
+		return nil, fmt.Errorf("failed to get commit refs: %w", err)
+	}
+
+	defer resp.Body.Close()
+
+	commitRefs := []*gitlablib.CommitRef{}
+	if err := json.NewDecoder(resp.Body).Decode(&commitRefs); err != nil {
+		return nil, fmt.Errorf("failed to decode response for commit refs: %w", err)
+	}
+
+	return commitRefs, nil
+}
+
+func releaseEntityV1FromProperties(props *properties.Properties) (*minderv1.EntityInstance, error) {
+	// validation
+	_, err := props.GetProperty(properties.PropertyUpstreamID).AsString()
+	if err != nil {
+		return nil, fmt.Errorf("upstream ID not found or invalid: %w", err)
+	}
+
+	_, err = props.GetProperty(ReleasePropertyProjectID).AsString()
+	if err != nil {
+		return nil, fmt.Errorf("project ID not found or invalid: %w", err)
+	}
+
+	_, err = props.GetProperty(ReleasePropertyBranch).AsString()
+	if err != nil {
+		return nil, fmt.Errorf("branch not found or invalid: %w", err)
+	}
+
+	if _, err = props.GetProperty(RepoPropertyNamespace).AsString(); err != nil {
+		return nil, fmt.Errorf("namespace not found or invalid: %w", err)
+	}
+
+	if _, err = props.GetProperty(RepoPropertyProjectName).AsString(); err != nil {
+		return nil, fmt.Errorf("project name not found or invalid: %w", err)
+	}
+
+	name, err := getReleaseNameFromProperties(props)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get release name: %w", err)
+	}
+
+	return &minderv1.EntityInstance{
+		Type:       minderv1.Entity_ENTITY_RELEASE,
+		Name:       name,
+		Properties: props.ToProtoStruct(),
+	}, nil
+}
+
+func getReleaseNameFromProperties(props *properties.Properties) (string, error) {
+	branch, err := props.GetProperty(ReleasePropertyBranch).AsString()
+	if err != nil {
+		return "", fmt.Errorf("branch not found or invalid: %w", err)
+	}
+
+	ns, err := props.GetProperty(RepoPropertyNamespace).AsString()
+	if err != nil {
+		return "", fmt.Errorf("namespace not found or invalid: %w", err)
+	}
+
+	projName, err := props.GetProperty(RepoPropertyProjectName).AsString()
+	if err != nil {
+		return "", fmt.Errorf("project name not found or invalid: %w", err)
+	}
+
+	return formatReleaseName(ns, projName, branch), nil
+}
+
+func gitlabReleaseToProperties(
+	releaseID string, proj *gitlablib.Project, branch string,
+) (*properties.Properties, error) {
+	ns, err := getGitlabProjectNamespace(proj)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get namespace: %w", err)
+	}
+
+	projName := proj.Name
+
+	return properties.NewProperties(map[string]interface{}{
+		properties.PropertyUpstreamID: releaseID,
+		ReleasePropertyProjectID:      FormatRepositoryUpstreamID(proj.ID),
+		ReleasePropertyBranch:         branch,
+		RepoPropertyNamespace:         ns,
+		RepoPropertyProjectName:       projName,
+	})
+}
+
+func guessBranchFromCommitRefs(refs []*gitlablib.CommitRef, tagName string) string {
+	if len(refs) == 1 {
+		return refs[0].Name
+	}
+
+	for _, ref := range refs {
+		// simple, if the ref name is the same as the tag name, return it
+		if ref.Name == tagName {
+			return ref.Name
+		}
+
+		// if the ref name starts with release, return it
+		if strings.HasPrefix(ref.Name, "release-") || strings.HasPrefix(ref.Name, "release/") {
+			return ref.Name
+		}
+
+		// semver - match major and minor versions
+		if semver.IsValid(ref.Name) && semver.IsValid(tagName) {
+			if semver.Major(ref.Name) == semver.Major(tagName) {
+				return ref.Name
+			}
+		}
+
+		// if the ref name starts with the tag name, return it
+		if strings.HasPrefix(ref.Name, tagName) {
+			return ref.Name
+		}
+
+		if strings.HasPrefix(tagName, ref.Name) {
+			return ref.Name
+		}
+
+		// if it's `main` or `master`, return it
+		if ref.Name == "main" || ref.Name == "master" {
+			return ref.Name
+		}
+	}
+
+	// If we can't find a match, just return the first ref
+	return refs[0].Name
+}
+
+func formatReleaseName(ns, projName, branch string) string {
+	return fmt.Sprintf("%s/%s/%s", ns, projName, branch)
+}

--- a/internal/providers/gitlab/release_properties.go
+++ b/internal/providers/gitlab/release_properties.go
@@ -53,7 +53,7 @@ func (c *gitlabClient) getPropertiesForRelease(
 		return nil, fmt.Errorf("project ID not found or invalid: %w", err)
 	}
 
-	releaseTagName, err := getByProps.GetProperty(ReleasePropertyTagName).AsString()
+	releaseTagName, err := getByProps.GetProperty(ReleasePropertyTag).AsString()
 	if err != nil {
 		return nil, fmt.Errorf("tag name not found or invalid: %w", err)
 	}
@@ -106,7 +106,7 @@ func (c *gitlabClient) getPropertiesForRelease(
 	// try to guess the branch from the commit refs
 	branch := guessBranchFromCommitRefs(refs, release.TagName)
 
-	outProps, err := gitlabReleaseToProperties(uid, proj, branch)
+	outProps, err := gitlabReleaseToProperties(uid, releaseTagName, proj, branch)
 	if err != nil {
 		return nil, fmt.Errorf("failed to convert release to properties: %w", err)
 	}
@@ -202,7 +202,7 @@ func releaseEntityV1FromProperties(props *properties.Properties) (*minderv1.Enti
 }
 
 func getReleaseNameFromProperties(props *properties.Properties) (string, error) {
-	branch, err := props.GetProperty(ReleasePropertyBranch).AsString()
+	branch, err := props.GetProperty(ReleasePropertyTag).AsString()
 	if err != nil {
 		return "", fmt.Errorf("branch not found or invalid: %w", err)
 	}
@@ -221,7 +221,7 @@ func getReleaseNameFromProperties(props *properties.Properties) (string, error) 
 }
 
 func gitlabReleaseToProperties(
-	releaseID string, proj *gitlablib.Project, branch string,
+	releaseID string, releaseTag string, proj *gitlablib.Project, branch string,
 ) (*properties.Properties, error) {
 	ns, err := getGitlabProjectNamespace(proj)
 	if err != nil {
@@ -233,6 +233,7 @@ func gitlabReleaseToProperties(
 	return properties.NewProperties(map[string]interface{}{
 		properties.PropertyUpstreamID: releaseID,
 		ReleasePropertyProjectID:      FormatRepositoryUpstreamID(proj.ID),
+		ReleasePropertyTag:            releaseTag,
 		ReleasePropertyBranch:         branch,
 		RepoPropertyNamespace:         ns,
 		RepoPropertyProjectName:       projName,


### PR DESCRIPTION
# Summary

This adds preliminary support for the `Release` entity within the gitlab provider.

A release is based on a tag and has branch information (critical for remediating the flow).

Note that it requires https://github.com/stacklok/minder/pull/4704 to merge beforehand.

## Change Type

***Mark the type of change your PR introduces:***

- [ ] Bug fix (resolves an issue without affecting existing features)
- [x] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [ ] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

***Outline how the changes were tested, including steps to reproduce and any relevant configurations. 
Attach screenshots if helpful.***

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [ ] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [ ] Included tests that validate the fix or feature.
- [ ] Checked that related changes are merged.
