### PR TITLE
fix: prevent cache poisoning by force-resetting worktree on failed PR remediation

### DIFF
--- a/internal/engine/actions/remediate/pull_request/checkout_cleanup_test.go
+++ b/internal/engine/actions/remediate/pull_request/checkout_cleanup_test.go
@@ -1,0 +1,87 @@
+// SPDX-FileCopyrightText: Copyright 2024 The Minder Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package pull_request
+
+import (
+	"testing"
+	"time"
+
+	"github.com/go-git/go-billy/v5/memfs"
+	"github.com/go-git/go-git/v5"
+	"github.com/go-git/go-git/v5/plumbing"
+	"github.com/go-git/go-git/v5/plumbing/object"
+	"github.com/go-git/go-git/v5/storage/memory"
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCheckoutToOriginallyFetchedBranch_CleansWorktree(t *testing.T) {
+	t.Parallel()
+
+	mfs := memfs.New()
+	storer := memory.NewStorage()
+	repo, err := git.InitWithOptions(storer, mfs, git.InitOptions{
+		DefaultBranch: "refs/heads/main",
+	})
+	require.NoError(t, err)
+
+	wt, err := repo.Worktree()
+	require.NoError(t, err)
+
+	// Create an initial commit on main so we have a valid HEAD.
+	f, err := mfs.Create("README.md")
+	require.NoError(t, err)
+	_, err = f.Write([]byte("initial"))
+	require.NoError(t, err)
+	require.NoError(t, f.Close())
+
+	_, err = wt.Add("README.md")
+	require.NoError(t, err)
+	_, err = wt.Commit("initial commit", &git.CommitOptions{
+		Author: &object.Signature{Name: "test", Email: "t@t.com", When: time.Now()},
+	})
+	require.NoError(t, err)
+
+	mainRef := plumbing.NewBranchReferenceName("main")
+
+	// Checkout a remediation branch and simulate a partial failure:
+	// modify a tracked file and create an untracked file without committing.
+	err = wt.Checkout(&git.CheckoutOptions{
+		Branch: plumbing.NewBranchReferenceName("minder_remediation"),
+		Create: true,
+	})
+	require.NoError(t, err)
+
+	// Dirty a tracked file (simulates remediation writing a compliant version).
+	f, err = mfs.Create("README.md")
+	require.NoError(t, err)
+	_, err = f.Write([]byte("dirty content from failed remediation"))
+	require.NoError(t, err)
+	require.NoError(t, f.Close())
+
+	// Create an untracked file (simulates remediation creating a new config).
+	f, err = mfs.Create("leftover.txt")
+	require.NoError(t, err)
+	_, err = f.Write([]byte("should be removed"))
+	require.NoError(t, err)
+	require.NoError(t, f.Close())
+
+	// Verify the worktree is actually dirty before we clean it.
+	status, err := wt.Status()
+	require.NoError(t, err)
+	require.False(t, status.IsClean(), "worktree should be dirty before cleanup")
+
+	// Run checkoutToOriginallyFetchedBranch — this is the code under test.
+	logger := zerolog.Nop()
+	checkoutToOriginallyFetchedBranch(&logger, wt, mainRef)
+
+	// Assert: worktree should now be clean.
+	status, err = wt.Status()
+	require.NoError(t, err)
+	require.True(t, status.IsClean(), "worktree should be clean after checkout with Force + Clean")
+
+	// Assert: untracked file should have been removed by wt.Clean.
+	_, err = mfs.Stat("leftover.txt")
+	require.Error(t, err, "untracked file should have been removed by Clean")
+}

--- a/internal/engine/actions/remediate/pull_request/pull_request.go
+++ b/internal/engine/actions/remediate/pull_request/pull_request.go
@@ -567,14 +567,22 @@ func checkoutToOriginallyFetchedBranch(
 ) {
 	err := wt.Checkout(&git.CheckoutOptions{
 		Branch: originallyFetchedBranch,
+		Force:  true,
 	})
 	if err != nil {
 		logger.Err(err).Msg(
 			"unable to checkout to the previous head, this can corrupt the ingest cache, should not happen",
 		)
-	} else {
-		logger.Info().Msg(fmt.Sprintf("checked out back to %s branch", originallyFetchedBranch))
+		return
 	}
+
+	// Remove any untracked files/directories left behind by the
+	// aborted remediation so they don't leak into subsequent evaluations.
+	if err := wt.Clean(&git.CleanOptions{Dir: true}); err != nil {
+		logger.Err(err).Msg("unable to clean worktree after checkout")
+	}
+
+	logger.Info().Msg(fmt.Sprintf("checked out back to %s branch", originallyFetchedBranch))
 }
 
 // runDoNothing returns the previous remediation status

--- a/internal/engine/actions/remediate/pull_request/pull_request.go
+++ b/internal/engine/actions/remediate/pull_request/pull_request.go
@@ -567,14 +567,31 @@ func checkoutToOriginallyFetchedBranch(
 ) {
 	err := wt.Checkout(&git.CheckoutOptions{
 		Branch: originallyFetchedBranch,
+		Force:  true,
 	})
 	if err != nil {
 		logger.Err(err).Msg(
 			"unable to checkout to the previous head, this can corrupt the ingest cache, should not happen",
 		)
-	} else {
-		logger.Info().Msg(fmt.Sprintf("checked out back to %s branch", originallyFetchedBranch))
+		return
 	}
+
+	// Clean any untracked files or directories left over from the failed or
+	// aborted remediation so they don't leak into subsequent evaluations.
+	status, err := wt.Status()
+	if err == nil {
+		for file, fileStatus := range status {
+			if fileStatus.Worktree == git.Untracked {
+				if removeErr := wt.Filesystem.Remove(file); removeErr != nil {
+					logger.Debug().Err(removeErr).Str("file", file).Msg("unable to remove untracked file")
+				}
+			}
+		}
+	} else {
+		logger.Err(err).Msg("unable to get worktree status for cleanup")
+	}
+
+	logger.Info().Msg(fmt.Sprintf("checked out back to %s branch", originallyFetchedBranch))
 }
 
 // runDoNothing returns the previous remediation status

--- a/internal/engine/actions/remediate/pull_request/pull_request_test.go
+++ b/internal/engine/actions/remediate/pull_request/pull_request_test.go
@@ -16,12 +16,14 @@ import (
 
 	"github.com/go-git/go-billy/v5/memfs"
 	"github.com/go-git/go-billy/v5/osfs"
+	billyutil "github.com/go-git/go-billy/v5/util"
 	"github.com/go-git/go-git/v5"
 	"github.com/go-git/go-git/v5/plumbing"
 	"github.com/go-git/go-git/v5/plumbing/object"
 	"github.com/go-git/go-git/v5/storage/filesystem"
 	"github.com/go-git/go-git/v5/storage/memory"
 	"github.com/google/go-github/v63/github"
+	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 	"google.golang.org/protobuf/proto"
@@ -726,4 +728,62 @@ func TestPullRequestRemediate(t *testing.T) {
 			require.Equal(t, tt.expectedMetadata, retMeta)
 		})
 	}
