### PR TITLE
Include rule name in PR branch name to avoid collisions

### DIFF
--- a/internal/engine/actions/remediate/pull_request/pull_request.go
+++ b/internal/engine/actions/remediate/pull_request/pull_request.go
@@ -78,6 +78,7 @@ type paramsPR struct {
 	ingested   *engifv1.Ingested
 	repo       *pb.Repository
 	title      string
+	ruleName   string
 	modifier   fsModifier
 	body       string
 	metadata   *pullRequestMetadata
@@ -238,6 +239,7 @@ func (r *Remediator) getParamsForPRRemediation(
 		ingested:   ingested,
 		repo:       repo,
 		title:      title,
+		ruleName:   params.GetRule().Name,
 		modifier:   modification,
 		body:       prFullBodyText,
 		metadata:   meta,
@@ -312,9 +314,9 @@ func (r *Remediator) runOn(
 	// This also makes sure, all new remediations check out from main branch rather than prev remediation branch.
 	defer checkoutToOriginallyFetchedBranch(&logger, wt, currHeadName)
 
-	logger.Debug().Str("branch", branchBaseName(p.title)).Msg("Checking out branch")
+	logger.Debug().Str("branch", branchBaseName(p.title, p.ruleName)).Msg("Checking out branch")
 	err = wt.Checkout(&git.CheckoutOptions{
-		Branch: plumbing.NewBranchReferenceName(branchBaseName(p.title)),
+		Branch: plumbing.NewBranchReferenceName(branchBaseName(p.title, p.ruleName)),
 		Create: true,
 	})
 	if err != nil {
@@ -346,12 +348,12 @@ func (r *Remediator) runOn(
 		return nil, fmt.Errorf("cannot commit: %w", err)
 	}
 
-	refspec := refFromBranch(branchBaseName(p.title))
+	refspec := refFromBranch(branchBaseName(p.title, p.ruleName))
 
-	l := logger.With().Str("branchBaseName", branchBaseName(p.title)).Logger()
+	l := logger.With().Str("branchBaseName", branchBaseName(p.title, p.ruleName)).Logger()
 
 	// Check if a PR already exists for this branch
-	prNumber := getPRNumberFromBranch(ctx, r.ghCli, p.repo, branchBaseName(p.title))
+	prNumber := getPRNumberFromBranch(ctx, r.ghCli, p.repo, branchBaseName(p.title, p.ruleName))
 
 	// If no PR exists, push the branch and create a PR
 	if prNumber == 0 {
@@ -492,10 +494,14 @@ func refFromBranch(branchFrom string) string {
 	return fmt.Sprintf("refs/heads/%s", branchFrom)
 }
 
-func branchBaseName(prTitle string) string {
+func branchBaseName(prTitle, ruleName string) string {
 	baseName := dflBranchBaseName
 	normalizedPrTitle := strings.ReplaceAll(strings.ToLower(prTitle), " ", "_")
-	return fmt.Sprintf("%s_%s", baseName, normalizedPrTitle)
+	if ruleName == "" {
+		return fmt.Sprintf("%s_%s", baseName, normalizedPrTitle)
+	}
+	normalizedRuleName := strings.ReplaceAll(strings.ToLower(ruleName), " ", "_")
+	return fmt.Sprintf("%s_%s_%s", baseName, normalizedRuleName, normalizedPrTitle)
 }
 
 func userNameForCommit(ctx context.Context, gh provifv1.GitHub) string {

--- a/internal/engine/actions/remediate/pull_request/pull_request_test.go
+++ b/internal/engine/actions/remediate/pull_request/pull_request_test.go
@@ -179,6 +179,7 @@ type remediateArgs struct {
 	ent       protoreflect.ProtoMessage
 	pol       map[string]any
 	params    map[string]any
+	ruleName  string
 }
 
 func createTestRemArgs() *remediateArgs {
@@ -636,6 +637,32 @@ func TestPullRequestRemediate(t *testing.T) {
 			expectedErr:      errors.ErrActionPending,
 			expectedMetadata: json.RawMessage(`{"pr_number":45}`),
 		},
+		{
+			name: "open a PR with a rule name",
+			newRemArgs: &newPullRequestRemediateArgs{
+				prRem:      dependabotPrRem(),
+				actionType: TestActionTypeValid,
+			},
+			remArgs: func() *remediateArgs {
+				args := createTestRemArgs()
+				args.ruleName = "my-rule"
+				return args
+			}(),
+			repoSetup: defaultMockRepoSetup,
+			mockSetup: func(_ *testing.T, mockGitHub *mockghclient.MockGitHub) {
+				happyPathMockSetup(mockGitHub)
+
+				mockGitHub.EXPECT().
+					CreatePullRequest(
+						gomock.Any(),
+						repoOwner, repoName,
+						commitTitle, prBody,
+						refFromBranch("minder_my-rule_add_dependabot_configuration_for_gomod"), dflBranchTo).
+					Return(&github.PullRequest{Number: github.Int(46)}, nil)
+			},
+			expectedErr:      errors.ErrActionPending,
+			expectedMetadata: json.RawMessage(`{"pr_number":46}`),
+		},
 	}
 
 	for _, tt := range tests {
@@ -672,6 +699,7 @@ func TestPullRequestRemediate(t *testing.T) {
 				Rule: &models.RuleInstance{
 					Def:    tt.remArgs.pol,
 					Params: tt.remArgs.params,
+					Name:   tt.remArgs.ruleName,
 				},
 			}
 
@@ -700,48 +728,3 @@ func TestPullRequestRemediate(t *testing.T) {
 	}
 }
 
-func TestBranchBaseName(t *testing.T) {
-	t.Parallel()
-
-	tests := []struct {
-		name     string
-		title    string
-		ruleName string
-		expected string
-	}{
-		{
-			name:     "no rule name falls back to title only",
-			title:    "Add Dependabot configuration for gomod",
-			ruleName: "",
-			expected: "minder_add_dependabot_configuration_for_gomod",
-		},
-		{
-			name:     "rule name is included in branch name",
-			title:    "Add Dependabot configuration for gomod",
-			ruleName: "my-rule",
-			expected: "minder_my-rule_add_dependabot_configuration_for_gomod",
-		},
-		{
-			name:     "two rules with same title produce different branches",
-			title:    "Replace tags with sha",
-			ruleName: "codeql-rule-1",
-			expected: "minder_codeql-rule-1_replace_tags_with_sha",
-		},
-		{
-			name:     "second rule with same title produces different branch",
-			title:    "Replace tags with sha",
-			ruleName: "codeql-rule-2",
-			expected: "minder_codeql-rule-2_replace_tags_with_sha",
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-			got := branchBaseName(tt.title, tt.ruleName)
-			if got != tt.expected {
-				t.Errorf("branchBaseName(%q, %q) = %q, want %q", tt.title, tt.ruleName, got, tt.expected)
-			}
-		})
-	}
-}

--- a/internal/engine/actions/remediate/pull_request/pull_request_test.go
+++ b/internal/engine/actions/remediate/pull_request/pull_request_test.go
@@ -381,7 +381,7 @@ func mockRepoSetupWithBranch(t *testing.T) (*git.Repository, error) {
 		// this is just a convoluted way of creating a new branch
 		ref := plumbing.NewHashReference(
 			plumbing.ReferenceName(
-				refFromBranch(branchBaseName(commitTitle)),
+				refFromBranch(branchBaseName(commitTitle, "")),
 			),
 			headRef.Hash())
 
@@ -423,7 +423,7 @@ func TestPullRequestRemediate(t *testing.T) {
 						gomock.Any(),
 						repoOwner, repoName,
 						commitTitle, prBody,
-						refFromBranch(branchBaseName(commitTitle)), dflBranchTo).
+						refFromBranch(branchBaseName(commitTitle, "")), dflBranchTo).
 					Return(&github.PullRequest{Number: github.Int(42)}, nil)
 			},
 			expectedErr:      errors.ErrActionPending,
@@ -445,7 +445,7 @@ func TestPullRequestRemediate(t *testing.T) {
 						gomock.Any(),
 						repoOwner, repoName,
 						commitTitle, prBody,
-						refFromBranch(branchBaseName(commitTitle)), dflBranchTo).
+						refFromBranch(branchBaseName(commitTitle, "")), dflBranchTo).
 					Return(nil, fmt.Errorf("failed to create PR"))
 			},
 			expectedErr:      errors.ErrActionFailed,
@@ -467,7 +467,7 @@ func TestPullRequestRemediate(t *testing.T) {
 						gomock.Any(),
 						repoOwner, repoName,
 						commitTitle, prBody,
-						refFromBranch(branchBaseName(commitTitle)), dflBranchTo).
+						refFromBranch(branchBaseName(commitTitle, "")), dflBranchTo).
 					Return(&github.PullRequest{Number: github.Int(41)}, nil)
 			},
 			expectedErr:      errors.ErrActionPending,
@@ -555,7 +555,7 @@ func TestPullRequestRemediate(t *testing.T) {
 						gomock.Any(),
 						repoOwner, repoName,
 						frizbeeCommitTitle, frizbeePrBody,
-						refFromBranch(branchBaseName(frizbeeCommitTitle)), dflBranchTo).
+						refFromBranch(branchBaseName(frizbeeCommitTitle, "")), dflBranchTo).
 					Return(&github.PullRequest{Number: github.Int(40)}, nil)
 			},
 			expectedErr:      errors.ErrActionPending,
