### PR TITLE
fix: prevent silent loop aborts during profile initialization

### DIFF
--- a/internal/reconcilers/run_profile.go
+++ b/internal/reconcilers/run_profile.go
@@ -17,6 +17,13 @@ import (
 	"github.com/mindersec/minder/pkg/eventer/constants"
 )
 
+var (
+	// toMessage is a package-level hook to allow injecting marshalling failures in tests
+	toMessage = func(entRefresh *entityMessage.HandleEntityAndDoMessage, m *message.Message) error {
+		return entRefresh.ToMessage(m)
+	}
+)
+
 // ProfileInitEvent is an event that is sent to the reconciler topic
 // when a new profile is created. It is used to initialize the profile
 // by iterating over all registered entities for the relevant project
@@ -90,9 +97,8 @@ func (r *Reconciler) publishProfileInitEvents(
 		m := message.NewMessage(uuid.New().String(), nil)
 		m.SetContext(ctx)
 
-		if err := entRefresh.ToMessage(m); err != nil {
+		if err := toMessage(entRefresh, m); err != nil {
 			zerolog.Ctx(ctx).Error().Err(err).Msg("error marshalling message")
-			// Skip this entity but continue processing the rest
 			continue
 		}
 

--- a/internal/reconcilers/run_profile.go
+++ b/internal/reconcilers/run_profile.go
@@ -18,7 +18,7 @@ import (
 )
 
 var (
-	// toMessage is a package-level hook to allow injecting marshalling failures in tests
+	// toMessage wraps ToMessage; overridden in tests
 	toMessage = func(entRefresh *entityMessage.HandleEntityAndDoMessage, m *message.Message) error {
 		return entRefresh.ToMessage(m)
 	}

--- a/internal/reconcilers/run_profile_test.go
+++ b/internal/reconcilers/run_profile_test.go
@@ -6,15 +6,14 @@ package reconcilers
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"testing"
 
+	watermillMsg "github.com/ThreeDotsLabs/watermill/message"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 
-	"errors"
-
-	watermillMsg "github.com/ThreeDotsLabs/watermill/message"
 	df "github.com/mindersec/minder/database/mock/fixtures"
 	"github.com/mindersec/minder/internal/db"
 	entityMessage "github.com/mindersec/minder/internal/entities/handlers/message"
@@ -24,12 +23,13 @@ import (
 
 var (
 	testReconcileProjectID = uuid.New()
-	simulateFailUUID       = uuid.MustParse("00000000-0000-0000-0000-000000000001")
+	failEntityID           = uuid.MustParse("00000000-0000-0000-0000-000000000001")
 )
 
+// override for tests
 func init() {
 	toMessage = func(entRefresh *entityMessage.HandleEntityAndDoMessage, m *watermillMsg.Message) error {
-		if entRefresh.Entity.EntityID == simulateFailUUID {
+		if entRefresh.Entity.EntityID == failEntityID {
 			return errors.New("mock marshal error")
 		}
 		return entRefresh.ToMessage(m)
@@ -80,7 +80,7 @@ func Test_handleProfileInitEvent(t *testing.T) {
 			numPublish:  0,
 		},
 		{
-			name: "marshal failure skips but continues",
+			name: "skip entity on marshal error",
 			setupDbMocks: func() df.MockStoreBuilder {
 				retEnts := []db.EntityInstance{
 					{
@@ -89,7 +89,7 @@ func Test_handleProfileInitEvent(t *testing.T) {
 					},
 					{
 						EntityType: db.EntitiesPullRequest,
-						ID:         simulateFailUUID, // this will fail to marshal in test hook
+						ID:         failEntityID, // triggers injected failure
 					},
 					{
 						EntityType: db.EntitiesRepository,

--- a/internal/reconcilers/run_profile_test.go
+++ b/internal/reconcilers/run_profile_test.go
@@ -12,15 +12,29 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 
+	"errors"
+
+	watermillMsg "github.com/ThreeDotsLabs/watermill/message"
 	df "github.com/mindersec/minder/database/mock/fixtures"
 	"github.com/mindersec/minder/internal/db"
+	entityMessage "github.com/mindersec/minder/internal/entities/handlers/message"
 	stubeventer "github.com/mindersec/minder/internal/events/stubs"
 	"github.com/mindersec/minder/pkg/eventer/constants"
 )
 
 var (
 	testReconcileProjectID = uuid.New()
+	simulateFailUUID       = uuid.MustParse("00000000-0000-0000-0000-000000000001")
 )
+
+func init() {
+	toMessage = func(entRefresh *entityMessage.HandleEntityAndDoMessage, m *watermillMsg.Message) error {
+		if entRefresh.Entity.EntityID == simulateFailUUID {
+			return errors.New("mock marshal error")
+		}
+		return entRefresh.ToMessage(m)
+	}
+}
 
 func Test_handleProfileInitEvent(t *testing.T) {
 	t.Parallel()
@@ -64,6 +78,30 @@ func Test_handleProfileInitEvent(t *testing.T) {
 			},
 			expectedErr: true,
 			numPublish:  0,
+		},
+		{
+			name: "marshal failure skips but continues",
+			setupDbMocks: func() df.MockStoreBuilder {
+				retEnts := []db.EntityInstance{
+					{
+						EntityType: db.EntitiesArtifact,
+						ID:         uuid.New(),
+					},
+					{
+						EntityType: db.EntitiesPullRequest,
+						ID:         simulateFailUUID, // this will fail to marshal in test hook
+					},
+					{
+						EntityType: db.EntitiesRepository,
+						ID:         uuid.New(),
+					},
+				}
+				return df.NewMockStore(
+					df.WithSuccessfulGetEntitiesByProjectHierarchy(retEnts, []uuid.UUID{testReconcileProjectID}),
+				)
+			},
+			expectedErr: false,
+			numPublish:  2,
 		},
 	}
 


### PR DESCRIPTION
## Summary
This PR fixes a critical data starvation flaw in the Reconciler where a single broken entity payload would prematurely abort the profile initialization loop for the rest of a project.

Currently in [internal/reconcilers/run_profile.go](cci:7://file:///c:/Users/aftab/Desktop/minder/internal/reconcilers/run_profile.go:0:0-0:0), when [publishProfileInitEvents](cci:1://file:///c:/Users/aftab/Desktop/minder/internal/reconcilers/run_profile.go:82:0-111:1) iterates through a project's entities to evaluate a new profile, it builds a refresh message payload using `entRefresh.ToMessage(m)`. If that single payload fails to marshal, the reconciler simply hits `return nil`. 

Returning `nil` instantly aborts the entire `for` loop, meaning any remaining repositories or artifacts in the project are silently discarded and never evaluated against the new profile rules. Worse, it causes the event router to ACK the payload as successful, so it is never retried.

## Changes
1. Swapped the hard `return nil` with a graceful `continue` inside the error block so the engine cleanly logs the specific entity's marshaling error and naturally continues querying the rest of the project's repositories.
2. Added a test (`skip entity on marshal error`) in [run_profile_test.go](cci:7://file:///c:/Users/aftab/Desktop/minder/internal/reconcilers/run_profile_test.go:0:0-0:0) that explicitly simulates a marshaling failure mid-batch to guarantee downstream entities continue processing unhindered.

Fixes #6351

## Checklist

- [x] Code compiles cleanly
- [x] Includes tests for the changes (existing tests pass)

