### PR TITLE
Fix engine handler context handling

### DIFF
--- a/internal/engine/handler.go
+++ b/internal/engine/handler.go
@@ -93,8 +93,8 @@ func (e *ExecutorEventHandler) HandleEntityEvent(msg *message.Message) error {
 	// We _do_ still want to cancel on shutdown, however.
 	// TODO: Make this timeout configurable
 	msgCtx := context.WithoutCancel(msg.Context())
+	//nolint:gosec // this is called when we iterate over e.cancels
 	msgCtx, shutdownCancel := context.WithCancel(msgCtx)
-	defer shutdownCancel()
 
 	e.lock.Lock()
 	e.cancels = append(e.cancels, &shutdownCancel)


### PR DESCRIPTION
# Summary

This got broken in #6167, when `shutdownCancel` got flagged by new lints in `gosec`, and I didn't read the nice comment above the block.  :facepalm:

The deferred `shutdownCancel` is called almost immediately, since the rest of the method is just spawning a goroutine.

# Testing

Discovered in staging testing; this basically causes rule evaluation to stop immediately on a context cancellation.
