### PR TITLE
fix: avoid overwriting remediation action status in eval logs

### DIFF
--- a/internal/engine/executor.go
+++ b/internal/engine/executor.go
@@ -319,10 +319,10 @@ func logEval(
 
 	// log evaluation result and actions status
 	evalLog.Info().
-		Str("action", string(remediate.ActionType)).
-		Str("action_status", string(dbadapter.ErrorAsRemediationStatus(params.GetActionsErr().RemediateErr))).
-		Str("action", string(alert.ActionType)).
-		Str("action_status", string(dbadapter.ErrorAsAlertStatus(params.GetActionsErr().AlertErr))).
+		Str("remediate_action", string(remediate.ActionType)).
+		Str("remediate_status", string(dbadapter.ErrorAsRemediationStatus(params.GetActionsErr().RemediateErr))).
+		Str("alert_action", string(alert.ActionType)).
+		Str("alert_status", string(dbadapter.ErrorAsAlertStatus(params.GetActionsErr().AlertErr))).
 		Msg("entity evaluation - completed")
 
 	// log business logic


### PR DESCRIPTION
## Description

This PR fixes a structured logging issue in the engine's executor where the remediation action status was being silently overwritten or dropped by downstream JSON parsers.

In [internal/engine/executor.go](cci:7://file:///c:/Users/aftab/Desktop/minder/internal/engine/executor.go:0:0-0:0), the [logEval](cci:1://file:///c:/Users/aftab/Desktop/minder/internal/engine/executor.go:307:0-329:1) function was logging both the remediation action and the alert action in a single `log.Info()` call using duplicate keys (`"action"` and `"action_status"`):

```go
evalLog.Info().
    Str("action", string(remediate.ActionType)).
    Str("action_status", string(dbadapter.ErrorAsRemediationStatus(params.GetActionsErr().RemediateErr))).
    Str("action", string(alert.ActionType)). // duplicate
    Str("action_status", string(dbadapter.ErrorAsAlertStatus(params.GetActionsErr().AlertErr))). // duplicate
    Msg("entity evaluation - completed")
```
Because of the overlapping keys, most log aggregation tools (or anything parsing the raw JSON) will just take the last value provided. This meant the remediate action type and status were effectively invisible in observability dashboards since they were clobbered by the alert values.

## Fix
I just renamed the keys to be distinct: remediate_action / remediate_status and alert_action / alert_status. This way both sets of data will show up properly in log indices.

Fixes #6332
### Checklist

- [x]  Includes tests for the changes
- [x]  Code compiles cleanly
- [ ]  Documentation updated (if applicable)