### PR TITLE
Avoid panic from re-registering on http.DefaultServeMux

### DIFF
--- a/internal/util/cli/rpc_client.go
+++ b/internal/util/cli/rpc_client.go
@@ -288,11 +288,13 @@ func Login(
 		}
 	}
 
-	http.Handle("/login", rp.AuthURLHandler(stateFn, provider))
-	http.Handle(callbackPath, rp.CodeExchangeHandler(callback, provider))
+	mux := http.NewServeMux()
+	mux.Handle("/login", rp.AuthURLHandler(stateFn, provider))
+	mux.Handle(callbackPath, rp.CodeExchangeHandler(callback, provider))
 
 	server := &http.Server{
 		Addr:              fmt.Sprintf(":%d", port),
+		Handler:           mux,
 		ReadHeaderTimeout: time.Second * 10,
 	}
 	// Start the server in a goroutine


### PR DESCRIPTION
# Summary

Avoids a panic on Linux (but apparently not on Windows) when running `minder auth login`:

``` minder auth login Your browser will now be opened to: http://localhost:35193/login Please follow 
the instructions on the page to log in. Waiting for token... panic: pattern "/login" (registered at 
github.com/mindersec/minder/internal/util/cli/rpc_client.go:291) conflicts with pattern "/login" 
(registered at github.com/mindersec/minder/internal/util/cli/rpc_client.go:291):
	/login matches the same requests as /login
```

## Change Type

***Mark the type of change your PR introduces:***

- [x] Bug fix (resolves an issue without affecting existing features)
- [ ] Feature (adds new functionality without breaking changes)
- [ ] Breaking change (may impact existing functionalities or require documentation updates)
- [ ] Documentation (updates or additions to documentation)
- [ ] Refactoring or test improvements (no bug fixes or new functionality)

# Testing

Manual testing; will cut a release with this and the Datasources patch once merged.

# Review Checklist:

- [x] Reviewed my own code for quality and clarity.
- [x] Added comments to complex or tricky code sections.
- [ ] Updated any affected documentation.
- [ ] Included tests that validate the fix or feature.
- [x] Checked that related changes are merged.