@@ -580,7 +580,7 @@ func TestPullRequestRemediate(t *testing.T) {
 						gomock.Any(),
 						repoOwner, repoName,
 						frizbeeCommitTitle, frizbeePrBodyWithExcludes,
-						refFromBranch(branchBaseName(frizbeeCommitTitle)), dflBranchTo).
+						refFromBranch(branchBaseName(frizbeeCommitTitle, "")), dflBranchTo).
 					Return(&github.PullRequest{Number: github.Int(43)}, nil)
 			},
 			expectedErr:      errors.ErrActionPending,
@@ -606,7 +606,7 @@ func TestPullRequestRemediate(t *testing.T) {
 						gomock.Any(),
 						repoOwner, repoName,
 						frizbeeCommitTitle, frizbeePrBodyWithExcludes,
-						refFromBranch(branchBaseName(frizbeeCommitTitle)), dflBranchTo).
+						refFromBranch(branchBaseName(frizbeeCommitTitle, "")), dflBranchTo).
 					Return(&github.PullRequest{Number: github.Int(44)}, nil)
 			},
 			expectedErr:      errors.ErrActionPending,
@@ -629,7 +629,7 @@ func TestPullRequestRemediate(t *testing.T) {
 						gomock.Any(),
 						repoOwner, repoName,
 						yqCommitTitle, yqPrBody,
-						refFromBranch(branchBaseName(yqCommitTitle)), dflBranchTo).
+						refFromBranch(branchBaseName(yqCommitTitle, "")), dflBranchTo).
 					Return(&github.PullRequest{Number: github.Int(45)}, nil)
 			},
 			remArgs:          createTestRemArgs(),
