### PR TITLE
Use the new property cache in ListEvaluationResults

### DIFF
--- a/internal/controlplane/handlers_evalstatus.go
+++ b/internal/controlplane/handlers_evalstatus.go
@@ -372,7 +372,7 @@ func (s *Server) sortEntitiesEvaluationStatus(
 	profileStatuses = map[uuid.UUID]*minderv1.ProfileStatus{}
 	statusByEntity = map[string]map[uuid.UUID][]*minderv1.RuleEvaluationStatus{}
 
-	psc, err := propSvc.WithEntityCache(s.props, 1000)
+	psc, err := propSvc.WithEntityCache(s.props, 0)
 	if err != nil {
 		return nil, nil, nil,
 			status.Errorf(codes.Internal, "error creating entity cache: %v", err)

--- a/internal/controlplane/handlers_evalstatus.go
+++ b/internal/controlplane/handlers_evalstatus.go
@@ -372,6 +372,12 @@ func (s *Server) sortEntitiesEvaluationStatus(
 	profileStatuses = map[uuid.UUID]*minderv1.ProfileStatus{}
 	statusByEntity = map[string]map[uuid.UUID][]*minderv1.RuleEvaluationStatus{}
 
+	psc, err := propSvc.WithEntityCache(s.props, 1000)
+	if err != nil {
+		return nil, nil, nil,
+			status.Errorf(codes.Internal, "error creating entity cache: %v", err)
+	}
+
 	for _, p := range profileList {
 		p := p
 		evals, err := store.ListRuleEvaluationsByProfileId(
@@ -393,7 +399,7 @@ func (s *Server) sortEntitiesEvaluationStatus(
 				continue
 			}
 
-			efp, err := s.props.EntityWithPropertiesByID(ctx, e.EntityID, nil)
+			efp, err := psc.EntityWithPropertiesByID(ctx, e.EntityID, nil)
 			if err != nil {
 				if errors.Is(err, propSvc.ErrEntityNotFound) {
 					// If the entity is not found, log and skip

--- a/internal/entities/properties/properties_test.go
+++ b/internal/entities/properties/properties_test.go
@@ -855,3 +855,57 @@ func TestProperties_ToLogDict(t *testing.T) {
 		require.Equal(t, expectedValue, actualValue)
 	}
 }
+
+func TestProperties_Len(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		p    *Properties
+		want int
+	}{
+		{
+			name: "nil Properties",
+			p:    nil,
+			want: 0,
+		},
+		{
+			name: "empty Properties",
+			p: func() *Properties {
+				p, _ := NewProperties(map[string]any{})
+				return p
+			}(),
+			want: 0,
+		},
+		{
+			name: "Properties with one item",
+			p: func() *Properties {
+				p, _ := NewProperties(map[string]any{"key1": "value1"})
+				return p
+			}(),
+			want: 1,
+		},
+		{
+			name: "Properties with multiple items",
+			p: func() *Properties {
+				p, _ := NewProperties(map[string]any{
+					"key1": "value1",
+					"key2": 42,
+					"key3": true,
+				})
+				return p
+			}(),
+			want: 3,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := tt.p.Len(); got != tt.want {
+				t.Errorf("Properties.Len() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
# Summary

Adds a bunch of tests for the new property module (the arrow needs to keep pointing up :-))
and uses the module in ListEvaluationResults

Related: #4690

## Change Type

- [x] Bug fix (resolves an issue without affecting existing features)
- [ ] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [ ] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

```
curl -XGET  -H "Authorization: Bearer $MINDER_BEARER_TOKEN" 'http://localhost:8080/api/v1/results?provider=github-app-jakubtestorg&context.project=88eb1151-5a5b-4c14-9c2e-2bc359c0db94&profile=f375e42e-07ff-4a2b-9f6c-ff98be57fc2c'
```

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [ ] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [x] Included tests that validate the fix or feature.
- [ ] Checked that related changes are merged.
