### PR TITLE
Remove redundant propsvc.RetrieveAllPropertiesForEntity when looking up entities for history lookup

### DIFF
--- a/internal/history/service.go
+++ b/internal/history/service.go
@@ -229,12 +229,6 @@ func (ehs *evaluationHistoryService) ListEvaluationHistory(
 				return nil, fmt.Errorf("error fetching entity for properties: %w", err)
 			}
 
-			err = propsvc.RetrieveAllPropertiesForEntity(ctx, lookupEwp, ehs.providerManager,
-				propertiessvc.ReadBuilder().WithStoreOrTransaction(qtx).TolerateStaleData())
-			if err != nil {
-				return nil, fmt.Errorf("error fetching properties for entity: %w", err)
-			}
-
 			entityCache[row.EntityID] = lookupEwp
 			ewp = lookupEwp
 		}


### PR DESCRIPTION
# Summary

We were doing 2 calls when serching for entities during the
`ListEvaluationHistory` lookup:

1) EntityWithPropertiesByID
2) RetrieveAllPropertiesForEntity with the TolerateStaleData option set.

The second is not needed right after the first if we set tolerate stale
data in this case. The flow of the calls is:

- EntityWithPropertiesByID
 - db.GetEntityByID
 - db.GetAllPropertiesForEntity
 - then convert to our data model and return

- RetrieveAllPropertiesForEntity
 - provMan.InstantiateFromID
 - db.GetAllPropertiesForEntity
 - check property validity always shortcuts because we set TolerateStaleData
 - turn into our model
 - write the properties into the entity model representation we passed
   in

Related: #4690

## Change Type

- [x] Bug fix (resolves an issue without affecting existing features)
- [ ] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [ ] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

I added a debug printf to verify that all the properties are there.

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [ ] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [ ] Included tests that validate the fix or feature.
- [ ] Checked that related changes are merged.
