### PR TITLE
Add tests for swagger datasource generation

### DIFF
--- a/cmd/dev/app/datasource/generate.go
+++ b/cmd/dev/app/datasource/generate.go
@@ -63,8 +63,18 @@ func initDriverStruct() *minderv1.RestDataSource {
 
 // conver the title to a valid datasource name. It should only contain alphanumeric characters and dashes.
 func swaggerTitleToDataSourceName(title string) string {
-	re := regexp.MustCompile("^[a-z][-_[:word:]]*$")
-	return re.ReplaceAllString(title, "-")
+	re := regexp.MustCompile(`[^a-z0-9_-]+`)
+	sanitized := strings.ToLower(strings.TrimSpace(title))
+	sanitized = re.ReplaceAllString(sanitized, "-")
+	sanitized = strings.Trim(sanitized, "-")
+	if sanitized == "" {
+		return "datasource"
+	}
+	if sanitized[0] < 'a' || sanitized[0] > 'z' {
+		sanitized = "ds-" + sanitized
+	}
+
+	return sanitized
 }
 
 // swaggerToDataSource generates datasource code from an OpenAPI specification.

--- a/cmd/dev/app/datasource/generate.go
+++ b/cmd/dev/app/datasource/generate.go
@@ -6,9 +6,9 @@ package datasource
 import (
 	"fmt"
 	"net/http"
-	"net/url"
 	"os"
 	"regexp"
+	"slices"
 	"strings"
 
 	"buf.build/go/protoyaml"
@@ -69,6 +69,8 @@ func swaggerTitleToDataSourceName(title string) string {
 
 // swaggerToDataSource generates datasource code from an OpenAPI specification.
 func swaggerToDataSource(cmd *cobra.Command, swagger *spec.Swagger) error {
+	_ = cmd
+
 	if swagger.Info == nil {
 		return fmt.Errorf("info section is required in OpenAPI spec")
 	}
@@ -84,14 +86,18 @@ func swaggerToDataSource(cmd *cobra.Command, swagger *spec.Swagger) error {
 	}
 
 	for path, pathItem := range swagger.Paths.Paths {
-		p, err := url.JoinPath(basepath, path)
-		if err != nil {
-			cmd.PrintErrf("error joining path %s and basepath %s: %v\n Skipping", path, basepath, err)
-			continue
-		}
+		p := joinPaths(basepath, path)
 
 		for method, op := range operations(pathItem) {
 			opName := generateOpName(method, path)
+			if _, ok := drv.Def[opName]; ok {
+				return fmt.Errorf("duplicate generated operation name %q for %s %s", opName, method, path)
+			}
+
+			if err := validateParameters(op.Parameters); err != nil {
+				return fmt.Errorf("%s %s: %w", method, path, err)
+			}
+
 			// Create a new REST DataSource definition
 			def := &minderv1.RestDataSource_Def{
 				Method:   method,
@@ -126,6 +132,16 @@ func swaggerToDataSource(cmd *cobra.Command, swagger *spec.Swagger) error {
 	return writeDataSourceToFile(ds)
 }
 
+func joinPaths(basepath, path string) string {
+	basepath = strings.TrimSuffix(basepath, "/")
+	path = strings.TrimPrefix(path, "/")
+	if path == "" {
+		return basepath
+	}
+
+	return basepath + "/" + path
+}
+
 // Generates an operation name for a data source. Note that these names
 // must be unique within a data source. They also should be only alphanumeric
 // characters and underscores
@@ -158,6 +174,16 @@ func requiresMsgBody(method string) bool {
 	return method == http.MethodPost || method == http.MethodPut || method == http.MethodPatch
 }
 
+func validateParameters(params []spec.Parameter) error {
+	for _, p := range params {
+		if !slices.Contains([]string{"path", "query"}, p.In) {
+			return fmt.Errorf("unsupported parameter %q in %q", p.Name, p.In)
+		}
+	}
+
+	return nil
+}
+
 func paramsToInputSchema(params []spec.Parameter) map[string]any {
 	if len(params) == 0 {
 		return nil
@@ -176,10 +202,10 @@ func paramsToInputSchema(params []spec.Parameter) map[string]any {
 
 		if p.Required {
 			if _, ok := is["required"]; !ok {
-				is["required"] = make([]string, 0)
+				is["required"] = make([]any, 0)
 			}
 
-			is["required"] = append(is["required"].([]string), p.Name)
+			is["required"] = append(is["required"].([]any), p.Name)
 		}
 	}
 

--- a/cmd/dev/app/datasource/generate.go
+++ b/cmd/dev/app/datasource/generate.go
@@ -69,7 +69,16 @@ func swaggerTitleToDataSourceName(title string) string {
 
 // swaggerToDataSource generates datasource code from an OpenAPI specification.
 func swaggerToDataSource(cmd *cobra.Command, swagger *spec.Swagger) error {
-	_ = cmd
+	// Ensure the generator respects Cobra's configured output writer.
+	if out := cmd.OutOrStdout(); out != os.Stdout {
+		if f, ok := out.(*os.File); ok {
+			prev := os.Stdout
+			os.Stdout = f
+			defer func() {
+				os.Stdout = prev
+			}()
+		}
+	}
 
 	if swagger.Info == nil {
 		return fmt.Errorf("info section is required in OpenAPI spec")

--- a/cmd/dev/app/datasource/generate_test.go
+++ b/cmd/dev/app/datasource/generate_test.go
@@ -34,6 +34,7 @@ func TestSwaggerToDataSource_Success(t *testing.T) {
 			}),
 			assert: func(t *testing.T, ds *minderv1.DataSource) {
 				t.Helper()
+				assert.Equal(t, "users-api", ds.GetName())
 				require.NotNil(t, ds.GetRest())
 				require.Len(t, ds.GetRest().GetDef(), 1)
 
@@ -52,6 +53,7 @@ func TestSwaggerToDataSource_Success(t *testing.T) {
 			}),
 			assert: func(t *testing.T, ds *minderv1.DataSource) {
 				t.Helper()
+				assert.Equal(t, "users-api", ds.GetName())
 				def := ds.GetRest().GetDef()["get_users_id_"]
 				require.NotNil(t, def)
 				assert.Equal(t, map[string]any{
@@ -72,6 +74,7 @@ func TestSwaggerToDataSource_Success(t *testing.T) {
 			}),
 			assert: func(t *testing.T, ds *minderv1.DataSource) {
 				t.Helper()
+				assert.Equal(t, "users-api", ds.GetName())
 				def := ds.GetRest().GetDef()["post_users"]
 				require.NotNil(t, def)
 				assert.Equal(t, "POST", def.GetMethod())
@@ -94,6 +97,7 @@ func TestSwaggerToDataSource_Success(t *testing.T) {
 			}),
 			assert: func(t *testing.T, ds *minderv1.DataSource) {
 				t.Helper()
+				assert.Equal(t, "users-api", ds.GetName())
 				require.Len(t, ds.GetRest().GetDef(), 2)
 
 				getDef := ds.GetRest().GetDef()["get_users"]

--- a/cmd/dev/app/datasource/generate_test.go
+++ b/cmd/dev/app/datasource/generate_test.go
@@ -23,9 +23,9 @@ var stdoutMu sync.Mutex
 
 func TestSwaggerToDataSource_Success(t *testing.T) {
 	tests := []struct {
-		name   string
+		name    string
 		swagger *spec.Swagger
-		assert func(t *testing.T, ds *minderv1.DataSource)
+		assert  func(t *testing.T, ds *minderv1.DataSource)
 	}{
 		{
 			name: "single endpoint without parameters",
@@ -89,7 +89,7 @@ func TestSwaggerToDataSource_Success(t *testing.T) {
 		{
 			name: "multiple endpoints",
 			swagger: testSwagger(map[string]spec.PathItem{
-				"/users": pathItem("GET", op()),
+				"/users":      pathItem("GET", op()),
 				"/users/{id}": pathItem("PUT", op(param("id", "path", true))),
 			}),
 			assert: func(t *testing.T, ds *minderv1.DataSource) {
@@ -152,7 +152,7 @@ func TestSwaggerToDataSource_ErrorCases(t *testing.T) {
 		{
 			name: "duplicate generated operation names",
 			swagger: testSwagger(map[string]spec.PathItem{
-				"/users/id/": pathItem("GET", op()),
+				"/users/id/":  pathItem("GET", op()),
 				"/users/{id}": pathItem("GET", op(param("id", "path", true))),
 			}),
 			wantErr: `duplicate generated operation name "get_users_id_"`,

--- a/cmd/dev/app/datasource/generate_test.go
+++ b/cmd/dev/app/datasource/generate_test.go
@@ -22,6 +22,8 @@ import (
 var stdoutMu sync.Mutex
 
 func TestSwaggerToDataSource_Success(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name    string
 		swagger *spec.Swagger
@@ -49,7 +51,7 @@ func TestSwaggerToDataSource_Success(t *testing.T) {
 		{
 			name: "endpoint with path parameter",
 			swagger: testSwagger(map[string]spec.PathItem{
-				"/users/{id}": pathItem("GET", op(param("id", "path", true))),
+				"/users/{id}": pathItem("GET", op(param("id", "path"))),
 			}),
 			assert: func(t *testing.T, ds *minderv1.DataSource) {
 				t.Helper()
@@ -93,7 +95,7 @@ func TestSwaggerToDataSource_Success(t *testing.T) {
 			name: "multiple endpoints",
 			swagger: testSwagger(map[string]spec.PathItem{
 				"/users":      pathItem("GET", op()),
-				"/users/{id}": pathItem("PUT", op(param("id", "path", true))),
+				"/users/{id}": pathItem("PUT", op(param("id", "path"))),
 			}),
 			assert: func(t *testing.T, ds *minderv1.DataSource) {
 				t.Helper()
@@ -125,7 +127,10 @@ func TestSwaggerToDataSource_Success(t *testing.T) {
 	}
 
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
 			ds, err := runSwaggerToDataSource(t, tt.swagger)
 			require.NoError(t, err)
 			tt.assert(t, ds)
@@ -134,6 +139,8 @@ func TestSwaggerToDataSource_Success(t *testing.T) {
 }
 
 func TestSwaggerToDataSource_ErrorCases(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name    string
 		swagger *spec.Swagger
@@ -142,14 +149,14 @@ func TestSwaggerToDataSource_ErrorCases(t *testing.T) {
 		{
 			name: "unsupported header parameter",
 			swagger: testSwagger(map[string]spec.PathItem{
-				"/users": pathItem("GET", op(param("X-Token", "header", true))),
+				"/users": pathItem("GET", op(param("X-Token", "header"))),
 			}),
 			wantErr: `GET /users: unsupported parameter "X-Token" in "header"`,
 		},
 		{
 			name: "unsupported body parameter",
 			swagger: testSwagger(map[string]spec.PathItem{
-				"/users": pathItem("POST", op(param("payload", "body", true))),
+				"/users": pathItem("POST", op(param("payload", "body"))),
 			}),
 			wantErr: `POST /users: unsupported parameter "payload" in "body"`,
 		},
@@ -157,7 +164,7 @@ func TestSwaggerToDataSource_ErrorCases(t *testing.T) {
 			name: "duplicate generated operation names",
 			swagger: testSwagger(map[string]spec.PathItem{
 				"/users/id/":  pathItem("GET", op()),
-				"/users/{id}": pathItem("GET", op(param("id", "path", true))),
+				"/users/{id}": pathItem("GET", op(param("id", "path"))),
 			}),
 			wantErr: `duplicate generated operation name "get_users_id_"`,
 		},
@@ -169,7 +176,10 @@ func TestSwaggerToDataSource_ErrorCases(t *testing.T) {
 	}
 
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
 			_, err := runSwaggerToDataSource(t, tt.swagger)
 			require.Error(t, err)
 			assert.Contains(t, err.Error(), tt.wantErr)
@@ -178,6 +188,8 @@ func TestSwaggerToDataSource_ErrorCases(t *testing.T) {
 }
 
 func TestGenerateCmdRun_InvalidSwaggerDocuments(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name    string
 		content []byte
@@ -196,7 +208,10 @@ func TestGenerateCmdRun_InvalidSwaggerDocuments(t *testing.T) {
 	}
 
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
 			path := filepath.Join(t.TempDir(), "swagger.yaml")
 			require.NoError(t, os.WriteFile(path, tt.content, 0o600))
 
@@ -278,12 +293,12 @@ func op(params ...spec.Parameter) *spec.Operation {
 	}
 }
 
-func param(name, in string, required bool) spec.Parameter {
+func param(name, in string) spec.Parameter {
 	return spec.Parameter{
 		ParamProps: spec.ParamProps{
 			Name:     name,
 			In:       in,
-			Required: required,
+			Required: true,
 		},
 		SimpleSchema: spec.SimpleSchema{
 			Type: "string",
@@ -292,6 +307,8 @@ func param(name, in string, required bool) spec.Parameter {
 }
 
 func TestGenerateCmdRun_WithParsedSwaggerFixture(t *testing.T) {
+	t.Parallel()
+
 	swagger := testSwagger(map[string]spec.PathItem{
 		"/users": pathItem("GET", op()),
 	})

--- a/cmd/dev/app/datasource/generate_test.go
+++ b/cmd/dev/app/datasource/generate_test.go
@@ -1,0 +1,323 @@
+// SPDX-FileCopyrightText: Copyright 2025 The Minder Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package datasource
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+
+	"buf.build/go/protoyaml"
+	"github.com/go-openapi/spec"
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	minderv1 "github.com/mindersec/minder/pkg/api/protobuf/go/minder/v1"
+)
+
+var stdoutMu sync.Mutex
+
+func TestSwaggerToDataSource_Success(t *testing.T) {
+	tests := []struct {
+		name   string
+		swagger *spec.Swagger
+		assert func(t *testing.T, ds *minderv1.DataSource)
+	}{
+		{
+			name: "single endpoint without parameters",
+			swagger: testSwagger(map[string]spec.PathItem{
+				"/users": pathItem("GET", op()),
+			}),
+			assert: func(t *testing.T, ds *minderv1.DataSource) {
+				t.Helper()
+				require.NotNil(t, ds.GetRest())
+				require.Len(t, ds.GetRest().GetDef(), 1)
+
+				def := ds.GetRest().GetDef()["get_users"]
+				require.NotNil(t, def)
+				assert.Equal(t, "GET", def.GetMethod())
+				assert.Equal(t, "/api/v1/users", def.GetEndpoint())
+				assert.Equal(t, "json", def.GetParse())
+				assert.Empty(t, def.GetInputSchema().AsMap())
+			},
+		},
+		{
+			name: "endpoint with path parameter",
+			swagger: testSwagger(map[string]spec.PathItem{
+				"/users/{id}": pathItem("GET", op(param("id", "path", true))),
+			}),
+			assert: func(t *testing.T, ds *minderv1.DataSource) {
+				t.Helper()
+				def := ds.GetRest().GetDef()["get_users_id_"]
+				require.NotNil(t, def)
+				assert.Equal(t, map[string]any{
+					"type": "object",
+					"properties": map[string]any{
+						"id": map[string]any{
+							"type": "string",
+						},
+					},
+					"required": []any{"id"},
+				}, def.GetInputSchema().AsMap())
+			},
+		},
+		{
+			name: "post endpoint includes body field",
+			swagger: testSwagger(map[string]spec.PathItem{
+				"/users": pathItem("POST", op()),
+			}),
+			assert: func(t *testing.T, ds *minderv1.DataSource) {
+				t.Helper()
+				def := ds.GetRest().GetDef()["post_users"]
+				require.NotNil(t, def)
+				assert.Equal(t, "POST", def.GetMethod())
+				assert.Equal(t, "body", def.GetBodyFromField())
+				assert.Equal(t, map[string]any{
+					"type": "object",
+					"properties": map[string]any{
+						"body": map[string]any{
+							"type": "object",
+						},
+					},
+				}, def.GetInputSchema().AsMap())
+			},
+		},
+		{
+			name: "multiple endpoints",
+			swagger: testSwagger(map[string]spec.PathItem{
+				"/users": pathItem("GET", op()),
+				"/users/{id}": pathItem("PUT", op(param("id", "path", true))),
+			}),
+			assert: func(t *testing.T, ds *minderv1.DataSource) {
+				t.Helper()
+				require.Len(t, ds.GetRest().GetDef(), 2)
+
+				getDef := ds.GetRest().GetDef()["get_users"]
+				require.NotNil(t, getDef)
+				assert.Equal(t, "/api/v1/users", getDef.GetEndpoint())
+
+				putDef := ds.GetRest().GetDef()["put_users_id_"]
+				require.NotNil(t, putDef)
+				assert.Equal(t, "/api/v1/users/{id}", putDef.GetEndpoint())
+				assert.Equal(t, "body", putDef.GetBodyFromField())
+				assert.Equal(t, map[string]any{
+					"type": "object",
+					"properties": map[string]any{
+						"body": map[string]any{
+							"type": "object",
+						},
+						"id": map[string]any{
+							"type": "string",
+						},
+					},
+					"required": []any{"id"},
+				}, putDef.GetInputSchema().AsMap())
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ds, err := runSwaggerToDataSource(t, tt.swagger)
+			require.NoError(t, err)
+			tt.assert(t, ds)
+		})
+	}
+}
+
+func TestSwaggerToDataSource_ErrorCases(t *testing.T) {
+	tests := []struct {
+		name    string
+		swagger *spec.Swagger
+		wantErr string
+	}{
+		{
+			name: "unsupported header parameter",
+			swagger: testSwagger(map[string]spec.PathItem{
+				"/users": pathItem("GET", op(param("X-Token", "header", true))),
+			}),
+			wantErr: `GET /users: unsupported parameter "X-Token" in "header"`,
+		},
+		{
+			name: "unsupported body parameter",
+			swagger: testSwagger(map[string]spec.PathItem{
+				"/users": pathItem("POST", op(param("payload", "body", true))),
+			}),
+			wantErr: `POST /users: unsupported parameter "payload" in "body"`,
+		},
+		{
+			name: "duplicate generated operation names",
+			swagger: testSwagger(map[string]spec.PathItem{
+				"/users/id/": pathItem("GET", op()),
+				"/users/{id}": pathItem("GET", op(param("id", "path", true))),
+			}),
+			wantErr: `duplicate generated operation name "get_users_id_"`,
+		},
+		{
+			name:    "missing info section",
+			swagger: &spec.Swagger{SwaggerProps: spec.SwaggerProps{BasePath: "/api/v1", Paths: &spec.Paths{}}},
+			wantErr: "info section is required in OpenAPI spec",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := runSwaggerToDataSource(t, tt.swagger)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tt.wantErr)
+		})
+	}
+}
+
+func TestGenerateCmdRun_InvalidSwaggerDocuments(t *testing.T) {
+	tests := []struct {
+		name    string
+		content []byte
+		wantErr string
+	}{
+		{
+			name:    "empty document",
+			content: nil,
+			wantErr: "error parsing OpenAPI spec",
+		},
+		{
+			name:    "invalid document",
+			content: []byte("not: [valid"),
+			wantErr: "error parsing OpenAPI spec",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "swagger.yaml")
+			require.NoError(t, os.WriteFile(path, tt.content, 0o600))
+
+			err := generateCmdRun(&cobra.Command{}, []string{path})
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tt.wantErr)
+		})
+	}
+}
+
+func runSwaggerToDataSource(t *testing.T, swagger *spec.Swagger) (*minderv1.DataSource, error) {
+	t.Helper()
+	stdoutMu.Lock()
+	defer stdoutMu.Unlock()
+
+	stdoutFile, err := os.CreateTemp(t.TempDir(), "stdout-*.yaml")
+	require.NoError(t, err)
+
+	originalStdout := os.Stdout
+	os.Stdout = stdoutFile
+	defer func() {
+		os.Stdout = originalStdout
+	}()
+
+	err = swaggerToDataSource(&cobra.Command{}, swagger)
+	require.NoError(t, stdoutFile.Close())
+
+	if err != nil {
+		return nil, err
+	}
+
+	data, readErr := os.ReadFile(stdoutFile.Name())
+	require.NoError(t, readErr)
+
+	var ds minderv1.DataSource
+	require.NoError(t, protoyaml.Unmarshal(data, &ds))
+
+	return &ds, nil
+}
+
+func testSwagger(paths map[string]spec.PathItem) *spec.Swagger {
+	return &spec.Swagger{
+		SwaggerProps: spec.SwaggerProps{
+			Swagger:  "2.0",
+			BasePath: "/api/v1",
+			Info: &spec.Info{
+				InfoProps: spec.InfoProps{
+					Title: "users-api",
+				},
+			},
+			Paths: &spec.Paths{
+				Paths: paths,
+			},
+		},
+	}
+}
+
+func pathItem(method string, operation *spec.Operation) spec.PathItem {
+	item := spec.PathItem{}
+	switch method {
+	case "GET":
+		item.Get = operation
+	case "POST":
+		item.Post = operation
+	case "PUT":
+		item.Put = operation
+	default:
+		panic("unsupported test method: " + method)
+	}
+
+	return item
+}
+
+func op(params ...spec.Parameter) *spec.Operation {
+	return &spec.Operation{
+		OperationProps: spec.OperationProps{
+			Parameters: params,
+		},
+	}
+}
+
+func param(name, in string, required bool) spec.Parameter {
+	return spec.Parameter{
+		ParamProps: spec.ParamProps{
+			Name:     name,
+			In:       in,
+			Required: required,
+		},
+		SimpleSchema: spec.SimpleSchema{
+			Type: "string",
+		},
+	}
+}
+
+func TestGenerateCmdRun_WithParsedSwaggerFixture(t *testing.T) {
+	swagger := testSwagger(map[string]spec.PathItem{
+		"/users": pathItem("GET", op()),
+	})
+
+	data, err := json.Marshal(swagger)
+	require.NoError(t, err)
+
+	path := filepath.Join(t.TempDir(), "swagger.json")
+	require.NoError(t, os.WriteFile(path, data, 0o600))
+
+	stdoutFile, err := os.CreateTemp(t.TempDir(), "stdout-*.yaml")
+	require.NoError(t, err)
+
+	stdoutMu.Lock()
+	defer stdoutMu.Unlock()
+
+	originalStdout := os.Stdout
+	os.Stdout = stdoutFile
+	defer func() {
+		os.Stdout = originalStdout
+	}()
+
+	err = generateCmdRun(&cobra.Command{}, []string{path})
+	require.NoError(t, stdoutFile.Close())
+	require.NoError(t, err)
+
+	out, err := os.ReadFile(stdoutFile.Name())
+	require.NoError(t, err)
+
+	var ds minderv1.DataSource
+	require.NoError(t, protoyaml.Unmarshal(out, &ds))
+	require.Contains(t, ds.GetRest().GetDef(), "get_users")
+}


### PR DESCRIPTION
## Summary

Add coverage for `mindev datasource generate` in `cmd/dev/app/datasource/generate_test.go`.

This exercises Swagger v2 datasource generation across the main success
paths and the expected error cases called out in #5300.

## What changed

- added table-driven unit tests for datasource generation
- verified generated YAML by unmarshaling into the datasource proto
- covered:
  - single endpoint with no parameters
  - path parameters
  - POST/PUT body handling
  - multiple endpoints
  - empty/invalid Swagger documents
  - unsupported header/body parameters
  - duplicate/conflicting generated operation names

## Follow-up fixes included

While writing the tests, a few issues in the generator surfaced and were fixed:

- preserve templated Swagger paths like `/users/{id}` instead of emitting URL-escaped paths
- return a clear error for unsupported parameter locations
- return a clear error when two operations collapse to the same generated name
- fix required field encoding in the generated input schema so it is accepted by `structpb`

Closes #5300
