### PR TITLE
fix(cli): address review feedback and stabilize ruletype test suite

### DIFF
--- a/cmd/cli/app/ruletype/common.go
+++ b/cmd/cli/app/ruletype/common.go
@@ -12,7 +12,6 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/spf13/viper"
 	"golang.org/x/exp/slices"
 
 	"github.com/mindersec/minder/internal/util"
@@ -30,9 +29,6 @@ func execOnOneRuleType(
 	proj string,
 	exec func(context.Context, string, *minderv1.RuleType) (*minderv1.RuleType, error),
 ) error {
-	ctx, cancel := cli.GetAppContext(ctx, viper.GetViper())
-	defer cancel()
-
 	reader, closer, err := util.OpenFileArg(f, dashOpen)
 	if err != nil {
 		return fmt.Errorf("error opening file arg: %w", err)

--- a/cmd/cli/app/ruletype/common.go
+++ b/cmd/cli/app/ruletype/common.go
@@ -125,7 +125,7 @@ func oneRuleTypeToRows(t table.Table, rt *minderv1.RuleType) {
 	t.AddRow("Description", rt.Description)
 	t.AddRow("Ingest type", rt.Def.Ingest.Type)
 	t.AddRow("Eval type", rt.Def.Eval.Type)
-	t.AddRow("Guidance", cli.RenderMarkdown(rt.Guidance, cli.WidthFraction(0.7)))
+	t.AddRow("Guidance", cli.RenderMarkdown(rt.Guidance, cli.WidthFraction(50.0)))
 	t.AddRow("Remediation", cmp.Or(rt.Def.GetRemediate().GetType(), "unsupported"))
 	t.AddRow("Alert", cmp.Or(rt.Def.GetAlert().GetType(), "unsupported"))
 }

--- a/cmd/cli/app/ruletype/ruletype.go
+++ b/cmd/cli/app/ruletype/ruletype.go
@@ -25,23 +25,28 @@ var ruleTypeCmd = &cobra.Command{
 
 // getRuleTypeClient returns the RuleTypeServiceClient, a cleanup function to close the connection and an error
 func getRuleTypeClient(cmd *cobra.Command) (minderv1.RuleTypeServiceClient, func(), error) {
-	ctx := cmd.Context()
+	ctx, cancel := cli.GetAppContext(cmd.Context(), viper.GetViper())
+	cmd.SetContext(ctx)
 
 	// Check the backpack. Are we running inside a test?
 	if mockClient, ok := cli.GetRPCClient[minderv1.RuleTypeServiceClient](ctx); ok {
-		return mockClient, func() {}, nil
+		return mockClient, func() { cancel() }, nil
 	}
 
 	// The backpack is empty. We are in production, make a real connection.
 	conn, err := cli.GrpcForCommand(cmd, viper.GetViper())
 	if err != nil {
+		cancel()
 		return nil, nil, err
 	}
 
 	client := minderv1.NewRuleTypeServiceClient(conn)
 
 	// Return the client and the closer so the subcommand can manage the lifecycle
-	return client, func() { _ = conn.Close() }, nil
+	return client, func() {
+		cancel()
+		_ = conn.Close()
+	}, nil
 }
 
 func init() {

--- a/cmd/cli/app/ruletype/ruletype.go
+++ b/cmd/cli/app/ruletype/ruletype.go
@@ -5,10 +5,8 @@
 package ruletype
 
 import (
-	"context"
-
 	"github.com/spf13/cobra"
-	"google.golang.org/grpc"
+	"github.com/spf13/viper"
 
 	"github.com/mindersec/minder/cmd/cli/app"
 	"github.com/mindersec/minder/internal/util/cli"
@@ -25,14 +23,25 @@ var ruleTypeCmd = &cobra.Command{
 	},
 }
 
-func getRuleTypeClient(ctx context.Context, conn grpc.ClientConnInterface) minderv1.RuleTypeServiceClient {
-	// 1. Check the backpack. Are we running inside a test?
+// getRuleTypeClient returns the RuleTypeServiceClient, a cleanup function to close the connection and an error
+func getRuleTypeClient(cmd *cobra.Command) (minderv1.RuleTypeServiceClient, func(), error) {
+	ctx := cmd.Context()
+
+	// Check the backpack. Are we running inside a test?
 	if mockClient, ok := cli.GetRPCClient[minderv1.RuleTypeServiceClient](ctx); ok {
-		return mockClient
+		return mockClient, func() {}, nil
 	}
 
-	// 2. The backpack is empty. We are in production, make a real connection.
-	return minderv1.NewRuleTypeServiceClient(conn)
+	// The backpack is empty. We are in production, make a real connection.
+	conn, err := cli.GrpcForCommand(cmd, viper.GetViper())
+	if err != nil {
+		return nil, nil, err
+	}
+
+	client := minderv1.NewRuleTypeServiceClient(conn)
+
+	// Return the client and the closer so the subcommand can manage the lifecycle
+	return client, func() { _ = conn.Close() }, nil
 }
 
 func init() {

--- a/cmd/cli/app/ruletype/ruletype_apply.go
+++ b/cmd/cli/app/ruletype/ruletype_apply.go
@@ -107,8 +107,7 @@ func applyCommand(cmd *cobra.Command, args []string) error {
 		if f.Path != "-" && shouldSkipFile(f.Path) {
 			continue
 		}
-		ctx, cancel := cli.GetAppContext(cmd.Context(), viper.GetViper())
-		if err = execOnOneRuleType(ctx, table, f.Path, os.Stdin, project, applyFunc); err != nil {
+		if err = execOnOneRuleType(cmd.Context(), table, f.Path, os.Stdin, project, applyFunc); err != nil {
 			if f.Expanded && minderv1.YouMayHaveTheWrongResource(err) {
 				cmd.PrintErrf("Skipping file %s: not a rule type\n", f.Path)
 				// We'll skip the file if it's not a rule type
@@ -116,7 +115,6 @@ func applyCommand(cmd *cobra.Command, args []string) error {
 			}
 			return cli.MessageAndError(fmt.Sprintf("error applying rule type from %s", f.Path), err)
 		}
-		cancel()
 	}
 	// Render the table
 	table.Render()

--- a/cmd/cli/app/ruletype/ruletype_apply.go
+++ b/cmd/cli/app/ruletype/ruletype_apply.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
-	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
@@ -23,30 +22,38 @@ var applyCmd = &cobra.Command{
 	Use:   "apply [files...]",
 	Short: "Apply a rule type",
 	Long:  `The ruletype apply subcommand lets you create or update rule types for a project within Minder.`,
-	RunE:  cli.GRPCClientWrapRunE(applyCommand),
-	Args:  cobra.ArbitraryArgs,
+	Args: func(cmd *cobra.Command, args []string) error {
+		fileFlag, err := cmd.Flags().GetStringArray("file")
+		if err != nil {
+			return cli.MessageAndError("Error parsing file flag", err)
+		}
+
+		if len(fileFlag) == 0 && len(args) == 0 {
+			return fmt.Errorf("no files specified: use positional arguments or the -f flag")
+		}
+		return nil
+	},
+	PreRunE: func(cmd *cobra.Command, _ []string) error {
+		if err := viper.BindPFlags(cmd.Flags()); err != nil {
+			return fmt.Errorf("error binding flags: %s", err)
+		}
+
+		fileFlag, _ := cmd.Flags().GetStringArray("file")
+
+		if err := validateFilesArg(fileFlag); err != nil {
+			return cli.MessageAndError("Error validating files", err)
+		}
+
+		return nil
+	},
+	RunE: applyCommand,
 }
 
-// applyCommand is the "rule type" apply subcommand
-func applyCommand(ctx context.Context, cmd *cobra.Command, args []string, conn *grpc.ClientConn) error {
-	client := getRuleTypeClient(ctx, conn)
-	project := viper.GetString("project")
-
-	fileFlag, err := cmd.Flags().GetStringArray("file")
-	if err != nil {
-		return cli.MessageAndError("Error parsing file flag", err)
-	}
+func applyCommand(cmd *cobra.Command, args []string) error {
+	fileFlag, _ := cmd.Flags().GetStringArray("file")
 
 	// Combine positional args with -f flag values
 	allFiles := append(fileFlag, args...)
-
-	if len(allFiles) == 0 {
-		return fmt.Errorf("no files specified: use positional arguments or the -f flag")
-	}
-
-	if err = validateFilesArg(fileFlag); err != nil {
-		return cli.MessageAndError("Error validating files", err)
-	}
 
 	files, err := util.ExpandFileArgs(allFiles...)
 	if err != nil {
@@ -56,6 +63,14 @@ func applyCommand(ctx context.Context, cmd *cobra.Command, args []string, conn *
 	// No longer print usage on returned error, since we've parsed our inputs
 	// See https://github.com/spf13/cobra/issues/340#issuecomment-374617413
 	cmd.SilenceUsage = true
+
+	client, closeConn, err := getRuleTypeClient(cmd)
+	if err != nil {
+		return cli.MessageAndError("Error connecting to server", err)
+	}
+	defer closeConn()
+
+	project := viper.GetString("project")
 
 	table := initializeTableForList(cmd.OutOrStdout())
 
@@ -92,9 +107,8 @@ func applyCommand(ctx context.Context, cmd *cobra.Command, args []string, conn *
 		if f.Path != "-" && shouldSkipFile(f.Path) {
 			continue
 		}
-		// cmd.Context() is the root context. We need to create a new context for each file
-		// so we can avoid the timeout.
-		if err = execOnOneRuleType(cmd.Context(), table, f.Path, os.Stdin, project, applyFunc); err != nil {
+		ctx, cancel := cli.GetAppContext(cmd.Context(), viper.GetViper())
+		if err = execOnOneRuleType(ctx, table, f.Path, os.Stdin, project, applyFunc); err != nil {
 			if f.Expanded && minderv1.YouMayHaveTheWrongResource(err) {
 				cmd.PrintErrf("Skipping file %s: not a rule type\n", f.Path)
 				// We'll skip the file if it's not a rule type
@@ -102,10 +116,12 @@ func applyCommand(ctx context.Context, cmd *cobra.Command, args []string, conn *
 			}
 			return cli.MessageAndError(fmt.Sprintf("error applying rule type from %s", f.Path), err)
 		}
+		cancel()
 	}
 	// Render the table
 	table.Render()
 	return nil
+
 }
 
 func init() {

--- a/cmd/cli/app/ruletype/ruletype_apply_test.go
+++ b/cmd/cli/app/ruletype/ruletype_apply_test.go
@@ -8,7 +8,6 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/spf13/cobra"
 	"go.uber.org/mock/gomock"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -25,23 +24,26 @@ func TestApplyCommand(t *testing.T) {
 	tests := []cli.CmdTestCase{
 		{
 			Name: "apply - create new rule type via flag",
-			Args: []string{"-f", applyFixture},
-			MockSetup: func(t *testing.T, client *mockv1.MockRuleTypeServiceClient) {
+			Args: []string{"ruletype", "apply", "-f", applyFixture},
+			MockSetup: func(t *testing.T, ctrl *gomock.Controller) context.Context {
 				t.Helper()
+				client := mockv1.NewMockRuleTypeServiceClient(ctrl)
 				mockResp := &minderv1.ListRuleTypesResponse{}
 				cli.LoadFixture(t, "mock_ruletypes_response.json", mockResp)
 
 				client.EXPECT().
 					CreateRuleType(gomock.Any(), gomock.Any()).
 					Return(&minderv1.CreateRuleTypeResponse{RuleType: mockResp.RuleTypes[0]}, nil)
+				return cli.WithRPCClient[minderv1.RuleTypeServiceClient](context.Background(), client)
 			},
 			GoldenFileName: "apply_create.table",
 		},
 		{
 			Name: "apply - update existing rule type via positional arg",
-			Args: []string{applyFixture},
-			MockSetup: func(t *testing.T, client *mockv1.MockRuleTypeServiceClient) {
+			Args: []string{"ruletype", "apply", applyFixture},
+			MockSetup: func(t *testing.T, ctrl *gomock.Controller) context.Context {
 				t.Helper()
+				client := mockv1.NewMockRuleTypeServiceClient(ctrl)
 				mockResp := &minderv1.ListRuleTypesResponse{}
 				cli.LoadFixture(t, "mock_ruletypes_response.json", mockResp)
 
@@ -52,20 +54,16 @@ func TestApplyCommand(t *testing.T) {
 				client.EXPECT().
 					UpdateRuleType(gomock.Any(), gomock.Any()).
 					Return(&minderv1.UpdateRuleTypeResponse{RuleType: mockResp.RuleTypes[0]}, nil)
+				return cli.WithRPCClient[minderv1.RuleTypeServiceClient](context.Background(), client)
 			},
 			GoldenFileName: "apply_update.table",
 		},
 		{
 			Name:          "no files specified",
-			Args:          []string{},
-			MockSetup:     func(_ *testing.T, _ *mockv1.MockRuleTypeServiceClient) {},
+			Args:          []string{"ruletype", "apply"},
 			ExpectedError: "no files specified",
 		},
 	}
 
-	execFunc := func(ctx context.Context, cmd *cobra.Command) error {
-		return applyCommand(ctx, cmd, cmd.Flags().Args(), nil)
-	}
-
-	cli.RunCmdTests(t, tests, applyCmd, execFunc)
+	cli.RunCmdTests(t, tests, ruleTypeCmd)
 }

--- a/cmd/cli/app/ruletype/ruletype_create.go
+++ b/cmd/cli/app/ruletype/ruletype_create.go
@@ -31,10 +31,6 @@ var createCmd = &cobra.Command{
 			return cli.MessageAndError("Error parsing file flag", err)
 		}
 
-		if len(fileFlag) == 0 {
-			return fmt.Errorf("required flag(s) \"file\" not set")
-		}
-
 		if err = validateFilesArg(fileFlag); err != nil {
 			return cli.MessageAndError("Error validating file flag", err)
 		}
@@ -62,9 +58,6 @@ func createCommand(cmd *cobra.Command, _ []string) error {
 	}
 	defer closeConn()
 
-	ctx, cancel := cli.GetAppContext(cmd.Context(), viper.GetViper())
-	defer cancel()
-
 	project := viper.GetString("project")
 
 	table := initializeTableForList(cmd.OutOrStdout())
@@ -86,7 +79,7 @@ func createCommand(cmd *cobra.Command, _ []string) error {
 		}
 		// cmd.Context() is the root context. We need to create a new context for each file
 		// so we can avoid the timeout.
-		if err = execOnOneRuleType(ctx, table, f.Path, os.Stdin, project, createFunc); err != nil {
+		if err = execOnOneRuleType(cmd.Context(), table, f.Path, os.Stdin, project, createFunc); err != nil {
 			// We swallow errors if you're loading a directory to avoid failing
 			// on test files.
 			if f.Expanded && minderv1.YouMayHaveTheWrongResource(err) {

--- a/cmd/cli/app/ruletype/ruletype_create.go
+++ b/cmd/cli/app/ruletype/ruletype_create.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
-	"google.golang.org/grpc"
 
 	"github.com/mindersec/minder/internal/util"
 	"github.com/mindersec/minder/internal/util/cli"
@@ -22,23 +21,31 @@ var createCmd = &cobra.Command{
 	Use:   "create",
 	Short: "Create a rule type",
 	Long:  `The ruletype create subcommand lets you create new rule types for a project within Minder.`,
-	RunE:  cli.GRPCClientWrapRunE(createCommand),
+	PreRunE: func(cmd *cobra.Command, _ []string) error {
+		if err := viper.BindPFlags(cmd.Flags()); err != nil {
+			return fmt.Errorf("error binding flags: %w", err)
+		}
+
+		fileFlag, err := cmd.Flags().GetStringArray("file")
+		if err != nil {
+			return cli.MessageAndError("Error parsing file flag", err)
+		}
+
+		if len(fileFlag) == 0 {
+			return fmt.Errorf("required flag(s) \"file\" not set")
+		}
+
+		if err = validateFilesArg(fileFlag); err != nil {
+			return cli.MessageAndError("Error validating file flag", err)
+		}
+
+		return nil
+	},
+	RunE: createCommand,
 }
 
-// createCommand is the profile create subcommand
-func createCommand(ctx context.Context, cmd *cobra.Command, _ []string, conn *grpc.ClientConn) error {
-	client := getRuleTypeClient(ctx, conn)
-
-	project := viper.GetString("project")
-
-	fileFlag, err := cmd.Flags().GetStringArray("file")
-	if err != nil {
-		return cli.MessageAndError("Error parsing file flag", err)
-	}
-
-	if err = validateFilesArg(fileFlag); err != nil {
-		return cli.MessageAndError("Error validating file flag", err)
-	}
+func createCommand(cmd *cobra.Command, _ []string) error {
+	fileFlag, _ := cmd.Flags().GetStringArray("file")
 
 	files, err := util.ExpandFileArgs(fileFlag...)
 	if err != nil {
@@ -48,6 +55,17 @@ func createCommand(ctx context.Context, cmd *cobra.Command, _ []string, conn *gr
 	// No longer print usage on returned error, since we've parsed our inputs
 	// See https://github.com/spf13/cobra/issues/340#issuecomment-374617413
 	cmd.SilenceUsage = true
+
+	client, closeConn, err := getRuleTypeClient(cmd)
+	if err != nil {
+		return cli.MessageAndError("Error connecting to server", err)
+	}
+	defer closeConn()
+
+	ctx, cancel := cli.GetAppContext(cmd.Context(), viper.GetViper())
+	defer cancel()
+
+	project := viper.GetString("project")
 
 	table := initializeTableForList(cmd.OutOrStdout())
 
@@ -68,7 +86,7 @@ func createCommand(ctx context.Context, cmd *cobra.Command, _ []string, conn *gr
 		}
 		// cmd.Context() is the root context. We need to create a new context for each file
 		// so we can avoid the timeout.
-		if err = execOnOneRuleType(cmd.Context(), table, f.Path, os.Stdin, project, createFunc); err != nil {
+		if err = execOnOneRuleType(ctx, table, f.Path, os.Stdin, project, createFunc); err != nil {
 			// We swallow errors if you're loading a directory to avoid failing
 			// on test files.
 			if f.Expanded && minderv1.YouMayHaveTheWrongResource(err) {
@@ -83,6 +101,7 @@ func createCommand(ctx context.Context, cmd *cobra.Command, _ []string, conn *gr
 	// Render the table
 	table.Render()
 	return nil
+
 }
 
 func init() {

--- a/cmd/cli/app/ruletype/ruletype_create_test.go
+++ b/cmd/cli/app/ruletype/ruletype_create_test.go
@@ -8,7 +8,6 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/spf13/cobra"
 	"go.uber.org/mock/gomock"
 
 	"github.com/mindersec/minder/internal/util/cli"
@@ -23,9 +22,10 @@ func TestCreateCommand(t *testing.T) {
 	tests := []cli.CmdTestCase{
 		{
 			Name: "create rule type from file",
-			Args: []string{"-f", sampleFile},
-			MockSetup: func(t *testing.T, client *mockv1.MockRuleTypeServiceClient) {
+			Args: []string{"ruletype", "create", "-f", sampleFile},
+			MockSetup: func(t *testing.T, ctrl *gomock.Controller) context.Context {
 				t.Helper()
+				client := mockv1.NewMockRuleTypeServiceClient(ctrl)
 				mockResp := &minderv1.ListRuleTypesResponse{}
 				cli.LoadFixture(t, "mock_ruletypes_response.json", mockResp)
 
@@ -34,24 +34,16 @@ func TestCreateCommand(t *testing.T) {
 					Return(&minderv1.CreateRuleTypeResponse{
 						RuleType: mockResp.RuleTypes[0],
 					}, nil)
+				return cli.WithRPCClient[minderv1.RuleTypeServiceClient](context.Background(), client)
 			},
 			GoldenFileName: "create_success.table",
 		},
 		{
-			Name: "missing required file flag",
-			Args: []string{},
-			// Fixed: unused-parameter (changed t to _)
-			MockSetup:     func(_ *testing.T, _ *mockv1.MockRuleTypeServiceClient) {},
+			Name:          "missing required file flag",
+			Args:          []string{"ruletype", "create"},
 			ExpectedError: "required flag(s) \"file\" not set",
 		},
 	}
 
-	execFunc := func(ctx context.Context, cmd *cobra.Command) error {
-		if valErr := cmd.ValidateRequiredFlags(); valErr != nil {
-			return valErr
-		}
-		return createCommand(ctx, cmd, cmd.Flags().Args(), nil)
-	}
-
-	cli.RunCmdTests(t, tests, createCmd, execFunc)
+	cli.RunCmdTests(t, tests, ruleTypeCmd)
 }

--- a/cmd/cli/app/ruletype/ruletype_delete.go
+++ b/cmd/cli/app/ruletype/ruletype_delete.go
@@ -5,12 +5,12 @@ package ruletype
 
 import (
 	"context"
+	"fmt"
 	"regexp"
 	"strings"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
-	"google.golang.org/grpc"
 
 	"github.com/mindersec/minder/internal/util/cli"
 	minderv1 "github.com/mindersec/minder/pkg/api/protobuf/go/minder/v1"
@@ -25,22 +25,43 @@ var deleteCmd = &cobra.Command{
 	Use:   "delete",
 	Short: "Delete a rule type",
 	Long:  `The ruletype delete subcommand lets you delete rule types within Minder.`,
-	RunE:  cli.GRPCClientWrapRunE(deleteCommand),
+	PreRunE: func(cmd *cobra.Command, _ []string) error {
+		if err := viper.BindPFlags(cmd.Flags()); err != nil {
+			return fmt.Errorf("error binding flags: %w", err)
+		}
+
+		id, _ := cmd.Flags().GetString("id")
+		name, _ := cmd.Flags().GetString("name")
+		deleteAll, _ := cmd.Flags().GetBool("all")
+
+		if id == "" && name == "" && !deleteAll {
+			return fmt.Errorf("at least one of the flags in the group [id name all] is required")
+		}
+
+		return nil
+	},
+	RunE: deleteCommand,
 }
 
-// deleteCommand is the rule type delete subcommand
-func deleteCommand(ctx context.Context, cmd *cobra.Command, _ []string, conn *grpc.ClientConn) error {
-	client := getRuleTypeClient(ctx, conn)
+func deleteCommand(cmd *cobra.Command, _ []string) error {
+	// No longer print usage on returned error, since we've parsed our inputs
+	// See https://github.com/spf13/cobra/issues/340#issuecomment-374617413
+	cmd.SilenceUsage = true
+
+	client, closeConn, err := getRuleTypeClient(cmd)
+	if err != nil {
+		return cli.MessageAndError("Error connecting to server", err)
+	}
+	defer closeConn()
+
+	ctx, cancel := cli.GetAppContext(cmd.Context(), viper.GetViper())
+	defer cancel()
 
 	project := viper.GetString("project")
 	id := viper.GetString("id")
 	name := viper.GetString("name")
 	deleteAll := viper.GetBool("all")
 	yesFlag := viper.GetBool("yes")
-
-	// No longer print usage on returned error, since we've parsed our inputs
-	// See https://github.com/spf13/cobra/issues/340#issuecomment-374617413
-	cmd.SilenceUsage = true
 
 	if deleteAll && !yesFlag {
 		// Ask for confirmation if deleteAll is set on purpose
@@ -99,6 +120,7 @@ func deleteCommand(ctx context.Context, cmd *cobra.Command, _ []string, conn *gr
 	printDeleteResults(cmd, deletedRuleTypes, remainingRuleTypes)
 
 	return nil
+
 }
 
 func deleteRuleTypes(
@@ -163,7 +185,6 @@ func printDeleteResults(
 				}
 			}
 		}
-
 	}
 }
 

--- a/cmd/cli/app/ruletype/ruletype_delete.go
+++ b/cmd/cli/app/ruletype/ruletype_delete.go
@@ -32,10 +32,9 @@ var deleteCmd = &cobra.Command{
 
 		id, _ := cmd.Flags().GetString("id")
 		name, _ := cmd.Flags().GetString("name")
-		deleteAll, _ := cmd.Flags().GetBool("all")
 
-		if id == "" && name == "" && !deleteAll {
-			return fmt.Errorf("at least one of the flags in the group [id name all] is required")
+		if id != "" && name != "" {
+			return fmt.Errorf("please provide either the --id or --name flag, but not both")
 		}
 
 		return nil
@@ -53,9 +52,6 @@ func deleteCommand(cmd *cobra.Command, _ []string) error {
 		return cli.MessageAndError("Error connecting to server", err)
 	}
 	defer closeConn()
-
-	ctx, cancel := cli.GetAppContext(cmd.Context(), viper.GetViper())
-	defer cancel()
 
 	project := viper.GetString("project")
 	id := viper.GetString("id")
@@ -81,7 +77,7 @@ func deleteCommand(cmd *cobra.Command, _ []string) error {
 	if !deleteAll {
 		// Fetch the rule type from the DB by either ID or Name
 		if id != "" {
-			rtype, err := client.GetRuleTypeById(ctx, &minderv1.GetRuleTypeByIdRequest{
+			rtype, err := client.GetRuleTypeById(cmd.Context(), &minderv1.GetRuleTypeByIdRequest{
 				Context: &minderv1.Context{Project: &project},
 				Id:      id,
 			})
@@ -92,7 +88,7 @@ func deleteCommand(cmd *cobra.Command, _ []string) error {
 		}
 
 		if name != "" {
-			rtype, err := client.GetRuleTypeByName(ctx, &minderv1.GetRuleTypeByNameRequest{
+			rtype, err := client.GetRuleTypeByName(cmd.Context(), &minderv1.GetRuleTypeByNameRequest{
 				Context: &minderv1.Context{Project: &project},
 				Name:    name,
 			})
@@ -104,7 +100,7 @@ func deleteCommand(cmd *cobra.Command, _ []string) error {
 
 	} else {
 		// List all rule types
-		resp, err := client.ListRuleTypes(ctx, &minderv1.ListRuleTypesRequest{
+		resp, err := client.ListRuleTypes(cmd.Context(), &minderv1.ListRuleTypesRequest{
 			Context: &minderv1.Context{Project: &project},
 		})
 		if err != nil {
@@ -114,7 +110,7 @@ func deleteCommand(cmd *cobra.Command, _ []string) error {
 	}
 
 	// Delete the rule types set for deletion
-	deletedRuleTypes, remainingRuleTypes := deleteRuleTypes(ctx, client, rulesToDelete, project)
+	deletedRuleTypes, remainingRuleTypes := deleteRuleTypes(cmd.Context(), client, rulesToDelete, project)
 
 	// Print the results
 	printDeleteResults(cmd, deletedRuleTypes, remainingRuleTypes)

--- a/cmd/cli/app/ruletype/ruletype_delete_test.go
+++ b/cmd/cli/app/ruletype/ruletype_delete_test.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/spf13/cobra"
 	"go.uber.org/mock/gomock"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -20,17 +19,17 @@ import (
 //nolint:paralleltest // Cannot run in parallel because it swaps global Viper/Stdout state
 func TestDeleteCommand(t *testing.T) {
 	const (
-		zeroUUID = "00000000-0000-0000-0000-000000000000"
-		ruleID1  = "00000000-0000-0000-0000-000000000001"
-		ruleID2  = "00000000-0000-0000-0000-000000000002"
+		ruleID1 = "00000000-0000-0000-0000-000000000001"
+		ruleID2 = "00000000-0000-0000-0000-000000000002"
 	)
 
 	tests := []cli.CmdTestCase{
 		{
 			Name: "delete single rule type by id",
-			Args: []string{"--id", ruleID1},
-			MockSetup: func(t *testing.T, client *mockv1.MockRuleTypeServiceClient) {
+			Args: []string{"ruletype", "delete", "--id", ruleID1},
+			MockSetup: func(t *testing.T, ctrl *gomock.Controller) context.Context {
 				t.Helper()
+				client := mockv1.NewMockRuleTypeServiceClient(ctrl)
 				mockResp := &minderv1.ListRuleTypesResponse{}
 				cli.LoadFixture(t, "mock_ruletypes_response.json", mockResp)
 
@@ -45,14 +44,18 @@ func TestDeleteCommand(t *testing.T) {
 				client.EXPECT().
 					DeleteRuleType(gomock.Any(), gomock.Any()).
 					Return(&minderv1.DeleteRuleTypeResponse{}, nil)
+
+				return cli.WithRPCClient[minderv1.RuleTypeServiceClient](context.Background(), client)
 			},
 			GoldenFileName: "delete_single.txt",
 		},
 		{
 			Name: "delete all rule types",
-			Args: []string{"--all", "--yes"},
-			MockSetup: func(t *testing.T, client *mockv1.MockRuleTypeServiceClient) {
+			Args: []string{"ruletype", "delete", "--all", "--yes"},
+			MockSetup: func(t *testing.T, ctrl *gomock.Controller) context.Context {
 				t.Helper()
+				client := mockv1.NewMockRuleTypeServiceClient(ctrl)
+
 				mockResp := &minderv1.ListRuleTypesResponse{}
 				cli.LoadFixture(t, "mock_ruletypes_response.json", mockResp)
 
@@ -67,14 +70,18 @@ func TestDeleteCommand(t *testing.T) {
 					DeleteRuleType(gomock.Any(), gomock.Any()).
 					Return(&minderv1.DeleteRuleTypeResponse{}, nil).
 					Times(len(mockResp.RuleTypes))
+
+				return cli.WithRPCClient[minderv1.RuleTypeServiceClient](context.Background(), client)
 			},
 			GoldenFileName: "delete_all.txt",
 		},
 		{
 			Name: "partial failure - profile reference",
-			Args: []string{"--id", ruleID2},
-			MockSetup: func(t *testing.T, client *mockv1.MockRuleTypeServiceClient) {
+			Args: []string{"ruletype", "delete", "--id", ruleID2},
+			MockSetup: func(t *testing.T, ctrl *gomock.Controller) context.Context {
 				t.Helper()
+				client := mockv1.NewMockRuleTypeServiceClient(ctrl)
+
 				mockResp := &minderv1.ListRuleTypesResponse{}
 				cli.LoadFixture(t, "mock_ruletypes_response.json", mockResp)
 
@@ -87,24 +94,17 @@ func TestDeleteCommand(t *testing.T) {
 				client.EXPECT().
 					DeleteRuleType(gomock.Any(), gomock.Any()).
 					Return(nil, status.Error(codes.FailedPrecondition, "cannot delete: used by profiles my-security-profile"))
+
+				return cli.WithRPCClient[minderv1.RuleTypeServiceClient](context.Background(), client)
 			},
 			GoldenFileName: "delete_partial_failure.txt",
 		},
 		{
 			Name:          "missing required flags",
-			Args:          []string{},
-			MockSetup:     func(_ *testing.T, _ *mockv1.MockRuleTypeServiceClient) {},
+			Args:          []string{"ruletype", "delete"},
 			ExpectedError: "at least one of the flags in the group [id name all] is required",
 		},
 	}
 
-	execFunc := func(ctx context.Context, cmd *cobra.Command) error {
-		if valErr := cmd.ValidateFlagGroups(); valErr != nil {
-			return valErr
-		}
-
-		return deleteCommand(ctx, cmd, cmd.Flags().Args(), nil)
-	}
-
-	cli.RunCmdTests(t, tests, deleteCmd, execFunc)
+	cli.RunCmdTests(t, tests, ruleTypeCmd)
 }

--- a/cmd/cli/app/ruletype/ruletype_get.go
+++ b/cmd/cli/app/ruletype/ruletype_get.go
@@ -4,13 +4,11 @@
 package ruletype
 
 import (
-	"context"
 	"fmt"
 	"strings"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
-	"google.golang.org/grpc"
 	"google.golang.org/protobuf/reflect/protoreflect"
 
 	"github.com/mindersec/minder/cmd/cli/app"
@@ -19,38 +17,61 @@ import (
 	minderv1 "github.com/mindersec/minder/pkg/api/protobuf/go/minder/v1"
 )
 
-var getCmd = &cobra.Command{
-	Use:   "get",
-	Short: "Get details for a rule type",
-	Long:  `The ruletype get subcommand lets you retrieve details for a rule type within Minder.`,
-	RunE:  cli.GRPCClientWrapRunE(getCommand),
-}
-
 type ruleTypeGetter interface {
 	protoreflect.ProtoMessage
 	GetRuleType() *minderv1.RuleType
 }
 
-// getCommand is the ruletype get subcommand
-func getCommand(ctx context.Context, cmd *cobra.Command, _ []string, conn *grpc.ClientConn) error {
-	client := getRuleTypeClient(ctx, conn)
+var getCmd = &cobra.Command{
+	Use:   "get",
+	Short: "Get details for a rule type",
+	Long:  `The ruletype get subcommand lets you retrieve details for a rule type within Minder.`,
+	PreRunE: func(cmd *cobra.Command, _ []string) error {
+		if err := viper.BindPFlags(cmd.Flags()); err != nil {
+			return fmt.Errorf("error binding flags: %w", err)
+		}
+
+		id, _ := cmd.Flags().GetString("id")
+		name, _ := cmd.Flags().GetString("name")
+		format, _ := cmd.Flags().GetString("output")
+
+		if id == "" && name == "" {
+			return fmt.Errorf("at least one of the flags in the group [id name] is required")
+		}
+		if id != "" && name != "" {
+			return fmt.Errorf("if any flags in the group [id name] are set they must all be set; but mutually exclusive flags were passed")
+		}
+
+		// Ensure the output format is supported
+		if !app.IsOutputFormatSupported(format) {
+			return cli.MessageAndError(fmt.Sprintf("Output format %s not supported", format), fmt.Errorf("invalid argument"))
+		}
+
+		return nil
+	},
+	RunE: getCommand,
+}
+
+func getCommand(cmd *cobra.Command, _ []string) error {
+	// No longer print usage on returned error, since we've parsed our inputs
+	// See https://github.com/spf13/cobra/issues/340#issuecomment-374617413
+	cmd.SilenceUsage = true
+
+	client, closeConn, err := getRuleTypeClient(cmd)
+	if err != nil {
+		return cli.MessageAndError("Error connecting to server", err)
+	}
+	defer closeConn()
+
+	ctx, cancel := cli.GetAppContext(cmd.Context(), viper.GetViper())
+	defer cancel()
 
 	project := viper.GetString("project")
 	format := viper.GetString("output")
 	id := viper.GetString("id")
 	name := viper.GetString("name")
 
-	// Ensure the output format is supported
-	if !app.IsOutputFormatSupported(format) {
-		return cli.MessageAndError(fmt.Sprintf("Output format %s not supported", format), fmt.Errorf("invalid argument"))
-	}
-
-	// No longer print usage on returned error, since we've parsed our inputs
-	// See https://github.com/spf13/cobra/issues/340#issuecomment-374617413
-	cmd.SilenceUsage = true
-
 	var rtype ruleTypeGetter
-	var err error
 
 	if id != "" {
 		rtype, err = client.GetRuleTypeById(ctx, &minderv1.GetRuleTypeByIdRequest{
@@ -67,6 +88,7 @@ func getCommand(ctx context.Context, cmd *cobra.Command, _ []string, conn *grpc.
 		return cli.MessageAndError("Error getting rule type", err)
 	}
 
+	// handle output formatting
 	switch format {
 	case app.YAML:
 		out, err := util.GetYamlFromProto(rtype.GetRuleType())
@@ -81,7 +103,7 @@ func getCommand(ctx context.Context, cmd *cobra.Command, _ []string, conn *grpc.
 		}
 		cmd.Println(out)
 	case app.Table:
-		// Initialize the table
+		// initialize and render the table
 		table := initializeTableForOne(cmd.OutOrStdout())
 		rt := rtype.GetRuleType()
 		oneRuleTypeToRows(table, rt)
@@ -89,6 +111,7 @@ func getCommand(ctx context.Context, cmd *cobra.Command, _ []string, conn *grpc.
 		table.Render()
 	}
 	return nil
+
 }
 
 func init() {

--- a/cmd/cli/app/ruletype/ruletype_get.go
+++ b/cmd/cli/app/ruletype/ruletype_get.go
@@ -35,11 +35,8 @@ var getCmd = &cobra.Command{
 		name, _ := cmd.Flags().GetString("name")
 		format, _ := cmd.Flags().GetString("output")
 
-		if id == "" && name == "" {
-			return fmt.Errorf("at least one of the flags in the group [id name] is required")
-		}
 		if id != "" && name != "" {
-			return fmt.Errorf("if any flags in the group [id name] are set they must all be set; but mutually exclusive flags were passed")
+			return fmt.Errorf("please provide either the --id or --name flag, but not both")
 		}
 
 		// Ensure the output format is supported
@@ -63,9 +60,6 @@ func getCommand(cmd *cobra.Command, _ []string) error {
 	}
 	defer closeConn()
 
-	ctx, cancel := cli.GetAppContext(cmd.Context(), viper.GetViper())
-	defer cancel()
-
 	project := viper.GetString("project")
 	format := viper.GetString("output")
 	id := viper.GetString("id")
@@ -74,12 +68,12 @@ func getCommand(cmd *cobra.Command, _ []string) error {
 	var rtype ruleTypeGetter
 
 	if id != "" {
-		rtype, err = client.GetRuleTypeById(ctx, &minderv1.GetRuleTypeByIdRequest{
+		rtype, err = client.GetRuleTypeById(cmd.Context(), &minderv1.GetRuleTypeByIdRequest{
 			Context: &minderv1.Context{Project: &project},
 			Id:      id,
 		})
 	} else {
-		rtype, err = client.GetRuleTypeByName(ctx, &minderv1.GetRuleTypeByNameRequest{
+		rtype, err = client.GetRuleTypeByName(cmd.Context(), &minderv1.GetRuleTypeByNameRequest{
 			Context: &minderv1.Context{Project: &project},
 			Name:    name,
 		})

--- a/cmd/cli/app/ruletype/ruletype_get_test.go
+++ b/cmd/cli/app/ruletype/ruletype_get_test.go
@@ -60,6 +60,11 @@ func TestGetCommand(t *testing.T) {
 			Args:          []string{"ruletype", "get", "-o", app.Table},
 			ExpectedError: "at least one of the flags in the group [id name] is required",
 		},
+		{
+			Name:          "giving both id and name",
+			Args:          []string{"ruletype", "get", "-n", ruleName, "-i", ruleID, app.Table},
+			ExpectedError: "please provide either the --id or --name flag, but not both",
+		},
 	}
 
 	cli.RunCmdTests(t, tests, ruleTypeCmd)

--- a/cmd/cli/app/ruletype/ruletype_get_test.go
+++ b/cmd/cli/app/ruletype/ruletype_get_test.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/spf13/cobra"
 	"go.uber.org/mock/gomock"
 
 	"github.com/mindersec/minder/cmd/cli/app"
@@ -26,46 +25,42 @@ func TestGetCommand(t *testing.T) {
 	tests := []cli.CmdTestCase{
 		{
 			Name: "get by id - table output",
-			Args: []string{"--id", ruleID, "-o", app.Table},
-			MockSetup: func(t *testing.T, client *mockv1.MockRuleTypeServiceClient) {
+			Args: []string{"ruletype", "get", "--id", ruleID, "-o", app.Table},
+			MockSetup: func(t *testing.T, ctrl *gomock.Controller) context.Context {
 				t.Helper()
+				client := mockv1.NewMockRuleTypeServiceClient(ctrl)
 				mockResp := &minderv1.ListRuleTypesResponse{}
 				cli.LoadFixture(t, "mock_ruletypes_response.json", mockResp)
 
 				client.EXPECT().
 					GetRuleTypeById(gomock.Any(), gomock.Any()).
 					Return(&minderv1.GetRuleTypeByIdResponse{RuleType: mockResp.RuleTypes[0]}, nil)
+				return cli.WithRPCClient[minderv1.RuleTypeServiceClient](context.Background(), client)
 			},
 			GoldenFileName: "get_by_id.table",
 		},
 		{
 			Name: "get by name - yaml output",
-			Args: []string{"--name", ruleName, "-o", app.YAML},
-			MockSetup: func(t *testing.T, client *mockv1.MockRuleTypeServiceClient) {
+			Args: []string{"ruletype", "get", "--name", ruleName, "-o", app.YAML},
+			MockSetup: func(t *testing.T, ctrl *gomock.Controller) context.Context {
 				t.Helper()
+				client := mockv1.NewMockRuleTypeServiceClient(ctrl)
 				mockResp := &minderv1.ListRuleTypesResponse{}
 				cli.LoadFixture(t, "mock_ruletypes_response.json", mockResp)
 
 				client.EXPECT().
 					GetRuleTypeByName(gomock.Any(), gomock.Any()).
 					Return(&minderv1.GetRuleTypeByNameResponse{RuleType: mockResp.RuleTypes[0]}, nil)
+				return cli.WithRPCClient[minderv1.RuleTypeServiceClient](context.Background(), client)
 			},
 			GoldenFileName: "get_by_name.yaml",
 		},
 		{
 			Name:          "missing both id and name",
-			Args:          []string{"-o", app.Table},
-			MockSetup:     func(_ *testing.T, _ *mockv1.MockRuleTypeServiceClient) {},
+			Args:          []string{"ruletype", "get", "-o", app.Table},
 			ExpectedError: "at least one of the flags in the group [id name] is required",
 		},
 	}
 
-	execFunc := func(ctx context.Context, cmd *cobra.Command) error {
-		if valErr := cmd.ValidateFlagGroups(); valErr != nil {
-			return valErr
-		}
-		return getCommand(ctx, cmd, cmd.Flags().Args(), nil)
-	}
-
-	cli.RunCmdTests(t, tests, getCmd, execFunc)
+	cli.RunCmdTests(t, tests, ruleTypeCmd)
 }

--- a/cmd/cli/app/ruletype/ruletype_list.go
+++ b/cmd/cli/app/ruletype/ruletype_list.go
@@ -57,10 +57,7 @@ func listCommand(cmd *cobra.Command, _ []string) error {
 
 	format := viper.GetString("output")
 
-	ctx, cancel := cli.GetAppContext(cmd.Context(), viper.GetViper())
-	defer cancel()
-
-	resp, err := client.ListRuleTypes(ctx, &minderv1.ListRuleTypesRequest{
+	resp, err := client.ListRuleTypes(cmd.Context(), &minderv1.ListRuleTypesRequest{
 		Context: &minderv1.Context{Project: &project},
 	})
 	if err != nil {

--- a/cmd/cli/app/ruletype/ruletype_list.go
+++ b/cmd/cli/app/ruletype/ruletype_list.go
@@ -4,14 +4,12 @@
 package ruletype
 
 import (
-	"context"
 	"fmt"
 	"slices"
 	"strings"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
-	"google.golang.org/grpc"
 
 	"github.com/mindersec/minder/cmd/cli/app"
 	"github.com/mindersec/minder/internal/util"
@@ -23,24 +21,44 @@ var listCmd = &cobra.Command{
 	Use:   "list",
 	Short: "List rule types",
 	Long:  `The ruletype list subcommand lets you list rule type within Minder.`,
-	RunE:  cli.GRPCClientWrapRunE(listCommand),
+	Args:  cobra.NoArgs,
+	PreRunE: func(cmd *cobra.Command, _ []string) error {
+		if err := viper.BindPFlags(cmd.Flags()); err != nil {
+			return fmt.Errorf("error binding flags: %w", err)
+		}
+
+		format, err := cmd.Flags().GetString("output")
+		if err != nil {
+			return cli.MessageAndError("Error parsing output flag", err)
+		}
+
+		// Ensure the output format is supported
+		if !app.IsOutputFormatSupported(format) {
+			return cli.MessageAndError(fmt.Sprintf("Output format %s not supported", format), fmt.Errorf("invalid argument"))
+		}
+
+		return nil
+	},
+	RunE: listCommand,
 }
 
-// listCommand is the ruletype list subcommand
-func listCommand(ctx context.Context, cmd *cobra.Command, _ []string, conn *grpc.ClientConn) error {
-	client := getRuleTypeClient(ctx, conn)
-
-	project := viper.GetString("project")
-	format := viper.GetString("output")
-
-	// Ensure the output format is supported
-	if !app.IsOutputFormatSupported(format) {
-		return cli.MessageAndError(fmt.Sprintf("Output format %s not supported", format), fmt.Errorf("invalid argument"))
-	}
-
+func listCommand(cmd *cobra.Command, _ []string) error {
 	// No longer print usage on returned error, since we've parsed our inputs
 	// See https://github.com/spf13/cobra/issues/340#issuecomment-374617413
 	cmd.SilenceUsage = true
+
+	client, closeConn, err := getRuleTypeClient(cmd)
+	if err != nil {
+		return cli.MessageAndError("Error connecting to server", err)
+	}
+	defer closeConn()
+
+	project := viper.GetString("project")
+
+	format := viper.GetString("output")
+
+	ctx, cancel := cli.GetAppContext(cmd.Context(), viper.GetViper())
+	defer cancel()
 
 	resp, err := client.ListRuleTypes(ctx, &minderv1.ListRuleTypesRequest{
 		Context: &minderv1.Context{Project: &project},
@@ -49,6 +67,7 @@ func listCommand(ctx context.Context, cmd *cobra.Command, _ []string, conn *grpc
 		return cli.MessageAndError("Error listing rule types", err)
 	}
 
+	// handle output formatting
 	switch format {
 	case app.JSON:
 		out, err := util.GetJsonFromProto(resp)
@@ -87,7 +106,7 @@ func listCommand(ctx context.Context, cmd *cobra.Command, _ []string, conn *grpc
 		}
 		table.Render()
 	}
-	// this is unreachable
+
 	return nil
 }
 

--- a/cmd/cli/app/ruletype/ruletype_list_test.go
+++ b/cmd/cli/app/ruletype/ruletype_list_test.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/spf13/cobra"
 	"go.uber.org/mock/gomock"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -23,67 +22,70 @@ func TestListCommand(t *testing.T) {
 	tests := []cli.CmdTestCase{
 		{
 			Name: "table output with data",
-			Args: []string{"-o", app.Table},
-			MockSetup: func(t *testing.T, client *mockv1.MockRuleTypeServiceClient) {
+			Args: []string{"ruletype", "list", "-o", app.Table},
+			MockSetup: func(t *testing.T, ctrl *gomock.Controller) context.Context {
 				t.Helper()
+				client := mockv1.NewMockRuleTypeServiceClient(ctrl)
 				mockResponse := &minderv1.ListRuleTypesResponse{}
 				cli.LoadFixture(t, "mock_ruletypes_response.json", mockResponse)
 
 				client.EXPECT().
 					ListRuleTypes(gomock.Any(), gomock.Any()).
 					Return(mockResponse, nil)
+				return cli.WithRPCClient[minderv1.RuleTypeServiceClient](context.Background(), client)
 			},
 			GoldenFileName: "list_populated.table",
 		},
 		{
 			Name: "table output empty",
-			Args: []string{"-o", app.Table},
-			MockSetup: func(t *testing.T, client *mockv1.MockRuleTypeServiceClient) {
+			Args: []string{"ruletype", "list", "-o", app.Table},
+			MockSetup: func(t *testing.T, ctrl *gomock.Controller) context.Context {
 				t.Helper()
+				client := mockv1.NewMockRuleTypeServiceClient(ctrl)
 				client.EXPECT().
 					ListRuleTypes(gomock.Any(), gomock.Any()).
 					Return(&minderv1.ListRuleTypesResponse{
 						RuleTypes: []*minderv1.RuleType{},
 					}, nil)
+				return cli.WithRPCClient[minderv1.RuleTypeServiceClient](context.Background(), client)
 			},
 			GoldenFileName: "list_empty.table",
 		},
 		{
 			Name: "yaml output",
-			Args: []string{"-o", app.YAML},
-			MockSetup: func(t *testing.T, client *mockv1.MockRuleTypeServiceClient) {
+			Args: []string{"ruletype", "list", "-o", app.YAML},
+			MockSetup: func(t *testing.T, ctrl *gomock.Controller) context.Context {
 				t.Helper()
+				client := mockv1.NewMockRuleTypeServiceClient(ctrl)
 				mockResponse := &minderv1.ListRuleTypesResponse{}
 				cli.LoadFixture(t, "mock_ruletypes_response.json", mockResponse)
 
 				client.EXPECT().
 					ListRuleTypes(gomock.Any(), gomock.Any()).
 					Return(mockResponse, nil)
+				return cli.WithRPCClient[minderv1.RuleTypeServiceClient](context.Background(), client)
 			},
 			GoldenFileName: "list_populated.yaml",
 		},
 		{
 			Name: "grpc error handling",
-			Args: []string{"-o", app.Table},
-			MockSetup: func(t *testing.T, client *mockv1.MockRuleTypeServiceClient) {
+			Args: []string{"ruletype", "list", "-o", app.Table},
+			MockSetup: func(t *testing.T, ctrl *gomock.Controller) context.Context {
 				t.Helper()
+				client := mockv1.NewMockRuleTypeServiceClient(ctrl)
 				client.EXPECT().
 					ListRuleTypes(gomock.Any(), gomock.Any()).
 					Return(nil, status.Error(codes.DeadlineExceeded, "request timed out"))
+				return cli.WithRPCClient[minderv1.RuleTypeServiceClient](context.Background(), client)
 			},
 			ExpectedError: "request timed out",
 		},
 		{
 			Name:          "invalid output format",
-			Args:          []string{"-o", "csv"},
-			MockSetup:     func(_ *testing.T, _ *mockv1.MockRuleTypeServiceClient) {},
+			Args:          []string{"ruletype", "list", "-o", "csv"},
 			ExpectedError: "invalid argument",
 		},
 	}
 
-	execFunc := func(ctx context.Context, cmd *cobra.Command) error {
-		return listCommand(ctx, cmd, cmd.Flags().Args(), nil)
-	}
-
-	cli.RunCmdTests(t, tests, listCmd, execFunc)
+	cli.RunCmdTests(t, tests, ruleTypeCmd)
 }

--- a/cmd/cli/app/ruletype/ruletype_test.go
+++ b/cmd/cli/app/ruletype/ruletype_test.go
@@ -4,13 +4,9 @@
 package ruletype
 
 import (
-	"context"
 	"testing"
 
-	"github.com/spf13/cobra"
-
 	"github.com/mindersec/minder/internal/util/cli"
-	mockv1 "github.com/mindersec/minder/pkg/api/protobuf/go/minder/v1/mock"
 )
 
 //nolint:paralleltest // Cannot run in parallel because it swaps global state
@@ -18,15 +14,10 @@ func TestRuleTypeRootCommand(t *testing.T) {
 	tests := []cli.CmdTestCase{
 		{
 			Name:           "ruletype root command shows help",
-			Args:           []string{},
-			MockSetup:      func(_ *testing.T, _ *mockv1.MockRuleTypeServiceClient) {},
+			Args:           []string{"ruletype"},
 			GoldenFileName: "ruletype_root.help",
 		},
 	}
 
-	execFunc := func(_ context.Context, cmd *cobra.Command) error {
-		return cmd.RunE(cmd, []string{})
-	}
-
-	cli.RunCmdTests(t, tests, ruleTypeCmd, execFunc)
+	cli.RunCmdTests(t, tests, ruleTypeCmd)
 }

--- a/cmd/cli/app/ruletype/testdata/apply_create.table.golden
+++ b/cmd/cli/app/ruletype/testdata/apply_create.table.golden
@@ -1,9 +1,8 @@
- NAME               │ ENTITY    │ DESCRIPTION                                                       
-                    │ TYPE      │                                                                   
-────────────────────┼───────────┼───────────────────────────────────────────────────────────────────
- secret_push_protec │ repositor │ Verifies that secret push protection is enabled for a given       
- tion               │ y         │ repository. Note that this will will not work as expected for     
- (release_phase:    │           │ private repositories unless you have GitHub Advanced Security     
- beta)              │           │ enabled. If you still want to use this rule because you have a    
-                    │           │ mixture of private and public repositories, enable the            
-                    │           │ `skip_private_repos` flag.                                        
+ NAME                   │ ENTITY TYPE │ DESCRIPTION                                                 
+────────────────────────┼─────────────┼─────────────────────────────────────────────────────────────
+ secret_push_protection │ repository  │ Verifies that secret push protection is enabled for a given 
+ (release_phase: beta)  │             │ repository. Note that this will will not work as expected   
+                        │             │ for private repositories unless you have GitHub Advanced    
+                        │             │ Security enabled. If you still want to use this rule        
+                        │             │ because you have a mixture of private and public            
+                        │             │ repositories, enable the `skip_private_repos` flag.         

--- a/cmd/cli/app/ruletype/testdata/apply_update.table.golden
+++ b/cmd/cli/app/ruletype/testdata/apply_update.table.golden
@@ -1,9 +1,8 @@
- NAME               │ ENTITY    │ DESCRIPTION                                                       
-                    │ TYPE      │                                                                   
-────────────────────┼───────────┼───────────────────────────────────────────────────────────────────
- secret_push_protec │ repositor │ Verifies that secret push protection is enabled for a given       
- tion               │ y         │ repository. Note that this will will not work as expected for     
- (release_phase:    │           │ private repositories unless you have GitHub Advanced Security     
- beta)              │           │ enabled. If you still want to use this rule because you have a    
-                    │           │ mixture of private and public repositories, enable the            
-                    │           │ `skip_private_repos` flag.                                        
+ NAME                   │ ENTITY TYPE │ DESCRIPTION                                                 
+────────────────────────┼─────────────┼─────────────────────────────────────────────────────────────
+ secret_push_protection │ repository  │ Verifies that secret push protection is enabled for a given 
+ (release_phase: beta)  │             │ repository. Note that this will will not work as expected   
+                        │             │ for private repositories unless you have GitHub Advanced    
+                        │             │ Security enabled. If you still want to use this rule        
+                        │             │ because you have a mixture of private and public            
+                        │             │ repositories, enable the `skip_private_repos` flag.         

--- a/cmd/cli/app/ruletype/testdata/create_success.table.golden
+++ b/cmd/cli/app/ruletype/testdata/create_success.table.golden
@@ -1,9 +1,8 @@
- NAME               │ ENTITY    │ DESCRIPTION                                                       
-                    │ TYPE      │                                                                   
-────────────────────┼───────────┼───────────────────────────────────────────────────────────────────
- secret_push_protec │ repositor │ Verifies that secret push protection is enabled for a given       
- tion               │ y         │ repository. Note that this will will not work as expected for     
- (release_phase:    │           │ private repositories unless you have GitHub Advanced Security     
- beta)              │           │ enabled. If you still want to use this rule because you have a    
-                    │           │ mixture of private and public repositories, enable the            
-                    │           │ `skip_private_repos` flag.                                        
+ NAME                   │ ENTITY TYPE │ DESCRIPTION                                                 
+────────────────────────┼─────────────┼─────────────────────────────────────────────────────────────
+ secret_push_protection │ repository  │ Verifies that secret push protection is enabled for a given 
+ (release_phase: beta)  │             │ repository. Note that this will will not work as expected   
+                        │             │ for private repositories unless you have GitHub Advanced    
+                        │             │ Security enabled. If you still want to use this rule        
+                        │             │ because you have a mixture of private and public            
+                        │             │ repositories, enable the `skip_private_repos` flag.         

--- a/cmd/cli/app/ruletype/testdata/get_by_id.table.golden
+++ b/cmd/cli/app/ruletype/testdata/get_by_id.table.golden
@@ -22,10 +22,9 @@
                    │ can use secret scanning to prevent supported secrets from being pushed into    
                    │ your repository by enabling secret scanning push protection. For more          
                    │ information, see GitHub's documentation                                        
-                   │ https://docs.github.com/en/code-security/secret-                               
-                   │ scanning/push-protection-for-repositories-and-                                 
-                   │ organizations#enabling-secret-scanning-as-a-push- protection-for-              
-                   │ a-repository.                                                                  
+                   │ https://docs.github.com/en/code-security/secret-scanning/push-protection-for-r 
+                   │ epositories-and-organizations#enabling-secret-scanning-as-a-push-protection-fo 
+                   │ r-a-repository.                                                                
 ───────────────────┼────────────────────────────────────────────────────────────────────────────────
  Remediation       │ rest                                                                           
 ───────────────────┼────────────────────────────────────────────────────────────────────────────────

--- a/cmd/cli/app/ruletype/testdata/list_populated.table.golden
+++ b/cmd/cli/app/ruletype/testdata/list_populated.table.golden
@@ -1,22 +1,21 @@
- NAME                            │ ENTITY  │ DESCRIPTION                                            
-                                 │ TYPE    │                                                        
-─────────────────────────────────┼─────────┼────────────────────────────────────────────────────────
- secret_push_protection          │ reposit │ Verifies that secret push protection is enabled for a  
- (release_phase: beta)           │ ory     │ given repository. Note that this will will not work as 
-                                 │         │ expected for private repositories unless you have      
-                                 │         │ GitHub Advanced Security enabled. If you still want to 
-                                 │         │ use this rule because you have a mixture of private    
-                                 │         │ and public repositories, enable the                    
-                                 │         │ `skip_private_repos` flag.                             
-─────────────────────────────────┤         ├────────────────────────────────────────────────────────
- secret_scanning (release_phase: │         │ Verifies that secret scanning is enabled for a given   
- beta)                           │         │ repository. Note that this will will not work as       
-                                 │         │ expected for private repositories unless you have      
-                                 │         │ GitHub Advanced Security enabled. If you still want to 
-                                 │         │ use this rule because you have a mixture of private    
-                                 │         │ and public repositories, enable the                    
-                                 │         │ `skip_private_repos` flag.                             
-─────────────────────────────────┤         ├────────────────────────────────────────────────────────
- test_base_file_rule             │         │ Checks whether README.md exists in the repository.     
- (release_phase: alpha,          │         │                                                        
- can_remediate: false)           │         │                                                        
+ NAME                            │ ENTITY TYPE │ DESCRIPTION                                        
+─────────────────────────────────┼─────────────┼────────────────────────────────────────────────────
+ secret_push_protection          │ repository  │ Verifies that secret push protection is enabled    
+ (release_phase: beta)           │             │ for a given repository. Note that this will will   
+                                 │             │ not work as expected for private repositories      
+                                 │             │ unless you have GitHub Advanced Security enabled.  
+                                 │             │ If you still want to use this rule because you     
+                                 │             │ have a mixture of private and public repositories, 
+                                 │             │ enable the `skip_private_repos` flag.              
+─────────────────────────────────┤             ├────────────────────────────────────────────────────
+ secret_scanning (release_phase: │             │ Verifies that secret scanning is enabled for a     
+ beta)                           │             │ given repository. Note that this will will not     
+                                 │             │ work as expected for private repositories unless   
+                                 │             │ you have GitHub Advanced Security enabled. If you  
+                                 │             │ still want to use this rule because you have a     
+                                 │             │ mixture of private and public repositories, enable 
+                                 │             │ the `skip_private_repos` flag.                     
+─────────────────────────────────┤             ├────────────────────────────────────────────────────
+ test_base_file_rule             │             │ Checks whether README.md exists in the repository. 
+ (release_phase: alpha,          │             │                                                    
+ can_remediate: false)           │             │                                                    

--- a/cmd/cli/app/ruletype/testdata/ruletype_root.help.golden
+++ b/cmd/cli/app/ruletype/testdata/ruletype_root.help.golden
@@ -10,6 +10,7 @@ Available Commands:
   list        List rule types
 
 Flags:
+  -h, --help             help for ruletype
   -j, --project string   ID of the project
 
 Global Flags:

--- a/internal/util/cli/table/table.go
+++ b/internal/util/cli/table/table.go
@@ -180,9 +180,12 @@ func (g *goPrettyTable) Render() {
 				share := int(float64(req) / float64(totalRequested) * float64(usableWidth))
 
 				// Ensure a minimum width so columns don't disappear
-				if share < 5 {
+				if share < req && req <= (usableWidth/3) {
+					share = req
+				} else if share < 5 {
 					share = 5
 				}
+
 				assignedWidths[i] = share
 				currentTotal += share
 			}

--- a/internal/util/cli/testing.go
+++ b/internal/util/cli/testing.go
@@ -19,18 +19,32 @@ import (
 	"go.uber.org/mock/gomock"
 	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/proto"
-
-	minderv1 "github.com/mindersec/minder/pkg/api/protobuf/go/minder/v1"
-	mockv1 "github.com/mindersec/minder/pkg/api/protobuf/go/minder/v1/mock"
 )
 
 var update = flag.Bool("update", false, "update golden files")
+
+// ResetEntireTree wipes flags and contexts so tests don't "bleed" into each other
+func ResetEntireTree(c *cobra.Command) {
+	//nolint:staticcheck // SA1012: Cobra requires nil to clear the context so it can resume inheriting from the root
+	c.SetContext(nil)
+	c.Flags().VisitAll(func(f *pflag.Flag) {
+		if slice, ok := f.Value.(pflag.SliceValue); ok {
+			_ = slice.Replace([]string{})
+		} else {
+			_ = f.Value.Set(f.DefValue)
+		}
+		f.Changed = false
+	})
+	for _, child := range c.Commands() {
+		ResetEntireTree(child)
+	}
+}
 
 // CmdTestCase is the shared struct for all rule type CLI tests
 type CmdTestCase struct {
 	Name           string
 	Args           []string
-	MockSetup      func(t *testing.T, client *mockv1.MockRuleTypeServiceClient)
+	MockSetup      func(t *testing.T, ctrl *gomock.Controller) context.Context
 	GoldenFileName string
 	ExpectedError  string
 }
@@ -40,46 +54,43 @@ func RunCmdTests(
 	t *testing.T,
 	tests []CmdTestCase,
 	cmd *cobra.Command,
-	execFunc func(ctx context.Context, c *cobra.Command) error,
 ) {
-
 	t.Helper()
 	const zeroUUID = "00000000-0000-0000-0000-000000000000"
+
+	cwd, _ := os.Getwd()
+	dummyConfig := filepath.Join(cwd, "config.yaml")
+	if _, err := os.Stat(dummyConfig); os.IsNotExist(err) {
+		_ = os.WriteFile(dummyConfig, []byte(""), 0600)
+		defer os.Remove(dummyConfig)
+	}
 
 	for _, tc := range tests {
 		t.Run(tc.Name, func(t *testing.T) {
 			viper.Reset()
-			cmd.Flags().VisitAll(func(f *pflag.Flag) {
-				if slice, ok := f.Value.(pflag.SliceValue); ok {
-					_ = slice.Replace([]string{})
-				} else {
-					_ = f.Value.Set(f.DefValue)
-				}
-				f.Changed = false
-			})
+
+			rootCmd := cmd.Root()
+			ResetEntireTree(rootCmd)
 
 			ctrl := gomock.NewController(t)
 			defer ctrl.Finish()
 
-			mockClient := mockv1.NewMockRuleTypeServiceClient(ctrl)
+			ctx := context.Background()
 			if tc.MockSetup != nil {
-				tc.MockSetup(t, mockClient)
+				ctx = tc.MockSetup(t, ctrl)
 			}
 
-			ctx := WithRPCClient[minderv1.RuleTypeServiceClient](context.Background(), mockClient)
-			cmd.SetContext(ctx)
-
 			buf := new(bytes.Buffer)
-			cmd.SetOut(buf)
-			cmd.SetErr(buf)
+			rootCmd.SetOut(buf)
+			rootCmd.SetErr(buf)
+			rootCmd.SetContext(ctx)
 
-			err := cmd.Flags().Parse(tc.Args)
-			require.NoError(t, err, "flag parsing should not fail")
+			rootCmd.SetArgs(tc.Args)
 
 			_ = viper.BindPFlags(cmd.Flags())
 			viper.Set("project", zeroUUID)
 
-			err = execFunc(ctx, cmd)
+			_, err := cmd.ExecuteContextC(ctx)
 
 			if tc.ExpectedError != "" {
 				require.Error(t, err)


### PR DESCRIPTION


# Summary

This PR addresses the review comments on [#6286 ](https://github.com/mindersec/minder/pull/6286) and refactors the `ruletype` CLI commands to properly support the isolated, deterministic test suite.

### Changes Made

- **Removed Test Execution Wrapper (execfunc):** Refactored the CLI test harness (internal/util/cli/testing.go) to remove the custom execfunc wrapper, transitioning instead to Cobra's native cmd.ExecuteContextC(ctx).

- **Impact:** Tests now accurately simulate real-world CLI execution by triggering the complete Cobra command lifecycle (including Args validation and PreRunE configuration binding). This eliminates the "bypassed mock" issue, ensures Viper contexts are properly isolated, and allows the command definitions to follow standard CLI design patterns without breaking the test suite.

- **Improved Table:** Fixed the unexpected spaces and improved table output

