### PR TITLE
feat: add interactive 'minder profile edit' command

### DIFF
--- a/cmd/cli/app/profile/edit.go
+++ b/cmd/cli/app/profile/edit.go
@@ -1,0 +1,188 @@
+// SPDX-FileCopyrightText: Copyright 2024 The Minder Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package profile
+
+import (
+	"bytes"
+	"cmp"
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"time"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+	"google.golang.org/grpc"
+	"google.golang.org/protobuf/proto"
+
+	"github.com/mindersec/minder/internal/util"
+	"github.com/mindersec/minder/internal/util/cli"
+	minderv1 "github.com/mindersec/minder/pkg/api/protobuf/go/minder/v1"
+)
+
+var editCmd = &cobra.Command{
+	Use:   "edit",
+	Short: "Edit an existing profile",
+	Long:  `The profile edit subcommand lets you fetch an existing profile, edit it in your $EDITOR, and apply the updates.`,
+	RunE:  cli.GRPCClientWrapRunE(editCommand),
+}
+
+func editCommand(ctx context.Context, cmd *cobra.Command, _ []string, conn *grpc.ClientConn) error {
+	client := minderv1.NewProfileServiceClient(conn)
+	project := viper.GetString("project")
+	id := viper.GetString("id")
+	name := viper.GetString("name")
+
+	if id == "" && name == "" {
+		return cli.MessageAndError("Error editing profile", fmt.Errorf("id or name required"))
+	}
+	cmd.SilenceUsage = true
+
+	prof, err := getProfile(ctx, client, project, id, name)
+	if err != nil {
+		return err
+	}
+
+	// hardcoded type and version since ParseResource requires it
+	if prof.Type == "" {
+		prof.Type = "profile"
+	}
+	if prof.Version == "" {
+		prof.Version = "v1"
+	}
+
+	yamlString, err := util.GetYamlFromProto(prof)
+	if err != nil {
+		return cli.MessageAndError("Error marshaling profile to YAML", err)
+	}
+
+	tmpFile, err := os.CreateTemp("", "tmp-minder-profile-*.yaml")
+	if err != nil {
+		return cli.MessageAndError("Error creating temporary file", err)
+	}
+	defer os.Remove(tmpFile.Name())
+
+	if _, err := tmpFile.WriteString(yamlString); err != nil {
+		return cli.MessageAndError("Error writing to temporary file", err)
+	}
+
+	// we must close the file descriptor before handing it to the editor
+	// many terminal editor perform atomic saves which changes the file's inode
+	// keeping the old FD open would read the orphaned file.
+	if err := tmpFile.Close(); err != nil {
+		return cli.MessageAndError("Error closing temporary file", err)
+	}
+
+	if err := handleEditor(tmpFile.Name()); err != nil {
+		return err
+	}
+
+	updatedBytes, err := os.ReadFile(tmpFile.Name())
+	if err != nil {
+		return cli.MessageAndError("Error reading updated temporary file", err)
+	}
+
+	if string(updatedBytes) == yamlString {
+		cmd.Println("No changes made to the profile. Aborting update.")
+		return nil
+	}
+
+	return updateProfile(ctx, client, prof, updatedBytes, cmd)
+}
+
+func getProfile(ctx context.Context, client minderv1.ProfileServiceClient, project, id, name string) (*minderv1.Profile, error) {
+	if id != "" {
+		p, err := client.GetProfileById(ctx, &minderv1.GetProfileByIdRequest{
+			Context: &minderv1.Context{Project: &project},
+			Id:      id,
+		})
+		if err != nil {
+			return nil, cli.MessageAndError("Error getting profile by ID", err)
+		}
+		return p.GetProfile(), nil
+	}
+
+	p, err := client.GetProfileByName(ctx, &minderv1.GetProfileByNameRequest{
+		Context: &minderv1.Context{Project: &project},
+		Name:    name,
+	})
+	if err != nil {
+		return nil, cli.MessageAndError("Error getting profile by name", err)
+	}
+	return p.GetProfile(), nil
+}
+
+func handleEditor(fileName string) error {
+	editorCmd := cmp.Or(os.Getenv("VISUAL"), os.Getenv("EDITOR"))
+
+	if editorCmd == "" {
+		commonEditors := []string{"nano", "vim", "nvim", "vi", "emacs"}
+		for _, e := range commonEditors {
+			if _, err := exec.LookPath(e); err == nil {
+				editorCmd = e
+				break
+			}
+		}
+	}
+
+	if editorCmd == "" {
+		msg := "no editor found in $PATH. Please set $EDITOR to your preferred editor"
+		return cli.MessageAndError(msg, fmt.Errorf("no editor found"))
+	}
+
+	// #nosec G204
+	// #nosec G702
+	execCmd := exec.Command(editorCmd, fileName)
+	execCmd.Stdin, execCmd.Stdout, execCmd.Stderr = os.Stdin, os.Stdout, os.Stderr
+
+	if err := execCmd.Run(); err != nil {
+		return cli.MessageAndError(fmt.Sprintf("Editor execution failed (%s)", editorCmd), err)
+	}
+	return nil
+}
+
+func updateProfile(
+	_ context.Context,
+	client minderv1.ProfileServiceClient,
+	oldProf *minderv1.Profile,
+	updatedBytes []byte,
+	cmd *cobra.Command,
+) error {
+	var updatedProfile minderv1.Profile
+	if err := minderv1.ParseResource(bytes.NewReader(updatedBytes), &updatedProfile); err != nil {
+		return cli.MessageAndError("Error parsing updated profile YAML", err)
+	}
+
+	updatedProfile.Id = proto.String(oldProf.GetId())
+	updatedProfile.Context = oldProf.GetContext()
+	updatedProfile.Type = oldProf.GetType()
+	if updatedProfile.Type == "" {
+		updatedProfile.Type = "profile"
+	}
+	updatedProfile.Version = oldProf.GetVersion()
+	if updatedProfile.Version == "" {
+		updatedProfile.Version = "v1"
+	}
+
+	updateCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	resp, err := client.UpdateProfile(updateCtx, &minderv1.UpdateProfileRequest{
+		Profile: &updatedProfile,
+	})
+	if err != nil {
+		return cli.MessageAndError("Error updating profile", err)
+	}
+
+	cmd.Println("Successfully updated profile named:", resp.GetProfile().GetName())
+	return nil
+}
+
+func init() {
+	ProfileCmd.AddCommand(editCmd)
+	editCmd.Flags().StringP("id", "i", "", "ID of the profile to edit")
+	editCmd.Flags().StringP("name", "n", "", "Name of the profile to edit")
+	editCmd.MarkFlagsMutuallyExclusive("id", "name")
+}

