### PR TITLE
Fix remaining lint error

### DIFF
--- a/internal/util/cli/rpc_client.go
+++ b/internal/util/cli/rpc_client.go
@@ -413,14 +413,15 @@ func loginWithDeviceFlow(
 		}
 		return nil, fmt.Errorf("failed to obtain device access token: %w", err)
 	}
-	if tokenResp.ExpiresIn >= maxLifetimeSec {
-		tokenResp.ExpiresIn = maxLifetimeSec
+	expiry := int64(maxLifetimeSec)
+	if tokenResp.ExpiresIn < maxLifetimeSec {
+		expiry = int64(tokenResp.ExpiresIn)
 	}
 
 	return &oauth2.Token{
 		AccessToken:  tokenResp.AccessToken,
 		TokenType:    tokenResp.TokenType,
 		RefreshToken: tokenResp.RefreshToken,
-		Expiry:       time.Now().Add(time.Duration(tokenResp.ExpiresIn) * time.Second),
+		Expiry:       time.Now().Add(time.Duration(expiry) * time.Second),
 	}, nil
 }


### PR DESCRIPTION
# Summary

Somehow I ended up missing one integer conversion warning.  You would need to have a truly enormous (now + `> MAX_SIGNED_INT_64`) token expiration time to hit it, but this should fix the lint warning.

# Testing

Ran the linter manually and verified no errors.
