### PR TITLE
Fix race between message.Ack and field access in tests

### DIFF
--- a/internal/providers/github/webhook/handlers_githubwebhooks_test.go
+++ b/internal/providers/github/webhook/handlers_githubwebhooks_test.go
@@ -3385,16 +3385,12 @@ func TestAll(t *testing.T) {
 
 //nolint:unparam
 func withTimeout(ch <-chan *message.Message, timeout time.Duration) *message.Message {
-	wrapper := make(chan *message.Message, 1)
-	go func() {
-		select {
-		case item := <-ch:
-			wrapper <- item
-		case <-time.After(timeout):
-			wrapper <- nil
-		}
-	}()
-	return <-wrapper
+	select {
+	case item := <-ch:
+		return item
+	case <-time.After(timeout):
+		return nil
+	}
 }
 
 //nolint:unparam


### PR DESCRIPTION
# Summary

We've been seeing frequent failures due to data races with PassthroughQueue and Watermill.  I *think* this is due to watermill calling `Ack()` on the message after the return from `Pass()`, while the test gets the same `message.Message` object in another thread via the channel.  Pass a *copy* to the testing code, to avoid races.

While debugging, I noticed a bunch of excessive channels and locks that may have been intended to resolve this without really understanding the issue, so I removed them.  (I added at least one.)

# Testing

Ran `go test -count 100 -race internal/providers/github/webhook`, which would previously produce a data race reliably on my "small" computer.
