### PR TITLE
Implement an entity cache for the properties service

### DIFF
--- a/internal/entities/models/models.go
+++ b/internal/entities/models/models.go
@@ -112,3 +112,13 @@ func DbPropToModel(dbProp db.Property) (*properties.Property, error) {
 func (e *EntityWithProperties) UpdateProperties(props *properties.Properties) {
 	e.Properties = props
 }
+
+// NeedsPropertyLoad returns true if the entity instance needs properties loaded
+// This is handy to determine if entities exist in the database without their
+// properties being migrated to the central table yet.
+func (e *EntityWithProperties) NeedsPropertyLoad() bool {
+	// We check if there is 2 or less properties.
+	// We check for this number since we might include the
+	// Upstream ID and a name as fallbacks.
+	return e.Properties.Len() <= 2
+}

--- a/internal/entities/properties/properties.go
+++ b/internal/entities/properties/properties.go
@@ -396,3 +396,11 @@ func (p *Properties) ToLogDict() *zerolog.Event {
 
 	return dict
 }
+
+// Len returns the number of properties
+func (p *Properties) Len() int {
+	if p == nil {
+		return 0
+	}
+	return p.props.Size()
+}

--- a/internal/entities/properties/service/entitycache.go
+++ b/internal/entities/properties/service/entitycache.go
@@ -1,0 +1,80 @@
+//
+// Copyright 2024 Stacklok, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package service
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/google/uuid"
+	"github.com/puzpuzpuz/xsync/v3"
+
+	"github.com/stacklok/minder/internal/entities/models"
+)
+
+// This uses a persistent entity cache, that is, a cache that is not cleared.
+// This is useful for a one-shot caching mechanism, where the cache is only
+// cleared once the cache instance goes out of scope.
+type propertyServiceWithPersistentEntityCache struct {
+	// Embeds a PropertyService to provide the actual service implementation.
+	PropertiesService
+
+	entCache *xsync.MapOf[uuid.UUID, *models.EntityWithProperties]
+}
+
+// WithEntityCache wraps a PropertiesService with a persistent entity cache.
+func WithEntityCache(ps PropertiesService, sizeHint int) (PropertiesService, error) {
+	if ps == nil {
+		return nil, fmt.Errorf("properties service is nil")
+	}
+
+	return newPropertyServiceWithPersistentEntityCache(ps, sizeHint), nil
+}
+
+func newPropertyServiceWithPersistentEntityCache(
+	ps PropertiesService,
+	sizeHint int,
+) *propertyServiceWithPersistentEntityCache {
+	opts := make([]func(*xsync.MapConfig), 0)
+	if sizeHint > 0 {
+		opts = append(opts, xsync.WithPresize(sizeHint))
+	}
+	return &propertyServiceWithPersistentEntityCache{
+		PropertiesService: ps,
+		entCache:          xsync.NewMapOf[uuid.UUID, *models.EntityWithProperties](opts...),
+	}
+}
+
+func (ps *propertyServiceWithPersistentEntityCache) EntityWithPropertiesByID(
+	ctx context.Context, entityID uuid.UUID,
+	opts *CallOptions,
+) (*models.EntityWithProperties, error) {
+	// Check the cache first.
+	if ent, ok := ps.entCache.Load(entityID); ok {
+		return ent, nil
+	}
+
+	// If not in the cache, call the underlying service.
+	ent, err := ps.PropertiesService.EntityWithPropertiesByID(ctx, entityID, opts)
+	if err != nil {
+		return nil, err
+	}
+
+	// Store the entity in the cache.
+	ps.entCache.Store(entityID, ent)
+
+	return ent, nil
+}


### PR DESCRIPTION
# Summary

This adds a wrapper that is able to cache entities for cases that need
to iterate them. This is handy for one-off calls like getting the
history of executions or showing reports. This way, we don't need to
query the database multiple times.

This cache is persistent, so it's only relevant for one execution.

## Change Type

***Mark the type of change your PR introduces:***

- [ ] Bug fix (resolves an issue without affecting existing features)
- [x] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [ ] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

***Outline how the changes were tested, including steps to reproduce and any relevant configurations. 
Attach screenshots if helpful.***

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [ ] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [ ] Included tests that validate the fix or feature.
- [ ] Checked that related changes are merged.
