### PR TITLE
Document bootstrap target in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,15 +70,43 @@ Minder consists of:
 
 ### Prerequisites
 
+**Required tools:**
 - Go 1.24+
 - Docker & Docker Compose
-- PostgreSQL (via Docker)
+- OpenSSL (for key generation)
+
+**Build tools (installed via `make bootstrap`):**
 - ko (for container builds)
 - buf (Protocol Buffer compilation)
 - sqlc (SQL code generation)
 - golangci-lint (linting)
 - gotestfmt (test output formatting)
-- Keycloak (via Docker for local auth)
+- protoc plugins (grpc-gateway, protoc-gen-go, etc.)
+- mockgen (mock generation)
+- yq (YAML processing)
+- fga (OpenFGA CLI)
+- helm-docs (Helm documentation)
+
+**Runtime services (via Docker):**
+- PostgreSQL (database)
+- Keycloak (authentication)
+- NATS (message queue)
+
+### Initial Setup
+
+Before building or running Minder, install all build dependencies and initialize configuration:
+
+```bash
+# Install build tools and initialize configuration
+make bootstrap
+```
+
+This command will:
+- Install all Go-based build tools (sqlc, protoc plugins, mockgen, etc.)
+- Create `config.yaml` and `server-config.yaml` from example templates (if they don't exist)
+- Generate encryption keys in `.ssh/` directory for token signing
+
+**Note**: Run `make bootstrap` once after cloning the repository. You may need to run it again if build tool versions change.
 
 ### Building
 
@@ -380,6 +408,7 @@ if errors.Is(err, sql.ErrNoRows) {
 
 ```bash
 make help           # Show all available targets
+make bootstrap      # Install build tools and initialize configuration (run once)
 make build          # Build CLI and server binaries
 make gen            # Run all code generators
 make test           # Run all tests with verbose output


### PR DESCRIPTION
## Summary
Adds comprehensive documentation for the `make bootstrap` target in CLAUDE.md. This target is essential for initial development environment setup but was not prominently documented in the Prerequisites or workflow sections.

## Changes
- **Reorganized Prerequisites section**: Clarified which tools are installed via `make bootstrap` vs. tools required beforehand (Go, Docker, OpenSSL)
- **Added "Initial Setup" section**: Provides clear step-by-step guidance that bootstrap should be run once after cloning to:
  - Install build tools (sqlc, protoc plugins, mockgen, yq, fga, helm-docs)
  - Initialize configuration files (config.yaml, server-config.yaml)
  - Generate encryption keys (.ssh/ directory)
- **Updated "Useful Make Targets"**: Added bootstrap to the quick reference list

## Motivation
New developers cloning the repository need to run `make bootstrap` before they can build or generate code, but this wasn't clearly documented. This change ensures developers have a smooth onboarding experience and understand the purpose of the bootstrap target.

## Test plan
- [x] Verified CLAUDE.md renders correctly
- [x] Confirmed all information about bootstrap target is accurate by reviewing `.mk/develop.mk`

🤖 Generated with [Claude Code](https://claude.com/claude-code)