### PR TITLE
Deflake flagged_driver_test by expanding mutex

### DIFF
--- a/internal/events/flagged_driver.go
+++ b/internal/events/flagged_driver.go
@@ -80,15 +80,15 @@ func (f *flaggedDriver) Subscribe(ctx context.Context, topic string) (<-chan *me
 					base = nil
 					continue
 				}
-				out <- msg
 				f.readMessages.Add(ctx, 1, metric.WithAttributes(attribute.Bool("experiment", false)))
+				out <- msg
 			case msg, ok := <-experiment:
 				if !ok {
 					experiment = nil
 					continue
 				}
-				out <- msg
 				f.readMessages.Add(ctx, 1, metric.WithAttributes(attribute.Bool("experiment", true)))
+				out <- msg
 			case <-ctx.Done():
 				return
 			}
@@ -149,5 +149,7 @@ func makeFlaggedDriver(ctx context.Context, cfg *serverconfig.EventConfig, flagC
 	return ret, ret, closer, nil
 }
 
-var _ message.Publisher = (*flaggedDriver)(nil)
-var _ message.Subscriber = (*flaggedDriver)(nil)
+var (
+	_ message.Publisher  = (*flaggedDriver)(nil)
+	_ message.Subscriber = (*flaggedDriver)(nil)
+)

--- a/internal/events/flagged_driver_test.go
+++ b/internal/events/flagged_driver_test.go
@@ -109,6 +109,9 @@ alternate_message_driver:
 			t.Parallel()
 			ctx := context.Background()
 
+			metricMutex.Lock() // Can run in parallel with non-metric-measuring tests
+			defer metricMutex.Unlock()
+
 			config := serverconfig.Config{
 				Events: serverconfig.EventConfig{
 					Driver: constants.FlaggedDriver,
@@ -152,9 +155,6 @@ alternate_message_driver:
 				}
 			})
 			<-eventer.Running()
-
-			metricMutex.Lock()
-			defer metricMutex.Unlock()
 
 			sendBefore := getMetric(t, reader, "events_published", tt.sendExperiment)
 			readBefore := getMetric(t, reader, "events_read", tt.sendExperiment)


### PR DESCRIPTION
# Summary

We seem to have a couple frequent flakes on GitHub that don't easily reproduce in my (fast) development environment.  Today I decided to try the same thing on a slower machine (4x 1.5Ghz), and was able to reproduce the failures, which seem to be due to flags being reinitialized outside the lock (e.g. "before = 2, after = 0" on an only-incrementing counter must be a reinit).

# Testing

5 runs of `go test -count 1000 ./internal/events` with zero flakes. (about 25 minutes on the aforementioned machine)
