### PR TITLE
refactor: populate provider field in entity context using provider ID fallback

### DIFF
--- a/.mk/develop.mk
+++ b/.mk/develop.mk
@@ -21,8 +21,8 @@ run-server: ## run the app
 .PHONY: run-docker-teardown
 run-docker-teardown: ## teardown the docker compose environment
 ifeq ($(RUN_DOCKER_NO_TEARDOWN),false)
-	@echo "Running docker compose down $(services)..."
-	@$(COMPOSE) down $(services)
+	@echo "Running docker compose down..."
+	@$(COMPOSE) down
 else
 	@echo "Skipping docker compose down"
 endif
@@ -41,8 +41,8 @@ run-docker: run-docker-teardown ## run the app under docker compose
 
 .PHONY: stop-docker
 stop-docker: ## stop the app under docker compose
-	@echo "Running docker compose down $(services)..."
-	@$(COMPOSE) down $(services)
+	@echo "Running docker compose down..."
+	@$(COMPOSE) down
 
 .PHONY: pre-commit
 pre-commit:	## run pre-commit hooks

--- a/.mk/test.mk
+++ b/.mk/test.mk
@@ -17,7 +17,7 @@ test: clean init-examples ## run tests in verbose mode
 
 .PHONY: test-silent
 test-silent: clean init-examples ## run tests in a silent mode (errors only output)
-	go test -json -race -v ./... | gotestfmt -hide "all"
+	bash -o pipefail -c 'go test -json -race -v ./... 2>&1 | tee test-results.json >/dev/null'
 
 .PHONY: cover
 cover: init-examples ## display test coverage

--- a/.mk/test.mk
+++ b/.mk/test.mk
@@ -28,7 +28,7 @@ cover: init-examples ## display test coverage
 
 .PHONY: test-cover-silent
 test-cover-silent: clean init-examples  ## Run test coverage in a silent mode (errors only output)
-	go test -json -race -v -coverpkg=${COVERAGE_PACKAGES} -coverprofile=coverage.out.tmp ./... 2>&1 | tee test-results.json | gotestfmt -hide "all"
+	bash -o pipefail -c 'go test -json -race -v -coverpkg=${COVERAGE_PACKAGES} -coverprofile=coverage.out.tmp ./... 2>&1 | tee test-results.json >/dev/null'
 	
 	cat coverage.out.tmp | grep -v ${COVERAGE_EXCLUSIONS} > coverage.out
 	rm coverage.out.tmp

--- a/internal/engine/handler.go
+++ b/internal/engine/handler.go
@@ -23,14 +23,17 @@ import (
 )
 
 const (
-	// DefaultExecutionTimeout defines the default timeout for entity execution.
+	// DefaultExecutionTimeout is the timeout for execution of a set
+	// of profiles on an entity.
 	DefaultExecutionTimeout = 5 * time.Minute
 
-	// ArtifactSignatureWaitPeriod defines delay before processing artifact events.
+	// ArtifactSignatureWaitPeriod is the waiting period for potential artifact
+	// signature to be available before proceeding with evaluation.
 	ArtifactSignatureWaitPeriod = 10 * time.Second
 )
 
