### PR TITLE
refactor: omit unnecessary reassignment

### DIFF
--- a/cmd/cli/app/auth/auth_test.go
+++ b/cmd/cli/app/auth/auth_test.go
@@ -29,7 +29,6 @@ func TestCobraMain(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		test := test
 
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()

--- a/cmd/cli/app/provider/provider_update_test.go
+++ b/cmd/cli/app/provider/provider_update_test.go
@@ -66,7 +66,6 @@ func (s *UnitTestSuite) TestParseConfigAttribute() {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
@@ -151,7 +150,6 @@ func (s *UnitTestSuite) TestByJSONName() {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
@@ -254,7 +252,6 @@ func (s *UnitTestSuite) TestGetField() {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
@@ -351,7 +348,6 @@ func (s *UnitTestSuite) TestInitField() {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
@@ -499,7 +495,6 @@ func (s *UnitTestSuite) TestConfigAttribute() {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()

--- a/cmd/cli/main_test.go
+++ b/cmd/cli/main_test.go
@@ -52,7 +52,6 @@ func TestCobraMain(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		test := test
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/cmd/server/main_test.go
+++ b/cmd/server/main_test.go
@@ -52,7 +52,6 @@ func TestCobraMain(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		test := test
 
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()

--- a/internal/api/api_test.go
+++ b/internal/api/api_test.go
@@ -69,7 +69,6 @@ func TestProtoValidationInterceptor(t *testing.T) {
 	interceptor := ProtoValidationInterceptor(validator)
 
 	for _, tt := range tests {
-		tt := tt
 
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()

--- a/internal/controlplane/common_test.go
+++ b/internal/controlplane/common_test.go
@@ -26,7 +26,6 @@ func TestGetRemediationURLFromMetadata(t *testing.T) {
 		{"no-slug-no-pr", []byte(`{}`), "", "", true},
 		{"invalid-json", []byte(`Yo!`), "", "", true},
 	} {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			url, err := getRemediationURLFromMetadata(tc.data, tc.repo)
@@ -58,7 +57,6 @@ func TestGetAlertURLFromMetadata(t *testing.T) {
 		{"no-advisory", []byte(`{"ghsa_id": ""}`), "", "", true},
 		{"invalid-slug", []byte(`{"ghsa_id": "abc"}`), "invalid slug", "", true},
 	} {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			res, err := getAlertURLFromMetadata(tc.data, tc.repo)

--- a/internal/controlplane/handlers_datasource_test.go
+++ b/internal/controlplane/handlers_datasource_test.go
@@ -55,7 +55,6 @@ func TestCreateDataSource(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt // capture range variable
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			ctrl := gomock.NewController(t)
@@ -151,7 +150,6 @@ func TestGetDataSourceById(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt // capture range variable
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			ctrl := gomock.NewController(t)
@@ -230,7 +228,6 @@ func TestGetDataSourceByName(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt // capture range variable
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			ctrl := gomock.NewController(t)
@@ -299,7 +296,6 @@ func TestListDataSources(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt // capture range variable
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			ctrl := gomock.NewController(t)
@@ -373,7 +369,6 @@ func TestUpdateDataSource(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt // capture range variable
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			ctrl := gomock.NewController(t)
@@ -463,7 +458,6 @@ func TestDeleteDataSourceById(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt // capture range variable
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			ctrl := gomock.NewController(t)
@@ -560,7 +554,6 @@ func TestDeleteDataSourceByName(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt // capture range variable
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			ctrl := gomock.NewController(t)

--- a/internal/controlplane/handlers_evalstatus.go
+++ b/internal/controlplane/handlers_evalstatus.go
@@ -368,7 +368,6 @@ func (s *Server) sortEntitiesEvaluationStatus(
 	}
 
 	for _, p := range profileList {
-		p := p
 		evals, err := store.ListRuleEvaluationsByProfileId(
 			ctx, db.ListRuleEvaluationsByProfileIdParams{ProfileID: p.Profile.ID},
 		)

--- a/internal/controlplane/handlers_evalstatus_test.go
+++ b/internal/controlplane/handlers_evalstatus_test.go
@@ -87,7 +87,6 @@ func TestBuildEvalResultAlertFromLRERow(t *testing.T) {
 			},
 		},
 	} {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			res := buildEvalResultAlertFromLRERow(tc.sut, tc.efp)

--- a/internal/controlplane/handlers_profile_test.go
+++ b/internal/controlplane/handlers_profile_test.go
@@ -287,7 +287,6 @@ func TestCreateProfile(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		tc := tc
 
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
@@ -1011,7 +1010,6 @@ func TestPatchProfile(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		tc := tc
 
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
@@ -1371,7 +1369,6 @@ func TestDeleteProfile(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -1486,7 +1483,6 @@ func TestListProfiles(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		tc := tc
 
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
@@ -1602,7 +1598,6 @@ func TestGetProfileById(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		tc := tc
 
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
@@ -1707,7 +1702,6 @@ func TestGetProfileByName(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		tc := tc
 
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()

--- a/internal/controlplane/handlers_reconciliationtasks_test.go
+++ b/internal/controlplane/handlers_reconciliationtasks_test.go
@@ -287,7 +287,6 @@ func TestServer_CreateRepositoryReconciliationTask(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()

--- a/internal/controlplane/handlers_ruletype_test.go
+++ b/internal/controlplane/handlers_ruletype_test.go
@@ -108,7 +108,6 @@ func TestCreateRuleType(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
@@ -228,7 +227,6 @@ func TestUpdateRuleType(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
@@ -377,7 +375,6 @@ func TestDeleteRuleType(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
@@ -465,7 +462,6 @@ func TestListRuleTypes(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()

--- a/internal/datasources/rest/handler_test.go
+++ b/internal/datasources/rest/handler_test.go
@@ -92,7 +92,6 @@ func Test_parseRequestBodyConfig(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			gotFromInput, gotStr, err := parseRequestBodyConfig(tt.args.def)
@@ -210,7 +209,6 @@ func Test_restHandler_HTTPCall(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			ctrl := gomock.NewController(t)
@@ -492,7 +490,6 @@ func Test_restHandler_ProviderCall(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			ctrl := gomock.NewController(t)
@@ -649,7 +646,6 @@ func Test_restHandler_ValidateUpdate(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/internal/datasources/service/service_test.go
+++ b/internal/datasources/service/service_test.go
@@ -1056,7 +1056,6 @@ func TestDelete(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -1520,7 +1519,6 @@ func TestUpdate(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -1692,7 +1690,6 @@ func TestUpsert(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/internal/db/eval_history_test.go
+++ b/internal/db/eval_history_test.go
@@ -695,7 +695,6 @@ func TestListEvaluationHistoryFilters(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
@@ -853,7 +852,6 @@ func TestListEvaluationHistoryPagination(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
@@ -934,7 +932,6 @@ func TestGetEvaluationHistory(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()

--- a/internal/db/profiles_test.go
+++ b/internal/db/profiles_test.go
@@ -474,7 +474,6 @@ func TestProfileLabels(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
@@ -632,7 +631,6 @@ func TestCreateProfileStatusSingleRuleTransitions(t *testing.T) {
 	randomEntities := createTestRandomEntities(t)
 
 	for _, tt := range tests {
-		tt := tt
 
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
@@ -2998,7 +2996,6 @@ func TestCreateProfileStatusMultiRuleTransitions(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
@@ -3335,7 +3332,6 @@ func TestCreateProfileStatusStoredProcedure(t *testing.T) {
 	randomEntities := createTestRandomEntities(t)
 
 	for _, tt := range tests {
-		tt := tt
 
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
@@ -3574,7 +3570,6 @@ func TestCreateProfileStatusStoredDeleteProcedure(t *testing.T) {
 	randomEntities := createTestRandomEntities(t)
 
 	for _, tt := range tests {
-		tt := tt
 
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
@@ -3846,7 +3841,6 @@ func TestListRuleEvaluations(t *testing.T) {
 	randomEntities := createTestRandomEntities(t)
 
 	for _, tt := range tests {
-		tt := tt
 
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()

--- a/internal/eea/eea.go
+++ b/internal/eea/eea.go
@@ -216,7 +216,6 @@ func (e *EEA) FlushAll(ctx context.Context) error {
 	}
 
 	for _, cache := range caches {
-		cache := cache
 
 		eiw, err := e.buildEntityWrapper(ctx, cache.Entity,
 			cache.ProjectID, cache.EntityInstanceID)

--- a/internal/eea/eea_test.go
+++ b/internal/eea/eea_test.go
@@ -331,7 +331,6 @@ func TestFlushAll(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()

--- a/internal/email/email_test.go
+++ b/internal/email/email_test.go
@@ -44,7 +44,6 @@ func TestIsValidField(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt // capture range variable for parallel execution
 		t.Run(tt.input, func(t *testing.T) {
 			t.Parallel()
 			err := isValidField(tt.input)
@@ -161,7 +160,6 @@ func TestValidateDataSourceTemplate(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt // capture range variable for parallel execution
 		t.Run(tt.input.AdminName, func(t *testing.T) {
 			t.Parallel()
 			err := tt.input.Validate()

--- a/internal/engine/actions/alert/pull_request_comment/pull_request_comment_test.go
+++ b/internal/engine/actions/alert/pull_request_comment/pull_request_comment_test.go
@@ -112,7 +112,6 @@ func TestPullRequestCommentAlert(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()

--- a/internal/engine/actions/alert/security_advisory/security_advisory_test.go
+++ b/internal/engine/actions/alert/security_advisory/security_advisory_test.go
@@ -65,7 +65,6 @@ func TestSecurityAdvisoryAlert(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()

--- a/internal/engine/actions/remediate/gh_branch_protect/gh_branch_protect_test.go
+++ b/internal/engine/actions/remediate/gh_branch_protect/gh_branch_protect_test.go
@@ -312,7 +312,6 @@ func TestBranchProtectionRemediate(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()

--- a/internal/engine/actions/remediate/pull_request/pull_request_test.go
+++ b/internal/engine/actions/remediate/pull_request/pull_request_test.go
@@ -639,7 +639,6 @@ func TestPullRequestRemediate(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()

--- a/internal/engine/actions/remediate/remediate_test.go
+++ b/internal/engine/actions/remediate/remediate_test.go
@@ -107,7 +107,6 @@ func TestNewRuleRemediator(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()

--- a/internal/engine/actions/remediate/rest/rest_test.go
+++ b/internal/engine/actions/remediate/rest/rest_test.go
@@ -139,7 +139,6 @@ func TestNewRestRemediate(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
@@ -424,7 +423,6 @@ func TestRestRemediate(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()

--- a/internal/engine/entities/entity_event_test.go
+++ b/internal/engine/entities/entity_event_test.go
@@ -225,7 +225,6 @@ func Test_parseEntityEvent(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()

--- a/internal/engine/errors/errors_test.go
+++ b/internal/engine/errors/errors_test.go
@@ -30,7 +30,6 @@ func TestLegacyEvaluationDetailRendering(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
@@ -103,7 +102,6 @@ func TestEvaluationDetailRendering(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()

--- a/internal/engine/eval/eval_test.go
+++ b/internal/engine/eval/eval_test.go
@@ -83,7 +83,6 @@ func TestNewRuleEvaluatorWorks(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
@@ -176,7 +175,6 @@ func TestNewRuleEvaluatorFails(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()

--- a/internal/engine/eval/homoglyphs/application/invisible_characters_eval_test.go
+++ b/internal/engine/eval/homoglyphs/application/invisible_characters_eval_test.go
@@ -60,7 +60,6 @@ func TestInvisibleCharactersEvaluationDetailRendering(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()

--- a/internal/engine/eval/homoglyphs/application/mixed_scripts_eval_test.go
+++ b/internal/engine/eval/homoglyphs/application/mixed_scripts_eval_test.go
@@ -70,7 +70,6 @@ func TestEvaluationDetailRendering(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()

--- a/internal/engine/eval/homoglyphs/domain/invisible_characters_test.go
+++ b/internal/engine/eval/homoglyphs/domain/invisible_characters_test.go
@@ -54,7 +54,6 @@ func TestFindInvisibleCharacters(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.description, func(t *testing.T) {
 			t.Parallel()
 

--- a/internal/engine/eval/homoglyphs/domain/mixed_scripts_test.go
+++ b/internal/engine/eval/homoglyphs/domain/mixed_scripts_test.go
@@ -67,7 +67,6 @@ func TestFindMixedScripts(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.description, func(t *testing.T) {
 			t.Parallel()
 
@@ -139,7 +138,6 @@ func TestStringToRune(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.description, func(t *testing.T) {
 			t.Parallel()
 

--- a/internal/engine/eval/jq/jq_test.go
+++ b/internal/engine/eval/jq/jq_test.go
@@ -66,7 +66,6 @@ func TestNewJQEvaluatorValid(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -175,7 +174,6 @@ func TestNewJQEvaluatorInvalid(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -358,7 +356,6 @@ func TestValidJQEvals(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -568,7 +565,6 @@ func TestValidJQEvalsFailed(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -639,7 +635,6 @@ func TestInvalidJQEvals(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
@@ -692,7 +687,6 @@ func TestEvaluationDetailRendering(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()

--- a/internal/engine/eval/rego/result_test.go
+++ b/internal/engine/eval/rego/result_test.go
@@ -86,7 +86,6 @@ func TestEvaluationDetailRendering(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()

--- a/internal/engine/eval/trusty/actions_test.go
+++ b/internal/engine/eval/trusty/actions_test.go
@@ -116,7 +116,6 @@ func TestBuildProvenanceStruct(t *testing.T) {
 			mustNil: true,
 		},
 	} {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			res := buildProvenanceStruct(tc.sut)

--- a/internal/engine/eval/trusty/trusty_test.go
+++ b/internal/engine/eval/trusty/trusty_test.go
@@ -104,7 +104,6 @@ func TestBuildEvalResult(t *testing.T) {
 			},
 		}, false, true},
 	} {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			res := buildEvalResult(tc.sut)
@@ -144,7 +143,6 @@ func TestParseRuleConfig(t *testing.T) {
 			}, true,
 		},
 	} {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			res, err := parseRuleConfig(tc.sut)
@@ -168,7 +166,6 @@ func TestReadPullRequestDependencies(t *testing.T) {
 		{name: "normal", sut: &interfaces.Ingested{Object: &pbinternal.PrDependencies{}}, mustErr: false},
 		{name: "invalid-object", sut: &interfaces.Ingested{Object: context.Background()}, mustErr: true},
 	} {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			deps, err := readPullRequestDependencies(tc.sut)
@@ -193,7 +190,6 @@ func TestNewTrustyEvaluator(t *testing.T) {
 		{"normal", ghProvider, false},
 		{"no-provider", nil, true},
 	} {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			c, err := NewTrustyEvaluator(context.Background(), tc.prv)
@@ -305,7 +301,6 @@ func TestClassifyDependency(t *testing.T) {
 			mustFilter: false,
 		},
 	} {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			handler := summaryPrHandler{}
@@ -370,7 +365,6 @@ func TestMakeScoreComponents(t *testing.T) {
 			},
 		},
 	} {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			scoreMatrix := makeScoreComponents(tc.sut)
@@ -434,7 +428,6 @@ func TestEvaluationDetailRendering(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()

--- a/internal/engine/eval/vulncheck/pkgdb_test.go
+++ b/internal/engine/eval/vulncheck/pkgdb_test.go
@@ -126,7 +126,6 @@ func TestNpmPkgDb(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -199,7 +198,6 @@ func TestPackageJsonLineHasDependency(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -292,7 +290,6 @@ func TestPyPiReplyLineHasDependency(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 		})
@@ -376,7 +373,6 @@ func TestPyPiPkgDb(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -582,7 +578,6 @@ golang.org/x/text v0.13.0 h1:ablQoSUd0tRdKxZewP80B+BaqeKJuVhuRxj/dkrun3k=`))
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -651,7 +646,6 @@ func TestRepoCache(t *testing.T) {
 	cache := newRepoCache()
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/internal/engine/eval/vulncheck/vulncheck_test.go
+++ b/internal/engine/eval/vulncheck/vulncheck_test.go
@@ -36,7 +36,6 @@ func TestEvaluationDetailRendering(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()

--- a/internal/engine/eval/vulncheck/vulndb_test.go
+++ b/internal/engine/eval/vulncheck/vulndb_test.go
@@ -288,7 +288,6 @@ func TestGoVulnDb(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -351,7 +350,6 @@ func TestOsvdb_NewQuery(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/internal/engine/ingestcache/cache_test.go
+++ b/internal/engine/ingestcache/cache_test.go
@@ -106,7 +106,6 @@ func TestCache(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 
 		t.Run("cache test "+tt.name, func(t *testing.T) {
 			t.Parallel()
@@ -130,7 +129,6 @@ func TestCache(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 
 		t.Run("noopcache test "+tt.name, func(t *testing.T) {
 			t.Parallel()

--- a/internal/engine/ingester/artifact/artifact_test.go
+++ b/internal/engine/ingester/artifact/artifact_test.go
@@ -208,7 +208,6 @@ func TestArtifactIngestMatching(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
@@ -314,7 +313,6 @@ func TestSignerIdentityFromCertificate(t *testing.T) {
 			true,
 		},
 	} {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			identity, err := signerIdentityFromCertificate(tc.sut)

--- a/internal/engine/ingester/builtin/builtin_test.go
+++ b/internal/engine/ingester/builtin/builtin_test.go
@@ -43,7 +43,6 @@ func TestBuiltInWorks(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
@@ -90,7 +89,6 @@ func TestBuiltinErrorCases(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()

--- a/internal/engine/ingester/diff/diff_test.go
+++ b/internal/engine/ingester/diff/diff_test.go
@@ -100,7 +100,6 @@ func TestGetEcosystemForFile(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()

--- a/internal/engine/ingester/diff/parse_test.go
+++ b/internal/engine/ingester/diff/parse_test.go
@@ -118,7 +118,6 @@ func TestGoParse(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.description, func(t *testing.T) {
 			t.Parallel()
 			got, err := goParse(tt.content)
@@ -339,7 +338,6 @@ func TestPyPiParse(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.description, func(t *testing.T) {
 			t.Parallel()
 			got, err := requirementsParse(tt.content)
@@ -507,7 +505,6 @@ func TestNpmParse(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.description, func(t *testing.T) {
 			t.Parallel()
 			got, err := npmParse(tt.content)

--- a/internal/engine/ingester/ingester_test.go
+++ b/internal/engine/ingester/ingester_test.go
@@ -143,7 +143,6 @@ func TestNewRuleDataIngest(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/internal/engine/ingester/rest/rest.go
+++ b/internal/engine/ingester/rest/rest.go
@@ -88,7 +88,6 @@ func NewRestRuleDataIngest(
 
 	fallback := make([]ingestorFallback, len(restCfg.Fallback))
 	for _, fb := range restCfg.Fallback {
-		fb := fb
 		fallback = append(fallback, ingestorFallback{
 			httpCode: int(fb.HttpCode),
 			body:     fb.Body,

--- a/internal/engine/ingester/rest/rest_test.go
+++ b/internal/engine/ingester/rest/rest_test.go
@@ -70,7 +70,6 @@ func TestNewRestRuleDataIngest(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
@@ -337,7 +336,6 @@ func TestRestIngest(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()

--- a/internal/entities/properties/service/service_test.go
+++ b/internal/entities/properties/service/service_test.go
@@ -606,7 +606,6 @@ func TestPropertiesService_EntityWithPropertiesByUpstreamHint(t *testing.T) {
 	}
 
 	for _, tt := range scenarios {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/internal/events/events_test.go
+++ b/internal/events/events_test.go
@@ -147,7 +147,6 @@ func TestEventer(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()

--- a/internal/history/models_test.go
+++ b/internal/history/models_test.go
@@ -115,7 +115,6 @@ func TestListEvaluationCursor(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
@@ -320,7 +319,6 @@ func TestListEvaluationFilter(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
@@ -1017,7 +1015,6 @@ func TestFilterOptions(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/internal/providers/artifact/versionsfilter_test.go
+++ b/internal/providers/artifact/versionsfilter_test.go
@@ -72,7 +72,6 @@ func TestBuildFilter(t *testing.T) {
 			},
 		},
 	} {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			f, err := BuildFilter(tc.tags, tc.regex)

--- a/internal/providers/github/clients/app_test.go
+++ b/internal/providers/github/clients/app_test.go
@@ -272,7 +272,6 @@ func TestArtifactAPIEscapesApp(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
@@ -358,7 +357,6 @@ func TestListPackagesByRepository(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()

--- a/internal/providers/github/clients/oauth_test.go
+++ b/internal/providers/github/clients/oauth_test.go
@@ -132,7 +132,6 @@ func TestArtifactAPIEscapesOAuth(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()

--- a/internal/providers/github/common_test.go
+++ b/internal/providers/github/common_test.go
@@ -157,7 +157,6 @@ func TestWaitForRateLimitReset(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			th := setupTest(t)
@@ -218,7 +217,6 @@ func TestPerformWithRetry(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			result, err := performWithRetry(context.Background(), tt.operation)
@@ -557,7 +555,6 @@ func TestGetArtifactVersions(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/internal/providers/github/installations/installations_test.go
+++ b/internal/providers/github/installations/installations_test.go
@@ -105,7 +105,6 @@ func TestInstallationEntityWrapper(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			iiw := NewInstallationInfoWrapper().

--- a/internal/providers/github/properties/artifact_test.go
+++ b/internal/providers/github/properties/artifact_test.go
@@ -73,7 +73,6 @@ func TestParseArtifactName(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt // capture range variable
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			owner, name, artifactType, err := parseArtifactName(tt.input)
@@ -126,7 +125,6 @@ func TestGetName(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt // capture range variable
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			props := properties.NewProperties(tt.props)
@@ -167,7 +165,6 @@ func TestGetNameFromParams(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt // capture range variable
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			result := getNameFromParams(tt.owner, tt.artifact)
@@ -215,7 +212,6 @@ func TestGetArtifactWrapperAttrsFromProps(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt // capture range variable
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			props := properties.NewProperties(tt.props)

--- a/internal/providers/github/webhook/handlers_githubwebhooks_test.go
+++ b/internal/providers/github/webhook/handlers_githubwebhooks_test.go
@@ -2661,7 +2661,6 @@ func (s *UnitTestSuite) TestHandleGitHubWebHook() {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
@@ -3255,7 +3254,6 @@ func (s *UnitTestSuite) TestHandleGitHubAppWebHook() {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()

--- a/internal/providers/selectors/selector_entity_test.go
+++ b/internal/providers/selectors/selector_entity_test.go
@@ -253,7 +253,6 @@ func TestEntityToSelectorEntity(t *testing.T) {
 	}
 
 	for _, scenario := range scenarios {
-		scenario := scenario
 
 		t.Run(scenario.name, func(t *testing.T) {
 			t.Parallel()

--- a/internal/reconcilers/entity_add_test.go
+++ b/internal/reconcilers/entity_add_test.go
@@ -132,7 +132,6 @@ func TestHandleEntityAdd(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()

--- a/internal/reconcilers/entity_delete_test.go
+++ b/internal/reconcilers/entity_delete_test.go
@@ -123,7 +123,6 @@ func TestHandleEntityDelete(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()

--- a/internal/reminder/reminder_test.go
+++ b/internal/reminder/reminder_test.go
@@ -144,7 +144,6 @@ func Test_getRepositoryBatch(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		test := test
 
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()

--- a/internal/util/cli/markdown_test.go
+++ b/internal/util/cli/markdown_test.go
@@ -63,7 +63,6 @@ func TestRenderMarkdown(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			res := RenderMarkdown(tt.input)

--- a/internal/util/cursor/cursor_test.go
+++ b/internal/util/cursor/cursor_test.go
@@ -30,7 +30,6 @@ func TestEncodeDecodeValue(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
@@ -74,7 +73,6 @@ func TestEncodeDecodeCursor(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
@@ -131,7 +129,6 @@ func TestDecodeListRepositoriesByProjectIDCursor(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()

--- a/internal/util/helpers_test.go
+++ b/internal/util/helpers_test.go
@@ -323,7 +323,6 @@ func TestGetConfigValue(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()

--- a/internal/util/jsonyaml/jsonyamlutils_test.go
+++ b/internal/util/jsonyaml/jsonyamlutils_test.go
@@ -46,7 +46,6 @@ bar:
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
@@ -98,7 +97,6 @@ foo: bar
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()

--- a/internal/util/safe_template_test.go
+++ b/internal/util/safe_template_test.go
@@ -63,7 +63,6 @@ func TestParseNewTemplate(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
@@ -79,7 +78,6 @@ func TestParseNewTemplate(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
@@ -162,7 +160,6 @@ func TestGenerateCurlCommand(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
@@ -326,7 +323,6 @@ func TestRenderStructPB(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()

--- a/internal/util/schemaupdate/schemaupdate_test.go
+++ b/internal/util/schemaupdate/schemaupdate_test.go
@@ -340,7 +340,6 @@ func TestValidateSchemaUpdate(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/internal/util/statuses_test.go
+++ b/internal/util/statuses_test.go
@@ -62,7 +62,6 @@ func TestSanitizingInterceptor(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
@@ -130,7 +129,6 @@ func TestNiceStatusFromRpcError(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
@@ -308,7 +306,6 @@ func TestSetCode(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()

--- a/internal/verifier/sigstore/container/container_test.go
+++ b/internal/verifier/sigstore/container/container_test.go
@@ -88,7 +88,6 @@ func TestBundleFromOCIImage(t *testing.T) {
 			err: ErrProvenanceNotFoundOrIncomplete,
 		},
 	} {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			tc.prepare(t, fmt.Sprintf("bundle-from-oci-image/%s", tc.name))

--- a/internal/verifier/sigstore/sigstore_test.go
+++ b/internal/verifier/sigstore/sigstore_test.go
@@ -65,7 +65,6 @@ func TestGetSigstoreOptions(t *testing.T) {
 			mustErr:    true,
 		},
 	} {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			tuf, verifier, err := getSigstoreOptions(tc.rootSource)

--- a/pkg/api/protobuf/go/minder/v1/rule_types_test.go
+++ b/pkg/api/protobuf/go/minder/v1/rule_types_test.go
@@ -37,7 +37,6 @@ func TestSeverity_MarshalJSON(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
@@ -84,7 +83,6 @@ func TestSeverity_UnmarshalJSON(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
@@ -127,7 +125,6 @@ func TestRuleType_WithDefaultShortFailureMessage(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
@@ -179,7 +176,6 @@ func TestRuleTypeState_MarshalJSON(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
@@ -224,7 +220,6 @@ func TestRuleTypeState_UnmarshalJSON(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()

--- a/pkg/api/protobuf/go/minder/v1/validators_test.go
+++ b/pkg/api/protobuf/go/minder/v1/validators_test.go
@@ -60,7 +60,6 @@ func TestRuleType_Definition_Ingest_Validate(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -135,7 +134,6 @@ func TestRuleType_Definition_Eval_Validate(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -266,7 +264,6 @@ func TestRuleType_Definition_Eval_JQComparison_Validate(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -321,7 +318,6 @@ func TestRuleType_Definition_Eval_Rego_Validate(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -370,7 +366,6 @@ func TestDataSourceReference_Validate(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -420,7 +415,6 @@ func TestRuleType_Definition_Alert_Validate(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -467,7 +461,6 @@ func TestRuleType_Definition_Alert_AlertTypePRComment_Validate(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -545,7 +538,6 @@ func TestRuleType_Definition_Remediate_Validate(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -664,7 +656,6 @@ func TestRuleType_Definition_Remediate_PullRequestRemediation_Validate(t *testin
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -700,7 +691,6 @@ func TestRuleType_Definition_Remediate_GhBranchProtectionType_Validate(t *testin
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/pkg/config/reminder/config_test.go
+++ b/pkg/config/reminder/config_test.go
@@ -92,7 +92,6 @@ func TestValidateConfig(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()

--- a/pkg/config/utils_test.go
+++ b/pkg/config/utils_test.go
@@ -121,7 +121,6 @@ key3: [value1, null, value2]
 	}
 
 	for _, test := range tests {
-		test := test
 
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()

--- a/pkg/mindpak/build/packer_test.go
+++ b/pkg/mindpak/build/packer_test.go
@@ -117,7 +117,6 @@ func TestPackerInitBundle(t *testing.T) {
 			mustErr: true,
 		},
 	} {
-		tc := tc
 		t.Run(t.Name(), func(t *testing.T) {
 			t.Parallel()
 
@@ -211,7 +210,6 @@ func TestValidateInitOpts(t *testing.T) {
 			shouldErr: true,
 		},
 	} {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			err := tc.opts.Validate()

--- a/pkg/mindpak/bundle_test.go
+++ b/pkg/mindpak/bundle_test.go
@@ -74,7 +74,6 @@ func TestReadSource(t *testing.T) {
 			},
 		},
 	} {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			m := Bundle{}

--- a/pkg/mindpak/manifest_test.go
+++ b/pkg/mindpak/manifest_test.go
@@ -53,7 +53,6 @@ func TestManifestWrite(t *testing.T) {
 			false,
 		},
 	} {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			b := bytes.NewBuffer([]byte{})

--- a/pkg/profiles/util_test.go
+++ b/pkg/profiles/util_test.go
@@ -295,7 +295,6 @@ repository:
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
@@ -482,7 +481,6 @@ func TestGetRulesForEntity(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
@@ -601,7 +599,6 @@ func TestFilterRulesForType(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
@@ -763,7 +760,6 @@ func TestDeriveProfileNameFromDisplayName(t *testing.T) {
 
 	for _, tt := range tests {
 
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 


### PR DESCRIPTION
# Summary

The new version of Go has been optimized, and variables do not need to be reassigned.

For more info: https://tip.golang.org/wiki/LoopvarExperiment#does-this-mean-i-dont-have-to-write-x--x-in-my-loops-anymore


Fixes #(related issue)

# Testing

***Outline how the changes were tested, including steps to reproduce and any relevant configurations. 
Attach screenshots if helpful.***
