### PR TITLE
fix: prevent panic when Trusty API call fails mid-flight

### DIFF
--- a/internal/engine/eval/trusty/trusty.go
+++ b/internal/engine/eval/trusty/trusty.go
@@ -14,6 +14,7 @@ import (
 	"github.com/rs/zerolog"
 	trusty "github.com/stacklok/trusty-sdk-go/pkg/v2/client"
 	trustytypes "github.com/stacklok/trusty-sdk-go/pkg/v2/types"
+	"golang.org/x/sync/errgroup"
 	"google.golang.org/protobuf/reflect/protoreflect"
 
 	"github.com/mindersec/minder/internal/constants"
@@ -308,57 +309,38 @@ func getDependencyScore(
 		PackageVersion: &dep.Dep.Version,
 	}
 
-	summary := make(chan *trustytypes.PackageSummaryAnnotation, 1)
-	metadata := make(chan *trustytypes.TrustyPackageData, 1)
-	alternatives := make(chan *trustytypes.PackageAlternatives, 1)
-	provenance := make(chan *trustytypes.Provenance, 1)
-	errors := make(chan error)
+	var (
+		respSummary      *trustytypes.PackageSummaryAnnotation
+		respPkg          *trustytypes.TrustyPackageData
+		respAlternatives *trustytypes.PackageAlternatives
+		respProvenance   *trustytypes.Provenance
+	)
 
-	defer func() {
-		close(summary)
-		close(metadata)
-		close(alternatives)
-		close(provenance)
-		close(errors)
-	}()
+	g, gctx := errgroup.WithContext(ctx)
+	g.Go(func() error {
+		var err error
+		respSummary, err = trustyClient.Summary(gctx, input)
+		return err
+	})
+	g.Go(func() error {
+		var err error
+		respPkg, err = trustyClient.PackageMetadata(gctx, input)
+		return err
+	})
+	g.Go(func() error {
+		var err error
+		respAlternatives, err = trustyClient.Alternatives(gctx, input)
+		return err
+	})
+	g.Go(func() error {
+		var err error
+		respProvenance, err = trustyClient.Provenance(gctx, input)
+		return err
+	})
 
-	go func() {
-		resp, err := trustyClient.Summary(ctx, input)
-		errors <- err
-		summary <- resp
-	}()
-
-	go func() {
-		resp, err := trustyClient.PackageMetadata(ctx, input)
-		errors <- err
-		metadata <- resp
-	}()
-
-	go func() {
-		resp, err := trustyClient.Alternatives(ctx, input)
-		errors <- err
-		alternatives <- resp
-	}()
-
-	go func() {
-		resp, err := trustyClient.Provenance(ctx, input)
-		errors <- err
-		provenance <- resp
-	}()
-
-	// Beware of the magic number 4, which is the number of
-	// asynchronous calls fired in the previous lines. This must
-	// be kept in sync.
-	for i := 0; i < 4; i++ {
-		err := <-errors
-		if err != nil {
-			return nil, fmt.Errorf("trusty call failed: %w", err)
-		}
+	if err := g.Wait(); err != nil {
+		return nil, fmt.Errorf("trusty call failed: %w", err)
 	}
-	respSummary := <-summary
-	respPkg := <-metadata
-	respAlternatives := <-alternatives
-	respProvenance := <-provenance
 
 	res := makeTrustyReport(dep,
 		*respSummary,

--- a/internal/engine/eval/trusty/trusty_test.go
+++ b/internal/engine/eval/trusty/trusty_test.go
@@ -447,9 +447,73 @@ func TestEvaluationDetailRendering(t *testing.T) {
 	}
 }
 
+func TestGetDependencyScore(t *testing.T) {
+	t.Parallel()
+	dep := &pbinternal.PrDependencies_ContextualDependency{
+		Dep: &pbinternal.Dependency{
+			Ecosystem: pbinternal.DepEcosystem_DEP_ECOSYSTEM_NPM,
+			Name:      "left-pad",
+			Version:   "1.3.0",
+		},
+	}
+
+	goroutineDone := make(chan struct{}, 4)
+	signal := func() { goroutineDone <- struct{}{} }
+
+	client := &mockTrustyClient{
+		summaryFn: func(_ context.Context, _ *trustytypes.Dependency) (*trustytypes.PackageSummaryAnnotation, error) {
+			defer signal()
+			return nil, fmt.Errorf("summary failed")
+		},
+		packageMetadataFn: func(ctx context.Context, _ *trustytypes.Dependency) (*trustytypes.TrustyPackageData, error) {
+			defer signal()
+			<-ctx.Done()
+			return nil, ctx.Err()
+		},
+		alternativesFn: func(ctx context.Context, _ *trustytypes.Dependency) (*trustytypes.PackageAlternatives, error) {
+			defer signal()
+			<-ctx.Done()
+			return nil, ctx.Err()
+		},
+		provenanceFn: func(ctx context.Context, _ *trustytypes.Dependency) (*trustytypes.Provenance, error) {
+			defer signal()
+			<-ctx.Done()
+			return nil, ctx.Err()
+		},
+	}
+	_, err := getDependencyScore(context.Background(), client, dep)
+
+	// Simulate a long-lived process: keep the test alive until all goroutines finish,
+	for i := 0; i < 4; i++ {
+		<-goroutineDone
+	}
+
+	require.ErrorContains(t, err, "summary failed")
+}
+
 func defaultConfig() *config {
 	return &config{
 		Action:          defaultAction,
 		EcosystemConfig: defaultEcosystemConfig,
 	}
+}
+
+type mockTrustyClient struct {
+	summaryFn         func(context.Context, *trustytypes.Dependency) (*trustytypes.PackageSummaryAnnotation, error)
+	packageMetadataFn func(context.Context, *trustytypes.Dependency) (*trustytypes.TrustyPackageData, error)
+	alternativesFn    func(context.Context, *trustytypes.Dependency) (*trustytypes.PackageAlternatives, error)
+	provenanceFn      func(context.Context, *trustytypes.Dependency) (*trustytypes.Provenance, error)
+}
+
+func (m *mockTrustyClient) Summary(ctx context.Context, d *trustytypes.Dependency) (*trustytypes.PackageSummaryAnnotation, error) {
+	return m.summaryFn(ctx, d)
+}
+func (m *mockTrustyClient) PackageMetadata(ctx context.Context, d *trustytypes.Dependency) (*trustytypes.TrustyPackageData, error) {
+	return m.packageMetadataFn(ctx, d)
+}
+func (m *mockTrustyClient) Alternatives(ctx context.Context, d *trustytypes.Dependency) (*trustytypes.PackageAlternatives, error) {
+	return m.alternativesFn(ctx, d)
+}
+func (m *mockTrustyClient) Provenance(ctx context.Context, d *trustytypes.Dependency) (*trustytypes.Provenance, error) {
+	return m.provenanceFn(ctx, d)
 }


### PR DESCRIPTION
## Summary
Fixes a latent panic in `getDependencyScore` that could crash the process under Trusty API errors.

The original implementation fired 4 concurrent API calls and coordinated them via channels. The errors channel was unbuffered, and all channels were closed in a defer on function return. When any call returned an error as example, the function already returned early which triggered the defer and closed all channels while the remaining 3 goroutines were still blocked trying to send to the (now-closed) errors channel. Sending to a closed channel in Go causes an **unrecovered panic**, which crashes the entire server process.

This is a realistic failure mode: the Trusty API is an external HTTP service subject to network errors, timeouts, and partial outages.

**Fix**: Replace the channel fan-out with [errgroup](https://pkg.go.dev/golang.org/x/sync/errgroup) as `errgroup.WithContext` guarantees:


- When one call fails, errgroup cancels gctx, signalling the other in-flight HTTP calls to abort rather than run to completion unnecessarily
- g.Wait() blocks until all 4 goroutines finish, so the function never returns while any goroutine is still running, eliminating the send-after-return entirely

Also , I removed the per-response buffered channels (summary, metadata, alternatives, provenance) and the unbuffered errors channel, results are now written directly to pre-declared variables, read safely after g.Wait() guarantees all writes are done

## Testing
- go test ./internal/engine/eval/trusty/... -race : passes, no data races
- `TestGetDependencyScore` directly reproduces the failure scenario: Summary errors while the other 3 goroutines are blocked mid-flight; confirms error propagation and no panic.