### PR TITLE
Generate and store failed test results for later consumption

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,7 +29,7 @@ jobs:
         uses: GoTestTools/gotestfmt-action@8b4478c7019be847373babde9300210e7de34bfb # v2.2.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-      - name: Install go-junit-report
+      - name: Install gotestsum
         run: |
           ARCH=$(echo "${{ runner.arch }}" | tr '[:upper:]' '[:lower:]' | sed 's/x64/amd64/')
           OS=$(echo "${{ runner.os }}" | tr '[:upper:]' '[:lower:]' | sed 's/macos/darwin/')
@@ -53,9 +53,11 @@ jobs:
           MINDER_TEST_REGISTRY: "localhost:5000"
         run: make test-cover-silent
       - name: Generate JUnit report
+        if: ${{ !cancelled() }}
         run: |
           gotestsum  --junitfile test-results.xml --junitfile-hide-empty-pkg --raw-command -- cat test-results.json
       - name: Upload test results
+        if: ${{ !cancelled() }}
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         with:
           name: test-results


### PR DESCRIPTION
# Summary

In #6063, I ensured that the test output HTML would run even if previous stages failed, but I forgot to apply the same treatment to creating (and uploading) the structured XML test output.  Fix those, along with the commented name of the XML report generation tool.

# Testing

Discovered while reviewing https://github.com/mindersec/minder/actions/runs/21348630225/job/61440761374?pr=6068
