### PR TITLE
Add security-events: write to main workflows, granular permissions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,7 +11,6 @@ on:
       - 'docs/**'
 permissions:
   contents: read
-  packages: write
 
 jobs:
   license-check:
@@ -26,10 +25,16 @@ jobs:
       checks: write
     uses: ./.github/workflows/lint.yml
   build:
+    permissions:
+      contents: read
+      packages: write
     uses: ./.github/workflows/build.yml
   test:
     uses: ./.github/workflows/test.yml
   image-build:
     uses: ./.github/workflows/image-build.yml
   security:
+    permissions:
+      contents: read
+      security-events: write
     uses: ./.github/workflows/security.yml

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -8,7 +8,6 @@ on:
 
 permissions:
   contents: read
-  security-events: write
 
 jobs:
   license-check:
@@ -29,6 +28,9 @@ jobs:
   image-build:
     uses: ./.github/workflows/image-build.yml
   security:
+    permissions:
+      contents: read
+      security-events: write
     uses: ./.github/workflows/security.yml
   compose-migrate:
     uses: ./.github/workflows/compose-migrate.yml


### PR DESCRIPTION
# Summary

#6406 adjusted `security.yml` to grant `security-events: write`, but missed adding these to `main.yml` for post-merge CI runs.  It also granted the access over-broadly, so reduce the permissions scopes in the CI as well.

# Testing

Adjusting the PR workflow to follow the same pattern allows checking that the settings in `main.yml` are likely to work.
