### PR TITLE
docs: add testing setup instructions to CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,21 +51,29 @@ PRs to resolve existing issues are greatly appreciated and issues labeled as ["g
 
 ### Running Tests
 
-Before running the full test suite, generate the example rules and profiles
-used by some tests:
+Before running the full test suite, install the required tools:
+
+```bash
+make bootstrap
+```
+
+Then generate the example rules and profiles used by some tests:
 
 ```bash
 make init-examples
 ```
 
-Then run the tests:
+Run the linter to check your changes:
+
+```bash
+make lint
+```
+
+Run the tests:
 
 ```bash
 go test ./...
 ```
-
-Note: some tests require additional infrastructure and may be skipped
-without a full local setup.
 
 ### Contributing to docs
 Follow [this guide](https://github.com/mindersec/minder/blob/main/docs/README.md) for instructions on building, running, and previewing Minder's documentation.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,6 +49,24 @@ PRs to resolve existing issues are greatly appreciated and issues labeled as ["g
 * Every pull request requires a review from the core Minder team before merging.
 * Once approved, all of your commits will be squashed into a single commit with your PR title.
 
+### Running Tests
+
+Before running the full test suite, generate the example rules and profiles
+used by some tests:
+
+```bash
+make init-examples
+```
+
+Then run the tests:
+
+```bash
+go test ./...
+```
+
+Note: some tests require additional infrastructure and may be skipped
+without a full local setup.
+
 ### Contributing to docs
 Follow [this guide](https://github.com/mindersec/minder/blob/main/docs/README.md) for instructions on building, running, and previewing Minder's documentation.
 


### PR DESCRIPTION
As a new contributor running `go test ./...` on a fresh clone, the profile test failed with 'make sure to do make init-examples'. This step isn't documented anywhere. Adding a Running Tests section to help future contributors.