### PR TITLE
refactor(cli): extract catalog loading logic from quickstart command

### DIFF
--- a/cmd/cli/app/quickstart/quickstart.go
+++ b/cmd/cli/app/quickstart/quickstart.go
@@ -250,8 +250,23 @@ func quickstartCommand(
 		registeredRepos = append(registeredRepos, r)
 	}
 
+	return loadCatalog(cmd, ruleClient, profileClient, provider, project, registeredRepos)
+}
+
+// loadCatalog loads and applies the quickstart rule type and profile catalog
+// using the same prompts and flow as the inline implementation.
+//
+//nolint:gocyclo // kept as a straight extraction to preserve behavior
+func loadCatalog(
+	cmd *cobra.Command,
+	ruleClient minderv1.RuleTypeServiceClient,
+	profileClient minderv1.ProfileServiceClient,
+	provider string,
+	project string,
+	registeredRepos []string,
+) error {
 	// Step 3 - Confirm rule type creation
-	yes = cli.PrintYesNoPrompt(cmd,
+	yes := cli.PrintYesNoPrompt(cmd,
 		stepPromptMsgRuleType,
 		"Proceed?",
 		"Quickstart operation cancelled.",
@@ -285,7 +300,7 @@ func quickstartCommand(
 	}
 
 	// New context so we don't time out between steps
-	ctx, cancel = getQuickstartContext(cmd.Context(), viper.GetViper())
+	ctx, cancel := getQuickstartContext(cmd.Context(), viper.GetViper())
 	defer cancel()
 
 	// Create the rule type in minder
@@ -368,6 +383,7 @@ func quickstartCommand(
 		profile.RenderProfileRulesTable(resp.GetProfile(), table)
 		table.Render()
 	}
+
 	return nil
 }
 


### PR DESCRIPTION
# Summary

This PR refactors the `quickstart` command by extracting the rule type and profile setup logic into a separate function.

Previously, the quickstart flow handled all steps inline, making it harder to extend or modify specific parts of the process. By isolating the catalog-loading logic into a dedicated function, this change improves code readability and maintainability.

This refactor also prepares the codebase for future enhancements, such as dynamically loading rule and profile catalogs using an in-memory repository clone, as suggested by maintainers.

No functional behavior has been changed in this PR. The quickstart flow remains identical from a user perspective.

Fixes #6339 

# Testing

- Ran the full test suite using:
      go test ./...

- Verified that `minder quickstart` behaves exactly the same as before
- Confirmed no regressions in CLI behavior
- Ran `make lint-fix` to ensure code quality and formatting

No additional configuration or dependencies are required for this change.