### PR TITLE
Simplify CreateProfile, fix bug filling list of profiles

### DIFF
--- a/pkg/profiles/service.go
+++ b/pkg/profiles/service.go
@@ -135,10 +135,8 @@ func (p *profileService) CreateProfile(
 
 	profileMap := MergeDatabaseListIntoProfiles(existingProfiles)
 
-	existingProfileNames := make([]string, 0, len(profileMap))
-
 	// Derive the profile name from the profile display name
-	name := DeriveProfileNameFromDisplayName(profile, existingProfileNames)
+	name := DeriveProfileNameFromDisplayName(profile, profileMap)
 
 	// if empty use the name
 	if displayName == "" {

--- a/pkg/profiles/util.go
+++ b/pkg/profiles/util.go
@@ -290,7 +290,7 @@ func MergeDatabaseGetByNameIntoProfiles(ppl []db.GetProfileByProjectAndNameRow) 
 // DeriveProfileNameFromDisplayName generates a unique profile name based on the display name and existing profiles.
 func DeriveProfileNameFromDisplayName(
 	profile *pb.Profile,
-	existingProfileNames []string,
+	existingProfileNames map[string]*pb.Profile,
 ) (name string) {
 
 	displayName := profile.GetDisplayName()
@@ -305,16 +305,14 @@ func DeriveProfileNameFromDisplayName(
 	// then the profile name from the incoming request is used as the profile name
 
 	derivedName := name
-	counter := 1
 
 	// check if the current project already has a profile with that name, then add a counter
-	for strings.Contains(strings.Join(existingProfileNames, " "), derivedName) {
+	for counter := 1; existingProfileNames[derivedName] != nil; counter++ {
 		derivedName = fmt.Sprintf("%s-%d", name, counter)
 		if len(derivedName) > profileNameMaxLength {
 			nameLength := profileNameMaxLength - len(fmt.Sprintf("-%d", counter))
 			derivedName = fmt.Sprintf("%s-%d", name[:nameLength], counter)
 		}
-		counter++
 	}
 	return derivedName
 

--- a/pkg/profiles/util_test.go
+++ b/pkg/profiles/util_test.go
@@ -742,7 +742,7 @@ func TestDeriveProfileNameFromDisplayName(t *testing.T) {
 				Name:        "",
 				DisplayName: "This is a very long display name that will exceed the limit when counter is added",
 			},
-			existingProfileNames: []string{"this_is_a_very_long_display_name_that_will_exceed_the_limit_when"},
+			existingProfileNames: []string{"this_is_a_very_long_display_name_that_will_exceed_the_limit_whe"},
 			expected:             "this_is_a_very_long_display_name_that_will_exceed_the_limit_w-1",
 		},
 		{
@@ -752,7 +752,7 @@ func TestDeriveProfileNameFromDisplayName(t *testing.T) {
 				DisplayName: "This is a very long display name that will exceed the limit when counter is added",
 			},
 			existingProfileNames: []string{
-				"this_is_a_very_long_display_name_that_will_exceed_the_limit_when",
+				"this_is_a_very_long_display_name_that_will_exceed_the_limit_whe",
 				"this_is_a_very_long_display_name_that_will_exceed_the_limit_w-1",
 				"this_is_a_very_long_display_name_that_will_exceed_the_limit_w-2",
 				"this_is_a_very_long_display_name_that_will_exceed_the_limit_w-3",
@@ -772,7 +772,13 @@ func TestDeriveProfileNameFromDisplayName(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			result := profiles.DeriveProfileNameFromDisplayName(tt.profile, tt.existingProfileNames)
+			emptyProfile := &minderv1.Profile{}
+			existingMap := make(map[string]*minderv1.Profile, len(tt.existingProfileNames))
+			for _, name := range tt.existingProfileNames {
+				existingMap[name] = emptyProfile
+			}
+
+			result := profiles.DeriveProfileNameFromDisplayName(tt.profile, existingMap)
 			if result != tt.expected {
 				t.Errorf("DeriveProfileNameFromDisplayName: for profile %+v, expected %s, but got %s", tt.profile, tt.expected, result)
 			}


### PR DESCRIPTION
# Summary

I was chasing a different bug, and noticed that CreateProfile was attempting to name unnamed profiles uniquely, but actually discarded the map of profile names.  Testing for membership in a map will also be faster (and more correct) than repeated `string.Contains`.  It turns out that some of the tests were also incorrect (wrong number of characters chopped), so fixed that as well.

# Testing

Verified via unit tests.
