### PR TITLE
feat(api): set output_only flag for output-only fields in protos

### DIFF
--- a/pkg/api/openapi/minder/v1/minder.swagger.json
+++ b/pkg/api/openapi/minder/v1/minder.swagger.json
@@ -5057,12 +5057,14 @@
         },
         "organization": {
           "type": "string",
-          "description": "The GitHub organization slug where the app is installed.  This is an\noutput-only parameter, and is validated on input if set (i.e. the value\nmust be either empty or match the org of the installation_id)."
+          "description": "The GitHub organization slug where the app is installed.  This is an\noutput-only parameter, and is validated on input if set (i.e. the value\nmust be either empty or match the org of the installation_id).",
+          "readOnly": true
         },
         "organizationId": {
           "type": "string",
           "format": "int64",
-          "description": "The GitHub organization ID where the app is installed.  This is an\noutput-only parameter, and is validated on input if set (i.e. the value\nmust be either empty or match the org of the installation_id)."
+          "description": "The GitHub organization ID where the app is installed.  This is an\noutput-only parameter, and is validated on input if set (i.e. the value\nmust be either empty or match the org of the installation_id).",
+          "readOnly": true
         }
       },
       "description": "GitHubAppParams is the parameters for a GitHub App provider."
@@ -5472,7 +5474,8 @@
         },
         "id": {
           "type": "string",
-          "description": "id is the id of the profile.\nThis is optional and is set by the system."
+          "description": "id is the id of the profile.\nThis is optional and is set by the system.",
+          "readOnly": true
         },
         "name": {
           "type": "string",
@@ -5678,7 +5681,8 @@
         },
         "project": {
           "type": "string",
-          "description": "project is the project where the provider is.  This is ignored on input\nin favor of the context field in CreateProviderRequest."
+          "description": "project is the project where the provider is.  This is ignored on input\nin favor of the context field in CreateProviderRequest.",
+          "readOnly": true
         },
         "version": {
           "type": "string",
@@ -5708,7 +5712,8 @@
         },
         "credentialsState": {
           "type": "string",
-          "description": "credentials_state is the state of the credentials for the provider.\nThis is an output-only field. It may be: \"set\", \"unset\", \"not_applicable\"."
+          "description": "credentials_state is the state of the credentials for the provider.\nThis is an output-only field. It may be: \"set\", \"unset\", \"not_applicable\".",
+          "readOnly": true
         },
         "id": {
           "type": "string",
@@ -6331,7 +6336,8 @@
         },
         "id": {
           "type": "string",
-          "description": "id is the id of the rule type.\nThis is mostly optional and is set by the server."
+          "description": "id is the id of the rule type.\nThis is mostly optional and is set by the server.",
+          "readOnly": true
         },
         "name": {
           "type": "string",
@@ -6636,14 +6642,16 @@
         "repoId": {
           "type": "string",
           "format": "int64",
-          "description": "The upstream identity of the repository, as an integer.\nThis is only set on output, and is ignored on input."
+          "description": "The upstream identity of the repository, as an integer.\nThis is only set on output, and is ignored on input.",
+          "readOnly": true
         },
         "context": {
           "$ref": "#/definitions/v1Context"
         },
         "registered": {
           "type": "boolean",
-          "description": "True if the repository is already registered in Minder.\nThis is only set on output, and is ignored on input."
+          "description": "True if the repository is already registered in Minder.\nThis is only set on output, and is ignored on input.",
+          "readOnly": true
         }
       },
       "required": [

--- a/pkg/api/protobuf/go/minder/v1/minder.pb.go
+++ b/pkg/api/protobuf/go/minder/v1/minder.pb.go
@@ -15052,15 +15052,14 @@ const file_minder_v1_minder_proto_rawDesc = "" +
 	"\x06entity\x18\x01 \x01(\v2\x1c.minder.v1.UpstreamEntityRefB\x03\xe0A\x02R\x06entity\x12\x1e\n" +
 	"\n" +
 	"registered\x18\x02 \x01(\bR\n" +
-	"registered\"\xfc\x01\n" +
+	"registered\"\x84\x02\n" +
 	"\x15UpstreamRepositoryRef\x129\n" +
 	"\x05owner\x18\x01 \x01(\tB#\xbaH \xd8\x01\x01r\x1b\x18\xc8\x012\x16^[A-Za-z][-[:word:]]*$R\x05owner\x125\n" +
-	"\x04name\x18\x02 \x01(\tB!\xe0A\x02\xbaH\x1b\xd8\x01\x01r\x16\x18\xc8\x012\x11^[-.[:alnum:]_]+$R\x04name\x12#\n" +
-	"\arepo_id\x18\x03 \x01(\x03B\n" +
-	"\xbaH\a\xd8\x01\x01\"\x02(\x01R\x06repoId\x12,\n" +
-	"\acontext\x18\x04 \x01(\v2\x12.minder.v1.ContextR\acontext\x12\x1e\n" +
+	"\x04name\x18\x02 \x01(\tB!\xe0A\x02\xbaH\x1b\xd8\x01\x01r\x16\x18\xc8\x012\x11^[-.[:alnum:]_]+$R\x04name\x12&\n" +
+	"\arepo_id\x18\x03 \x01(\x03B\r\xe0A\x03\xbaH\a\xd8\x01\x01\"\x02(\x01R\x06repoId\x12,\n" +
+	"\acontext\x18\x04 \x01(\v2\x12.minder.v1.ContextR\acontext\x12#\n" +
 	"\n" +
-	"registered\x18\x05 \x01(\bR\n" +
+	"registered\x18\x05 \x01(\bB\x03\xe0A\x03R\n" +
 	"registered\"\xc4\x05\n" +
 	"\n" +
 	"Repository\x12\x18\n" +
@@ -15471,11 +15470,11 @@ const file_minder_v1_minder_proto_rawDesc = "" +
 	"\xea\xdc\x14\x06medium\x12\x18\n" +
 	"\n" +
 	"VALUE_HIGH\x10\x05\x1a\b\xea\xdc\x14\x04high\x12 \n" +
-	"\x0eVALUE_CRITICAL\x10\x06\x1a\f\xea\xdc\x14\bcritical\"\xea%\n" +
+	"\x0eVALUE_CRITICAL\x10\x06\x1a\f\xea\xdc\x14\bcritical\"\xed%\n" +
 	"\bRuleType\x12&\n" +
 	"\aversion\x18\v \x01(\tB\f\xbaH\tr\a2\x05^v\\d$R\aversion\x12$\n" +
-	"\x04type\x18\f \x01(\tB\x10\xbaH\rr\v2\trule-typeR\x04type\x12\x1d\n" +
-	"\x02id\x18\x01 \x01(\tB\b\xbaH\x05r\x03\xb0\x01\x01H\x00R\x02id\x88\x01\x01\x128\n" +
+	"\x04type\x18\f \x01(\tB\x10\xbaH\rr\v2\trule-typeR\x04type\x12 \n" +
+	"\x02id\x18\x01 \x01(\tB\v\xe0A\x03\xbaH\x05r\x03\xb0\x01\x01H\x00R\x02id\x88\x01\x01\x128\n" +
 	"\x04name\x18\x02 \x01(\tB$\xe0A\x02\xbaH\x1er\x1c\x18\xc8\x012\x17^[A-Za-z][-/[:word:]]*$R\x04name\x12L\n" +
 	"\fdisplay_name\x18\b \x01(\tB)\xbaH&\xd8\x01\x01r!\x18\xc8\x012\x1c^[A-Za-z][-/'()[:word:] :]*$R\vdisplayName\x12?\n" +
 	"\x15short_failure_message\x18\n" +
@@ -15586,10 +15585,10 @@ const file_minder_v1_minder_proto_rawDesc = "" +
 	"\x12_security_advisoryB\x17\n" +
 	"\x15_pull_request_commentB\x0f\n" +
 	"\r_param_schemaB\x05\n" +
-	"\x03_id\"\xff\v\n" +
+	"\x03_id\"\x82\f\n" +
 	"\aProfile\x12,\n" +
-	"\acontext\x18\x01 \x01(\v2\x12.minder.v1.ContextR\acontext\x12\x1d\n" +
-	"\x02id\x18\x02 \x01(\tB\b\xbaH\x05r\x03\xb0\x01\x01H\x00R\x02id\x88\x01\x01\x128\n" +
+	"\acontext\x18\x01 \x01(\v2\x12.minder.v1.ContextR\acontext\x12 \n" +
+	"\x02id\x18\x02 \x01(\tB\v\xe0A\x03\xbaH\x05r\x03\xb0\x01\x01H\x00R\x02id\x88\x01\x01\x128\n" +
 	"\x04name\x18\x03 \x01(\tB$\xbaH!\xd8\x01\x01r\x1c\x18\xc8\x012\x17^[A-Za-z][-/[:word:]]*$R\x04name\x12\x88\x01\n" +
 	"\x06labels\x18\f \x03(\tBp\xbaHm\x92\x01j\x18\x01\"frd2b^([a-zA-Z0-9_]([-a-zA-Z0-9_]{0,61}[a-zA-Z0-9_])?:)?[a-zA-Z0-9_]([-a-zA-Z0-9_]{0,61}[a-zA-Z0-9_])?$R\x06labels\x127\n" +
 	"\n" +
@@ -15797,17 +15796,16 @@ const file_minder_v1_minder_proto_rawDesc = "" +
 	"\n" +
 	"github_app\x18\x01 \x01(\v2\x1a.minder.v1.GitHubAppParamsH\x00R\tgithubAppB\f\n" +
 	"\n" +
-	"parameters\"\x9f\x01\n" +
+	"parameters\"\xa7\x01\n" +
 	"\x0fGitHubAppParams\x123\n" +
 	"\x0finstallation_id\x18\x01 \x01(\x03B\n" +
-	"\xbaH\a\xd8\x01\x01\"\x02 \x00R\x0einstallationId\x12\"\n" +
-	"\forganization\x18\x02 \x01(\tR\forganization\x123\n" +
-	"\x0forganization_id\x18\x03 \x01(\x03B\n" +
-	"\xbaH\a\xd8\x01\x01\"\x02 \x00R\x0eorganizationId\"\xeb\x03\n" +
+	"\xbaH\a\xd8\x01\x01\"\x02 \x00R\x0einstallationId\x12'\n" +
+	"\forganization\x18\x02 \x01(\tB\x03\xe0A\x03R\forganization\x126\n" +
+	"\x0forganization_id\x18\x03 \x01(\x03B\r\xe0A\x03\xbaH\a\xd8\x01\x01\"\x02 \x00R\x0eorganizationId\"\xf5\x03\n" +
 	"\bProvider\x127\n" +
 	"\x04name\x18\x01 \x01(\tB#\xbaH \xd8\x01\x01r\x1b\x18\xc8\x012\x16^[A-Za-z][-[:word:]]*$R\x04name\x125\n" +
-	"\x05class\x18\a \x01(\tB\x1f\xbaH\x1c\xd8\x01\x01r\x17\x18\xc8\x012\x12^[a-z][a-z0-9_-]*$R\x05class\x12\x18\n" +
-	"\aproject\x18\x02 \x01(\tR\aproject\x12&\n" +
+	"\x05class\x18\a \x01(\tB\x1f\xbaH\x1c\xd8\x01\x01r\x17\x18\xc8\x012\x12^[a-z][a-z0-9_-]*$R\x05class\x12\x1d\n" +
+	"\aproject\x18\x02 \x01(\tB\x03\xe0A\x03R\aproject\x12&\n" +
 	"\aversion\x18\x03 \x01(\tB\f\xbaH\t\xd8\x01\x01r\x042\x02v1R\aversion\x127\n" +
 	"\n" +
 	"implements\x18\x04 \x03(\x0e2\x17.minder.v1.ProviderTypeR\n" +
@@ -15817,8 +15815,8 @@ const file_minder_v1_minder_proto_rawDesc = "" +
 	"auth_flows\x18\x06 \x03(\x0e2\x1c.minder.v1.AuthorizationFlowR\tauthFlows\x12<\n" +
 	"\n" +
 	"parameters\x18\b \x01(\v2\x1c.minder.v1.ProviderParameterR\n" +
-	"parameters\x12+\n" +
-	"\x11credentials_state\x18\t \x01(\tR\x10credentialsState\x12\x1b\n" +
+	"parameters\x120\n" +
+	"\x11credentials_state\x18\t \x01(\tB\x03\xe0A\x03R\x10credentialsState\x12\x1b\n" +
 	"\x02id\x18\n" +
 	" \x01(\tB\v\xbaH\b\xd8\x01\x01r\x03\xb0\x01\x01R\x02id\"\x91\x01\n" +
 	"\x1bGetEvaluationHistoryRequest\x12\x1b\n" +

--- a/proto/minder/v1/minder.proto
+++ b/proto/minder/v1/minder.proto
@@ -1274,12 +1274,15 @@ message UpstreamRepositoryRef {
     // This is only set on output, and is ignored on input.
     int64 repo_id = 3 [
         (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE, // Given it's ignored on input, we can ignore empty values
-        (buf.validate.field).int64 = { gte: 1 }
+        (buf.validate.field).int64 = { gte: 1 },
+        (google.api.field_behavior) = OUTPUT_ONLY
     ];
     Context context = 4;
     // True if the repository is already registered in Minder.
     // This is only set on output, and is ignored on input.
-    bool registered = 5;
+    bool registered = 5 [
+        (google.api.field_behavior) = OUTPUT_ONLY
+    ];
 }
 
 // Repository API objects. This is only used in responses.
@@ -2580,7 +2583,8 @@ message RuleType {
     // id is the id of the rule type.
     // This is mostly optional and is set by the server.
     optional string id = 1 [
-        (buf.validate.field).string = {uuid: true}
+        (buf.validate.field).string = {uuid: true},
+        (google.api.field_behavior) = OUTPUT_ONLY
     ];
 
     // name is the name of the rule type.
@@ -2996,7 +3000,8 @@ message Profile {
     // id is the id of the profile.
     // This is optional and is set by the system.
     optional string id = 2 [
-        (buf.validate.field).string = {uuid: true}
+        (buf.validate.field).string = {uuid: true},
+        (google.api.field_behavior) = OUTPUT_ONLY
     ];
 
     // name is the name of the profile instance.
@@ -3744,13 +3749,16 @@ message GitHubAppParams {
     // The GitHub organization slug where the app is installed.  This is an
     // output-only parameter, and is validated on input if set (i.e. the value
     // must be either empty or match the org of the installation_id).
-    string organization = 2;
+    string organization = 2 [
+        (google.api.field_behavior) = OUTPUT_ONLY
+    ];
     // The GitHub organization ID where the app is installed.  This is an
     // output-only parameter, and is validated on input if set (i.e. the value
     // must be either empty or match the org of the installation_id).
     int64 organization_id = 3 [
         (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE,
-        (buf.validate.field).int64 = {gt: 0}
+        (buf.validate.field).int64 = {gt: 0},
+        (google.api.field_behavior) = OUTPUT_ONLY
     ];
 }
 
@@ -3809,7 +3817,9 @@ message Provider {
     ];
     // project is the project where the provider is.  This is ignored on input
     // in favor of the context field in CreateProviderRequest.
-    string project = 2;
+    string project = 2 [
+        (google.api.field_behavior) = OUTPUT_ONLY
+    ];
     // version is the version of the provider.
     // if unset, "v1" is assumed.
     string version = 3 [
@@ -3833,7 +3843,9 @@ message Provider {
 
     // credentials_state is the state of the credentials for the provider.
     // This is an output-only field. It may be: "set", "unset", "not_applicable".
-    string credentials_state = 9;
+    string credentials_state = 9 [
+        (google.api.field_behavior) = OUTPUT_ONLY
+    ];
 
     // id is the unique identifier of the provider.
     string id = 10 [


### PR DESCRIPTION
## Summary
This PR addresses issue #4951 by adding the (google.api.field_behavior) = OUTPUT_ONLY flag to all fields in minder.proto that are documented via comments as being output-only, ignored on input, or set by the server/system.
By explicitly annotating these fields with OUTPUT_ONLY, the generated OpenAPI specification will now correctly mark them as readOnly: true. This greatly improves the developer experience for API consumers (like our TypeScript clients) by ensuring that generated client code automatically applies readonly modifiers, clarifying that these fields do not need to be provided in the request body.

The following fields were updated:

- UpstreamRepositoryRef.repo_id
- UpstreamRepositoryRef.registered
- RuleType.id
- Profile.id
- GitHubAppParams.organization
- GitHubAppParams.organization_id
- Provider.project
- Provider.credentials_state

Fixes #4951

## Testing

- Verified that the ``` google.api.field_behavior ``` changes compile correctly.
- Ran buf lint on the protobuf files; passed with zero errors.
- Ran buf breaking against the upstream repository; confirmed no breaking changes were introduced.
- Ran the core backend unit/integration tests suite ``` go test ./pkg/api/... ./internal/controlplane/... ./pkg/ruletypes/... ``` to ensure standard parsing and interactions still function successfully.