### PR TITLE
Add Minder resource parsing using protojson and use it for data sources

### DIFF
--- a/pkg/api/protobuf/go/minder/v1/api_test.go
+++ b/pkg/api/protobuf/go/minder/v1/api_test.go
@@ -1,0 +1,61 @@
+// SPDX-FileCopyrightText: Copyright 2024 The Minder Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package v1
+
+import (
+	"fmt"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParseResourceProto(t *testing.T) {
+	t.Parallel()
+
+	type args struct {
+		r  io.Reader
+		rm *DataSource
+	}
+	tests := []struct {
+		name    string
+		args    args
+		wantErr assert.ErrorAssertionFunc
+	}{
+		{
+			name: "test data source parsing",
+			args: args{
+				r: strings.NewReader(`
+version: v1
+type: "data-source"
+name: "foo"
+rest:
+  def:
+    foo:
+      input_schema:
+        properties:
+          foo:
+            type: "string"
+            description: "foo"
+        required:
+          - foo
+      endpoint: "http://example.com"
+      method: "GET"
+      headers:
+        Content-Type: "application/json"
+`),
+				rm: &DataSource{},
+			},
+			wantErr: assert.NoError,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			tt.wantErr(t, ParseResourceProto(tt.args.r, tt.args.rm), fmt.Sprintf("ParseResourceProto(%v, %v)", tt.args.r, tt.args.rm))
+			t.Logf("Resource: %+v", tt.args.rm)
+		})
+	}
+}


### PR DESCRIPTION
# Summary

This adds a new helper utility to parse YAML using the protojson
library. This allows us to parse more complex protobuf structures such
as `one-of`.

Moreover, this adds the ability to parse data source YAML files.

## Change Type

***Mark the type of change your PR introduces:***

- [ ] Bug fix (resolves an issue without affecting existing features)
- [x] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [ ] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

***Outline how the changes were tested, including steps to reproduce and any relevant configurations. 
Attach screenshots if helpful.***

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [ ] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [x] Included tests that validate the fix or feature.
- [ ] Checked that related changes are merged.
