### PR TITLE
Fix GitLab Service Account enrollment

### DIFF
--- a/docs/docs/integrations/provider_integrations/github.md
+++ b/docs/docs/integrations/provider_integrations/github.md
@@ -10,12 +10,6 @@ to make them available for registration. It also tells Minder how to interact
 with your supply chain to enable features such as alerting and remediation.
 Finally, it handles the way Minder authenticates to the external service.
 
-The currently supported providers are:
-
-- GitHub
-
-Stay tuned as we add more providers in the future!
-
 ## Enrolling a provider
 
 To enroll GitHub as a provider, use the following command:

--- a/docs/docs/integrations/provider_integrations/gitlab.md
+++ b/docs/docs/integrations/provider_integrations/gitlab.md
@@ -1,0 +1,125 @@
+---
+title: GitLab provider
+sidebar_label: GitLab
+sidebar_position: 20
+---
+
+A provider connects Minder to your software supply chain. It lets Minder know
+where to look for your repositories, artifacts, and other entities, in order to
+make them available for registration. It also tells Minder how to interact with
+your supply chain to enable features such as alerting and remediation. Finally,
+it handles the way Minder authenticates to the external service.
+
+## Authorization methods
+
+Minder supports two ways to authorize the GitLab provider: **OAuth** and a
+**Personal Access Token (PAT)**. Both grant Minder access to your GitLab
+resources, but they differ in how credentials are obtained and managed.
+
+|                     | OAuth                                                                                             | Personal Access Token (PAT)                                             |
+| ------------------- | ------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------- |
+| **Access scope**    | Tied to the authorizing user's GitLab account                                                     | Scoped to a dedicated service account; access can be tightly controlled |
+| **Recommended for** | Individual developers and quick evaluations                                                       | Teams and production deployments                                        |
+| **How it works**    | Browser-based OAuth 2.0 flow; Minder receives a short-lived token that is refreshed automatically | You generate a token in GitLab and supply it to Minder manually         |
+| **Setup effort**    | Low — follow the browser prompt                                                                   | Medium — create a service account, set scopes, copy the token           |
+| **Token lifetime**  | Managed automatically by Minder                                                                   | Fixed expiry set at creation; requires manual rotation                  |
+| **Rotation**        | Automatic                                                                                         | Manual — re-run `provider enroll` with the existing provider name       |
+
+For production environments, the PAT approach with a dedicated service account
+is recommended because it decouples Minder's access from any individual user's
+account, survives employee offboarding, and gives you precise control over which
+projects Minder can access.
+
+## Prerequisites (PAT method)
+
+Before enrolling GitLab as a provider using a PAT, you will need a Personal
+Access Token with sufficient permissions for Minder to read and interact with
+your repositories.
+
+### Creating a service account and PAT
+
+It is recommended to create a dedicated **project-linked service account** in
+GitLab rather than using a personal account token. This keeps Minder's access
+isolated and makes token rotation easier to manage.
+
+1. **Create a service account** by navigating to the **Service accounts** page
+   for your group or project and selecting **Add service account**. Enter a name
+   and select **Create service account**. See the
+   [GitLab service accounts documentation](https://docs.gitlab.com/user/profile/service_accounts/)
+   for details on the types of service accounts and any prerequisites (such as
+   group Owner or administrator access).
+
+2. **Generate a Personal Access Token** for the service account via the
+   **Service accounts** page:
+   - Go to the **Service accounts** page.
+   - Find the service account, select the vertical ellipsis (**⋮**) next to it,
+     and choose **Manage access tokens**.
+   - Select **Add new token**.
+   - Enter a **Token name** and an **Expiration date** appropriate for your
+     organization's rotation policy.
+   - Select the following scopes:
+     - `api`: required for full API access (repository data, merge requests,
+       security findings)
+     - `read_repository`: required for reading repository contents
+     - `write_repository`: required to create branches to remediate code
+       findings via MR.
+   - Copy the token value — it will not be shown again.
+
+3. **Add the service account** to the relevant projects or group. Use **Add
+   users to a group** or **Add users to a project** in the GitLab UI, or the
+   group/project members API.
+   [Choose a role](https://docs.gitlab.com/user/permissions/) based on which
+   Minder features you need:
+   - **Maintainer** _(recommended)_: Grants full access to repository settings,
+     branch protection rules, and merge request management. Required if you want
+     Minder to apply remediations that modify protected branches or repository
+     settings. This is the recommended role for most deployments.
+   - **Security Manager** _(minimum)_: Allows Minder to read repository
+     contents, security findings, but cannot create merge requests for
+     remediations or update most repository settings. Choose this role when you
+     want to limit Minder's write access, accepting that most remediation
+     actions will not be available.
+
+## Enrolling a provider
+
+### Using a PAT
+
+To enroll GitLab using a Personal Access Token, pass the `--token` flag:
+
+```bash
+minder provider enroll --class gitlab --token <your-pat>
+```
+
+Once enrolled, your GitLab repositories can be registered with Minder and
+security profiles can be applied.
+
+### Using OAuth
+
+To enroll GitLab using the OAuth flow, run:
+
+```bash
+minder provider enroll --class gitlab
+```
+
+Minder will open a browser window and guide you through the GitLab OAuth
+authorization flow. Once you grant access, Minder stores the resulting token and
+refreshes it automatically.
+
+## Token rotation
+
+Personal Access Tokens expire according to the expiry date set when they were
+created. When a token expires, Minder will no longer be able to communicate with
+GitLab and provider operations will fail.
+
+To update Minder with a new token, re-run `provider enroll` using the **existing
+provider name** so that Minder updates the credentials in place rather than
+creating a duplicate provider:
+
+```bash
+minder provider enroll --class gitlab --name <existing-provider-name> --token <new-token>
+```
+
+You will be prompted to supply the new PAT. Minder will update the stored
+credentials for that provider without affecting any repositories or profiles
+already registered under it.
+

--- a/internal/providers/gitlab/manager/auth.go
+++ b/internal/providers/gitlab/manager/auth.go
@@ -6,6 +6,7 @@ package manager
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"golang.org/x/oauth2"
 	"golang.org/x/oauth2/gitlab"
@@ -46,25 +47,19 @@ func (g *providerClassManager) NewOAuthConfig(_ db.ProviderClass, cli bool) (*oa
 func (*providerClassManager) ValidateCredentials(
 	_ context.Context, cred provv1.Credential, _ *m.CredentialVerifyParams,
 ) error {
-	tokenCred, ok := cred.(provv1.OAuth2TokenCredential)
-	if !ok {
+	switch c := cred.(type) {
+	case provv1.OAuth2TokenCredential:
+		_, err := c.GetAsOAuth2TokenSource().Token()
+		if err != nil {
+			return fmt.Errorf("cannot get token from credential: %w", err)
+		}
+	case string:
+		if !strings.HasPrefix(c, "glpat-") {
+			return fmt.Errorf("expected token to start with 'glpat-'")
+		}
+	default:
 		return fmt.Errorf("invalid credential type: %T", cred)
 	}
-
-	_, err := tokenCred.GetAsOAuth2TokenSource().Token()
-	if err != nil {
-		return fmt.Errorf("cannot get token from credential: %w", err)
-	}
-
-	// TODO: verify token identity
-	// if params.RemoteUser != "" {
-	// 	err := g.ghService.VerifyProviderTokenIdentity(ctx, params.RemoteUser, token.AccessToken)
-	// 	if err != nil {
-	// 		return fmt.Errorf("error verifying token identity: %w", err)
-	// 	}
-	// } else {
-	// 	zerolog.Ctx(ctx).Warn().Msg("RemoteUser not found in session state")
-	// }
 
 	return nil
 }

--- a/internal/providers/gitlab/manager/manager.go
+++ b/internal/providers/gitlab/manager/manager.go
@@ -12,6 +12,7 @@ import (
 	"fmt"
 	"net/url"
 	"slices"
+	"strings"
 	"time"
 
 	"github.com/rs/zerolog"
@@ -255,5 +256,7 @@ func (m *providerClassManager) persistToken(
 }
 
 func tokenNeedsRefresh(token oauth2.Token) bool {
-	return !token.Valid() || token.Expiry.UTC().Add(tokenExpirationThreshold).Before(time.Now().UTC())
+	bufferedExpiration := time.Now().UTC().Add(-1 * tokenExpirationThreshold)
+	return !strings.HasPrefix(token.AccessToken, "glpat-") && // is a PAT, not an OAuth token
+		(!token.Valid() || token.Expiry.UTC().Before(bufferedExpiration))
 }

--- a/internal/providers/gitlab/manager/manager_test.go
+++ b/internal/providers/gitlab/manager/manager_test.go
@@ -45,6 +45,14 @@ func Test_tokenNeedsRefresh(t *testing.T) {
 			},
 			want: true,
 		},
+		{
+			name: "stored a PAT",
+			token: oauth2.Token{
+				AccessToken:  "glpat-notarealtoken.01.1234567",
+				RefreshToken: "",
+			},
+			want: false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/providers/gitlab/repo_lister.go
+++ b/internal/providers/gitlab/repo_lister.go
@@ -23,7 +23,7 @@ var minAccessLevelControl = 25 // "Security Manager"
 
 func (c *gitlabClient) ListAllRepositories(ctx context.Context) ([]*minderv1.Repository, error) {
 	managedProjects := []*gitlab.Project{}
-	if err := glRESTGet(ctx, c, "projects?min_access_level=40", &managedProjects); err != nil {
+	if err := glRESTGet(ctx, c, fmt.Sprintf("projects?min_access_level=%d", minAccessLevelControl), &managedProjects); err != nil {
 		return nil, fmt.Errorf("failed to get projects: %w", err)
 	}
 

--- a/internal/providers/gitlab/repo_lister.go
+++ b/internal/providers/gitlab/repo_lister.go
@@ -6,7 +6,6 @@ package gitlab
 import (
 	"context"
 	"fmt"
-	"net/url"
 
 	"github.com/rs/zerolog"
 	gitlab "gitlab.com/gitlab-org/api/client-go"
@@ -14,49 +13,33 @@ import (
 	minderv1 "github.com/mindersec/minder/pkg/api/protobuf/go/minder/v1"
 )
 
+// Access levels, from https://docs.gitlab.com/api/projects/#list-all-projects:
+// 20 => "Reporter"
+// 25 => "Security Manager"
+// 30 => "Developer"
+// 40 => "Maintainer"
+// 50 => "Owner"
+var minAccessLevelControl = 25 // "Security Manager"
+
 func (c *gitlabClient) ListAllRepositories(ctx context.Context) ([]*minderv1.Repository, error) {
-	groups := []*gitlab.Group{}
-	if err := glRESTGet(ctx, c, "groups", &groups); err != nil {
-		return nil, fmt.Errorf("failed to get groups: %w", err)
+	managedProjects := []*gitlab.Project{}
+	if err := glRESTGet(ctx, c, "projects?min_access_level=40", &managedProjects); err != nil {
+		return nil, fmt.Errorf("failed to get projects: %w", err)
 	}
 
-	if len(groups) == 0 {
-		zerolog.Ctx(ctx).Debug().Msg("no groups found")
-		return nil, nil
-	}
-
-	var repos []*minderv1.Repository
-	for _, g := range groups {
-		projs := []*gitlab.Project{}
-		path, err := url.JoinPath("groups", fmt.Sprintf("%d", g.ID), "projects")
+	repos := make([]*minderv1.Repository, 0, len(managedProjects))
+	for _, p := range managedProjects {
+		props, err := gitlabProjectToProperties(p)
 		if err != nil {
-			return nil, fmt.Errorf("failed to join URL path for projects: %w", err)
-		}
-		if err := glRESTGet(ctx, c, path, &projs); err != nil {
-			return nil, fmt.Errorf("failed to get projects for group %s: %w", g.FullPath, err)
+			return nil, fmt.Errorf("failed to convert project to properties: %w", err)
 		}
 
-		if repos == nil {
-			repos = make([]*minderv1.Repository, 0, len(projs))
+		outRep, err := repoV1FromProperties(props)
+		if err != nil {
+			return nil, fmt.Errorf("failed to convert properties to repository: %w", err)
 		}
 
-		if len(projs) == 0 {
-			zerolog.Ctx(ctx).Debug().Msgf("no projects found for group %s", g.FullPath)
-		}
-
-		for _, p := range projs {
-			props, err := gitlabProjectToProperties(p)
-			if err != nil {
-				return nil, fmt.Errorf("failed to convert project to properties: %w", err)
-			}
-
-			outRep, err := repoV1FromProperties(props)
-			if err != nil {
-				return nil, fmt.Errorf("failed to convert properties to repository: %w", err)
-			}
-
-			repos = append(repos, outRep)
-		}
+		repos = append(repos, outRep)
 	}
 
 	zerolog.Ctx(ctx).Debug().Int("num_repos", len(repos)).Msg("found repositories in gitlab provider")


### PR DESCRIPTION
# Summary

#6478 fixed the API validation for GitLab tokens, but the underlying code still expected tokens to be of the "OAuth" format, even when a PAT was explicitly provided.  Relax this constraint (which probably fixes GitHub as well, but the app flow for GitHub generally automates the service account creation and token rotation, so we still prefer that for GitHub).

Additionally, simplify ListAllRepositories (used to populate the list in `repo register`) for GitLab, using the `min_access_level` filter.  This should avoid recommending repos that the token doesn't have sufficient access to.

Includes user documentation on setting up GitLab service account PATs.

# Testing

Manual testing alongside API double-checks with the `glab api` tool.  I was able to create a service account ("Custcodian-minder"), assign it a role in the "custcodian" group, and then use it to list and enroll a repository.
