### PR TITLE
fix: avoid silently aborting profile init on single entity marshalling error

### DIFF
--- a/internal/reconcilers/run_profile.go
+++ b/internal/reconcilers/run_profile.go
@@ -92,8 +92,8 @@ func (r *Reconciler) publishProfileInitEvents(
 
 		if err := entRefresh.ToMessage(m); err != nil {
 			zerolog.Ctx(ctx).Error().Err(err).Msg("error marshalling message")
-			// no point in retrying, so we return nil
-			return nil
+			// Skip this entity but continue processing the rest
+			continue
 		}
 
 		if err := r.evt.Publish(constants.TopicQueueRefreshEntityByIDAndEvaluate, m); err != nil {


### PR DESCRIPTION
## Description

This PR fixes a bug in the profile initialization flow where a single entity's parsing/marshalling issue could completely stop the rest of a project's entities from being evaluated against a new profile.

In [internal/reconcilers/run_profile.go](cci:7://file:///c:/Users/aftab/Desktop/minder/internal/reconcilers/run_profile.go:0:0-0:0), [publishProfileInitEvents](cci:1://file:///c:/Users/aftab/Desktop/minder/internal/reconcilers/run_profile.go:75:0-105:1) loops over all registered entities for a project. Previously, if `entRefresh.ToMessage(m)` failed inside that loop, the code returned `nil`. This silently exited the entire function, abandoning all remaining entities in the slice. From the caller's perspective ([handleProfileInitEvent](cci:1://file:///c:/Users/aftab/Desktop/minder/internal/reconcilers/run_profile.go:43:0-73:1)), the function returned successfully, so no retries were triggered and nothing was visibly wrong except that some entities were randomly skipped during profile initialization.

## Change:
Instead of `return nil`, this simply logs the error and uses `continue` to move on to the next entity in the loop. 

Fixes #6330 

## Checklist

- [x] Includes tests for the changes
- [x] Code compiles cleanly
- [ ] Documentation updated (if applicable)
