### PR TITLE
Clean up react dependabot batching, remove old docusarus v2 holdbacks

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -29,17 +29,12 @@ updates:
       docusaurus:
         patterns:
           - "*docusaurus*"
+      react:
+        patterns:
+          - "*react*"
       eslint:
         patterns:
           - "*eslint*"
-    ignore:
-      # facebook/docusaurus#4029 suggests MDX v2 will only be in the v3 release.
-      # facebook/docusaurus#9053 has some more details on the migration.
-      - dependency-name: "@mdx-js/react"
-        update-types: ["version-update:semver-major"]
-      # facebook/docusaurus#8940 docusaurus uses v1
-      - dependency-name: "prism-react-renderer"
-        update-types: ["version-update:semver-major"]
   - package-ecosystem: "docker"
     directory: "/"
     schedule:


### PR DESCRIPTION
# Summary

#5542 and #5543 try to bump `react-dom` and `react`, respectively, and each fails with:

```
[cause]: Error: Incompatible React versions: The "react" and "react-dom" packages must have the exact same version. Instead got:
    - react:      19.1.0
    - react-dom:  19.0.0
```
or an equivalent dependency error.  This should group them together.

I also noticed some comments about upgrades to MDX which were relevant for docusaurus v2, but shouldn't be a problems for v3.


## Change Type

***Mark the type of change your PR introduces:***

- [ ] Bug fix (resolves an issue without affecting existing features)
- [ ] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [x] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

Unit tests.

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [ ] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [x] Included tests that validate the fix or feature.
- [x] Checked that related changes are merged.
