### PR TITLE
fix: abort repository deletion if upstream webhook deregistration fails

### DIFF
--- a/internal/repositories/service.go
+++ b/internal/repositories/service.go
@@ -405,6 +405,7 @@ func (r *repositoryService) deleteRepository(
 		zerolog.Ctx(ctx).Error().
 			Dict("properties", repo.Properties.ToLogDict()).
 			Err(err).Msg("error deregistering repo")
+		return fmt.Errorf("failed to deregister entity upstream, aborting deletion to prevent orphaned webhook: %w", err)
 	}
 
 	_, err = db.WithTransaction(r.store, func(t db.ExtendQuerier) (*pb.Repository, error) {

--- a/internal/repositories/service_test.go
+++ b/internal/repositories/service_test.go
@@ -191,14 +191,15 @@ func TestRepositoryService_DeleteRepository(t *testing.T) {
 			ExpectedError: "error instantiating provider",
 		},
 		{
-			Name:         "DeleteByName still works when entity cannot be deregistered",
+			Name:         "DeleteByName fails when entity cannot be deregistered",
 			DeleteType:   ByName,
-			DBSetup:      newDBMock(withSuccessfulGetByName, withSuccessfulDelete),
+			DBSetup:      newDBMock(withSuccessfulGetByName),
 			ServiceSetup: newPropSvcMock(withSuccessfulEntityWithProps),
 			ProviderManagerSetup: func(p provinfv1.Provider) pf.ProviderManagerMockBuilder {
 				return pf.NewProviderManagerMock(pf.WithSuccessfulInstantiateFromID(p))
 			},
 			ProviderSetup: newProviderMock(withFailedDeregister),
+			ExpectedError: "failed to deregister entity upstream",
 		},
 		{
 			Name:         "DeleteByName by ID fails when repo cannot be deleted from DB",
@@ -244,14 +245,15 @@ func TestRepositoryService_DeleteRepository(t *testing.T) {
 			ExpectedError: "error instantiating provider",
 		},
 		{
-			Name:         "DeleteByID works when entity cannot be deregistered",
+			Name:         "DeleteByID fails when entity cannot be deregistered",
 			DeleteType:   ByID,
-			DBSetup:      newDBMock(withSuccessfulDelete),
+			DBSetup:      newDBMock(),
 			ServiceSetup: newPropSvcMock(withSuccessfulEntityWithProps),
 			ProviderManagerSetup: func(p provinfv1.Provider) pf.ProviderManagerMockBuilder {
 				return pf.NewProviderManagerMock(pf.WithSuccessfulInstantiateFromID(p))
 			},
 			ProviderSetup: newProviderMock(withFailedDeregister),
+			ExpectedError: "failed to deregister entity upstream",
 		},
 		{
 			Name:         "DeleteByID by ID fails when repo cannot be deleted from DB",


### PR DESCRIPTION
Fixes #6369

## Description
This fixes a critical resource leak where deleting a repository from Minder could leave a permanently orphaned "zombie" webhook in the user's GitHub repository.

Previously, when a user deleted a repo, [deleteRepository](cci:1://file:///c:/Users/aftab/Desktop/minder/internal/repositories/service.go:397:0-427:1) in [internal/repositories/service.go](cci:7://file:///c:/Users/aftab/Desktop/minder/internal/repositories/service.go:0:0-0:0) would attempt to deregister the webhook upstream. If that GitHub API call failed (e.g., due to a temporary network issue, rate limit, or revoked token), the code simply logged the error and blithely continued to delete the repository from the Minder database.

Once deleted from Minder, the user had absolutely no way to retry the deletion, leaving the active webhook permanently installed on their GitHub repo. This webhook would continuously spray ingress traffic against Minder, which would just `404` or `sql.ErrNoRows` since the repo no longer existed in the database.

## Changes
- Added a fail-fast return to [deleteRepository](cci:1://file:///c:/Users/aftab/Desktop/minder/internal/repositories/service.go:397:0-427:1). The DB transaction that wipes the repository is now completely skipped if `client.DeregisterEntity` fails, allowing users to safely retry the deletion once credentials or upstream connectivity are restored.
- Updated the two [DeleteRepository](cci:1://file:///c:/Users/aftab/Desktop/minder/internal/controlplane/handlers_repositories.go:263:0-286:1) unit tests that previously baked in the old leak behavior (they expected the DB deletion to succeed even when deregistration failed). These tests now correctly expect an error.

## Checklist
- [x] Code compiles correctly
- [x] Added tests that fail without the change (if possible)
- [x] All tests passing
- [x] Extended the README / documentation, if necessary
