### PR TITLE
Migrate test policies to Rego v1

### DIFF
--- a/cmd/cli/app/quickstart/embed/secret_scanning.yaml
+++ b/cmd/cli/app/quickstart/embed/secret_scanning.yaml
@@ -59,10 +59,12 @@ def:
       def: |
         package minder
 
-        import future.keywords.if
+        import rego.v1
 
         default allow := false
+
         default skip := false
+
         default message := "Secret scanning is disabled"
 
         allow if {

--- a/cmd/cli/app/ruletype/fixture/rule_type_apply.yaml
+++ b/cmd/cli/app/ruletype/fixture/rule_type_apply.yaml
@@ -29,8 +29,8 @@ def:
       def: |
         package minder
 
+        import rego.v1
+
         default allow := false
 
-        allow { 
-            true 
-        }
+        allow := true

--- a/cmd/cli/app/ruletype/fixture/rule_type_sample.yaml
+++ b/cmd/cli/app/ruletype/fixture/rule_type_sample.yaml
@@ -33,9 +33,11 @@ def:
       def: |
         package minder
 
+        import rego.v1
+
         default allow := false
 
-        allow {
-            # Check if the required review count meets our minimum
-            input.ingested.required_pull_request_reviews.required_approving_review_count >= input.profile.required_reviews
+        allow if {
+          # Check if the required review count meets our minimum
+          input.ingested.required_pull_request_reviews.required_approving_review_count >= input.profile.required_reviews
         }

--- a/docs/docs/how-to/manage_profiles.md
+++ b/docs/docs/how-to/manage_profiles.md
@@ -102,7 +102,7 @@ def:
       def: |
         package minder
 
-        import future.keywords.if
+        import rego.v1
 
         default allow := false
         default skip := false

--- a/docs/docs/how-to/writing-rules-in-rego.md
+++ b/docs/docs/how-to/writing-rules-in-rego.md
@@ -311,9 +311,7 @@ def:
       def: |
         package minder
 
-        import future.keywords.contains
-        import future.keywords.if
-        import future.keywords.in
+        import rego.v1
 
         severity_to_number := {
           null: -1,

--- a/internal/engine/eval/eval_test.go
+++ b/internal/engine/eval/eval_test.go
@@ -48,7 +48,7 @@ func TestNewRuleEvaluatorWorks(t *testing.T) {
 				Type: "rego",
 				Rego: &pb.RuleType_Definition_Eval_Rego{
 					Type: rego.DenyByDefaultEvaluationType.String(),
-					Def:  "package minder\n\ndefault allow = false\n\nallow {\n\tinput.ingested.data == \"bar\"\n}",
+					Def:  "package minder\n\nimport rego.v1\n\ndefault allow := false\n\nallow if {\n\tinput.ingested.data == \"bar\"\n}",
 				},
 			},
 			out: &interfaces.EvaluationResult{
@@ -61,7 +61,7 @@ func TestNewRuleEvaluatorWorks(t *testing.T) {
 				Type: "rego",
 				Rego: &pb.RuleType_Definition_Eval_Rego{
 					Type: rego.DenyByDefaultEvaluationType.String(),
-					Def:  "package minder\n\nallow := false\noutput := [\"always fail\",\"never pass\"]",
+					Def:  "package minder\n\nimport rego.v1\n\nallow := false\noutput := [\"always fail\", \"never pass\"]",
 				},
 			},
 			out: &interfaces.EvaluationResult{
@@ -74,7 +74,7 @@ func TestNewRuleEvaluatorWorks(t *testing.T) {
 				Type: "rego",
 				Rego: &pb.RuleType_Definition_Eval_Rego{
 					Type: rego.ConstraintsEvaluationType.String(),
-					Def:  "package minder\n\nviolations[results] {\n\tinput.ingested.data == \"foo\"\n\tresults := {\"status\": \"denied\", \"msg\": \"foo is not allowed\"}\n}",
+					Def:  "package minder\n\nimport rego.v1\n\nviolations contains results if {\n\tinput.ingested.data == \"foo\"\n\tresults := {\"status\": \"denied\", \"msg\": \"foo is not allowed\"}\n}",
 				},
 			},
 			out: &interfaces.EvaluationResult{

--- a/internal/engine/eval/rego/lib_test.go
+++ b/internal/engine/eval/rego/lib_test.go
@@ -35,14 +35,16 @@ func TestFileExistsWithExistingFile(t *testing.T) {
 	e, err := rego.NewRegoEvaluator(
 		&minderv1.RuleType_Definition_Eval_Rego{
 			Type: rego.DenyByDefaultEvaluationType.String(),
-			Def: `
-package minder
+			Def: `package minder
 
-default allow = false
+import rego.v1
 
-allow {
+default allow := false
+
+allow if {
 	file.exists("foo")
-}`,
+}
+`,
 		},
 	)
 	require.NoError(t, err, "could not create evaluator")
@@ -67,14 +69,16 @@ func TestFileExistsInBase(t *testing.T) {
 	e, err := rego.NewRegoEvaluator(
 		&minderv1.RuleType_Definition_Eval_Rego{
 			Type: rego.DenyByDefaultEvaluationType.String(),
-			Def: `
-package minder
+			Def: `package minder
 
-default allow = false
+import rego.v1
 
-allow {
-    base_file.exists("foo")
-}`,
+default allow := false
+
+allow if {
+	base_file.exists("foo")
+}
+`,
 		},
 	)
 	require.NoError(t, err, "could not create evaluator")
@@ -96,14 +100,16 @@ func TestFileExistsWithNonExistentFile(t *testing.T) {
 	e, err := rego.NewRegoEvaluator(
 		&minderv1.RuleType_Definition_Eval_Rego{
 			Type: rego.DenyByDefaultEvaluationType.String(),
-			Def: `
-package minder
+			Def: `package minder
 
-default allow = false
+import rego.v1
 
-allow {
+default allow := false
+
+allow if {
 	file.exists("unexistent")
-}`,
+}
+`,
 		},
 	)
 	require.NoError(t, err, "could not create evaluator")
@@ -132,15 +138,17 @@ func TestFileReadWithContentsMatching(t *testing.T) {
 	e, err := rego.NewRegoEvaluator(
 		&minderv1.RuleType_Definition_Eval_Rego{
 			Type: rego.DenyByDefaultEvaluationType.String(),
-			Def: `
-package minder
+			Def: `package minder
 
-default allow = false
+import rego.v1
 
-allow {
+default allow := false
+
+allow if {
 	contents := file.read("foo")
 	contents == "bar"
-}`,
+}
+`,
 		},
 	)
 	require.NoError(t, err, "could not create evaluator")
@@ -169,15 +177,17 @@ func TestFileReadWithContentsNotMatching(t *testing.T) {
 	e, err := rego.NewRegoEvaluator(
 		&minderv1.RuleType_Definition_Eval_Rego{
 			Type: rego.DenyByDefaultEvaluationType.String(),
-			Def: `
-package minder
+			Def: `package minder
 
-default allow = false
+import rego.v1
 
-allow {
+default allow := false
+
+allow if {
 	contents := file.read("foo")
 	contents == "bar"
-}`,
+}
+`,
 		},
 	)
 	require.NoError(t, err, "could not create evaluator")
@@ -199,15 +209,17 @@ func TestFileLsWithUnexistentFile(t *testing.T) {
 	e, err := rego.NewRegoEvaluator(
 		&minderv1.RuleType_Definition_Eval_Rego{
 			Type: rego.DenyByDefaultEvaluationType.String(),
-			Def: `
-package minder
+			Def: `package minder
 
-default allow = false
+import rego.v1
 
-allow {
+default allow := false
+
+allow if {
 	files := file.ls("unexistent")
 	is_null(files)
-}`,
+}
+`,
 		},
 	)
 	require.NoError(t, err, "could not create evaluator")
@@ -231,15 +243,17 @@ func TestFileLsWithEmptyDirectory(t *testing.T) {
 	e, err := rego.NewRegoEvaluator(
 		&minderv1.RuleType_Definition_Eval_Rego{
 			Type: rego.DenyByDefaultEvaluationType.String(),
-			Def: `
-package minder
+			Def: `package minder
 
-default allow = false
+import rego.v1
 
-allow {
+default allow := false
+
+allow if {
 	files := file.ls("foo")
 	count(files) == 0
-}`,
+}
+`,
 		},
 	)
 	require.NoError(t, err, "could not create evaluator")
@@ -267,16 +281,18 @@ func TestFileLsWithSingleFile(t *testing.T) {
 	e, err := rego.NewRegoEvaluator(
 		&minderv1.RuleType_Definition_Eval_Rego{
 			Type: rego.DenyByDefaultEvaluationType.String(),
-			Def: `
-package minder
+			Def: `package minder
 
-default allow = false
+import rego.v1
 
-allow {
+default allow := false
+
+allow if {
 	files := file.ls("foo")
 	count(files) == 1
 	files[0] == "foo/bar"
-}`,
+}
+`,
 		},
 	)
 	require.NoError(t, err, "could not create evaluator")
@@ -304,16 +320,18 @@ func TestFileLsWithSingleFileDirect(t *testing.T) {
 	e, err := rego.NewRegoEvaluator(
 		&minderv1.RuleType_Definition_Eval_Rego{
 			Type: rego.DenyByDefaultEvaluationType.String(),
-			Def: `
-package minder
+			Def: `package minder
 
-default allow = false
+import rego.v1
 
-allow {
+default allow := false
+
+allow if {
 	files := file.ls("foo/bar")
 	count(files) == 1
 	files[0] == "foo/bar"
-}`,
+}
+`,
 		},
 	)
 	require.NoError(t, err, "could not create evaluator")
@@ -345,15 +363,17 @@ func TestFileLsWithMultipleFiles(t *testing.T) {
 	e, err := rego.NewRegoEvaluator(
 		&minderv1.RuleType_Definition_Eval_Rego{
 			Type: rego.DenyByDefaultEvaluationType.String(),
-			Def: `
-package minder
+			Def: `package minder
 
-default allow = false
+import rego.v1
 
-allow {
+default allow := false
+
+allow if {
 	files := file.ls("foo")
 	count(files) == 3
-}`,
+}
+`,
 		},
 	)
 	require.NoError(t, err, "could not create evaluator")
@@ -388,15 +408,17 @@ func TestFileLsWithSimpleSymlink(t *testing.T) {
 	e, err := rego.NewRegoEvaluator(
 		&minderv1.RuleType_Definition_Eval_Rego{
 			Type: rego.DenyByDefaultEvaluationType.String(),
-			Def: `
-package minder
+			Def: `package minder
 
-default allow = false
+import rego.v1
 
-allow {
+default allow := false
+
+allow if {
 	files := file.ls("beer")
 	count(files) == 3
-}`,
+}
+`,
 		},
 	)
 	require.NoError(t, err, "could not create evaluator")
@@ -426,15 +448,17 @@ func TestFileLsWithSymlinkToDir(t *testing.T) {
 	e, err := rego.NewRegoEvaluator(
 		&minderv1.RuleType_Definition_Eval_Rego{
 			Type: rego.DenyByDefaultEvaluationType.String(),
-			Def: `
-package minder
+			Def: `package minder
 
-default allow = false
+import rego.v1
 
-allow {
+default allow := false
+
+allow if {
 	files := file.ls("foo/baz")
 	count(files) == 1
-}`,
+}
+`,
 		},
 	)
 	require.NoError(t, err, "could not create evaluator")
@@ -522,16 +546,18 @@ func TestListGithubActionsDirectory(t *testing.T) {
 	e, err := rego.NewRegoEvaluator(
 		&minderv1.RuleType_Definition_Eval_Rego{
 			Type: rego.DenyByDefaultEvaluationType.String(),
-			Def: `
-package minder
+			Def: `package minder
 
-default allow = false
+import rego.v1
 
-allow {
+default allow := false
+
+allow if {
 	actions := github_workflow.ls_actions("workflows")
 	expected_set = {"actions/checkout", "actions/setup-go", "GoTestTools/gotestfmt-action", "azure/setup-helm"}
 	actions == expected_set
-}`,
+}
+`,
 		},
 	)
 	require.NoError(t, err, "could not create evaluator")
@@ -558,16 +584,18 @@ func TestListGithubActionsFile(t *testing.T) {
 	e, err := rego.NewRegoEvaluator(
 		&minderv1.RuleType_Definition_Eval_Rego{
 			Type: rego.DenyByDefaultEvaluationType.String(),
-			Def: `
-package minder
+			Def: `package minder
 
-default allow = false
+import rego.v1
 
-allow {
+default allow := false
+
+allow if {
 	actions := github_workflow.ls_actions("build.yml")
 	expected_set = {"actions/checkout", "actions/setup-go"}
 	actions == expected_set
-}`,
+}
+`,
 		},
 	)
 	require.NoError(t, err, "could not create evaluator")
@@ -594,15 +622,17 @@ func TestListYamlUsingLSGlob(t *testing.T) {
 	e, err := rego.NewRegoEvaluator(
 		&minderv1.RuleType_Definition_Eval_Rego{
 			Type: rego.DenyByDefaultEvaluationType.String(),
-			Def: `
-package minder
+			Def: `package minder
 
-default allow = false
+import rego.v1
 
-allow {
+default allow := false
+
+allow if {
 	files := file.ls_glob(".github/dependabot.y*ml")
 	count(files) == 1
-}`,
+}
+`,
 		},
 	)
 	require.NoError(t, err, "could not create evaluator")
@@ -640,15 +670,17 @@ func TestListYamlsUsingLSGlob(t *testing.T) {
 	e, err := rego.NewRegoEvaluator(
 		&minderv1.RuleType_Definition_Eval_Rego{
 			Type: rego.DenyByDefaultEvaluationType.String(),
-			Def: `
-package minder
+			Def: `package minder
 
-default allow = false
+import rego.v1
 
-allow {
+default allow := false
+
+allow if {
 	files := file.ls_glob(".github/workflows/*.y*ml")
 	count(files) == 3
-}`,
+}
+`,
 		},
 	)
 	require.NoError(t, err, "could not create evaluator")
@@ -676,15 +708,17 @@ func TestHTTPTypeWithTextFile(t *testing.T) {
 	e, err := rego.NewRegoEvaluator(
 		&minderv1.RuleType_Definition_Eval_Rego{
 			Type: rego.DenyByDefaultEvaluationType.String(),
-			Def: `
-package minder
+			Def: `package minder
 
-default allow = false
+import rego.v1
 
-allow {
+default allow := false
+
+allow if {
 	htype := file.http_type("textfile")
 	htype == "text/plain; charset=utf-8"
-}`,
+}
+`,
 		},
 	)
 	require.NoError(t, err, "could not create evaluator")
@@ -713,15 +747,17 @@ func TestHTTPTypeWithBinaryFile(t *testing.T) {
 	e, err := rego.NewRegoEvaluator(
 		&minderv1.RuleType_Definition_Eval_Rego{
 			Type: rego.DenyByDefaultEvaluationType.String(),
-			Def: `
-package minder
+			Def: `package minder
 
-default allow = false
+import rego.v1
 
-allow {
+default allow := false
+
+allow if {
 	htype := file.http_type("binfile")
 	htype == "application/octet-stream"
-}`,
+}
+`,
 		},
 	)
 	require.NoError(t, err, "could not create evaluator")
@@ -763,15 +799,17 @@ func TestFileWalk(t *testing.T) {
 	e, err := rego.NewRegoEvaluator(
 		&minderv1.RuleType_Definition_Eval_Rego{
 			Type: rego.DenyByDefaultEvaluationType.String(),
-			Def: `
-package minder
+			Def: `package minder
 
-default allow = false
+import rego.v1
 
-allow {
+default allow := false
+
+allow if {
 	files := file.walk(".")
 	count(files) == 7
-}`,
+}
+`,
 		},
 	)
 	require.NoError(t, err, "could not create evaluator")
@@ -817,8 +855,8 @@ func TestFileArchive(t *testing.T) {
 	e, err := rego.NewRegoEvaluator(
 		&minderv1.RuleType_Definition_Eval_Rego{
 			Type: rego.ConstraintsEvaluationType.String(),
-			Def: `
-package minder
+			Def: `package minder
+
 import rego.v1
 
 tarball := file.archive(["foo", "file.txt"])
@@ -969,11 +1007,13 @@ on:
 			regoCode := fmt.Sprintf(`
 package minder
 
-default allow = false
+import rego.v1
 
-allow {
+default allow := false
+
+allow if {
 	workflowstr := file.read("%s")
-    parsed := parse_yaml(workflowstr)
+	parsed := parse_yaml(workflowstr)
 	jq.is_true(parsed, %q)
 }`, workflowFile, jqQuery)
 
@@ -1074,12 +1114,14 @@ array: [1, 2, 3]`,
 			regoCode := fmt.Sprintf(`
 package minder
 
-default allow = false
+import rego.v1
 
-allow {
-    parsed := parse_yaml(%q)
-    expected := json.unmarshal(%q)
-    parsed == expected
+default allow := false
+
+allow if {
+	parsed := parse_yaml(%q)
+	expected := json.unmarshal(%q)
+	parsed == expected
 }`, s.yaml, s.want)
 
 			e, err := rego.NewRegoEvaluator(
@@ -1146,9 +1188,11 @@ name = "bar"`,
 			regoCode := fmt.Sprintf(`
 package minder
 
-default allow = false
+import rego.v1
 
-allow {
+default allow := false
+
+allow if {
 	parsed := parse_toml(%q)
 	print(parsed)
 	expected := json.unmarshal(%q)
@@ -1235,19 +1279,20 @@ require (
 		&minderv1.RuleType_Definition_Eval_Rego{
 			Type: rego.DenyByDefaultEvaluationType.String(),
 			// TODO: update rego for different APIs
-			Def: `
-package minder
+			Def: `package minder
+
 import rego.v1
 
 deps := file.deps(input.profile.path)
-depsSet := { x |  x = deps.node_list.nodes[_].name }
-expected := { x | x = input.profile.expected[_] }
+depsSet := {x | x = deps.node_list.nodes[_].name}
+expected := {x | x = input.profile.expected[_]}
 
-default allow = false
+default allow := false
+
 allow if {
-  count(depsSet) > 0
-  count(depsSet - expected) == 0
-  count(expected - depsSet) == 0
+	count(depsSet) > 0
+	count(depsSet - expected) == 0
+	count(expected - depsSet) == 0
 }
 `,
 		},

--- a/internal/engine/eval/rego/rego_test.go
+++ b/internal/engine/eval/rego/rego_test.go
@@ -103,16 +103,17 @@ func TestEvaluatorDenyByDefaultEvalSimple(t *testing.T) {
 	e, err := rego.NewRegoEvaluator(
 		&minderv1.RuleType_Definition_Eval_Rego{
 			Type: rego.DenyByDefaultEvaluationType.String(),
-			Def: `
-package minder
+			Def: `package minder
 
-default allow = false
+import rego.v1
 
-allow {
+default allow := false
+
+allow if {
 	input.ingested.data == "foo"
 }
-	
-message = "By the pricking of my thumbs..."
+
+message := "By the pricking of my thumbs..."
 `,
 		},
 	)
@@ -147,10 +148,12 @@ func TestEvaluatorDenyByDefaultEvalWrongType(t *testing.T) {
 	e, err := rego.NewRegoEvaluator(
 		&minderv1.RuleType_Definition_Eval_Rego{
 			Type: rego.DenyByDefaultEvaluationType.String(),
-			Def: `
-package minder
+			Def: `package minder
 
-allow := "false"`,
+import rego.v1
+
+allow := "false"
+`,
 		},
 	)
 	require.NoError(t, err, "could not create evaluator")
@@ -169,18 +172,17 @@ func TestEvaluatorDenyByDefaultSkip(t *testing.T) {
 	e, err := rego.NewRegoEvaluator(
 		&minderv1.RuleType_Definition_Eval_Rego{
 			Type: rego.DenyByDefaultEvaluationType.String(),
-			Def: `
-package minder
+			Def: `package minder
 
-default allow = false
+import rego.v1
 
-allow {
+default allow := false
+
+allow if {
 	input.ingested.data == "foo"
 }
 
-skip {
-	true
-}
+skip := true
 `,
 		},
 	)
@@ -203,8 +205,9 @@ func TestEvaluatorDenyByDefaultSkipWrongType(t *testing.T) {
 	e, err := rego.NewRegoEvaluator(
 		&minderv1.RuleType_Definition_Eval_Rego{
 			Type: rego.DenyByDefaultEvaluationType.String(),
-			Def: `
-package minder
+			Def: `package minder
+
+import rego.v1
 
 allow := true
 
@@ -229,8 +232,9 @@ func TestEvaluatorDenyByDefaultJSONOutput(t *testing.T) {
 		&minderv1.RuleType_Definition_Eval_Rego{
 			Type:            rego.DenyByDefaultEvaluationType.String(),
 			ViolationFormat: ptr.Ptr(rego.OutputJSON.String()),
-			Def: `
-package minder
+			Def: `package minder
+
+import rego.v1
 
 allow := false
 
@@ -261,8 +265,9 @@ func TestEvaluatorDenyByDefaultJSONOutputFromMessage(t *testing.T) {
 			Type: rego.DenyByDefaultEvaluationType.String(),
 			// ViolationFormat is not used for deny_by_default
 			ViolationFormat: ptr.Ptr(rego.OutputJSON.String()),
-			Def: `
-package minder
+			Def: `package minder
+
+import rego.v1
 
 allow := false
 
@@ -289,13 +294,15 @@ func TestEvaluatorDenyByConstraintsEvalSimple(t *testing.T) {
 	e, err := rego.NewRegoEvaluator(
 		&minderv1.RuleType_Definition_Eval_Rego{
 			Type: rego.ConstraintsEvaluationType.String(),
-			Def: `
-package minder
+			Def: `package minder
 
-violations[{"msg": msg}] {
+import rego.v1
+
+violations contains {"msg": msg} if {
 	input.ingested.data != "foo"
 	msg := "data did not contain foo"
-}`,
+}
+`,
 		},
 	)
 	require.NoError(t, err, "could not create evaluator")
@@ -327,12 +334,13 @@ func TestEvaluatorConstraintWithOutput(t *testing.T) {
 	e, err := rego.NewRegoEvaluator(
 		&minderv1.RuleType_Definition_Eval_Rego{
 			Type: rego.ConstraintsEvaluationType.String(),
-			Def: `
-package minder
+			Def: `package minder
 
-messages = ["one", "two"]
-violations[{"msg": msg}] {
-    msg := messages[_]
+import rego.v1
+
+messages := ["one", "two"]
+violations contains {"msg": msg} if {
+	msg := messages[_]
 }
 
 output := {"messages_len": 2, "messages": messages}
@@ -360,15 +368,16 @@ func TestEvaluatorDenyByConstraintsEvalMultiple(t *testing.T) {
 	e, err := rego.NewRegoEvaluator(
 		&minderv1.RuleType_Definition_Eval_Rego{
 			Type: rego.ConstraintsEvaluationType.String(),
-			Def: `
-package minder
+			Def: `package minder
 
-violations[{"msg": msg}] {
+import rego.v1
+
+violations contains {"msg": msg} if {
 	input.ingested.data == "foo"
 	msg := "data should not contain foo"
 }
 
-violations[{"msg": msg}] {
+violations contains {"msg": msg} if {
 	input.ingested.datum == "bar"
 	msg := "datum should not contain bar"
 }
@@ -397,8 +406,9 @@ func TestEvaluatorConstraintWrongType(t *testing.T) {
 	e, err := rego.NewRegoEvaluator(
 		&minderv1.RuleType_Definition_Eval_Rego{
 			Type: rego.ConstraintsEvaluationType.String(),
-			Def: `
-package minder
+			Def: `package minder
+
+import rego.v1
 
 violations := {"msg": "I forgot the list"}
 `,
@@ -422,11 +432,12 @@ func TestEvaluatorConstraintWrongTypeInArray(t *testing.T) {
 	e, err := rego.NewRegoEvaluator(
 		&minderv1.RuleType_Definition_Eval_Rego{
 			Type: rego.ConstraintsEvaluationType.String(),
-			Def: `
-package minder
+			Def: `package minder
 
-violations[msg] {
-  msg := "I forgot the list"
+import rego.v1
+
+violations contains msg if {
+	msg := "I forgot the list"
 }
 `,
 		},
@@ -449,11 +460,12 @@ func TestEvaluatorConstraintWrongKeyInMap(t *testing.T) {
 	e, err := rego.NewRegoEvaluator(
 		&minderv1.RuleType_Definition_Eval_Rego{
 			Type: rego.ConstraintsEvaluationType.String(),
-			Def: `
-package minder
+			Def: `package minder
 
-violations[{"problem": msg}] {
-  msg := "this is the wrong key!"
+import rego.v1
+
+violations contains {"problem": msg} if {
+	msg := "this is the wrong key!"
 }
 `,
 		},
@@ -476,11 +488,12 @@ func TestEvaluatorConstraintWrongTypeInObject(t *testing.T) {
 	e, err := rego.NewRegoEvaluator(
 		&minderv1.RuleType_Definition_Eval_Rego{
 			Type: rego.ConstraintsEvaluationType.String(),
-			Def: `
-package minder
+			Def: `package minder
 
-violations[{"msg": msg}] {
-  msg := {"detail": "this is the wrong key!"}
+import rego.v1
+
+violations contains {"msg": msg} if {
+	msg := {"detail": "this is the wrong key!"}
 }
 `,
 		},
@@ -508,14 +521,16 @@ func TestDenyByDefaultEvaluationWithProfile(t *testing.T) {
 	e, err := rego.NewRegoEvaluator(
 		&minderv1.RuleType_Definition_Eval_Rego{
 			Type: rego.DenyByDefaultEvaluationType.String(),
-			Def: `
-package minder
+			Def: `package minder
 
-default allow = false
+import rego.v1
 
-allow {
+default allow := false
+
+allow if {
 	input.profile.data == input.ingested.data
-}`,
+}
+`,
 		},
 	)
 	require.NoError(t, err, "could not create evaluator")
@@ -547,13 +562,15 @@ func TestConstrainedEvaluationWithProfile(t *testing.T) {
 	e, err := rego.NewRegoEvaluator(
 		&minderv1.RuleType_Definition_Eval_Rego{
 			Type: rego.ConstraintsEvaluationType.String(),
-			Def: `
-package minder
+			Def: `package minder
 
-violations[{"msg": msg}] {
+import rego.v1
+
+violations contains {"msg": msg} if {
 	input.profile.data != input.ingested.data
 	msg := sprintf("data did not match profile: %s", [input.profile.data])
-}`,
+}
+`,
 		},
 	)
 	require.NoError(t, err, "could not create evaluator")
@@ -582,29 +599,30 @@ violations[{"msg": msg}] {
 }
 
 const (
-	jsonPolicyDef = `
-package minder
+	jsonPolicyDef = `package minder
 
-violations[{"msg": msg}] {
-  expected_set := {x | x := input.profile.data[_]}
-  input_set := {x | x := input.ingested.data[_]}
+import rego.v1
 
-  intersection := expected_set & input_set
-  not count(intersection) == count(input.ingested.data)
+violations contains {"msg": msg} if {
+	expected_set := {x | x := input.profile.data[_]}
+	input_set := {x | x := input.ingested.data[_]}
 
-  difference := [x | x := input.ingested.data[_]; not intersection[x]]
-  
-  msg = format_message(difference, input.output_format)
+	intersection := expected_set & input_set
+	not count(intersection) == count(input.ingested.data)
+
+	difference := [x | x := input.ingested.data[_]; not intersection[x]]
+
+	msg = format_message(difference, input.output_format)
 }
 
-format_message(difference, format) = msg {
-    format == "json"
+format_message(difference, format) := msg if {
+	format == "json"
 	json_body := {"actions_not_allowed": difference}
-    msg := json.marshal(json_body)
+	msg := json.marshal(json_body)
 }
 
-format_message(difference, format) = msg {
-    not format == "json"
+format_message(difference, format) := msg if {
+	not format == "json"
 	msg := sprintf("extra actions found in workflows but not allowed in the profile: %v", [difference])
 }
 `
@@ -662,13 +680,15 @@ func TestConstraintsJSONFalback(t *testing.T) {
 		&minderv1.RuleType_Definition_Eval_Rego{
 			Type:            rego.ConstraintsEvaluationType.String(),
 			ViolationFormat: &violationFormat,
-			Def: `
-package minder
+			Def: `package minder
 
-violations[{"msg": msg}] {
+import rego.v1
+
+violations contains {"msg": msg} if {
 	input.profile.data != input.ingested.data
 	msg := sprintf("data did not match profile: %s", [input.profile.data])
-}`,
+}
+`,
 		},
 	)
 	require.NoError(t, err, "could not create evaluator")
@@ -767,7 +787,9 @@ func TestCantEvaluateWithInvalidProfile(t *testing.T) {
 			Def: `
 package minder
 
-violations[{"msg": msg}] {`,
+import rego.v1
+
+violations contains {"msg": msg} if {`,
 		},
 	)
 	require.NoError(t, err, "could not create evaluator")
@@ -788,7 +810,9 @@ func TestCantEvaluateWithCompilerError(t *testing.T) {
 			Def: `
 package minder
 
-violations[{"msg": msg}] {
+import rego.v1
+
+violations contains {"msg": msg} if {
 	input := 12345
 	msg := "data did not contain foo"
 }`,
@@ -824,14 +848,16 @@ func TestCustomDatasourceRegister(t *testing.T) {
 	e, err := rego.NewRegoEvaluator(
 		&minderv1.RuleType_Definition_Eval_Rego{
 			Type: rego.DenyByDefaultEvaluationType.String(),
-			Def: `
-package minder
+			Def: `package minder
 
-default allow = false
+import rego.v1
 
-allow {
+default allow := false
+
+allow if {
 	minder.datasource.fake.source({"datasourcetest": input.ingested.data}) == "foo"
-}`,
+}
+`,
 		},
 		options.WithDataSources(fdsr),
 	)
@@ -871,60 +897,68 @@ func TestDenyByDefaultWithShortFailureMessage(t *testing.T) {
 		{
 			name:                "uses custom message when provided in rego",
 			shortFailureMessage: "Repository does not meet security requirements",
-			regoDef: `
-package minder
+			regoDef: `package minder
 
-default allow = false
+import rego.v1
 
-allow {
+default allow := false
+
+allow if {
 	input.ingested.secure == true
 }
 
-message = "Custom rego message: security check failed"`,
+message := "Custom rego message: security check failed"
+`,
 			expectedMessage: "Custom rego message: security check failed",
 			expectedDetails: "Custom rego message: security check failed",
 		},
 		{
 			name:                "falls back to short_failure_message when no custom message",
 			shortFailureMessage: "Repository does not meet security requirements",
-			regoDef: `
-package minder
+			regoDef: `package minder
 
-default allow = false
+import rego.v1
 
-allow {
+default allow := false
+
+allow if {
 	input.ingested.secure == true
-}`,
+}
+`,
 			expectedMessage: "Repository does not meet security requirements",
 			expectedDetails: "Repository does not meet security requirements",
 		},
 		{
 			name:                "falls back to denied when neither message is provided",
 			shortFailureMessage: "",
-			regoDef: `
-package minder
+			regoDef: `package minder
 
-default allow = false
+import rego.v1
 
-allow {
+default allow := false
+
+allow if {
 	input.ingested.secure == true
-}`,
+}
+`,
 			expectedMessage: "denied",
 			expectedDetails: "denied",
 		},
 		{
 			name:                "empty custom message falls back to short_failure_message",
 			shortFailureMessage: "Short failure message used",
-			regoDef: `
-package minder
+			regoDef: `package minder
 
-default allow = false
+import rego.v1
 
-allow {
+default allow := false
+
+allow if {
 	input.ingested.secure == true
 }
 
-message = ""`,
+message := ""
+`,
 			expectedMessage: "Short failure message used",
 			expectedDetails: "Short failure message used",
 		},
@@ -972,13 +1006,15 @@ func TestDenyByDefaultShortFailureMessageOnlyAppliedToDenyByDefault(t *testing.T
 	e, err := rego.NewRegoEvaluator(
 		&minderv1.RuleType_Definition_Eval_Rego{
 			Type: rego.ConstraintsEvaluationType.String(),
-			Def: `
-package minder
+			Def: `package minder
 
-violations[{"msg": msg}] {
+import rego.v1
+
+violations contains {"msg": msg} if {
 	input.ingested.data != "foo"
 	msg := "data did not contain foo"
-}`,
+}
+`,
 		},
 		rego.WithShortFailureMessage("This should be ignored"),
 	)
@@ -1002,14 +1038,16 @@ func TestDenyByDefaultShortFailureMessageWithEntityName(t *testing.T) {
 	e, err := rego.NewRegoEvaluator(
 		&minderv1.RuleType_Definition_Eval_Rego{
 			Type: rego.DenyByDefaultEvaluationType.String(),
-			Def: `
-package minder
+			Def: `package minder
 
-default allow = false
+import rego.v1
 
-allow {
+default allow := false
+
+allow if {
 	input.ingested.compliant == true
-}`,
+}
+`,
 		},
 		rego.WithShortFailureMessage("Repository is not compliant"),
 	)

--- a/internal/engine/eval/rego/version_test.go
+++ b/internal/engine/eval/rego/version_test.go
@@ -50,20 +50,17 @@ allow if {
 			wantStr: "v1",
 		},
 		{
-			name: "v0 policy with future.keywords parses as v1",
+			name: "v1 policy with keyword syntax",
 			def: `
 package minder
 
-import future.keywords.if
-import future.keywords.in
+import rego.v1
 
-default allow = false
+default allow := false
 
 allow if {
 	"admin" in input.profile.roles
 }`,
-			// future.keywords policies are accepted by OPA's V1 parser
-			// for backward compatibility during migration.
 			want:    ast.RegoV1,
 			wantStr: "v1",
 		},

--- a/internal/engine/eval/rego/version_test.go
+++ b/internal/engine/eval/rego/version_test.go
@@ -50,11 +50,27 @@ allow if {
 			wantStr: "v1",
 		},
 		{
-			name: "v1 policy with keyword syntax",
+			name: "v0 policy with future.keywords parses as v1",
 			def: `
 package minder
 
-import rego.v1
+import future.keywords.if
+import future.keywords.in
+
+default allow = false
+
+allow if {
+	"admin" in input.profile.roles
+}`,
+			// future.keywords policies are accepted by OPA's V1 parser
+			// for backward compatibility during migration.
+			want:    ast.RegoV1,
+			wantStr: "v1",
+		},
+		{
+			name: "v1 policy with keyword syntax without rego.v1 import",
+			def: `
+package minder
 
 default allow := false
 

--- a/pkg/engine/v1/rtengine/engine_test.go
+++ b/pkg/engine/v1/rtengine/engine_test.go
@@ -54,11 +54,15 @@ func TestGitProvider(t *testing.T) {
 						Rego: &minderv1.RuleType_Definition_Eval_Rego{
 							Type: "deny-by-default",
 							Def: `package minder
-default allow = false
 
-allow {
+import rego.v1
+
+default allow := false
+
+allow if {
 	file.exists("README.md")
-}`,
+}
+`,
 						},
 					},
 				},
@@ -95,11 +99,15 @@ allow {
 						Rego: &minderv1.RuleType_Definition_Eval_Rego{
 							Type: "deny-by-default",
 							Def: `package minder
-default allow = false
 
-allow {
+import rego.v1
+
+default allow := false
+
+allow if {
 	file.exists("README.md")
-}`,
+}
+`,
 						},
 					},
 				},

--- a/pkg/mindpak/bundle_test.go
+++ b/pkg/mindpak/bundle_test.go
@@ -40,7 +40,7 @@ func TestReadSource(t *testing.T) {
 					RuleTypes: []*File{
 						{
 							Name:   "secret_scanning.yaml",
-							Hashes: map[HashAlgorithm]string{SHA256: "3857bca2ccabdac3d136eb3df4549ddd87a00ddef9fdcf88d8f824e5e796d34c"},
+							Hashes: map[HashAlgorithm]string{SHA256: "f15e935b96674f4d47776a7c323f77bb36c1cc783112fededce721a7b4c7edd5"},
 						},
 					},
 					DataSources: []*File{},

--- a/pkg/mindpak/testdata/no-data-sources/rule_types/branch_protection_enabled.yaml
+++ b/pkg/mindpak/testdata/no-data-sources/rule_types/branch_protection_enabled.yaml
@@ -50,12 +50,11 @@ def:
       type: deny-by-default
       def: |
         package minder
-        
-        import future.keywords.every
-        import future.keywords.if
-        
+
+        import rego.v1
+
         default allow := false
-        
+
         allow if {
           input.ingested.url != ""
         }

--- a/pkg/mindpak/testdata/t1/rule_types/secret_scanning.yaml
+++ b/pkg/mindpak/testdata/t1/rule_types/secret_scanning.yaml
@@ -55,9 +55,10 @@ def:
       def: |
         package minder
 
-        import future.keywords.if
+        import rego.v1
 
         default allow := false
+
         default skip := false
 
         allow if {

--- a/pkg/mindpak/testdata/t2/rule_types/branch_protection_enabled.yaml
+++ b/pkg/mindpak/testdata/t2/rule_types/branch_protection_enabled.yaml
@@ -50,12 +50,11 @@ def:
       type: deny-by-default
       def: |
         package minder
-        
-        import future.keywords.every
-        import future.keywords.if
-        
+
+        import rego.v1
+
         default allow := false
-        
+
         allow if {
           input.ingested.url != ""
         }


### PR DESCRIPTION
## Summary

This PR migrates Minder's embedded Rego test fixtures, sample rule YAML, and Rego docs examples to Rego v1 syntax as part of Phase 2 of #5262. (Parent issue)
Child issue #6463 

The production evaluator already supports Rego version detection. This change moves the policy corpus we own toward the Rego v1 baseline by replacing v0 syntax and `future.keywords` examples with `import rego.v1`.

## What changed

- Migrated embedded Rego snippets in evaluator and rtengine tests to Rego v1 syntax.
- Updated Minder sample/fixture rule YAML and quickstart policy YAML to `import rego.v1`.
- Updated Rego documentation snippets to stop recommending `future.keywords` imports.
- Refreshed the affected mindpak fixture hash after the YAML policy migration.

## Validation

- `git diff --check`
- `go test ./pkg/mindpak ./internal/engine/eval/... ./pkg/engine/v1/rtengine ./pkg/api/protobuf/go/minder/v1 ./cmd/cli/app/ruletype ./cmd/cli/app/quickstart`
- `go test ./...` was also attempted. It reaches unrelated failures in `internal/engine/actions/remediate/pull_request` where tests cannot create a temporary git repository in this local environment.

## Notes for reviewers

This is intended to be a syntax-only migration. The remaining v0 snippets in `internal/engine/eval/rego/version_test.go` are deliberate detector coverage and do not use `future.keywords`.