### PR TITLE
test(ruletypes): add table-driven unit tests for release phase conver…

### DIFF
--- a/pkg/ruletypes/util_test.go
+++ b/pkg/ruletypes/util_test.go
@@ -1,0 +1,137 @@
+// SPDX-FileCopyrightText: Copyright 2024 The Minder Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package ruletypes_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/mindersec/minder/internal/db"
+	pb "github.com/mindersec/minder/pkg/api/protobuf/go/minder/v1"
+	"github.com/mindersec/minder/pkg/ruletypes"
+)
+
+func TestGetPBReleasePhaseFromDBReleaseStatus(t *testing.T) {
+	t.Parallel()
+
+	alpha := db.ReleaseStatusAlpha
+	beta := db.ReleaseStatusBeta
+	ga := db.ReleaseStatusGa
+	deprecated := db.ReleaseStatusDeprecated
+	bogus := db.ReleaseStatus("bogus")
+
+	tests := []struct {
+		name      string
+		input     *db.ReleaseStatus
+		expected  pb.RuleTypeReleasePhase
+		expectErr bool
+	}{
+		{
+			name:     "nil returns unspecified",
+			input:    nil,
+			expected: pb.RuleTypeReleasePhase_RULE_TYPE_RELEASE_PHASE_UNSPECIFIED,
+		},
+		{
+			name:     "alpha maps correctly",
+			input:    &alpha,
+			expected: pb.RuleTypeReleasePhase_RULE_TYPE_RELEASE_PHASE_ALPHA,
+		},
+		{
+			name:     "beta maps correctly",
+			input:    &beta,
+			expected: pb.RuleTypeReleasePhase_RULE_TYPE_RELEASE_PHASE_BETA,
+		},
+		{
+			name:     "ga maps correctly",
+			input:    &ga,
+			expected: pb.RuleTypeReleasePhase_RULE_TYPE_RELEASE_PHASE_GA,
+		},
+		{
+			name:     "deprecated maps correctly",
+			input:    &deprecated,
+			expected: pb.RuleTypeReleasePhase_RULE_TYPE_RELEASE_PHASE_DEPRECATED,
+		},
+		{
+			name:      "invalid status returns error",
+			input:     &bogus,
+			expectErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			result, err := ruletypes.GetPBReleasePhaseFromDBReleaseStatus(tt.input)
+
+			if tt.expectErr {
+				require.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+			require.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestGetDBReleaseStatusFromPBReleasePhase(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		input     pb.RuleTypeReleasePhase
+		expected  db.ReleaseStatus
+		expectErr bool
+	}{
+		{
+			name:     "alpha maps correctly",
+			input:    pb.RuleTypeReleasePhase_RULE_TYPE_RELEASE_PHASE_ALPHA,
+			expected: db.ReleaseStatusAlpha,
+		},
+		{
+			name:     "beta maps correctly",
+			input:    pb.RuleTypeReleasePhase_RULE_TYPE_RELEASE_PHASE_BETA,
+			expected: db.ReleaseStatusBeta,
+		},
+		{
+			name:     "ga maps correctly",
+			input:    pb.RuleTypeReleasePhase_RULE_TYPE_RELEASE_PHASE_GA,
+			expected: db.ReleaseStatusGa,
+		},
+		{
+			name:     "deprecated maps correctly",
+			input:    pb.RuleTypeReleasePhase_RULE_TYPE_RELEASE_PHASE_DEPRECATED,
+			expected: db.ReleaseStatusDeprecated,
+		},
+		{
+			name:     "unspecified defaults to ga",
+			input:    pb.RuleTypeReleasePhase_RULE_TYPE_RELEASE_PHASE_UNSPECIFIED,
+			expected: db.ReleaseStatusGa,
+		},
+		{
+			name:      "invalid enum value returns error",
+			input:     pb.RuleTypeReleasePhase(999),
+			expectErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			result, err := ruletypes.GetDBReleaseStatusFromPBReleasePhase(tt.input)
+
+			if tt.expectErr {
+				require.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+			require.NotNil(t, result)
+			require.Equal(t, tt.expected, *result)
+		})
+	}
+}


### PR DESCRIPTION
### What

Adds `pkg/ruletypes/util_test.go` with 12 table-driven test cases covering the two public conversion helpers in `pkg/ruletypes/util.go` that were previously at **0%** statement coverage:

| Function | Coverage before | Coverage after |
|---|---|---|
| `GetPBReleasePhaseFromDBReleaseStatus` | 0% | **100%** |
| `GetDBReleaseStatusFromPBReleasePhase` | 0% | **85.7%** |

**The remaining ~14% of `GetDBReleaseStatusFromPBReleasePhase` is the `Scan` type-switch fallback path, which is unreachable from valid Go code because `db.ReleaseStatus` only accepts `string` or `[]byte` inputs.**

### Why

These functions are called by controlplane handlers on every rule-type read/write path but were not exercised by any dedicated unit tests, leaving conversion bugs invisible to CI.

### Test cases

**`TestGetPBReleasePhaseFromDBReleaseStatus`** (6 cases)

- `nil` input → `RULE_TYPE_RELEASE_PHASE_UNSPECIFIED` (no error)
- `alpha`, `beta`, `ga`, `deprecated` → correct protobuf enum value
- Unrecognised `db.ReleaseStatus` string → error returned

**`TestGetDBReleaseStatusFromPBReleasePhase`** (6 cases)

- `ALPHA`, `BETA`, `GA`, `DEPRECATED` → correct `db.ReleaseStatus` constant
- `UNSPECIFIED` → defaults to `ga` (via `EnsureDefault()`)
- Out-of-range enum value `999` → error wrapped with `ErrRuleTypeInvalid`

### Notes

- All subtests run with `t.Parallel()` and are race-clean (`go test -race` passes)
- No DB mock, network, or external dependency required — pure function testing
- Follows the same table-driven pattern used in the adjacent `service_test.go`

### Related

Continues the coverage push toward the project 60% threshold, following [#6309](https://github.com/mindersec/minder/pull/6309) which covered `pkg/profiles/models/`.