### PR TITLE
fix: gracefully skip invalid repositories in webhooks instead of aborting

### DIFF
--- a/internal/providers/github/webhook/app.go
+++ b/internal/providers/github/webhook/app.go
@@ -325,7 +325,8 @@ func processInstallationRepositoriesAppEvent(
 			installation,
 		)
 		if err != nil {
-			return nil, err
+			zerolog.Ctx(ctx).Warn().Err(err).Msg("skipping invalid repository in batch")
+			continue
 		}
 
 		results = append(results, res)
@@ -336,15 +337,22 @@ func processInstallationRepositoriesAppEvent(
 	// be deleted by means of "meta" and "repository" events as
 	// well.
 	for _, repo := range event.GetRepositoriesRemoved() {
-		res := repositoryRemoved(repo)
+		res, err := repositoryRemoved(repo)
+		if err != nil {
+			zerolog.Ctx(ctx).Warn().Err(err).Msg("skipping invalid repository removal in batch")
+			continue
+		}
 		results = append(results, res)
 	}
 
 	return results, nil
 }
 
-func repositoryRemoved(repo *repo) *processingResult {
-	return sendEvaluateRepoMessage(repo, constants.TopicQueueGetEntityAndDelete)
+func repositoryRemoved(repo *repo) (*processingResult, error) {
+	if repo.GetID() == 0 {
+		return nil, errors.New("invalid repository: id is 0")
+	}
+	return sendEvaluateRepoMessage(repo, constants.TopicQueueGetEntityAndDelete), nil
 }
 
 func repositoryAdded(

--- a/internal/providers/github/webhook/app.go
+++ b/internal/providers/github/webhook/app.go
@@ -317,15 +317,13 @@ func processInstallationRepositoriesAppEvent(
 
 	results := make([]*processingResult, 0)
 	for _, repo := range addedRepos {
-		// caveat: we're accessing the database once for every
-		// repository, which might be inefficient at scale.
 		res, err := repositoryAdded(
 			ctx,
 			repo,
 			installation,
 		)
 		if err != nil {
-			zerolog.Ctx(ctx).Warn().Err(err).Msg("skipping invalid repository in batch")
+			zerolog.Ctx(ctx).Warn().Err(err).Msg("skipping invalid repository in added batch")
 			continue
 		}
 
@@ -337,22 +335,19 @@ func processInstallationRepositoriesAppEvent(
 	// be deleted by means of "meta" and "repository" events as
 	// well.
 	for _, repo := range event.GetRepositoriesRemoved() {
-		res, err := repositoryRemoved(repo)
-		if err != nil {
-			zerolog.Ctx(ctx).Warn().Err(err).Msg("skipping invalid repository removal in batch")
+		if repo.GetID() == 0 {
+			zerolog.Ctx(ctx).Warn().Msg("skipping removed repository with zero ID")
 			continue
 		}
+		res := repositoryRemoved(repo)
 		results = append(results, res)
 	}
 
 	return results, nil
 }
 
-func repositoryRemoved(repo *repo) (*processingResult, error) {
-	if repo.GetID() == 0 {
-		return nil, errors.New("invalid repository: id is 0")
-	}
-	return sendEvaluateRepoMessage(repo, constants.TopicQueueGetEntityAndDelete), nil
+func repositoryRemoved(repo *repo) *processingResult {
+	return sendEvaluateRepoMessage(repo, constants.TopicQueueGetEntityAndDelete)
 }
 
 func repositoryAdded(

--- a/internal/providers/github/webhook/app_batch_test.go
+++ b/internal/providers/github/webhook/app_batch_test.go
@@ -1,0 +1,149 @@
+// SPDX-FileCopyrightText: Copyright 2024 The Minder Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package webhook
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+
+	df "github.com/mindersec/minder/database/mock/fixtures"
+	"github.com/mindersec/minder/internal/db"
+)
+
+func TestProcessInstallationRepositoriesAppEvent_BatchResilience(t *testing.T) {
+	t.Parallel()
+
+	projectID := uuid.New()
+	providerID := uuid.New()
+
+	autoregEnabled := `{"github-app": {}, "auto_registration": {"entities": {"repository": {"enabled": true}}}}`
+
+	validRepo := func(id int, name, fullName string) *repo {
+		idVal := int64(id)
+		return &repo{
+			ID:       &idVal,
+			Name:     &name,
+			FullName: &fullName,
+		}
+	}
+
+	invalidRepo := func() *repo {
+		// name is empty, triggers repositoryAdded validation error
+		emptyName := ""
+		return &repo{
+			Name: &emptyName,
+		}
+	}
+
+	zeroIDRepo := func() *repo {
+		// ID is 0, triggers repositoryRemoved validation error
+		var zero int64
+		name := "bad-repo"
+		return &repo{
+			ID:   &zero,
+			Name: &name,
+		}
+	}
+
+	mockInstallation := db.ProviderGithubAppInstallation{
+		ProjectID:  uuid.NullUUID{UUID: projectID, Valid: true},
+		ProviderID: uuid.NullUUID{UUID: providerID, Valid: true},
+	}
+
+	baseMocks := func(ctrl *gomock.Controller) db.Store {
+		return df.NewMockStore(
+			df.WithSuccessfulGetInstallationIDByAppID(mockInstallation, 54321),
+			df.WithSuccessfulGetProviderByID(
+				db.Provider{
+					ID:         providerID,
+					Definition: json.RawMessage(autoregEnabled),
+				},
+				providerID,
+			),
+		)(ctrl)
+	}
+
+	tests := []struct {
+		name          string
+		payload       *installationRepositoriesEvent
+		expectedCount int
+		expectErr     bool
+	}{
+		{
+			name: "full batch success",
+			payload: &installationRepositoriesEvent{
+				Action:              strPtr("added"),
+				RepositorySelection: strPtr("selected"),
+				RepositoriesAdded: []*repo{
+					validRepo(111, "repo-a", "org/repo-a"),
+					validRepo(222, "repo-b", "org/repo-b"),
+				},
+				RepositoriesRemoved: []*repo{
+					validRepo(333, "repo-c", "org/repo-c"),
+				},
+				Installation: &installation{ID: int64Ptr(54321)},
+			},
+			expectedCount: 3,
+		},
+		{
+			name: "skip invalid added repo",
+			payload: &installationRepositoriesEvent{
+				Action:              strPtr("added"),
+				RepositorySelection: strPtr("selected"),
+				RepositoriesAdded: []*repo{
+					validRepo(111, "repo-a", "org/repo-a"),
+					invalidRepo(), // bad name → skipped
+					validRepo(333, "repo-c", "org/repo-c"),
+				},
+				Installation: &installation{ID: int64Ptr(54321)},
+			},
+			expectedCount: 2,
+		},
+		{
+			name: "skip invalid removed repo",
+			payload: &installationRepositoriesEvent{
+				Action:              strPtr("removed"),
+				RepositorySelection: strPtr("selected"),
+				RepositoriesRemoved: []*repo{
+					validRepo(111, "repo-a", "org/repo-a"),
+					zeroIDRepo(), // id=0 → skipped
+					validRepo(333, "repo-c", "org/repo-c"),
+				},
+				Installation: &installation{ID: int64Ptr(54321)},
+			},
+			expectedCount: 2,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			store := baseMocks(ctrl)
+			payload, err := json.Marshal(tt.payload)
+			require.NoError(t, err)
+
+			results, err := processInstallationRepositoriesAppEvent(
+				context.Background(), store, payload,
+			)
+			if tt.expectErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.Len(t, results, tt.expectedCount)
+		})
+	}
+}
+
+func strPtr(s string) *string { return &s }
+func int64Ptr(i int64) *int64 { return &i }

--- a/internal/providers/github/webhook/app_test.go
+++ b/internal/providers/github/webhook/app_test.go
@@ -14,6 +14,7 @@ import (
 
 	df "github.com/mindersec/minder/database/mock/fixtures"
 	"github.com/mindersec/minder/internal/db"
+	"github.com/mindersec/minder/internal/util/ptr"
 )
 
 func TestProcessInstallationRepositoriesAppEvent_BatchResilience(t *testing.T) {
@@ -23,33 +24,6 @@ func TestProcessInstallationRepositoriesAppEvent_BatchResilience(t *testing.T) {
 	providerID := uuid.New()
 
 	autoregEnabled := `{"github-app": {}, "auto_registration": {"entities": {"repository": {"enabled": true}}}}`
-
-	validRepo := func(id int, name, fullName string) *repo {
-		idVal := int64(id)
-		return &repo{
-			ID:       &idVal,
-			Name:     &name,
-			FullName: &fullName,
-		}
-	}
-
-	invalidRepo := func() *repo {
-		// name is empty, triggers repositoryAdded validation error
-		emptyName := ""
-		return &repo{
-			Name: &emptyName,
-		}
-	}
-
-	zeroIDRepo := func() *repo {
-		// ID is 0, triggers repositoryRemoved validation error
-		var zero int64
-		name := "bad-repo"
-		return &repo{
-			ID:   &zero,
-			Name: &name,
-		}
-	}
 
 	mockInstallation := db.ProviderGithubAppInstallation{
 		ProjectID:  uuid.NullUUID{UUID: projectID, Valid: true},
@@ -78,44 +52,44 @@ func TestProcessInstallationRepositoriesAppEvent_BatchResilience(t *testing.T) {
 		{
 			name: "full batch success",
 			payload: &installationRepositoriesEvent{
-				Action:              strPtr("added"),
-				RepositorySelection: strPtr("selected"),
+				Action:              ptr.Ptr("added"),
+				RepositorySelection: ptr.Ptr("selected"),
 				RepositoriesAdded: []*repo{
-					validRepo(111, "repo-a", "org/repo-a"),
-					validRepo(222, "repo-b", "org/repo-b"),
+					newValidRepo(111, "repo-a", "org/repo-a"),
+					newValidRepo(222, "repo-b", "org/repo-b"),
 				},
 				RepositoriesRemoved: []*repo{
-					validRepo(333, "repo-c", "org/repo-c"),
+					newValidRepo(333, "repo-c", "org/repo-c"),
 				},
-				Installation: &installation{ID: int64Ptr(54321)},
+				Installation: &installation{ID: ptr.Ptr(int64(54321))},
 			},
 			expectedCount: 3,
 		},
 		{
 			name: "skip invalid added repo",
 			payload: &installationRepositoriesEvent{
-				Action:              strPtr("added"),
-				RepositorySelection: strPtr("selected"),
+				Action:              ptr.Ptr("added"),
+				RepositorySelection: ptr.Ptr("selected"),
 				RepositoriesAdded: []*repo{
-					validRepo(111, "repo-a", "org/repo-a"),
-					invalidRepo(), // bad name → skipped
-					validRepo(333, "repo-c", "org/repo-c"),
+					newValidRepo(111, "repo-a", "org/repo-a"),
+					newInvalidRepo(), // empty name → skipped
+					newValidRepo(333, "repo-c", "org/repo-c"),
 				},
-				Installation: &installation{ID: int64Ptr(54321)},
+				Installation: &installation{ID: ptr.Ptr(int64(54321))},
 			},
 			expectedCount: 2,
 		},
 		{
 			name: "skip invalid removed repo",
 			payload: &installationRepositoriesEvent{
-				Action:              strPtr("removed"),
-				RepositorySelection: strPtr("selected"),
+				Action:              ptr.Ptr("removed"),
+				RepositorySelection: ptr.Ptr("selected"),
 				RepositoriesRemoved: []*repo{
-					validRepo(111, "repo-a", "org/repo-a"),
-					zeroIDRepo(), // id=0 → skipped
-					validRepo(333, "repo-c", "org/repo-c"),
+					newValidRepo(111, "repo-a", "org/repo-a"),
+					newZeroIDRepo(), // id=0 → skipped
+					newValidRepo(333, "repo-c", "org/repo-c"),
 				},
-				Installation: &installation{ID: int64Ptr(54321)},
+				Installation: &installation{ID: ptr.Ptr(int64(54321))},
 			},
 			expectedCount: 2,
 		},
@@ -145,5 +119,28 @@ func TestProcessInstallationRepositoriesAppEvent_BatchResilience(t *testing.T) {
 	}
 }
 
-func strPtr(s string) *string { return &s }
-func int64Ptr(i int64) *int64 { return &i }
+// newValidRepo constructs a repo with all required fields set.
+func newValidRepo(id int64, name, fullName string) *repo {
+	return &repo{
+		ID:       ptr.Ptr(id),
+		Name:     ptr.Ptr(name),
+		FullName: ptr.Ptr(fullName),
+	}
+}
+
+// newInvalidRepo constructs a repo with an empty name, which triggers
+// a repositoryAdded validation error and causes the entry to be skipped.
+func newInvalidRepo() *repo {
+	return &repo{
+		Name: ptr.Ptr(""),
+	}
+}
+
+// newZeroIDRepo constructs a repo with ID=0, which triggers a
+// repositoryRemoved validation error and causes the entry to be skipped.
+func newZeroIDRepo() *repo {
+	return &repo{
+		ID:   ptr.Ptr(int64(0)),
+		Name: ptr.Ptr("bad-repo"),
+	}
+}


### PR DESCRIPTION
## Description

This PR improves batch resilience inside the GitHub App Webhook processor ([processInstallationRepositoriesAppEvent](cci:1://file:///C:/Users/aftab/Desktop/minder/internal/providers/github/webhook/app.go:258:0-346:1)) by preventing a single invalid repository entry from aborting the entire synchronization event.

When an `installation_repositories` payload arrives from GitHub, it iterates through both `addedRepos` and `removedRepos` to synchronize the installation. Previously, if *any single repository* failed the basic name or ID parsing validation (e.g. an empty name string), the function would instantly return an `error`. 

This caused two minor but unwanted behaviors:
1. It returned a 500 error to GitHub, causing GitHub to retry the exact same webhook payload and repeatedly hit the same validation error.
2. It dropped subsequent valid repositories in the same batch, meaning that minor data anomalies could temporarily stall syncing. 

## Changes
- Swapped the `return nil, err` across both the added and removed loops with a graceful `zerolog` warning and a `continue`, allowing valid entries to continue processing.
- Ensured the [repositoryRemoved()](cci:1://file:///C:/Users/aftab/Desktop/minder/internal/providers/github/webhook/app.go:348:0-350:1) loop validates `repo.GetID() != 0` to safely surface errors rather than passing zero-values downstream.
- Added explicit unit tests ([app_test.go](cci:7://file:///C:/Users/aftab/Desktop/minder/internal/providers/github/webhook/app_test.go:0:0-0:0)) validating batch resilience when dropping mixed invalid repositories into both the added and removed slices.

Fixes #6359

## Checklist

- [x] Code compiles cleanly
- [x] Includes tests for the changes
