### PR TITLE
Fix unterminated warning message that breaks gotestsum -> junit parsing

### DIFF
--- a/internal/util/cli/credentials.go
+++ b/internal/util/cli/credentials.go
@@ -244,7 +244,7 @@ func GetRealmUrl(
 		// Unable to get the header, fall back to static configuration
 	}
 
-	cmd.Printf("Unable to fetch WWW-Authenticate header (%s), falling back on static configuration", err)
+	cmd.Printf("Unable to fetch WWW-Authenticate header (%s), falling back on static configuration\n", err)
 	parsedURL, err := url.Parse(issuerUrl)
 	if err != nil {
 		return "", fmt.Errorf("error parsing issuer URL: %v", err)


### PR DESCRIPTION
# Summary

The HTML error summary often erroneously reports that `TestGetGrpcConnection` and some subset of tests have failed due to corrupted output from the terminal:

```
=== RUN   TestGetGrpcConnection
=== RUN   TestGetGrpcConnection/If_the_token_is_provided,_create_connection_without_calling_server
=== RUN   TestGetGrpcConnection/With_token,_don't_dial_or_handshake_endpoint
=== RUN   TestGetGrpcConnection/Connect_and_get_token_from_GRPC_handshake
=== RUN   TestGetGrpcConnection/Localhost_GRPC_auto-discovery
=== RUN   TestGetGrpcConnection/GRPC_auto-discovery_with_insecure_external_host
=== RUN   TestGetGrpcConnection/Defaults_connect_to_legacy_endpoint
Unable to fetch WWW-Authenticate header (rpc error: code = Unavailable desc = connection error: desc = "transport: Error while dialing: dial tcp 127.0.0.1:35443: connect: connection refused"), falling back on static configuration--- PASS: TestGetGrpcConnection (0.02s)
    --- PASS: TestGetGrpcConnection/If_the_token_is_provided,_create_connection_without_calling_server (0.00s)
    --- PASS: TestGetGrpcConnection/With_token,_don't_dial_or_handshake_endpoint (0.00s)
    --- PASS: TestGetGrpcConnection/Connect_and_get_token_from_GRPC_handshake (0.00s)
    --- PASS: TestGetGrpcConnection/Localhost_GRPC_auto-discovery (0.01s)
    --- PASS: TestGetGrpcConnection/GRPC_auto-discovery_with_insecure_external_host (0.00s)
    --- PASS: TestGetGrpcConnection/Defaults_connect_to_legacy_endpoint (0.00s)
```

# Testing

Manual / eyeball testing
