### PR TITLE
Avoid leaking internal error messages, simplify code

### DIFF
--- a/internal/controlplane/handlers_user.go
+++ b/internal/controlplane/handlers_user.go
@@ -313,11 +313,7 @@ func (s *Server) ListInvitations(ctx context.Context, _ *pb.ListInvitationsReque
 
 	invitations, err := s.invites.GetInvitesForSelf(ctx, s.store, s.idClient)
 	if err != nil {
-		var niceErr *util.NiceStatus // no need to wrap formatted errors
-		if errors.As(err, &niceErr) {
-			return nil, err
-		}
-		return nil, status.Errorf(codes.Internal, "failed to get invitations: %s", err)
+		return nil, err
 	}
 
 	return &pb.ListInvitationsResponse{
@@ -344,11 +340,7 @@ func (s *Server) ResolveInvitation(ctx context.Context, req *pb.ResolveInvitatio
 
 	invite, err := s.invites.GetInvite(ctx, qtx, req.Code)
 	if err != nil || invite == nil {
-		var niceErr *util.NiceStatus // no need to wrap formatted errors
-		if errors.As(err, &niceErr) {
-			return nil, err
-		}
-		return nil, status.Errorf(codes.Internal, "failed to get invitation: %s", err)
+		return nil, err
 	}
 	project, err := uuid.Parse(invite.GetProject())
 	if err != nil {


### PR DESCRIPTION
# Summary

In #5959, I noticed that the pattern:

```golang
var userErr *util.NiceStatus
if errors.As(err, &userErr) {
  return nil, err
}
return nil, util.UserVisibleError(codes.Internal, "some description: %s", err)
```

Often leaks the internal implementation details that `UserVisibleError` was supposed to prevent.  Sadly, I did this a couple times recently, so simplify the code to simply `return nil, err`

# Testing

Unit tests.
