### PR TITLE
Fix diff full ingester double deref.

### DIFF
--- a/internal/engine/ingester/diff/diff.go
+++ b/internal/engine/ingester/diff/diff.go
@@ -175,7 +175,7 @@ func (di *Diff) getFullTypeDiff(ctx context.Context, prNumber int, pr *pb.PullRe
 		page = resp.NextPage
 	}
 
-	return &engif.Result{Object: &diff, Checkpoint: checkpoints.NewCheckpointV1Now()}, nil
+	return &engif.Result{Object: diff, Checkpoint: checkpoints.NewCheckpointV1Now()}, nil
 }
 
 func (di *Diff) ingestFileForDepDiff(


### PR DESCRIPTION
# Summary

This was causing errors during evaluations of rules that cast `res.Object` like
https://github.com/stacklok/minder/blob/main/internal/engine/eval/homoglyphs/application/homoglyphs_service.go#L84

## Change Type

- [X] Bug fix (resolves an issue without affecting existing features)
- [ ] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [ ] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

Manual tests.

# Review Checklist:

- [X] Reviewed my own code for quality and clarity.
- [ ] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [ ] Included tests that validate the fix or feature.
- [X] Checked that related changes are merged.
