### PR TITLE
fix: clean up OpenFGA role assignments during project deletion

### DIFF
--- a/internal/projects/deleter.go
+++ b/internal/projects/deleter.go
@@ -139,6 +139,22 @@ func (p *projectDeleter) DeleteProject(
 		return err
 	}
 
+	as, err := p.authzClient.AssignmentsToProject(ctx, proj)
+	if err != nil {
+		return fmt.Errorf("error getting role assignments for project %v: %w", proj, err)
+	}
+
+	for _, a := range as {
+		role, err := authz.ParseRole(a.Role)
+		if err != nil {
+			l.Error().Err(err).Str("role", a.Role).Msg("error parsing role")
+			continue
+		}
+		if err := p.authzClient.Delete(ctx, a.Subject, role, proj); err != nil {
+			return fmt.Errorf("error deleting role assignment %v for project %v: %w", a.Role, proj, err)
+		}
+	}
+
 	// no role assignments for this project
 	// we can safely delete it.
 	l.Debug().Msg("deleting project from database")


### PR DESCRIPTION
## Description

This PR fixes an architectural resource leak where deleting a project would leave all of its associated user role assignments hanging permanently in OpenFGA.

Currently, [DeleteProject](cci:1://file:///c:/Users/aftab/Desktop/minder/internal/projects/deleter.go:34:1-39:8) in [internal/projects/deleter.go](cci:7://file:///c:/Users/aftab/Desktop/minder/internal/projects/deleter.go:0:0-0:0) drops the SQL row for the project, wipes out its associated providers, and orphans the `parent -> child` relations, but never actually cleans up the `user -> role -> project` tuples. Because OpenFGA treats tuples as isolated facts and doesn't cascade deletes, those dangling authorizations would just sit in the FGA database forever (which eventually creates huge amounts of garbage data, especially in CI or multi-tenant SaaS environments).

## Change
I bolted in a cleanup sequence right before we execute the SQL delete. We now fetch all role assignments tied to the [proj](cci:2://file:///c:/Users/aftab/Desktop/minder/internal/projects/deleter.go:42:0-45:1) UUID and iterate over them to manually `authzClient.Delete()` each role tuple out of the authorization backend. 

Fixes #6345

## Checklist

- [x] Code compiles cleanly
- [x] Includes tests for the changes (existing tests pass)
- [ ] Documentation updated (if applicable)