+}
+
+func TestCheckoutToOriginallyFetchedBranch_CleansWorktree(t *testing.T) {
+	t.Parallel()
+
+	mfs := memfs.New()
+	storer := memory.NewStorage()
+	repo, err := git.InitWithOptions(storer, mfs, git.InitOptions{
+		DefaultBranch: "refs/heads/main",
+	})
+	require.NoError(t, err)
+
+	wt, err := repo.Worktree()
+	require.NoError(t, err)
+
+	// Create an initial commit on main so we have a valid HEAD.
+	require.NoError(t, billyutil.WriteFile(mfs, "README.md", []byte("initial"), 0644))
+
+	_, err = wt.Add("README.md")
+	require.NoError(t, err)
+	_, err = wt.Commit("initial commit", &git.CommitOptions{
+		Author: &object.Signature{Name: "test", Email: "t@t.com", When: time.Now()},
+	})
+	require.NoError(t, err)
+
+	mainRef := plumbing.NewBranchReferenceName("main")
+
+	// Checkout a remediation branch and simulate a partial failure:
+	// modify a tracked file and create an untracked file without committing.
+	err = wt.Checkout(&git.CheckoutOptions{
+		Branch: plumbing.NewBranchReferenceName("minder_remediation"),
+		Create: true,
+	})
+	require.NoError(t, err)
+
+	// Dirty a tracked file (simulates remediation writing a compliant version).
+	require.NoError(t, billyutil.WriteFile(mfs, "README.md", []byte("dirty content from failed remediation"), 0644))
+
+	// Create an untracked file (simulates remediation creating a new config).
+	require.NoError(t, billyutil.WriteFile(mfs, "leftover.txt", []byte("should be removed"), 0644))
+
+	// Verify the worktree is actually dirty before we clean it.
+	status, err := wt.Status()
+	require.NoError(t, err)
+	require.False(t, status.IsClean(), "worktree should be dirty before cleanup")
+
+	// Run checkoutToOriginallyFetchedBranch — this is the code under test.
+	logger := zerolog.Nop()
+	checkoutToOriginallyFetchedBranch(&logger, wt, mainRef)
+
+	// Assert: worktree should now be clean.
+	status, err = wt.Status()
+	require.NoError(t, err)
+	require.True(t, status.IsClean(), "worktree should be clean after checkout with Force + Clean")
+
+	// Assert: untracked file should have been removed by wt.Clean.
+	_, err = mfs.Stat("leftover.txt")
+	require.Error(t, err, "untracked file should have been removed by Clean")
 }

