### PR TITLE
Clean up profile handling, avoid doubling eval status in ListEvaluationResults

### DIFF
--- a/internal/controlplane/handlers_evalstatus.go
+++ b/internal/controlplane/handlers_evalstatus.go
@@ -4,6 +4,7 @@
 package controlplane
 
 import (
+	"cmp"
 	"context"
 	"database/sql"
 	"encoding/base64"
@@ -353,14 +354,12 @@ func (s *Server) ListEvaluationResults(
 		return nil, err
 	}
 
-	// Filter the profile and status lists to those in the reques params
-	profileList, profileStatusList = filterProfileLists(in, profileList, profileStatusList)
+	// Filter the profile and status lists to those in the request params
+	profileStatuses := filterProfileLists(in, profileList, profileStatusList)
 
 	// Do the final sort of all the data
-	entities, profileStatuses, statusByEntity, err := s.sortEntitiesEvaluationStatus(
-		ctx, s.store, profileList, profileStatusList, rtIndex, entIdIndex, entTypeIndex,
-		in.GetIncludeOutputs(),
-	)
+	entities, statusByEntity, err := s.sortEntitiesEvaluationStatus(
+		ctx, s.store, profileStatuses, rtIndex, entIdIndex, entTypeIndex, in.GetIncludeOutputs())
 	if err != nil {
 		return nil, fmt.Errorf("sorting rule evaluations: %w", err)
 	}
@@ -374,44 +373,36 @@ func (s *Server) ListEvaluationResults(
 // and compiles the unified entities map, the map of profile statuses and the
 // status by entity map that will be assembled into the evaluation status
 // response.
-//
-//nolint:gocyclo // This function is complex by nature
 func (s *Server) sortEntitiesEvaluationStatus(
 	ctx context.Context, store db.Store,
-	profileList []db.ListProfilesByProjectIDAndLabelRow,
-	profileStatusList map[uuid.UUID]db.GetProfileStatusByProjectRow,
+	profileStatuses map[uuid.UUID]*minderv1.ProfileStatus,
 	rtIndex, entIdIndex, entTypeIndex map[string]struct{},
 	includeOutputs bool,
 ) (
 	entities map[string]*minderv1.EntityTypedId,
-	profileStatuses map[uuid.UUID]*minderv1.ProfileStatus,
-	statusByEntity map[string]map[uuid.UUID][]*minderv1.RuleEvaluationStatus, err error,
+	statusByEntity map[string]map[uuid.UUID][]*minderv1.RuleEvaluationStatus,
+	err error,
 ) {
 	entities = map[string]*minderv1.EntityTypedId{}
-	profileStatuses = map[uuid.UUID]*minderv1.ProfileStatus{}
 	statusByEntity = map[string]map[uuid.UUID][]*minderv1.RuleEvaluationStatus{}
 
 	psc, err := propSvc.WithEntityCache(s.props, 0)
 	if err != nil {
-		return nil, nil, nil,
+		return nil, nil,
 			status.Errorf(codes.Internal, "error creating entity cache: %v", err)
 	}
 
-	for _, p := range profileList {
+	for profileID := range profileStatuses {
 		evals, err := store.ListRuleEvaluationsByProfileId(
 			ctx, db.ListRuleEvaluationsByProfileIdParams{
-				ProfileID:      p.Profile.ID,
+				ProfileID:      profileID,
 				IncludeOutputs: includeOutputs,
 			},
 		)
 		if err != nil {
-			if errors.Is(err, sql.ErrNoRows) {
-				return nil, nil, nil,
-					util.UserVisibleError(codes.NotFound, "profile not found")
-			}
-			return nil, nil, nil,
+			return nil, nil,
 				status.Errorf(codes.Internal,
-					"error reading evaluations from profile %q: %v", p.Profile.ID.String(), err)
+					"error reading evaluations from profile %q: %v", profileID.String(), err)
 		}
 
 		for _, e := range evals {
@@ -422,14 +413,6 @@ func (s *Server) sortEntitiesEvaluationStatus(
 
 			efp, err := psc.EntityWithPropertiesByID(ctx, e.EntityID, nil)
 			if err != nil {
-				if errors.Is(err, propSvc.ErrEntityNotFound) {
-					// If the entity is not found, log and skip
-					zerolog.Ctx(ctx).Error().
-						Str("entity_id", e.EntityID.String()).
-						Err(err).Msg("Entity not found while building rule evaluation status")
-					continue
-				}
-
 				zerolog.Ctx(ctx).Error().
 					Str("entity_id", e.EntityID.String()).
 					Err(err).Msg("error building entity for rule evaluation status")
@@ -439,7 +422,7 @@ func (s *Server) sortEntitiesEvaluationStatus(
 			ent := buildEntityFromEvaluation(efp)
 			entString := fmt.Sprintf("%s/%s", ent.Type, ent.Id)
 
-			/// If we're constrained to a single entity type, ignore others
+			// If we're constrained to a single entity type, ignore others
 			if _, ok := entTypeIndex[ent.Type.String()]; !ok && len(entTypeIndex) > 0 {
 				continue
 			}
@@ -451,11 +434,7 @@ func (s *Server) sortEntitiesEvaluationStatus(
 
 			entities[entString] = ent
 
-			if _, ok := profileStatuses[p.Profile.ID]; !ok {
-				profileStatuses[p.Profile.ID] = buildProfileStatus(&p, profileStatusList)
-			}
-
-			stat, err := s.buildRuleEvaluationStatusFromDBEvaluation(ctx, &p, e, efp)
+			stat, err := s.buildRuleEvaluationStatusFromDBEvaluation(ctx, profileID, e, efp)
 			if err != nil {
 				// A failure parsing the PR metadata points to a corrupt record. Log but don't err.
 				zerolog.Ctx(ctx).Error().Err(err).Msg("error building rule evaluation status")
@@ -463,11 +442,11 @@ func (s *Server) sortEntitiesEvaluationStatus(
 				if _, ok := statusByEntity[entString]; !ok {
 					statusByEntity[entString] = make(map[uuid.UUID][]*minderv1.RuleEvaluationStatus)
 				}
-				statusByEntity[entString][p.Profile.ID] = append(statusByEntity[entString][p.Profile.ID], stat)
+				statusByEntity[entString][profileID] = append(statusByEntity[entString][profileID], stat)
 			}
 		}
 	}
-	return entities, profileStatuses, statusByEntity, err
+	return entities, statusByEntity, err
 }
 
 // buildListEvaluationResponse builds the final response from the sorted and
@@ -571,6 +550,7 @@ func buildProjectsProfileList(
 
 		profileList = append(profileList, profiles...)
 	}
+	// profileProtos := profiles.MergeDatabaseListIntoProfiles(profileList)
 	return profileList, nil
 }
 
@@ -578,32 +558,36 @@ func filterProfileLists(
 	in *minderv1.ListEvaluationResultsRequest,
 	inProfileList []db.ListProfilesByProjectIDAndLabelRow,
 	inProfileStatus map[uuid.UUID]db.GetProfileStatusByProjectRow,
-) ([]db.ListProfilesByProjectIDAndLabelRow, map[uuid.UUID]db.GetProfileStatusByProjectRow) {
-	if in.GetProfile() == "" {
-		return inProfileList, inProfileStatus
-	}
-
-	outProfileList := []db.ListProfilesByProjectIDAndLabelRow{}
-	outProfileStatus := map[uuid.UUID]db.GetProfileStatusByProjectRow{}
+) map[uuid.UUID]*minderv1.ProfileStatus {
+	profileStatusMap := map[uuid.UUID]*minderv1.ProfileStatus{}
 
 	for _, p := range inProfileList {
-		if p.Profile.ID.String() == in.GetProfile() {
-			outProfileList = append(outProfileList, p)
+		profileID := p.Profile.ID
+		//nolint:staticcheck  // QF1001: Not applying DeMorgan's law as it's less clear.
+		if !(in.GetProfile() == "" || in.GetProfile() == profileID.String()) {
+			continue
 		}
+		profileStatus := &minderv1.ProfileStatus{
+			ProfileId:          profileID.String(),
+			ProfileName:        p.Profile.Name,
+			ProfileDisplayName: cmp.Or(p.Profile.DisplayName, p.Profile.Name),
+			LastUpdated:        timestamppb.New(p.Profile.UpdatedAt),
+		}
+		if ps, ok := inProfileStatus[profileID]; ok {
+			profileStatus.ProfileStatus = string(ps.ProfileStatus)
+		}
+
+		profileStatusMap[profileID] = profileStatus
 	}
 
-	if v, ok := inProfileStatus[uuid.MustParse(in.GetProfile())]; ok {
-		outProfileStatus[uuid.MustParse(in.GetProfile())] = v
-	}
-
-	return outProfileList, outProfileStatus
+	return profileStatusMap
 }
 
 // buildRuleEvaluationStatusFromDBEvaluation converts from an evaluation and a
 // profile from the database to a minder RuleEvaluationStatus
 func (s *Server) buildRuleEvaluationStatusFromDBEvaluation(
 	ctx context.Context,
-	profile *db.ListProfilesByProjectIDAndLabelRow, eval db.ListRuleEvaluationsByProfileIdRow,
+	profileID uuid.UUID, eval db.ListRuleEvaluationsByProfileIdRow,
 	efp *entmodels.EntityWithProperties,
 ) (*minderv1.RuleEvaluationStatus, error) {
 	guidance := ""
@@ -675,7 +659,7 @@ func (s *Server) buildRuleEvaluationStatusFromDBEvaluation(
 	res := &minderv1.RuleEvaluationStatus{
 		RuleEvaluationId:       eval.RuleEvaluationID.String(),
 		RuleId:                 eval.RuleTypeID.String(),
-		ProfileId:              profile.Profile.ID.String(),
+		ProfileId:              profileID.String(),
 		RuleName:               eval.RuleName,
 		Entity:                 string(eval.EntityType),
 		Status:                 string(eval.EvalStatus),
@@ -715,30 +699,6 @@ func buildEntityFromEvaluation(efp *entmodels.EntityWithProperties) *minderv1.En
 	}
 
 	return ent
-}
-
-// buildProfileStatus build a minderv1.ProfileStatus struct from a lookup row
-func buildProfileStatus(
-	row *db.ListProfilesByProjectIDAndLabelRow,
-	profileStatusList map[uuid.UUID]db.GetProfileStatusByProjectRow,
-) *minderv1.ProfileStatus {
-	pfStatus := ""
-	if _, ok := profileStatusList[row.Profile.ID]; ok {
-		pfStatus = string(profileStatusList[row.Profile.ID].ProfileStatus)
-	}
-
-	displayName := row.Profile.DisplayName
-	if displayName == "" {
-		displayName = row.Profile.Name
-	}
-
-	return &minderv1.ProfileStatus{
-		ProfileId:          row.Profile.ID.String(),
-		ProfileName:        row.Profile.Name,
-		ProfileDisplayName: displayName,
-		ProfileStatus:      pfStatus,
-		LastUpdated:        timestamppb.New(row.Profile.UpdatedAt),
-	}
 }
 
 // buildEvalResultAlertFromLRERow build the evaluation result alert from a

--- a/internal/controlplane/handlers_profile.go
+++ b/internal/controlplane/handlers_profile.go
@@ -116,7 +116,6 @@ func (s *Server) ListProfiles(ctx context.Context,
 	}
 
 	var resp minderv1.ListProfilesResponse
-	resp.Profiles = make([]*minderv1.Profile, 0, len(profiles))
 	profileMap := prof.MergeDatabaseListIntoProfiles(profiles)
 
 	// Sort the profiles by name to get a consistent order. This is important for UI.
@@ -126,6 +125,7 @@ func (s *Server) ListProfiles(ctx context.Context,
 	}
 	sort.Strings(profileNames)
 
+	resp.Profiles = make([]*minderv1.Profile, 0, len(profileNames))
 	for _, prfName := range profileNames {
 		profile := profileMap[prfName]
 		resp.Profiles = append(resp.Profiles, profile)

--- a/internal/controlplane/handlers_profile_test.go
+++ b/internal/controlplane/handlers_profile_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"slices"
 	"strings"
 	"testing"
 
@@ -1520,6 +1521,10 @@ func TestListProfiles(t *testing.T) {
 				t.Errorf("ListProfiles() got %d profiles, want %d", len(res.Profiles), len(tc.wantProfiles))
 				return
 			}
+
+			slices.SortFunc(res.Profiles, func(a, b *minderv1.Profile) int {
+				return strings.Compare(a.Name, b.Name)
+			})
 
 			for i, wantName := range tc.wantProfiles {
 				if res.Profiles[i].Name != wantName {

--- a/pkg/profiles/util.go
+++ b/pkg/profiles/util.go
@@ -180,11 +180,12 @@ func MergeDatabaseListIntoProfiles[T db.ProfileRow](ppl []T) map[string]*pb.Prof
 	for idx := range ppl {
 		p := ppl[idx]
 
+		profileID := p.GetProfile().ID.String()
+
 		// NOTE: names are unique within a given Provider & Project ID (Unique index),
 		// so we don't need to worry about collisions.
 		// first we check if profile already exists, if not we create a new one
-		if _, ok := profiles[p.GetProfile().Name]; !ok {
-			profileID := p.GetProfile().ID.String()
+		if _, ok := profiles[profileID]; !ok {
 			project := p.GetProfile().ProjectID.String()
 
 			displayName := p.GetProfile().DisplayName
@@ -192,7 +193,7 @@ func MergeDatabaseListIntoProfiles[T db.ProfileRow](ppl []T) map[string]*pb.Prof
 				displayName = p.GetProfile().Name
 			}
 
-			profiles[p.GetProfile().Name] = &pb.Profile{
+			newProfile := &pb.Profile{
 				Id:          &profileID,
 				Name:        p.GetProfile().Name,
 				DisplayName: displayName,
@@ -202,23 +203,23 @@ func MergeDatabaseListIntoProfiles[T db.ProfileRow](ppl []T) map[string]*pb.Prof
 			}
 
 			if p.GetProfile().Remediate.Valid {
-				profiles[p.GetProfile().Name].Remediate = proto.String(string(p.GetProfile().Remediate.ActionType))
+				newProfile.Remediate = proto.String(string(p.GetProfile().Remediate.ActionType))
 			} else {
-				profiles[p.GetProfile().Name].Remediate = proto.String(string(db.ActionTypeOff))
+				newProfile.Remediate = proto.String(string(db.ActionTypeOff))
 			}
 
 			if p.GetProfile().Alert.Valid {
-				profiles[p.GetProfile().Name].Alert = proto.String(string(p.GetProfile().Alert.ActionType))
+				newProfile.Alert = proto.String(string(p.GetProfile().Alert.ActionType))
 			} else {
-				profiles[p.GetProfile().Name].Alert = proto.String(string(db.ActionTypeOn))
+				newProfile.Alert = proto.String(string(db.ActionTypeOn))
 			}
 
-			selectorsToProfile(profiles[p.GetProfile().Name], p.GetSelectors())
+			selectorsToProfile(newProfile, p.GetSelectors())
+
+			profiles[profileID] = newProfile
 		}
-		if pm := rowInfoToProfileMap(
-			profiles[p.GetProfile().Name], p.GetEntityProfile(),
-			p.GetContextualRules()); pm != nil {
-			profiles[p.GetProfile().Name] = pm
+		if pm := rowInfoToProfileMap(profiles[profileID], p.GetEntityProfile(), p.GetContextualRules()); pm != nil {
+			profiles[profileID] = pm
 		}
 	}
 


### PR DESCRIPTION
# Summary

It turns out a profile which contains rules for multiple entity types will end up duplicating the evaluation results due to the (previous) logic handling profiles from ListProfilesByProjectIDAndLabel, which actually returns a row for each `entity_profiles` row.  `entity_profiles` separates out the repeated contextual ruletypes by entity, so a profile which applies to two entity types will produce two output rows.  The other callers of this query feed it through MengeDatabaseListIntoProfiles, which ends up building a map of profiles by (string) UUID, but ListEvaluationResults only needs a subset of data, and did not do this.

There was also a lot of convoluted passing of arrays and maps in the ListEvaluationResults function, which I've hopefully simplified.

# Testing

Unit testing and a small manual test.
