### PR TITLE
fix(datasource): initialize context to allow fallback to default project

### DIFF
--- a/cmd/cli/app/datasource/common.go
+++ b/cmd/cli/app/datasource/common.go
@@ -53,6 +53,11 @@ func executeOnOneDataSource(
 		ds.Context.ProjectId = proj
 	}
 
+	// Ensure context is not nil so the server can fall back to the default project
+	if ds.Context == nil {
+		ds.Context = &minderv1.ContextV2{}
+	}
+
 	if err := ds.Validate(); err != nil {
 		return fmt.Errorf("error validating data source: %w", err)
 	}


### PR DESCRIPTION
# Summary

This PR addresses an issue where running `minder datasource apply` on a YAML file lacking a `context` block throws an unexpected `context cannot be nil` gRPC validation error.

The problem stems from the fact that when the YAML is parsed in the CLI, `ds.Context` drops to `nil`. Because the server needs a valid context to gracefully fall back to the user's default project, sending a `nil` payload was crashing the flow. By simply initializing an empty `ContextV2` struct in `cmd/cli/app/datasource/common.go` (if the context resolves to nil), the backend logic kicks in and uses the default project as intended just like other RPCs do!

Fixes #5164

# Testing

- Created a minimal `test-ds.yaml` missing the project/context blocks.
- Verified that running `./bin/minder datasource apply -f test-ds.yaml` successfully triggers the default project fallback without throwing the "context cannot be nil" error.
- Verified changes against the control plane tests and ran `make test` to ensure no other components were broken.