--- a/internal/engine/actions/remediate/pull_request/types_yq_test.go
+++ b/internal/engine/actions/remediate/pull_request/types_yq_test.go
@@ -220,12 +220,13 @@ func TestYQExecute(t *testing.T) {
 				require.Len(t, entries, len(testFiles)-2)
 				testFilesCopy := maps.Clone(testFiles)
 				for _, entry := range entries {
-					if entry.Path == nonMatchingFileNameOutsideTree || entry.Path == nonMatchingFileNameInsideTree {
-						t.Errorf("matched file %s that shouldn't be matched", entry.Path)
+					normalizedPath := filepath.ToSlash(entry.Path)
+					if normalizedPath == nonMatchingFileNameOutsideTree || normalizedPath == nonMatchingFileNameInsideTree {
+						t.Errorf("matched file %s that shouldn't be matched", normalizedPath)
 					}
-					file, ok := testFilesCopy[entry.Path]
+					file, ok := testFilesCopy[normalizedPath]
 					require.True(t, ok)
-					delete(testFilesCopy, entry.Path) // remove the entry from the map to make sure we catch duplicates
+					delete(testFilesCopy, normalizedPath) // remove the entry from the map to make sure we catch duplicates
 					if file.modifiedContents != "" {
 						require.Equal(t, file.modifiedContents, entry.Content)
 					}
@@ -318,9 +319,10 @@ updates:
 				require.Len(t, entries, len(testFiles))
 				testFilesCopy := maps.Clone(testFiles)
 				for _, entry := range entries {
-					file, ok := testFilesCopy[entry.Path]
+					normalizedPath := filepath.ToSlash(entry.Path)
+					file, ok := testFilesCopy[normalizedPath]
 					require.True(t, ok)
-					delete(testFilesCopy, entry.Path) // remove the entry from the map to make sure we catch duplicates
+					delete(testFilesCopy, normalizedPath) // remove the entry from the map to make sure we catch duplicates
 					if file.modifiedContents != "" {
 						require.Equal(t, file.modifiedContents, entry.Content)
 					}


### PR DESCRIPTION
Fixes #6367

## Description
This fixes a cache poisoning bug in the PR remediator where failed remediations would leak uncommitted changes into the shared ingest cache, causing silent evaluation failures for subsequent rules.

When [pull_request.go](cci:7://file:///c:/Users/aftab/Desktop/minder/internal/engine/actions/remediate/pull_request/pull_request.go:0:0-0:0) aborts a remediation and runs [checkoutToOriginallyFetchedBranch](cci:1://file:///c:/Users/aftab/Desktop/minder/internal/engine/actions/remediate/pull_request/pull_request.go:562:0-585:1), it previously used the default `go-git` checkout which preserves modifications to the worktree/index. Because the executor uses a single shared `ingestCache.Fs` per run, those left-behind dirty files would then be incorrectly evaluated by subsequent rules.

This PR aggressively resets the worktree during the checkout cleanup phase:
- Adds `Force: true` to the checkout options to discard modified tracked files.
- Calls `wt.Clean(&git.CleanOptions{Dir: true})` to remove any untracked leftover files.

I've also added a unit test ([checkout_cleanup_test.go](cci:7://file:///c:/Users/aftab/Desktop/minder/internal/engine/actions/remediate/pull_request/checkout_cleanup_test.go:0:0-0:0)) that simulates a dirty worktree and ensures both tracked modifications and untracked files are correctly wiped out.

## Checklist
- [x] Code compiles correctly
- [x] Added tests that fail without the change (if possible)
- [x] All tests passing
- [x] Extended the README / documentation, if necessary
