### PR TITLE
Add names to returned entities-with-types

### DIFF
--- a/cmd/cli/app/repo/repo_reconcile.go
+++ b/cmd/cli/app/repo/repo_reconcile.go
@@ -33,29 +33,19 @@ func reconcileCommand(ctx context.Context, cmd *cobra.Command, _ []string, conn 
 	// See https://github.com/spf13/cobra/issues/340#issuecomment-374617413
 	cmd.SilenceUsage = true
 
-	if id == "" {
-		repoClient := minderv1.NewRepositoryServiceClient(conn)
-
-		repo, err := repoClient.GetRepositoryByName(ctx, &minderv1.GetRepositoryByNameRequest{
-			Name: name,
-			Context: &minderv1.Context{
-				Provider: &provider,
-				Project:  &project,
-			},
-		})
-		if err != nil {
-			return cli.MessageAndError("Failed to get repository", err)
-		}
-
-		id = repo.GetRepository().GetId()
+	entity := &minderv1.EntityTypedId{
+		Type: minderv1.Entity_ENTITY_REPOSITORIES,
+	}
+	if id != "" {
+		entity.Id = id
+	}
+	if name != "" {
+		entity.Name = name
 	}
 
 	projectsClient := minderv1.NewProjectsServiceClient(conn)
 	_, err := projectsClient.CreateEntityReconciliationTask(ctx, &minderv1.CreateEntityReconciliationTaskRequest{
-		Entity: &minderv1.EntityTypedId{
-			Id:   id,
-			Type: minderv1.Entity_ENTITY_REPOSITORIES,
-		},
+		Entity: entity,
 		Context: &minderv1.Context{
 			Provider: &provider,
 			Project:  &project,

--- a/database/query/profile_status.sql
+++ b/database/query/profile_status.sql
@@ -88,6 +88,7 @@ SELECT
     rt.guidance as rule_type_guidance,
     rt.display_name as rule_type_display_name,
     ere.entity_instance_id as entity_id,
+    ei.name as entity_name,
     ei.project_id as project_id,
     rt.release_phase as rule_type_release_phase
 FROM latest_evaluation_statuses les
@@ -99,8 +100,9 @@ FROM latest_evaluation_statuses les
          INNER JOIN rule_type rt ON rt.id = ri.rule_type_id
          INNER JOIN entity_instances ei ON ei.id = ere.entity_instance_id
          INNER JOIN providers prov ON prov.id = ei.provider_id
-WHERE les.profile_id = $1 AND
-    (ere.entity_instance_id = sqlc.narg(entity_id)::UUID OR sqlc.narg(entity_id)::UUID IS NULL)
+WHERE les.profile_id = $1
+    AND (ere.entity_instance_id = sqlc.narg(entity_id)::UUID OR sqlc.narg(entity_id)::UUID IS NULL)
+    AND (ei.name = sqlc.narg(entity_name) OR sqlc.narg(entity_name) IS NULL)
     AND (rt.name = sqlc.narg(rule_type_name) OR sqlc.narg(rule_type_name) IS NULL)
     AND (lower(ri.name) = lower(sqlc.narg(rule_name)) OR sqlc.narg(rule_name) IS NULL)
 ;

--- a/docs/docs/ref/proto.mdx
+++ b/docs/docs/ref/proto.mdx
@@ -965,14 +965,17 @@ used for parsing resources in ruletypes
 
 <Message id="minder-v1-EntityTypedId">EntityTypedId</Message>
 
-EntiryTypeId is a message that carries an ID together with a type to uniquely identify an entity
+EntityTypedId is a message that carries an ID together with a type to uniquely identify an entity
 such as (repo, 1), (artifact, 2), ...
 
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
-| type | <TypeLink type="minder-v1-Entity">Entity</TypeLink> |  | entity is the entity to get status for. Incompatible with `all` |
+| type | <TypeLink type="minder-v1-Entity">Entity</TypeLink> |  | entity is the entity to get status for. Incompatible with `all`
+
+On input, at least one of id and name must be set. If both are set, they must both match. On output, both id and name will be set. |
 | id | <TypeLink type="string">string</TypeLink> |  | id is the ID of the entity to get status for. Incompatible with `all` |
+| name | <TypeLink type="string">string</TypeLink> |  | name is the name of the entity. This name is unique within a given project, type, and provider, but may not be globally unique. |
 
 
 

--- a/internal/controlplane/handlers_evalstatus.go
+++ b/internal/controlplane/handlers_evalstatus.go
@@ -666,11 +666,10 @@ func (s *Server) buildRuleEvaluationStatusFromDBEvaluation(
 func buildEntityFromEvaluation(efp *entmodels.EntityWithProperties) *minderv1.EntityTypedId {
 	ent := &minderv1.EntityTypedId{
 		Type: efp.Entity.Type,
+		Id:   efp.Entity.ID.String(),
+		Name: efp.Entity.Name,
 	}
 
-	if ent.Type == minderv1.Entity_ENTITY_REPOSITORIES {
-		ent.Id = efp.Entity.ID.String()
-	}
 	return ent
 }
 

--- a/internal/controlplane/handlers_profile_test.go
+++ b/internal/controlplane/handlers_profile_test.go
@@ -1200,6 +1200,8 @@ func TestGetProfileStatusByName(t *testing.T) {
 		require.Equal(t, dbProfile.ID.String(), resp.ProfileStatus.ProfileId, "Profile ID should match")
 		require.Equal(t, expectedProfileName, resp.ProfileStatus.ProfileName, "Profile name should match")
 	})
+
+	// TODO: add test case for requesting evaluation details
 }
 
 func TestGetProfileStatusById(t *testing.T) {
@@ -1255,6 +1257,8 @@ func TestGetProfileStatusById(t *testing.T) {
 		require.Equal(t, dbProfile.ID.String(), resp.ProfileStatus.ProfileId, "Profile ID should match")
 		require.Equal(t, expectedProfileName, resp.ProfileStatus.ProfileName, "Profile name should match")
 	})
+
+	// TODO: add test case for requesting evaluation details
 }
 
 type deleteProfileTestCase struct {

--- a/internal/engine/engcontext/context.go
+++ b/internal/engine/engcontext/context.go
@@ -56,18 +56,18 @@ type EntityContext struct {
 }
 
 // Validate validates that the entity context contains values that are present in the DB
-func (c *EntityContext) Validate(ctx context.Context, q db.Querier, providerStore providers.ProviderStore) error {
+func (c *EntityContext) Validate(ctx context.Context, q db.Querier, providerStore providers.ProviderStore) (*db.Provider, error) {
 	_, err := q.GetProjectByID(ctx, c.Project.ID)
 	if err != nil {
-		return fmt.Errorf("unable to get context: failed getting project: %w", err)
+		return nil, fmt.Errorf("unable to get context: failed getting project: %w", err)
 	}
 
-	_, err = providerStore.GetByName(ctx, c.Project.ID, c.Provider.Name)
+	dbProvider, err := providerStore.GetByName(ctx, c.Project.ID, c.Provider.Name)
 	if err != nil {
-		return fmt.Errorf("unable to get context: failed getting provider: %w", err)
+		return nil, fmt.Errorf("unable to get context: failed getting provider: %w", err)
 	}
 
-	return nil
+	return dbProvider, nil
 }
 
 // ValidateProject validates that the entity context contains a project that is present in the DB

--- a/pkg/api/openapi/minder/v1/minder.swagger.json
+++ b/pkg/api/openapi/minder/v1/minder.swagger.json
@@ -1573,7 +1573,7 @@
           },
           {
             "name": "entity.type",
-            "description": "entity is the entity to get status for. Incompatible with `all`",
+            "description": "entity is the entity to get status for. Incompatible with `all`\n\nOn input, at least one of id and name must be set.  If both are set, they must both match.\n On output, both id and name will be set.",
             "in": "query",
             "required": true,
             "type": "string",
@@ -1594,7 +1594,14 @@
             "name": "entity.id",
             "description": "id is the ID of the entity to get status for. Incompatible with `all`",
             "in": "query",
-            "required": true,
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "entity.name",
+            "description": "name is the name of the entity.  This name is unique within a given project, type, and provider, but may not be globally unique.",
+            "in": "query",
+            "required": false,
             "type": "string"
           },
           {
@@ -1812,7 +1819,7 @@
           },
           {
             "name": "entity.type",
-            "description": "entity is the entity to get status for. Incompatible with `all`",
+            "description": "entity is the entity to get status for. Incompatible with `all`\n\nOn input, at least one of id and name must be set.  If both are set, they must both match.\n On output, both id and name will be set.",
             "in": "query",
             "required": true,
             "type": "string",
@@ -1833,7 +1840,14 @@
             "name": "entity.id",
             "description": "id is the ID of the entity to get status for. Incompatible with `all`",
             "in": "query",
-            "required": true,
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "entity.name",
+            "description": "name is the name of the entity.  This name is unique within a given project, type, and provider, but may not be globally unique.",
+            "in": "query",
+            "required": false,
             "type": "string"
           },
           {
@@ -4496,17 +4510,21 @@
       "properties": {
         "type": {
           "$ref": "#/definitions/v1Entity",
+          "description": "On input, at least one of id and name must be set.  If both are set, they must both match.\n On output, both id and name will be set.",
           "title": "entity is the entity to get status for. Incompatible with `all`"
         },
         "id": {
           "type": "string",
           "title": "id is the ID of the entity to get status for. Incompatible with `all`"
+        },
+        "name": {
+          "type": "string",
+          "description": "name is the name of the entity.  This name is unique within a given project, type, and provider, but may not be globally unique."
         }
       },
-      "description": "EntiryTypeId is a message that carries an ID together with a type to uniquely identify an entity\nsuch as (repo, 1), (artifact, 2), ...",
+      "description": "EntityTypedId is a message that carries an ID together with a type to uniquely identify an entity\nsuch as (repo, 1), (artifact, 2), ...",
       "required": [
-        "type",
-        "id"
+        "type"
       ]
     },
     "v1EvalResultAlert": {

--- a/pkg/api/protobuf/go/minder/v1/minder.pb.go
+++ b/pkg/api/protobuf/go/minder/v1/minder.pb.go
@@ -5702,14 +5702,16 @@ func (x *RuleEvaluationStatus) GetReleasePhase() RuleTypeReleasePhase {
 	return RuleTypeReleasePhase_RULE_TYPE_RELEASE_PHASE_UNSPECIFIED
 }
 
-// EntiryTypeId is a message that carries an ID together with a type to uniquely identify an entity
+// EntityTypedId is a message that carries an ID together with a type to uniquely identify an entity
 // such as (repo, 1), (artifact, 2), ...
 type EntityTypedId struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// entity is the entity to get status for. Incompatible with `all`
 	Type Entity `protobuf:"varint,1,opt,name=type,proto3,enum=minder.v1.Entity" json:"type,omitempty"`
 	// id is the ID of the entity to get status for. Incompatible with `all`
-	Id            string `protobuf:"bytes,2,opt,name=id,proto3" json:"id,omitempty"`
+	Id string `protobuf:"bytes,2,opt,name=id,proto3" json:"id,omitempty"`
+	// name is the name of the entity.  This name is unique within a given project, type, and provider, but may not be globally unique.
+	Name          string `protobuf:"bytes,3,opt,name=name,proto3" json:"name,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -5754,6 +5756,13 @@ func (x *EntityTypedId) GetType() Entity {
 func (x *EntityTypedId) GetId() string {
 	if x != nil {
 		return x.Id
+	}
+	return ""
+}
+
+func (x *EntityTypedId) GetName() string {
+	if x != nil {
+		return x.Name
 	}
 	return ""
 }
@@ -15097,10 +15106,11 @@ const file_minder_v1_minder_proto_rawDesc = "" +
 	"\x0fEntityInfoEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
 	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01B\x1b\n" +
-	"\x19_remediation_last_updated\"X\n" +
+	"\x19_remediation_last_updated\"\x94\x01\n" +
 	"\rEntityTypedId\x12*\n" +
 	"\x04type\x18\x01 \x01(\x0e2\x11.minder.v1.EntityB\x03\xe0A\x02R\x04type\x12\x1b\n" +
-	"\x02id\x18\x02 \x01(\tB\v\xe0A\x02\xbaH\x05r\x03\xb0\x01\x01R\x02id\"\xee\x02\n" +
+	"\x02id\x18\x02 \x01(\tB\v\xe0A\x01\xbaH\x05r\x03\xb0\x01\x01R\x02id\x12:\n" +
+	"\x04name\x18\x03 \x01(\tB&\xe0A\x01\xbaH r\x1e(\xc8\x012\x19^[[:alnum:]][-/[:word:]]*R\x04name\"\xee\x02\n" +
 	"\x1dGetProfileStatusByNameRequest\x12,\n" +
 	"\acontext\x18\x01 \x01(\v2\x12.minder.v1.ContextR\acontext\x128\n" +
 	"\x04name\x18\x02 \x01(\tB$\xbaH!\xd8\x01\x01r\x1c\x18\xc8\x012\x17^[A-Za-z][-/[:word:]]*$R\x04name\x120\n" +

--- a/proto/minder/v1/minder.proto
+++ b/proto/minder/v1/minder.proto
@@ -1883,17 +1883,28 @@ message RuleEvaluationStatus {
     ];
 }
 
-// EntiryTypeId is a message that carries an ID together with a type to uniquely identify an entity
+// EntityTypedId is a message that carries an ID together with a type to uniquely identify an entity
 // such as (repo, 1), (artifact, 2), ...
 message EntityTypedId {
     // entity is the entity to get status for. Incompatible with `all`
     Entity type = 1 [
         (google.api.field_behavior) = REQUIRED
     ];
+    // On input, at least one of id and name must be set.  If both are set, they must both match.
+    // On output, both id and name will be set.
+
     // id is the ID of the entity to get status for. Incompatible with `all`
     string id = 2 [
         (buf.validate.field).string = {uuid: true},
-        (google.api.field_behavior) = REQUIRED
+        (google.api.field_behavior) = OPTIONAL
+    ];
+    // name is the name of the entity.  This name is unique within a given project, type, and provider, but may not be globally unique.
+    string name = 3 [
+        (buf.validate.field).string = {
+            max_bytes: 200
+            pattern: "^[[:alnum:]][-/[:word:]]*"
+        },
+        (google.api.field_behavior) = OPTIONAL
     ];
 }
 


### PR DESCRIPTION
# Summary

Adds an optional input and output name to EntityTypedId, which reduces the number of API round-trips needed when displaying rule evaluation status or reconciling repositories by name.

# Testing

Tested manually with a live instance and the `EvalResultsService.ListEvaluationResults`.