--- a/cmd/cli/app/profile/edit.go
+++ b/cmd/cli/app/profile/edit.go
@@ -14,7 +14,6 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
-	"google.golang.org/grpc"
 	"google.golang.org/protobuf/proto"
 
 	"github.com/mindersec/minder/internal/util"
@@ -22,35 +21,52 @@ import (
 	minderv1 "github.com/mindersec/minder/pkg/api/protobuf/go/minder/v1"
 )
 
+const (
+	defaultProfileType    = "profile"
+	defaultProfileVersion = "v1"
+)
+
 var editCmd = &cobra.Command{
 	Use:   "edit",
 	Short: "Edit an existing profile",
 	Long:  `The profile edit subcommand lets you fetch an existing profile, edit it in your $EDITOR, and apply the updates.`,
-	RunE:  cli.GRPCClientWrapRunE(editCommand),
+	PreRunE: func(cmd *cobra.Command, _ []string) error {
+		if err := viper.BindPFlags(cmd.Flags()); err != nil {
+			return fmt.Errorf("error binding flags: %s", err)
+		}
+		return nil
+	},
+	RunE: editCommand,
 }
 
-func editCommand(ctx context.Context, cmd *cobra.Command, _ []string, conn *grpc.ClientConn) error {
-	client := minderv1.NewProfileServiceClient(conn)
+// editCommand is the profile edit subcommand
+func editCommand(cmd *cobra.Command, _ []string) error {
 	project := viper.GetString("project")
 	id := viper.GetString("id")
 	name := viper.GetString("name")
 
+	cmd.SilenceUsage = true
+
+	client, closeConn, err := cli.GetCLIClient(cmd, minderv1.NewProfileServiceClient)
+	if err != nil {
+		return cli.MessageAndError("Error connecting to server", err)
+	}
+	defer closeConn()
+
 	if id == "" && name == "" {
 		return cli.MessageAndError("Error editing profile", fmt.Errorf("id or name required"))
 	}
-	cmd.SilenceUsage = true
 
-	prof, err := getProfile(ctx, client, project, id, name)
+	prof, err := getProfile(cmd.Context(), client, project, id, name)
 	if err != nil {
 		return err
 	}
 
-	// hardcoded type and version since ParseResource requires it
 	if prof.Type == "" {
-		prof.Type = "profile"
+		prof.Type = defaultProfileType
 	}
 	if prof.Version == "" {
-		prof.Version = "v1"
+		prof.Version = defaultProfileVersion
 	}
 
 	yamlString, err := util.GetYamlFromProto(prof)
@@ -89,7 +105,7 @@ func editCommand(ctx context.Context, cmd *cobra.Command, _ []string, conn *grpc
 		return nil
 	}
 
-	return updateProfile(ctx, client, prof, updatedBytes, cmd)
+	return updateProfile(client, prof, updatedBytes, cmd)
 }
 
 func getProfile(ctx context.Context, client minderv1.ProfileServiceClient, project, id, name string) (*minderv1.Profile, error) {
@@ -144,7 +160,6 @@ func handleEditor(fileName string) error {
 }
 
 func updateProfile(
-	_ context.Context,
 	client minderv1.ProfileServiceClient,
 	oldProf *minderv1.Profile,
 	updatedBytes []byte,
@@ -157,16 +172,13 @@ func updateProfile(
 
 	updatedProfile.Id = proto.String(oldProf.GetId())
 	updatedProfile.Context = oldProf.GetContext()
-	updatedProfile.Type = oldProf.GetType()
-	if updatedProfile.Type == "" {
-		updatedProfile.Type = "profile"
-	}
+	updatedProfile.Type = cmp.Or(oldProf.GetType(), defaultProfileType)
 	updatedProfile.Version = oldProf.GetVersion()
 	if updatedProfile.Version == "" {
-		updatedProfile.Version = "v1"
+		updatedProfile.Version = defaultProfileVersion
 	}
 
-	updateCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	updateCtx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 	defer cancel()
 
 	resp, err := client.UpdateProfile(updateCtx, &minderv1.UpdateProfileRequest{

--- a/cmd/cli/app/profile/testdata/profile_root.txt.golden
+++ b/cmd/cli/app/profile/testdata/profile_root.txt.golden
@@ -6,6 +6,7 @@ Available Commands:
   apply       Create or update a profile
   create      Create a profile
   delete      Delete a profile
+  edit        Edit an existing profile
   export      Export profile and associated resources
   get         Get details for a profile
   list        List profiles

--- a/cmd/cli/app/profile/testdata/profile_root_help.txt.golden
+++ b/cmd/cli/app/profile/testdata/profile_root_help.txt.golden
@@ -8,6 +8,7 @@ Available Commands:
   apply       Create or update a profile
   create      Create a profile
   delete      Delete a profile
+  edit        Edit an existing profile
   export      Export profile and associated resources
   get         Get details for a profile
   list        List profiles


### PR DESCRIPTION
# Summary

This PR introduces the minder profile edit command, allowing users to fetch a profile, modify it in their local text editor, and apply changes in a single interactive workflow.

- Implemented a robust lookup system that checks $VISUAL -> $EDITOR -> system path (searching for nano, vim, nvim, vi, or emacs) using exec.LookPath.

- The implementation ensures that critical fields such as Id, Context, Type, and Version are preserved from the original fetch. This prevents validation errors if the user accidentally deletes these fields during the editing session.

---

- Fixes #2283 

---

**Before** 
<img width="1028" height="588" alt="swappy-20260413_185940" src="https://github.com/user-attachments/assets/6778e78b-8eaf-4734-87a0-86579893a265" />

**After**
<img width="1027" height="493" alt="swappy-20260413_190001" src="https://github.com/user-attachments/assets/71e3fd8e-1f04-409e-bcbe-7eaaf2f9bc1f" />