@@ -696,6 +696,52 @@ func TestPullRequestRemediate(t *testing.T) {
 
 			require.ErrorIs(t, err, tt.expectedErr, "expected error")
 			require.Equal(t, tt.expectedMetadata, retMeta)
+		})
+	}
+}
+
+func TestBranchBaseName(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		title    string
+		ruleName string
+		expected string
+	}{
+		{
+			name:     "no rule name falls back to title only",
+			title:    "Add Dependabot configuration for gomod",
+			ruleName: "",
+			expected: "minder_add_dependabot_configuration_for_gomod",
+		},
+		{
+			name:     "rule name is included in branch name",
+			title:    "Add Dependabot configuration for gomod",
+			ruleName: "my-rule",
+			expected: "minder_my-rule_add_dependabot_configuration_for_gomod",
+		},
+		{
+			name:     "two rules with same title produce different branches",
+			title:    "Replace tags with sha",
+			ruleName: "codeql-rule-1",
+			expected: "minder_codeql-rule-1_replace_tags_with_sha",
+		},
+		{
+			name:     "second rule with same title produces different branch",
+			title:    "Replace tags with sha",
+			ruleName: "codeql-rule-2",
+			expected: "minder_codeql-rule-2_replace_tags_with_sha",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := branchBaseName(tt.title, tt.ruleName)
+			if got != tt.expected {
+				t.Errorf("branchBaseName(%q, %q) = %q, want %q", tt.title, tt.ruleName, got, tt.expected)
+			}
 		})
 	}
 }

--- a/internal/engine/actions/remediate/pull_request/pull_request_test.go
+++ b/internal/engine/actions/remediate/pull_request/pull_request_test.go
@@ -727,4 +727,3 @@ func TestPullRequestRemediate(t *testing.T) {
 		})
 	}
 }
-


### PR DESCRIPTION
# Summary

When a profile uses two rules that share the same rule type, the PR remediation engine derives the "from" branch name solely from the rule type's title template. This causes both rules to generate identical branch names and race each other — whichever runs second overwrites the first's branch and no separate PR is opened for it.

This fix incorporates the rule instance name into the branch name:

- With a rule name: `minder_<rule-name>_<normalized-title>`
- Without a rule name (empty/legacy): `minder_<normalized-title>` (backward compatible)

No dependencies required.

Fixes #2350

# Testing

- Added `TestBranchBaseName` unit tests covering:
  - Empty rule name falls back to the old format (backward compatibility)
  - Rule name is included when present
  - Two rules with the same title but different names produce distinct branch names
- All existing `TestPullRequestRemediate` table-driven tests updated to pass the rule name argument and continue to pass