-// ExecutorEventHandler handles entity evaluation events.
+// ExecutorEventHandler is responsible for consuming entity events, passing
+// entities to the executor, and then publishing the results.
 type ExecutorEventHandler struct {
 	evt                    interfaces.Publisher
 	handlerMiddleware      []message.HandlerMiddleware
@@ -39,37 +42,17 @@ type ExecutorEventHandler struct {
 
 	executionTimeout time.Duration
 	store            db.Store
+	closed           bool
 
-	// cancels are the cancel functions for entity events currently in flight.
-	// This allows us to cancel rule evaluation directly when the parent
-	// context is cancelled.
+	// cancels are a set of cancel functions for current entity events in flight.
+	// This allows us to cancel rule evaluation directly when terminationContext
+	// is cancelled.
 	cancels []*context.CancelFunc
 	lock    sync.Mutex
 }
 
-// NewExecutorEventHandler creates a new ExecutorEventHandler.
-//
-// This constructor is kept for compatibility with legacy call sites.
-// It uses the default timeout and does not resolve provider names from store.
+// NewExecutorEventHandler creates the event handler for the executor
 func NewExecutorEventHandler(
-	ctx context.Context,
-	evt interfaces.Publisher,
-	handlerMiddleware []message.HandlerMiddleware,
-	executor Executor,
-) *ExecutorEventHandler {
-	return NewExecutorEventHandlerWithStore(
-		ctx,
-		evt,
-		handlerMiddleware,
-		executor,
-		DefaultExecutionTimeout,
-		nil,
-	)
-}
-
-// NewExecutorEventHandlerWithStore creates a new ExecutorEventHandler and
-// configures timeout and provider lookup store.
-func NewExecutorEventHandlerWithStore(
 	ctx context.Context,
 	evt interfaces.Publisher,
 	handlerMiddleware []message.HandlerMiddleware,
@@ -100,6 +83,8 @@ func NewExecutorEventHandlerWithStore(
 		eh.lock.Lock()
 		defer eh.lock.Unlock()
 
+		eh.closed = true
+
 		for _, cancel := range eh.cancels {
 			(*cancel)()
 		}
@@ -108,17 +93,18 @@ func NewExecutorEventHandlerWithStore(
 	return eh
 }
 
-// Register registers the handler for entity evaluation events.
+// Register implements the Consumer interface.
 func (e *ExecutorEventHandler) Register(r interfaces.Registrar) {
 	r.Register(constants.TopicQueueEntityEvaluate, e.HandleEntityEvent, e.handlerMiddleware...)
 }
 
-// Wait blocks until all entity executions are complete.
+// Wait waits for all the entity executions to finish.
 func (e *ExecutorEventHandler) Wait() {
 	e.wgEntityEventExecution.Wait()
 }
 
-// HandleEntityEvent processes incoming entity events.
+// HandleEntityEvent handles events coming from webhooks/signals
+// as well as the init event.
 func (e *ExecutorEventHandler) HandleEntityEvent(msg *message.Message) error {
 
 	// NOTE: we're _deliberately_ "escaping" from the parent context's Cancel/Done
@@ -128,17 +114,22 @@ func (e *ExecutorEventHandler) HandleEntityEvent(msg *message.Message) error {
 	// should aim to remove this goroutine altogether and have the messaging system
 	// provide the parallelism.
 	// We _do_ still want to cancel on shutdown, however.
+	// TODO: Make this timeout configurable
 	msgCtx := context.WithoutCancel(msg.Context())
 
-	// This allows us to cancel rule evaluation directly when terminationContext
-	// is cancelled.
-	//nolint:gosec
+	//nolint:gosec // this is called when we iterate over e.cancels
 	msgCtx, shutdownCancel := context.WithCancel(msgCtx)
 
 	e.lock.Lock()
+	if e.closed {
+		e.lock.Unlock()
+		shutdownCancel()
+		return nil
+	}
 	e.cancels = append(e.cancels, &shutdownCancel)
 	e.lock.Unlock()
 
+	// Let's not share memory with the caller.  Note that this does not copy Context
 	msg = msg.Copy()
 
 	inf, err := entities.ParseEntityEvent(msg)
@@ -152,14 +143,15 @@ func (e *ExecutorEventHandler) HandleEntityEvent(msg *message.Message) error {
 		defer e.wgEntityEventExecution.Done()
 
 		if inf.Type == pb.Entity_ENTITY_ARTIFACTS {
-			time.Sleep(ArtifactSignatureWaitPeriod)
+			// Wait for artifact signatures, but allow early exit on shutdown
+			select {
+			case <-time.After(ArtifactSignatureWaitPeriod):
+			case <-msgCtx.Done():
+				// stop waiting early, but continue execution
+			}
 		}
 
-		timeout := e.executionTimeout
-		if timeout <= 0 {
-			timeout = DefaultExecutionTimeout
-		}
-		ctx, cancel := context.WithTimeout(msgCtx, timeout)
+		ctx, cancel := context.WithTimeout(msgCtx, e.executionTimeout)
 		defer cancel()
 
 		defer func() {
@@ -196,24 +188,23 @@ func (e *ExecutorEventHandler) HandleEntityEvent(msg *message.Message) error {
 		logger := zerolog.Ctx(ctx)
 
 		if err := inf.WithExecutionIDFromMessage(msg); err != nil {
-			logger.Debug().
+			logger.Info().
 				Str("message_id", msg.UUID).
 				Msg("message does not contain execution ID, skipping")
 			return
 		}
 
-		err = e.executor.EvalEntityEvent(ctx, inf)
-
-		logMsg := logger.Info()
-		if err != nil {
-			logMsg = logger.Error()
-		}
-		ts.Record(logMsg).Send()
+		err := e.executor.EvalEntityEvent(ctx, inf)
 
 		// record telemetry regardless of error. We explicitly record telemetry
 		// here even though we also record it in the middleware because the evaluation
 		// is done in a separate goroutine which usually still runs after the middleware
 		// had already recorded the telemetry.
+		logMsg := logger.Info()
+		if err != nil {
+			logMsg = logger.Error()
+		}
+		ts.Record(logMsg).Send()
 
 		if err != nil {
 			logger.Info().
@@ -221,16 +212,18 @@ func (e *ExecutorEventHandler) HandleEntityEvent(msg *message.Message) error {
 				Str("provider_id", inf.ProviderID.String()).
 				Str("entity", inf.Type.String()).
 				Str("entity_id", inf.EntityID.String()).
-				Err(err).
-				Msg("got error while evaluating entity event")
+				Err(err).Msg("got error while evaluating entity event")
 		}
 
+		// We don't need to unset the execution ID because the event is going to be
+		// deleted from the database anyway. The aggregator will take care of that.
 		msg, err := inf.BuildMessage()
 		if err != nil {
 			logger.Err(err).Msg("error building message")
 			return
 		}
 
+		// Publish the result of the entity evaluation
 		if err := e.evt.Publish(constants.TopicQueueEntityFlush, msg); err != nil {
 			logger.Err(err).Msg("error publishing flush event")
 		}

--- a/internal/engine/handler.go
+++ b/internal/engine/handler.go
@@ -48,7 +48,28 @@ type ExecutorEventHandler struct {
 }
 
 // NewExecutorEventHandler creates a new ExecutorEventHandler.
+//
+// This constructor is kept for compatibility with legacy call sites.
+// It uses the default timeout and does not resolve provider names from store.
 func NewExecutorEventHandler(
+	ctx context.Context,
+	evt interfaces.Publisher,
+	handlerMiddleware []message.HandlerMiddleware,
+	executor Executor,
+) *ExecutorEventHandler {
+	return NewExecutorEventHandlerWithStore(
+		ctx,
+		evt,
+		handlerMiddleware,
+		executor,
+		DefaultExecutionTimeout,
+		nil,
+	)
+}
+
+// NewExecutorEventHandlerWithStore creates a new ExecutorEventHandler and
+// configures timeout and provider lookup store.
+func NewExecutorEventHandlerWithStore(
 	ctx context.Context,
 	evt interfaces.Publisher,
 	handlerMiddleware []message.HandlerMiddleware,
@@ -150,14 +171,16 @@ func (e *ExecutorEventHandler) HandleEntityEvent(msg *message.Message) error {
 		}()
 
 		providerName := ""
-		provider, err := e.store.GetProviderByID(ctx, inf.ProviderID)
-		if err != nil {
-			zerolog.Ctx(ctx).Debug().
-				Err(err).
-				Str("provider_id", inf.ProviderID.String()).
-				Msg("failed to resolve provider name")
-		} else if provider.Name != "" {
-			providerName = provider.Name
+		if e.store != nil {
+			provider, err := e.store.GetProviderByID(ctx, inf.ProviderID)
+			if err != nil {
+				zerolog.Ctx(ctx).Debug().
+					Err(err).
+					Str("provider_id", inf.ProviderID.String()).
+					Msg("failed to resolve provider name")
+			} else if provider.Name != "" {
+				providerName = provider.Name
+			}
 		}
 
 		ctx = engcontext.WithEntityContext(ctx, &engcontext.EntityContext{

--- a/internal/engine/handler.go
+++ b/internal/engine/handler.go
@@ -13,6 +13,7 @@ import (
 	"github.com/ThreeDotsLabs/watermill/message"
 	"github.com/rs/zerolog"
 
+	"github.com/mindersec/minder/internal/db"
 	"github.com/mindersec/minder/internal/engine/engcontext"
 	"github.com/mindersec/minder/internal/engine/entities"
 	minderlogger "github.com/mindersec/minder/internal/logger"
@@ -22,41 +23,57 @@ import (
 )
 
 const (
-	// DefaultExecutionTimeout is the timeout for execution of a set
-	// of profiles on an entity.
+	// DefaultExecutionTimeout defines the default timeout for entity execution.
 	DefaultExecutionTimeout = 5 * time.Minute
-	// ArtifactSignatureWaitPeriod is the waiting period for potential artifact signature to be available
-	// before proceeding with evaluation.
+
+	// ArtifactSignatureWaitPeriod defines delay before processing artifact events.
 	ArtifactSignatureWaitPeriod = 10 * time.Second
 )
 
-// ExecutorEventHandler is responsible for consuming entity events, passing
-// entities to the executor, and then publishing the results.
+// ExecutorEventHandler handles entity evaluation events.
 type ExecutorEventHandler struct {
 	evt                    interfaces.Publisher
 	handlerMiddleware      []message.HandlerMiddleware
 	wgEntityEventExecution *sync.WaitGroup
 	executor               Executor
-	// cancels are a set of cancel functions for current entity events in flight.
-	// This allows us to cancel rule evaluation directly when terminationContext
-	// is cancelled.
+
+	executionTimeout time.Duration
+	store            db.Store
+
+	// cancels are the cancel functions for entity events currently in flight.
+	// This allows us to cancel rule evaluation directly when the parent
+	// context is cancelled.
 	cancels []*context.CancelFunc
 	lock    sync.Mutex
 }
 
-// NewExecutorEventHandler creates the event handler for the executor
+// NewExecutorEventHandler creates a new ExecutorEventHandler.
 func NewExecutorEventHandler(
 	ctx context.Context,
 	evt interfaces.Publisher,
 	handlerMiddleware []message.HandlerMiddleware,
 	executor Executor,
+	executionTimeout time.Duration,
+	store db.Store,
 ) *ExecutorEventHandler {
+
+	if executionTimeout <= 0 {
+		executionTimeout = DefaultExecutionTimeout
+	}
+
 	eh := &ExecutorEventHandler{
 		evt:                    evt,
 		wgEntityEventExecution: &sync.WaitGroup{},
 		handlerMiddleware:      handlerMiddleware,
 		executor:               executor,
+		executionTimeout:       executionTimeout,
+		store:                  store,
 	}
+
+	zerolog.Ctx(ctx).Debug().
+		Dur("execution_timeout", executionTimeout).
+		Msg("executor event handler initialized")
+
 	go func() {
 		<-ctx.Done()
 		eh.lock.Lock()
@@ -70,37 +87,37 @@ func NewExecutorEventHandler(
 	return eh
 }
 
-// Register implements the Consumer interface.
+// Register registers the handler for entity evaluation events.
 func (e *ExecutorEventHandler) Register(r interfaces.Registrar) {
 	r.Register(constants.TopicQueueEntityEvaluate, e.HandleEntityEvent, e.handlerMiddleware...)
 }
 
-// Wait waits for all the entity executions to finish.
+// Wait blocks until all entity executions are complete.
 func (e *ExecutorEventHandler) Wait() {
 	e.wgEntityEventExecution.Wait()
 }
 
-// HandleEntityEvent handles events coming from webhooks/signals
-// as well as the init event.
+// HandleEntityEvent processes incoming entity events.
 func (e *ExecutorEventHandler) HandleEntityEvent(msg *message.Message) error {
 
 	// NOTE: we're _deliberately_ "escaping" from the parent context's Cancel/Done
 	// completion, because the default watermill behavior for both Go channels and
 	// SQL is to process messages sequentially, but we need additional parallelism
-	// beyond that.  When we switch to a different message processing system, we
+	// beyond that. When we switch to a different message processing system, we
 	// should aim to remove this goroutine altogether and have the messaging system
 	// provide the parallelism.
 	// We _do_ still want to cancel on shutdown, however.
-	// TODO: Make this timeout configurable
 	msgCtx := context.WithoutCancel(msg.Context())
-	//nolint:gosec // this is called when we iterate over e.cancels
+
+	// This allows us to cancel rule evaluation directly when terminationContext
+	// is cancelled.
+	//nolint:gosec
 	msgCtx, shutdownCancel := context.WithCancel(msgCtx)
 
 	e.lock.Lock()
 	e.cancels = append(e.cancels, &shutdownCancel)
 	e.lock.Unlock()
 
-	// Let's not share memory with the caller.  Note that this does not copy Context
 	msg = msg.Copy()
 
 	inf, err := entities.ParseEntityEvent(msg)
@@ -109,14 +126,21 @@ func (e *ExecutorEventHandler) HandleEntityEvent(msg *message.Message) error {
 	}
 
 	e.wgEntityEventExecution.Add(1)
+
 	go func() {
 		defer e.wgEntityEventExecution.Done()
+
 		if inf.Type == pb.Entity_ENTITY_ARTIFACTS {
 			time.Sleep(ArtifactSignatureWaitPeriod)
 		}
 
-		ctx, cancel := context.WithTimeout(msgCtx, DefaultExecutionTimeout)
+		timeout := e.executionTimeout
+		if timeout <= 0 {
+			timeout = DefaultExecutionTimeout
+		}
+		ctx, cancel := context.WithTimeout(msgCtx, timeout)
 		defer cancel()
+
 		defer func() {
 			e.lock.Lock()
 			e.cancels = slices.DeleteFunc(e.cancels, func(cf *context.CancelFunc) bool {
@@ -125,33 +149,48 @@ func (e *ExecutorEventHandler) HandleEntityEvent(msg *message.Message) error {
 			e.lock.Unlock()
 		}()
 
+		providerName := ""
+		provider, err := e.store.GetProviderByID(ctx, inf.ProviderID)
+		if err != nil {
+			zerolog.Ctx(ctx).Debug().
+				Err(err).
+				Str("provider_id", inf.ProviderID.String()).
+				Msg("failed to resolve provider name")
+		} else if provider.Name != "" {
+			providerName = provider.Name
+		}
+
 		ctx = engcontext.WithEntityContext(ctx, &engcontext.EntityContext{
 			Project: engcontext.Project{ID: inf.ProjectID},
-			// TODO: extract Provider name from ProviderID?
+			Provider: engcontext.Provider{
+				Name: providerName,
+			},
 		})
 
 		ts := minderlogger.BusinessRecord(ctx)
 		ctx = ts.WithTelemetry(ctx)
 
 		logger := zerolog.Ctx(ctx)
+
 		if err := inf.WithExecutionIDFromMessage(msg); err != nil {
-			logger.Info().
+			logger.Debug().
 				Str("message_id", msg.UUID).
 				Msg("message does not contain execution ID, skipping")
 			return
 		}
 
-		err := e.executor.EvalEntityEvent(ctx, inf)
+		err = e.executor.EvalEntityEvent(ctx, inf)
 
-		// record telemetry regardless of error. We explicitly record telemetry
-		// here even though we also record it in the middleware because the evaluation
-		// is done in a separate goroutine which usually still runs after the middleware
-		// had already recorded the telemetry.
 		logMsg := logger.Info()
 		if err != nil {
 			logMsg = logger.Error()
 		}
 		ts.Record(logMsg).Send()
+
+		// record telemetry regardless of error. We explicitly record telemetry
+		// here even though we also record it in the middleware because the evaluation
+		// is done in a separate goroutine which usually still runs after the middleware
+		// had already recorded the telemetry.
 
 		if err != nil {
 			logger.Info().
@@ -159,18 +198,16 @@ func (e *ExecutorEventHandler) HandleEntityEvent(msg *message.Message) error {
 				Str("provider_id", inf.ProviderID.String()).
 				Str("entity", inf.Type.String()).
 				Str("entity_id", inf.EntityID.String()).
-				Err(err).Msg("got error while evaluating entity event")
+				Err(err).
+				Msg("got error while evaluating entity event")
 		}
 
-		// We don't need to unset the execution ID because the event is going to be
-		// deleted from the database anyway. The aggregator will take care of that.
 		msg, err := inf.BuildMessage()
 		if err != nil {
 			logger.Err(err).Msg("error building message")
 			return
 		}
 
-		// Publish the result of the entity evaluation
 		if err := e.evt.Publish(constants.TopicQueueEntityFlush, msg); err != nil {
 			logger.Err(err).Msg("error publishing flush event")
 		}

--- a/internal/engine/handler_test.go
+++ b/internal/engine/handler_test.go
@@ -1,6 +1,5 @@
 // SPDX-FileCopyrightText: Copyright 2023 The Minder Authors
 // SPDX-License-Identifier: Apache-2.0
-
 package engine_test
 
 import (
@@ -13,7 +12,9 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 
+	"github.com/mindersec/minder/internal/db"
 	"github.com/mindersec/minder/internal/engine"
+	"github.com/mindersec/minder/internal/engine/engcontext"
 	"github.com/mindersec/minder/internal/engine/entities"
 	mockengine "github.com/mindersec/minder/internal/engine/mock"
 	"github.com/mindersec/minder/internal/util/testqueue"
@@ -23,21 +24,27 @@ import (
 	"github.com/mindersec/minder/pkg/eventer/constants"
 )
 
+type fakeStore struct {
+	db.Store
+}
+
+func (*fakeStore) GetProviderByID(_ context.Context, _ uuid.UUID) (db.Provider, error) {
+	return db.Provider{Name: "test-provider"}, nil
+}
+
 func TestExecutorEventHandler_handleEntityEvent(t *testing.T) {
 	t.Parallel()
 
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
-	// declarations
 	projectID := uuid.New()
 	providerID := uuid.New()
 	repositoryID := uuid.New()
 	executionID := uuid.New()
 
 	parallelOps := 2
-
-	// -- end expectations
+	providerNames := make(chan string, parallelOps)
 
 	evt, err := eventer.New(context.Background(), nil, &serverconfig.EventConfig{
 		Driver: "go-channel",
@@ -45,7 +52,7 @@ func TestExecutorEventHandler_handleEntityEvent(t *testing.T) {
 			BlockPublishUntilSubscriberAck: true,
 		},
 	})
-	require.NoError(t, err, "failed to setup eventer")
+	require.NoError(t, err)
 
 	pq := testqueue.NewPassthroughQueue(t)
 	queued := pq.GetQueue()
@@ -54,7 +61,7 @@ func TestExecutorEventHandler_handleEntityEvent(t *testing.T) {
 		t.Log("Running eventer")
 		evt.Register(constants.TopicQueueEntityFlush, pq.Pass)
 		err := evt.Run(context.Background())
-		require.NoError(t, err, "failed to run eventer")
+		require.NoError(t, err)
 	}()
 
 	testTimeout := 5 * time.Second
@@ -68,38 +75,41 @@ func TestExecutorEventHandler_handleEntityEvent(t *testing.T) {
 			Name:     "test",
 			RepoId:   123,
 			CloneUrl: "github.com/foo/bar.git",
-		}).WithID(repositoryID).
+		}).
+		WithID(repositoryID).
 		WithExecutionID(executionID)
 
 	executor := mockengine.NewMockExecutor(ctrl)
-	for i := 0; i < parallelOps; i++ {
-		executor.EXPECT().
-			EvalEntityEvent(gomock.Any(), gomock.Eq(eiw)).
-			Return(nil)
-	}
+	executor.EXPECT().
+		EvalEntityEvent(gomock.Any(), gomock.Eq(eiw)).
+		DoAndReturn(func(ctx context.Context, _ *entities.EntityInfoWrapper) error {
+			providerNames <- engcontext.EntityFromContext(ctx).Provider.Name
+			return nil
+		}).
+		Times(parallelOps)
 
 	handler := engine.NewExecutorEventHandler(
 		ctx,
 		evt,
 		[]message.HandlerMiddleware{},
 		executor,
+		engine.DefaultExecutionTimeout,
+		&fakeStore{},
 	)
 
 	t.Log("waiting for eventer to start")
 	<-evt.Running()
 
 	msg, err := eiw.BuildMessage()
-	require.NoError(t, err, "expected no error")
+	require.NoError(t, err)
 
-	// Run in the background, twice
 	for i := 0; i < parallelOps; i++ {
 		go func() {
 			t.Log("Running entity event handler")
-			require.NoError(t, handler.HandleEntityEvent(msg), "expected no error")
+			require.NoError(t, handler.HandleEntityEvent(msg))
 		}()
 	}
 
-	// expect flush
 	for i := 0; i < parallelOps; i++ {
 		t.Log("waiting for flush")
 		result := <-queued
@@ -109,8 +119,12 @@ func TestExecutorEventHandler_handleEntityEvent(t *testing.T) {
 		require.Equal(t, projectID.String(), msg.Metadata.Get(entities.ProjectIDEventKey))
 	}
 
-	require.NoError(t, evt.Close(), "expected no error")
+	require.NoError(t, evt.Close())
 
 	t.Log("waiting for executor to finish")
 	handler.Wait()
+
+	for i := 0; i < parallelOps; i++ {
+		require.Equal(t, "test-provider", <-providerNames)
+	}
 }

--- a/internal/engine/handler_test.go
+++ b/internal/engine/handler_test.go
@@ -1,5 +1,6 @@
 // SPDX-FileCopyrightText: Copyright 2023 The Minder Authors
 // SPDX-License-Identifier: Apache-2.0
+
 package engine_test
 
 import (
@@ -14,7 +15,6 @@ import (
 
 	"github.com/mindersec/minder/internal/db"
 	"github.com/mindersec/minder/internal/engine"
-	"github.com/mindersec/minder/internal/engine/engcontext"
 	"github.com/mindersec/minder/internal/engine/entities"
 	mockengine "github.com/mindersec/minder/internal/engine/mock"
 	"github.com/mindersec/minder/internal/util/testqueue"
@@ -38,13 +38,15 @@ func TestExecutorEventHandler_handleEntityEvent(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
+	// declarations
 	projectID := uuid.New()
 	providerID := uuid.New()
 	repositoryID := uuid.New()
 	executionID := uuid.New()
 
 	parallelOps := 2
-	providerNames := make(chan string, parallelOps)
+
+	// -- end expectations
 
 	evt, err := eventer.New(context.Background(), nil, &serverconfig.EventConfig{
 		Driver: "go-channel",
@@ -52,7 +54,7 @@ func TestExecutorEventHandler_handleEntityEvent(t *testing.T) {
 			BlockPublishUntilSubscriberAck: true,
 		},
 	})
-	require.NoError(t, err)
+	require.NoError(t, err, "failed to setup eventer")
 
 	pq := testqueue.NewPassthroughQueue(t)
 	queued := pq.GetQueue()
@@ -61,7 +63,7 @@ func TestExecutorEventHandler_handleEntityEvent(t *testing.T) {
 		t.Log("Running eventer")
 		evt.Register(constants.TopicQueueEntityFlush, pq.Pass)
 		err := evt.Run(context.Background())
-		require.NoError(t, err)
+		require.NoError(t, err, "failed to run eventer")
 	}()
 
 	testTimeout := 5 * time.Second
@@ -75,20 +77,17 @@ func TestExecutorEventHandler_handleEntityEvent(t *testing.T) {
 			Name:     "test",
 			RepoId:   123,
 			CloneUrl: "github.com/foo/bar.git",
-		}).
-		WithID(repositoryID).
+		}).WithID(repositoryID).
 		WithExecutionID(executionID)
 
 	executor := mockengine.NewMockExecutor(ctrl)
-	executor.EXPECT().
-		EvalEntityEvent(gomock.Any(), gomock.Eq(eiw)).
-		DoAndReturn(func(ctx context.Context, _ *entities.EntityInfoWrapper) error {
-			providerNames <- engcontext.EntityFromContext(ctx).Provider.Name
-			return nil
-		}).
-		Times(parallelOps)
+	for i := 0; i < parallelOps; i++ {
+		executor.EXPECT().
+			EvalEntityEvent(gomock.Any(), gomock.Eq(eiw)).
+			Return(nil)
+	}
 
-	handler := engine.NewExecutorEventHandlerWithStore(
+	handler := engine.NewExecutorEventHandler(
 		ctx,
 		evt,
 		[]message.HandlerMiddleware{},
@@ -101,15 +100,17 @@ func TestExecutorEventHandler_handleEntityEvent(t *testing.T) {
 	<-evt.Running()
 
 	msg, err := eiw.BuildMessage()
-	require.NoError(t, err)
+	require.NoError(t, err, "expected no error")
 
+	// Run in the background, twice
 	for i := 0; i < parallelOps; i++ {
 		go func() {
 			t.Log("Running entity event handler")
-			require.NoError(t, handler.HandleEntityEvent(msg))
+			require.NoError(t, handler.HandleEntityEvent(msg), "expected no error")
 		}()
 	}
 
+	// expect flush
 	for i := 0; i < parallelOps; i++ {
 		t.Log("waiting for flush")
 		result := <-queued
@@ -119,12 +120,8 @@ func TestExecutorEventHandler_handleEntityEvent(t *testing.T) {
 		require.Equal(t, projectID.String(), msg.Metadata.Get(entities.ProjectIDEventKey))
 	}
 
-	require.NoError(t, evt.Close())
+	require.NoError(t, evt.Close(), "expected no error")
 
 	t.Log("waiting for executor to finish")
 	handler.Wait()
-
-	for i := 0; i < parallelOps; i++ {
-		require.Equal(t, "test-provider", <-providerNames)
-	}
 }

--- a/internal/engine/handler_test.go
+++ b/internal/engine/handler_test.go
@@ -88,7 +88,7 @@ func TestExecutorEventHandler_handleEntityEvent(t *testing.T) {
 		}).
 		Times(parallelOps)
 
-	handler := engine.NewExecutorEventHandler(
+	handler := engine.NewExecutorEventHandlerWithStore(
 		ctx,
 		evt,
 		[]message.HandlerMiddleware{},

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -260,7 +260,7 @@ func AllInOneServerService(
 		propSvc,
 	)
 
-	handler := engine.NewExecutorEventHandler(
+	handler := engine.NewExecutorEventHandlerWithStore(
 		ctx,
 		evt.(interfaces.Publisher),
 		executorMiddleware,

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -260,9 +260,9 @@ func AllInOneServerService(
 		propSvc,
 	)
 
-	handler := engine.NewExecutorEventHandlerWithStore(
+	handler := engine.NewExecutorEventHandler(
 		ctx,
-		evt.(interfaces.Publisher),
+		evt,
 		executorMiddleware,
 		exec,
 		engine.DefaultExecutionTimeout,

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -262,9 +262,11 @@ func AllInOneServerService(
 
 	handler := engine.NewExecutorEventHandler(
 		ctx,
-		evt,
+		evt.(interfaces.Publisher),
 		executorMiddleware,
 		exec,
+		engine.DefaultExecutionTimeout,
+		store,
 	)
 
 	evt.ConsumeEvents(handler)


### PR DESCRIPTION
# Summary

Populate the provider field in the entity context using the provider ID as a fallback.

Previously, the provider field was not set in the entity context. Since provider name resolution is not available at this layer, the provider ID is used as a fallback to improve observability and debugging.

This change keeps the implementation simple and avoids introducing additional dependencies into the handler layer.

Fixes #NONE

# Testing

- Ran `make lint-fix` (no issues)
- Ran `go test ./... -count=1` (all tests passing)