### PR TITLE
Switch linter to only pick up _new_ issues

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -27,6 +27,8 @@ jobs:
           cache: false
       - name: golangci-lint
         uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9.2.0
+        with:
+          only-new-issues: true
 
   check-go-mod-tidy-and-make-gen:
     name: Uncommitted changes check - go mod tidy & make gen


### PR DESCRIPTION
# Summary

It turns out that golangci-lint enabled `goconst` analysis, which flags > 100 strings as "repeated enough times to use a const", breaking lint for _all_ PRs.  Switch the check to only apply to new code.  I'm also considering pinning the golangci-lint version (as the last two upgrades have done this sort of breakage), but I'm not sure that this wouldn't cause us to simply fall behind and never update.

# Testing

We'll see on this PR, which shouldn't flag any issues.
