### PR TITLE
feat(identity): add smoke-test-client Keycloak OIDC client for automted testing

### DIFF
--- a/identity/config/stacklok.yaml
+++ b/identity/config/stacklok.yaml
@@ -139,6 +139,29 @@ clients:
     optionalClientScopes:
       - microprofile-jwt
       - offline_access
+  # Dedicated client for automated integration / smoke tests.
+  # Uses Resource Owner Password Credentials (ROPC / Direct Access Grants)
+  # so the bootstrap script can obtain an offline token without a browser.
+  # This client MUST NOT be used in production or user-facing flows.
+  - clientId: smoke-test-client
+    name: "Smoke Test Client"
+    description: "Headless OIDC client for automated integration tests only"
+    enabled: true
+    publicClient: true
+    # ROPC (Direct Access Grants) — required by bootstrap.sh
+    directAccessGrantsEnabled: true
+    defaultClientScopes:
+      - basic
+      - acr
+      - email
+      - profile
+      - roles
+      - web-origins
+      - minder-audience
+      - offline_access
+    optionalClientScopes:
+      - microprofile-jwt
+      - gh-data
   # From:
   # create clients -r stacklok -s clientId=minder-server -s serviceAccountsEnabled=true -s clientAuthenticatorType=client-secret -s secret="$KC_MINDER_SERVER_SECRET" -s enabled=true -s defaultClientScopes='["acr","email","profile","roles","web-origins","gh-data"]' -s optionalClientScopes='["microprofile-jwt","offline_access"]'
   - clientId: minder-server


### PR DESCRIPTION
# Summary

Adds a dedicated `smoke-test-client` OIDC client to the Keycloak `stacklok`
realm configuration (`identity/config/stacklok.yaml`).

This client enables **Resource Owner Password Credentials (ROPC / Direct
Access Grants)** so that the smoke-test suite bootstrap script can obtain an
offline token programmatically - without any browser interaction or GitHub
OAuth flow.

## Why a separate client and not `minder-cli`?

The `minder-cli` client intentionally does **not** have ROPC enabled - it
uses the Device Authorization Grant + browser-based GitHub OAuth. Enabling
ROPC on `minder-cli` would weaken its security posture. A dedicated test
client:

- Keeps security concerns cleanly separated
- Makes it trivial to disable/restrict test access independently
- Avoids any risk of accidentally using a ROPC-enabled client in
  production user flows

## Client configuration

| Property | Value |
|---|---|
| `clientId` | `smoke-test-client` |
| `publicClient` | `true` |
| `directAccessGrantsEnabled` | `true` (ROPC) |
| Default scopes | `basic`, `acr`, `email`, `profile`, `roles`, `web-origins`, `minder-audience`, `offline_access` |
| Optional scopes | `microprofile-jwt`, `gh-data` |

`offline_access` is a **default** scope (not optional) so the bootstrap
script can request an offline token in a single grant call without needing
to enumerate scopes explicitly.

`gh-data` is **optional** because automated test users are created
programmatically and have no GitHub account linked.

## Related

Companion PR in smoke-tests repo: mindersec/smoke-tests#XX
The smoke-tests bootstrap script (`scripts/bootstrap.sh`) uses this client
via `CLIENT_ID=smoke-test-client`.

# Testing

1. Start the Minder stack locally:
   ```bash
   make run-docker

2. Verify smoke-test-client appears in the Keycloak admin UI at http://localhost:8081 → Realm stacklok → Clients

3. Run the smoke-tests bootstrap script (from the companion PR):

```bash
./scripts/bootstrap.sh
# Expected: offline token written to ./offline.token, no browser opens

4. Confirm that minder-cli behaviour is unchanged (no ROPC, existing device-auth flow still works):

```bash
minder auth login
# Should still open browser / use device flow as before
