### PR TITLE
Publish docs to mindersec.dev domain

### DIFF
--- a/.github/workflows/deploy-doc.yml
+++ b/.github/workflows/deploy-doc.yml
@@ -33,4 +33,4 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           # Build output to publish to the `gh-pages` branch:
           publish_dir: ./docs/build
-          cname: minder-docs.stacklok.dev
+          cname: docs.mindersec.dev


### PR DESCRIPTION
# Summary

Publishes docs at docs.mindersec.dev, rather than the old (retired) Stacklok URL.  This will also replace the `mindersec.github.io` URL, which will be set up to redirect to `docs.mindersec.dev`.

# Testing

Kate Powell [set up the DNS records](https://openssf.slack.com/archives/C05BETTLHEE/p1761256713871669), and I verified the custom domain in GitHub Pages today ("DNS check successful").
