### PR TITLE
docs: deprecate quickstart documentation and remove CLI references

### DIFF
--- a/docs/docs/getting_started/quickstart.md
+++ b/docs/docs/getting_started/quickstart.md
@@ -1,3 +1,6 @@
+> ⚠️ **Deprecated:** This quickstart flow is outdated and currently being redesigned.
+> It may not reflect the recommended onboarding process.
+
 ---
 title: Quickstart with Minder (< 1 min)
 sidebar_position: 30

--- a/docs/docs/ref/cli/minder.md
+++ b/docs/docs/ref/cli/minder.md
@@ -34,7 +34,6 @@ https://mindersec.github.io/
 * [minder profile](minder_profile.md)	 - Manage profiles
 * [minder project](minder_project.md)	 - Manage project within a minder control plane
 * [minder provider](minder_provider.md)	 - Manage providers within a minder control plane
-* [minder quickstart](minder_quickstart.md)	 - Quickstart minder
 * [minder repo](minder_repo.md)	 - Manage repositories within a Minder project
 * [minder ruletype](minder_ruletype.md)	 - Manage rule types
 * [minder set-project](minder_set-project.md)	 - Move the current context to another project


### PR DESCRIPTION
This PR deprecates the current quickstart documentation and removes prominent references to it from the CLI docs.

As discussed in #6339, the existing quickstart flow is outdated and may guide users toward a setup that is no longer recommended (e.g., PAT-based onboarding and limited rule configuration). To prevent confusion for new users, this change adds a deprecation notice to the quickstart guide and removes it from the CLI reference index.

This is an initial step toward improving the onboarding experience without introducing breaking changes.

Follow-up work:
I plan to propose a redesigned quickstart flow that:

uses GitHub App–based onboarding
leverages minder apply for batch configuration
supports a more scalable, config-driven (GitOps-style) setup

No additional dependencies are required for this change.

Fixes #6399

Testing
Verified that the documentation builds/rendering are unaffected after removing the quickstart reference from the CLI index
Confirmed that the quickstart page is still accessible directly but clearly marked as deprecated
Ensured no broken links or formatting issues in modified files

No runtime or functional changes were introduced, as this PR only affects documentation.