### PR TITLE
Set entity columns to be 'timestamp with time zone' to avoid TZ-related test failures

### DIFF
--- a/database/migrations/000107_entity_properties_timestamp_tz.down.sql
+++ b/database/migrations/000107_entity_properties_timestamp_tz.down.sql
@@ -1,0 +1,28 @@
+-- Copyright 2024 Stacklok, Inc
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--      http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+BEGIN;
+
+SET timezone = 'UTC';
+ALTER TABLE properties
+  ALTER COLUMN updated_at TYPE TIMESTAMP,
+  ALTER updated_at SET DEFAULT NOW();  -- Default needs to be set explicitly after type change
+
+ALTER TABLE entity_instances
+    ALTER created_at TYPE TIMESTAMP,
+    ALTER created_at SET DEFAULT NOW();
+
+-- There are more TIMESTAMP columns, but these are affecting unit tests in some timezones.
+
+COMMIT;

--- a/database/migrations/000107_entity_properties_timestamp_tz.up.sql
+++ b/database/migrations/000107_entity_properties_timestamp_tz.up.sql
@@ -1,0 +1,32 @@
+-- Copyright 2024 Stacklok, Inc
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--      http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+BEGIN;
+
+-- Postgres only needs to rewrite metadata (and not the column data) when altering
+-- a column from timezoneless when timezone='UTC' is set in the session.
+-- Ref: https://www.postgresql.org/docs/release/12.0/
+
+SET timezone = 'UTC';
+ALTER TABLE properties
+  ALTER COLUMN updated_at TYPE TIMESTAMPTZ,
+  ALTER updated_at SET DEFAULT NOW()::timestamptz;  -- Default needs to be set explicitly after type change
+
+ALTER TABLE entity_instances
+    ALTER created_at TYPE TIMESTAMPTZ,
+    ALTER created_at SET DEFAULT NOW()::timestamptz;
+
+-- There are more TIMESTAMP columns, but these are affecting unit tests in some timezones.
+
+COMMIT;


### PR DESCRIPTION
# Summary

The Postgres `TIMESTAMP` type records a date and time irrespective of (ignoring) timezone.  This aligns with the SQL standard, but they also have a `TIMESTAMP WITH TIME ZONE` (aka `TIMESTAMPTZ`) which _is_ timezone aware.  It turns out that `lib/pq` (at least) _stores_ `time.Time` values into the database using local time for `TIMESTAMP` columns, but reads back the columns in the zero-timezone.  In PDT (UTC+7), this results in reading back times which are 7 hours later than when they were stored.  This mostly doesn't bother our code and tests at the moment, but it _does_ break tests in `internal/entities/properties/service`, which use `updated_at` as a cache validation mechanism.

This PR migrates the `TIMESTAMP` fields added in `000090` to `TIMESTAMPTZ` in a way which should avoid table locks, and which causes the above tests to _pass_ on my machine where they failed otherwise.  Note that the tests would only fail for people in timezones west of GMT, so this probably wouldn't affect affect folks in CET or easterly.

## Change Type

***Mark the type of change your PR introduces:***

- [x] Bug fix (resolves an issue without affecting existing features)
- [ ] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [ ] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

Unit tests pass for my on my local machine, where they failed before.

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [x] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [x] Included tests that validate the fix or feature.
- [x] Checked that related changes are merged.
