### PR TITLE
Implement capabilities list via reflection

### DIFF
--- a/internal/providers/dockerhub/metadata.go
+++ b/internal/providers/dockerhub/metadata.go
@@ -5,6 +5,7 @@ package dockerhub
 
 import (
 	minderv1 "github.com/mindersec/minder/pkg/api/protobuf/go/minder/v1"
+	provifv1 "github.com/mindersec/minder/pkg/providers/v1"
 )
 
 const (
@@ -12,16 +13,12 @@ const (
 	providerDocsURL     = providerDocsBaseURL + "/understand/providers"
 )
 
-// ClassInfo returns metadata for the Docker Hub provider class.
-func ClassInfo() *minderv1.ProviderClassInfo {
+func (d *dockerHubImageLister) ProviderClassInfo() *minderv1.ProviderClassInfo {
 	return &minderv1.ProviderClassInfo{
-		Class:       DockerHub,
-		DisplayName: "Docker Hub",
-		Description: "Docker Hub registry provider for image and OCI interactions.",
-		SupportedProviderTypes: []minderv1.ProviderType{
-			minderv1.ProviderType_PROVIDER_TYPE_IMAGE_LISTER,
-			minderv1.ProviderType_PROVIDER_TYPE_OCI,
-		},
+		Class:                  DockerHub,
+		DisplayName:            "Docker Hub",
+		Description:            "Docker Hub registry provider for image and OCI interactions.",
+		SupportedProviderTypes: provifv1.ProviderTypesFromImpl(d),
 		SupportedAuthFlows: []minderv1.AuthorizationFlow{
 			minderv1.AuthorizationFlow_AUTHORIZATION_FLOW_USER_INPUT,
 		},
@@ -30,6 +27,8 @@ func ClassInfo() *minderv1.ProviderClassInfo {
 	}
 }
 
-func (*dockerHubImageLister) ProviderClassInfo() *minderv1.ProviderClassInfo {
-	return ClassInfo()
+// ClassInfo returns metadata for the Docker Hub provider class.
+// It uses a nil-pointer receiver to avoid needing a live client instance.
+func ClassInfo() *minderv1.ProviderClassInfo {
+	return (*dockerHubImageLister)(nil).ProviderClassInfo()
 }

--- a/internal/providers/github/clients/app.go
+++ b/internal/providers/github/clients/app.go
@@ -26,9 +26,6 @@ import (
 // GithubApp is the string that represents the GitHubApp provider
 const GithubApp = "github-app"
 
-// AppImplements is the list of provider types that the GitHub App provider implements.
-var AppImplements = github.AppImplements
-
 // AppAuthorizationFlows is the list of authorization flows that the GitHub App provider supports.
 var AppAuthorizationFlows = github.AppAuthorizationFlows
 

--- a/internal/providers/github/clients/oauth.go
+++ b/internal/providers/github/clients/oauth.go
@@ -25,9 +25,6 @@ import (
 // Github is the string that represents the GitHubOAuth provider
 const Github = "github"
 
-// OAuthImplements is the list of provider types that the GitHub OAuth provider implements.
-var OAuthImplements = github.OAuthImplements
-
 // OAuthAuthorizationFlows is the list of authorization flows that the GitHub OAuth provider supports.
 var OAuthAuthorizationFlows = github.OAuthAuthorizationFlows
 

--- a/internal/providers/github/metadata.go
+++ b/internal/providers/github/metadata.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/mindersec/minder/internal/db"
 	minderv1 "github.com/mindersec/minder/pkg/api/protobuf/go/minder/v1"
+	provifv1 "github.com/mindersec/minder/pkg/providers/v1"
 )
 
 const (
@@ -15,26 +16,10 @@ const (
 	providerDocsURL     = providerDocsBaseURL + "/integrations/provider_integrations/github"
 )
 
-// OAuthImplements is the list of provider types that the GitHub OAuth provider implements.
-var OAuthImplements = []db.ProviderType{
-	db.ProviderTypeGithub,
-	db.ProviderTypeGit,
-	db.ProviderTypeRest,
-	db.ProviderTypeRepoLister,
-}
-
 // OAuthAuthorizationFlows is the list of authorization flows that the GitHub OAuth provider supports.
 var OAuthAuthorizationFlows = []db.AuthorizationFlow{
 	db.AuthorizationFlowUserInput,
 	db.AuthorizationFlowOauth2AuthorizationCodeFlow,
-}
-
-// AppImplements is the list of provider types that the GitHub App provider implements.
-var AppImplements = []db.ProviderType{
-	db.ProviderTypeGithub,
-	db.ProviderTypeGit,
-	db.ProviderTypeRest,
-	db.ProviderTypeRepoLister,
 }
 
 // AppAuthorizationFlows is the list of authorization flows that the GitHub App provider supports.
@@ -42,80 +27,50 @@ var AppAuthorizationFlows = []db.AuthorizationFlow{
 	db.AuthorizationFlowGithubAppFlow,
 }
 
-// ProviderClassInfo returns class metadata for GitHub-backed provider classes.
-func ProviderClassInfo(class db.ProviderClass) (*minderv1.ProviderClassInfo, error) {
-	switch class {
+// ProviderClassInfo implements the Provider interface.
+func (c *GitHub) ProviderClassInfo() *minderv1.ProviderClassInfo {
+	supportedTypes := provifv1.ProviderTypesFromImpl(c)
+	supportedEntities := []minderv1.Entity{
+		minderv1.Entity_ENTITY_REPOSITORIES,
+		minderv1.Entity_ENTITY_PULL_REQUESTS,
+		minderv1.Entity_ENTITY_ARTIFACTS,
+		minderv1.Entity_ENTITY_RELEASE,
+	}
+	//nolint:exhaustive
+	switch c.providerClass {
 	case db.ProviderClassGithub:
 		return &minderv1.ProviderClassInfo{
 			Class:                  string(db.ProviderClassGithub),
 			DisplayName:            "GitHub OAuth",
 			Description:            "GitHub provider using OAuth credentials.",
-			SupportedProviderTypes: dbProviderTypesToPB(OAuthImplements),
+			SupportedProviderTypes: supportedTypes,
 			SupportedAuthFlows:     dbAuthFlowsToPB(OAuthAuthorizationFlows),
-			SupportedEntities: []minderv1.Entity{
-				minderv1.Entity_ENTITY_REPOSITORIES,
-				minderv1.Entity_ENTITY_PULL_REQUESTS,
-				minderv1.Entity_ENTITY_ARTIFACTS,
-				minderv1.Entity_ENTITY_RELEASE,
-			},
-			DocumentationUrl: providerDocsURL,
-		}, nil
+			SupportedEntities:      supportedEntities,
+			DocumentationUrl:       providerDocsURL,
+		}
 	case db.ProviderClassGithubApp:
 		return &minderv1.ProviderClassInfo{
 			Class:                  string(db.ProviderClassGithubApp),
 			DisplayName:            "GitHub App",
 			Description:            "GitHub App-based provider with installation-based authorization.",
-			SupportedProviderTypes: dbProviderTypesToPB(AppImplements),
+			SupportedProviderTypes: supportedTypes,
 			SupportedAuthFlows:     dbAuthFlowsToPB(AppAuthorizationFlows),
-			SupportedEntities: []minderv1.Entity{
-				minderv1.Entity_ENTITY_REPOSITORIES,
-				minderv1.Entity_ENTITY_PULL_REQUESTS,
-				minderv1.Entity_ENTITY_ARTIFACTS,
-				minderv1.Entity_ENTITY_RELEASE,
-			},
-			DocumentationUrl: providerDocsURL,
-		}, nil
-	case db.ProviderClassGhcr:
-		fallthrough
-	case db.ProviderClassDockerhub:
-		fallthrough
-	case db.ProviderClassGitlab:
-		return nil, fmt.Errorf("unsupported GitHub provider class: %s", class)
+			SupportedEntities:      supportedEntities,
+			DocumentationUrl:       providerDocsURL,
+		}
 	default:
-		return nil, fmt.Errorf("unsupported GitHub provider class: %s", class)
-	}
-}
-
-// ProviderClassInfo implements the Provider interface.
-func (c *GitHub) ProviderClassInfo() *minderv1.ProviderClassInfo {
-	info, err := ProviderClassInfo(c.providerClass)
-	if err != nil {
 		return nil
 	}
-
-	return info
 }
 
-func dbProviderTypesToPB(types []db.ProviderType) []minderv1.ProviderType {
-	out := make([]minderv1.ProviderType, 0, len(types))
-	for _, t := range types {
-		switch t {
-		case db.ProviderTypeGit:
-			out = append(out, minderv1.ProviderType_PROVIDER_TYPE_GIT)
-		case db.ProviderTypeGithub:
-			out = append(out, minderv1.ProviderType_PROVIDER_TYPE_GITHUB)
-		case db.ProviderTypeRest:
-			out = append(out, minderv1.ProviderType_PROVIDER_TYPE_REST)
-		case db.ProviderTypeRepoLister:
-			out = append(out, minderv1.ProviderType_PROVIDER_TYPE_REPO_LISTER)
-		case db.ProviderTypeOci:
-			out = append(out, minderv1.ProviderType_PROVIDER_TYPE_OCI)
-		case db.ProviderTypeImageLister:
-			out = append(out, minderv1.ProviderType_PROVIDER_TYPE_IMAGE_LISTER)
-		}
+// ProviderClassInfo returns class metadata for GitHub-backed provider classes.
+// It uses a nil-pointer receiver to avoid needing a live client instance.
+func ProviderClassInfo(class db.ProviderClass) (*minderv1.ProviderClassInfo, error) {
+	info := (&GitHub{providerClass: class}).ProviderClassInfo()
+	if info == nil {
+		return nil, fmt.Errorf("unsupported GitHub provider class: %s", class)
 	}
-
-	return out
+	return info, nil
 }
 
 func dbAuthFlowsToPB(flows []db.AuthorizationFlow) []minderv1.AuthorizationFlow {

--- a/internal/providers/github/provider_test.go
+++ b/internal/providers/github/provider_test.go
@@ -4,8 +4,13 @@
 package github
 
 import (
+	"slices"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/mindersec/minder/internal/db"
 	"github.com/mindersec/minder/internal/providers/github/properties"
 	minderv1 "github.com/mindersec/minder/pkg/api/protobuf/go/minder/v1"
 	testhelper "github.com/mindersec/minder/pkg/providers/v1/testing"
@@ -20,4 +25,76 @@ func TestRegistration(t *testing.T) {
 	// Repositories do a bunch of special registration, so skip them
 	// in this test -- we test them in common_test.go.
 	testhelper.CheckRegistrationExcept(t, gh, minderv1.Entity_ENTITY_REPOSITORIES)
+}
+
+func TestProviderClassInfo(t *testing.T) {
+	t.Parallel()
+
+	wantEntities := []minderv1.Entity{
+		minderv1.Entity_ENTITY_REPOSITORIES,
+		minderv1.Entity_ENTITY_PULL_REQUESTS,
+		minderv1.Entity_ENTITY_ARTIFACTS,
+		minderv1.Entity_ENTITY_RELEASE,
+	}
+	wantTypes := []minderv1.ProviderType{
+		minderv1.ProviderType_PROVIDER_TYPE_GITHUB,
+		minderv1.ProviderType_PROVIDER_TYPE_GIT,
+		minderv1.ProviderType_PROVIDER_TYPE_REST,
+		minderv1.ProviderType_PROVIDER_TYPE_REPO_LISTER,
+		minderv1.ProviderType_PROVIDER_TYPE_IMAGE_LISTER,
+	}
+
+	tests := []struct {
+		name          string
+		providerClass db.ProviderClass
+		wantClass     string
+		wantDisplay   string
+		wantAuthFlows []minderv1.AuthorizationFlow
+	}{
+		{
+			name:          "GitHub OAuth",
+			providerClass: db.ProviderClassGithub,
+			wantClass:     string(db.ProviderClassGithub),
+			wantDisplay:   "GitHub OAuth",
+			wantAuthFlows: []minderv1.AuthorizationFlow{
+				minderv1.AuthorizationFlow_AUTHORIZATION_FLOW_USER_INPUT,
+				minderv1.AuthorizationFlow_AUTHORIZATION_FLOW_OAUTH2_AUTHORIZATION_CODE_FLOW,
+			},
+		},
+		{
+			name:          "GitHub App",
+			providerClass: db.ProviderClassGithubApp,
+			wantClass:     string(db.ProviderClassGithubApp),
+			wantDisplay:   "GitHub App",
+			wantAuthFlows: []minderv1.AuthorizationFlow{
+				minderv1.AuthorizationFlow_AUTHORIZATION_FLOW_GITHUB_APP_FLOW,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			gh := &GitHub{
+				propertyFetchers: properties.NewPropertyFetcherFactory(),
+				providerClass:    tt.providerClass,
+			}
+
+			info := gh.ProviderClassInfo()
+			require.NotNil(t, info)
+
+			assert.Equal(t, tt.wantClass, info.Class)
+			assert.Equal(t, tt.wantDisplay, info.DisplayName)
+			assert.NotEmpty(t, info.Description)
+			assert.Equal(t, providerDocsURL, info.DocumentationUrl)
+
+			assert.ElementsMatch(t, tt.wantAuthFlows, info.SupportedAuthFlows)
+			assert.ElementsMatch(t, wantEntities, info.SupportedEntities)
+
+			for _, want := range wantTypes {
+				assert.True(t, slices.Contains(info.SupportedProviderTypes, want),
+					"expected SupportedProviderTypes to contain %v", want)
+			}
+		})
+	}
 }

--- a/internal/providers/github/service/service_test.go
+++ b/internal/providers/github/service/service_test.go
@@ -273,7 +273,10 @@ func TestProviderService_CreateGitHubAppProvider(t *testing.T) {
 
 	require.Equal(t, dbProv.ProjectID, dbproj.ID)
 	require.Equal(t, dbProv.AuthFlows, clients.AppAuthorizationFlows)
-	require.Equal(t, dbProv.Implements, clients.AppImplements)
+	require.ElementsMatch(t, dbProv.Implements, []db.ProviderType{
+		db.ProviderTypeGithub, db.ProviderTypeGit, db.ProviderTypeRest,
+		db.ProviderTypeRepoLister, db.ProviderTypeImageLister,
+	})
 	require.Equal(t, dbProv.Class, db.ProviderClassGithubApp)
 	require.Contains(t, dbProv.Name, db.ProviderClassGithubApp)
 	require.Contains(t, dbProv.Name, accountLogin)

--- a/internal/providers/gitlab/metadata.go
+++ b/internal/providers/gitlab/metadata.go
@@ -5,6 +5,7 @@ package gitlab
 
 import (
 	minderv1 "github.com/mindersec/minder/pkg/api/protobuf/go/minder/v1"
+	provifv1 "github.com/mindersec/minder/pkg/providers/v1"
 )
 
 const (
@@ -12,17 +13,12 @@ const (
 	providerDocsURL     = providerDocsBaseURL + "/understand/providers"
 )
 
-// ClassInfo returns metadata for the GitLab provider class.
-func ClassInfo() *minderv1.ProviderClassInfo {
+func (c *gitlabClient) ProviderClassInfo() *minderv1.ProviderClassInfo {
 	return &minderv1.ProviderClassInfo{
-		Class:       Class,
-		DisplayName: "GitLab",
-		Description: "GitLab provider using OAuth credentials.",
-		SupportedProviderTypes: []minderv1.ProviderType{
-			minderv1.ProviderType_PROVIDER_TYPE_GIT,
-			minderv1.ProviderType_PROVIDER_TYPE_REST,
-			minderv1.ProviderType_PROVIDER_TYPE_REPO_LISTER,
-		},
+		Class:                  Class,
+		DisplayName:            "GitLab",
+		Description:            "GitLab provider using OAuth credentials.",
+		SupportedProviderTypes: provifv1.ProviderTypesFromImpl(c),
 		SupportedAuthFlows: []minderv1.AuthorizationFlow{
 			minderv1.AuthorizationFlow_AUTHORIZATION_FLOW_USER_INPUT,
 			minderv1.AuthorizationFlow_AUTHORIZATION_FLOW_OAUTH2_AUTHORIZATION_CODE_FLOW,
@@ -36,6 +32,8 @@ func ClassInfo() *minderv1.ProviderClassInfo {
 	}
 }
 
-func (*gitlabClient) ProviderClassInfo() *minderv1.ProviderClassInfo {
-	return ClassInfo()
+// ClassInfo returns metadata for the GitLab provider class.
+// It uses a nil-pointer receiver to avoid needing a live client instance.
+func ClassInfo() *minderv1.ProviderClassInfo {
+	return (*gitlabClient)(nil).ProviderClassInfo()
 }

--- a/internal/providers/gitlab/metadata_test.go
+++ b/internal/providers/gitlab/metadata_test.go
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: Copyright 2026 The Minder Authors
 // SPDX-License-Identifier: Apache-2.0
 
-package dockerhub
+package gitlab
 
 import (
 	"testing"
@@ -10,15 +10,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	minderv1 "github.com/mindersec/minder/pkg/api/protobuf/go/minder/v1"
-	testhelper "github.com/mindersec/minder/pkg/providers/v1/testing"
 )
-
-func TestRegistration(t *testing.T) {
-	t.Parallel()
-	// We don't need a full constructor here, so we're naughty
-	dh := &dockerHubImageLister{}
-	testhelper.CheckRegistrationExcept(t, dh)
-}
 
 func TestClassInfo(t *testing.T) {
 	t.Parallel()
@@ -26,19 +18,25 @@ func TestClassInfo(t *testing.T) {
 	info := ClassInfo()
 	require.NotNil(t, info)
 
-	assert.Equal(t, DockerHub, info.Class)
-	assert.Equal(t, "Docker Hub", info.DisplayName)
+	assert.Equal(t, Class, info.Class)
+	assert.Equal(t, "GitLab", info.DisplayName)
 	assert.NotEmpty(t, info.Description)
 	assert.Equal(t, providerDocsURL, info.DocumentationUrl)
 
 	assert.ElementsMatch(t, []minderv1.AuthorizationFlow{
 		minderv1.AuthorizationFlow_AUTHORIZATION_FLOW_USER_INPUT,
+		minderv1.AuthorizationFlow_AUTHORIZATION_FLOW_OAUTH2_AUTHORIZATION_CODE_FLOW,
 	}, info.SupportedAuthFlows)
 
-	assert.Empty(t, info.SupportedEntities)
+	assert.ElementsMatch(t, []minderv1.Entity{
+		minderv1.Entity_ENTITY_REPOSITORIES,
+		minderv1.Entity_ENTITY_PULL_REQUESTS,
+		minderv1.Entity_ENTITY_RELEASE,
+	}, info.SupportedEntities)
 
 	assert.ElementsMatch(t, []minderv1.ProviderType{
-		minderv1.ProviderType_PROVIDER_TYPE_IMAGE_LISTER,
-		minderv1.ProviderType_PROVIDER_TYPE_OCI,
+		minderv1.ProviderType_PROVIDER_TYPE_GIT,
+		minderv1.ProviderType_PROVIDER_TYPE_REST,
+		minderv1.ProviderType_PROVIDER_TYPE_REPO_LISTER,
 	}, info.SupportedProviderTypes)
 }

--- a/pkg/providers/v1/providers.go
+++ b/pkg/providers/v1/providers.go
@@ -12,6 +12,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"reflect"
 	"time"
 
 	"github.com/go-git/go-git/v5"
@@ -300,6 +301,30 @@ func ParseAndValidate(rawConfig json.RawMessage, to any) error {
 	}
 
 	return nil
+}
+
+// providerTypeMap maps each ProviderType to the interface type that a provider
+// must implement to support it.
+var providerTypeMap = map[minderv1.ProviderType]reflect.Type{
+	minderv1.ProviderType_PROVIDER_TYPE_GITHUB:       reflect.TypeOf((*GitHub)(nil)).Elem(),
+	minderv1.ProviderType_PROVIDER_TYPE_REST:         reflect.TypeOf((*REST)(nil)).Elem(),
+	minderv1.ProviderType_PROVIDER_TYPE_GIT:          reflect.TypeOf((*Git)(nil)).Elem(),
+	minderv1.ProviderType_PROVIDER_TYPE_OCI:          reflect.TypeOf((*OCI)(nil)).Elem(),
+	minderv1.ProviderType_PROVIDER_TYPE_REPO_LISTER:  reflect.TypeOf((*RepoLister)(nil)).Elem(),
+	minderv1.ProviderType_PROVIDER_TYPE_IMAGE_LISTER: reflect.TypeOf((*ImageLister)(nil)).Elem(),
+}
+
+// ProviderTypesFromImpl returns the set of ProviderType values supported by the given
+// Provider, determined by checking which interfaces it implements.
+func ProviderTypesFromImpl(p Provider) []minderv1.ProviderType {
+	t := reflect.TypeOf(p)
+	out := make([]minderv1.ProviderType, 0, len(providerTypeMap))
+	for ptype, iface := range providerTypeMap {
+		if t.Implements(iface) {
+			out = append(out, ptype)
+		}
+	}
+	return out
 }
 
 // As is a type-cast function for Providers


### PR DESCRIPTION
# Summary

Implement reporting provider types (facets) via reflection on the provider interface.  This should eliminate possible errors in double-bookkeeping.  Added tests to illustrate the current values reported by the providers.

# Testing

Unit testing, as this is a refactoring change only.
