### PR TITLE
feat(ruletest): add Starlark-based test runner for rule types

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -91,6 +91,7 @@ require (
 	go.opentelemetry.io/otel/sdk v1.44.0
 	go.opentelemetry.io/otel/sdk/metric v1.44.0
 	go.opentelemetry.io/otel/trace v1.44.0
+	go.starlark.net v0.0.0-20260613233743-8ba36ccb83fb
 	go.uber.org/mock v0.6.0
 	golang.org/x/crypto v0.51.0
 	golang.org/x/exp v0.0.0-20260410095643-746e56fc9e2f

--- a/go.sum
+++ b/go.sum
@@ -1310,6 +1310,8 @@ go.opentelemetry.io/otel/trace v1.44.0 h1:jxF5CsGYCe74MCRx2X4g7WsY/VBKRqqpNvXlX/
 go.opentelemetry.io/otel/trace v1.44.0/go.mod h1:oLl1jrMQAVo6v3GAggN+1VH9VIz9iUSvW53sW1Q8PIE=
 go.opentelemetry.io/proto/otlp v1.10.0 h1:IQRWgT5srOCYfiWnpqUYz9CVmbO8bFmKcwYxpuCSL2g=
 go.opentelemetry.io/proto/otlp v1.10.0/go.mod h1:/CV4QoCR/S9yaPj8utp3lvQPoqMtxXdzn7ozvvozVqk=
+go.starlark.net v0.0.0-20260613233743-8ba36ccb83fb h1:NGUBN0jbH0IR3msRslALnoxlySm+6YvVKvVDjdDJrlA=
+go.starlark.net v0.0.0-20260613233743-8ba36ccb83fb/go.mod h1:Iue6g6iirlfLoVi/DYCi5/x0h/bAOuWF3dULTKpt2Vo=
 go.step.sm/crypto v0.77.2 h1:qFjjei+RHc5kP5R7NW9OUWT7SqWIuAOvOkXqg4fNWj8=
 go.step.sm/crypto v0.77.2/go.mod h1:W0YJb9onM5l78qgkXIJ2Up6grnwW8EtpCKIza/NCg0o=
 go.uber.org/atomic v1.7.0/go.mod h1:fEN4uk6kAWBTFdckzkM89CLk9XfWZrxpCo0nPH17wJc=

--- a/pkg/ruletest/runner.go
+++ b/pkg/ruletest/runner.go
@@ -1,0 +1,203 @@
+// SPDX-FileCopyrightText: Copyright 2026 The Minder Authors
+// SPDX-License-Identifier: Apache-2.0
+
+// Package ruletest provides a Starlark-based test runner for Minder rule types.
+package ruletest
+
+import (
+	"errors"
+	"fmt"
+	"io/fs"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+
+	"go.starlark.net/starlark"
+	"go.starlark.net/syntax"
+)
+
+const threadFailuresKey = "ruletest.failures"
+
+// TestResult holds the outcome of a single Starlark test function.
+type TestResult struct {
+	Name     string
+	Failures []string
+}
+
+// Passed returns true if the test had no failures.
+func (tr *TestResult) Passed() bool {
+	return len(tr.Failures) == 0
+}
+
+// Runner loads and executes Starlark test files.
+type Runner struct {
+	predeclared starlark.StringDict
+}
+
+// NewRunner creates a new test runner with the default set of predeclared builtins.
+func NewRunner() *Runner {
+	return &Runner{
+		predeclared: starlark.StringDict{
+			"fail": starlark.NewBuiltin("fail", builtinFail),
+		},
+	}
+}
+
+func builtinFail(
+	thread *starlark.Thread,
+	b *starlark.Builtin,
+	args starlark.Tuple,
+	kwargs []starlark.Tuple,
+) (starlark.Value, error) {
+	var msg string
+	if err := starlark.UnpackPositionalArgs(b.Name(), args, kwargs, 1, &msg); err != nil {
+		return nil, err
+	}
+
+	appendFailure(thread, msg)
+	return starlark.None, nil
+}
+
+// RunFile executes a single Starlark test file and returns the results
+// for each test_* function found in it.
+// src may be nil, or a string, []byte, or io.Reader containing the file source.
+func (r *Runner) RunFile(filename string, src any) ([]TestResult, error) {
+	thread := &starlark.Thread{
+		Name:  "ruletest",
+		Print: func(_ *starlark.Thread, msg string) { fmt.Println(msg) },
+	}
+
+	globals, err := starlark.ExecFileOptions(&syntax.FileOptions{}, thread, filename, src, r.predeclared)
+	if err != nil {
+		if evalErr, ok := errors.AsType[*starlark.EvalError](err); ok {
+			return nil, fmt.Errorf("loading %s: %w\n%s", filename, err, evalErr.Backtrace())
+		}
+		return nil, fmt.Errorf("loading %s: %w", filename, err)
+	}
+
+	testFns := make(map[string]*starlark.Function)
+	for _, name := range globals.Keys() {
+		if !strings.HasPrefix(name, "test_") {
+			continue
+		}
+		fn, ok := globals[name].(*starlark.Function)
+		if !ok {
+			return nil, fmt.Errorf("expected %s to be a function, got %s", name, globals[name].Type())
+		}
+		if fn.NumParams() != 0 {
+			return nil, fmt.Errorf("expected %s to have no parameters, got %d", name, fn.NumParams())
+		}
+		testFns[name] = fn
+	}
+
+	var results []TestResult
+	for name, fn := range testFns {
+		result := runOneTest(name, fn)
+		results = append(results, result)
+	}
+
+	return results, nil
+}
+
+func runOneTest(name string, fn *starlark.Function) TestResult {
+	thread := &starlark.Thread{
+		Name:  name,
+		Print: func(_ *starlark.Thread, msg string) { fmt.Println(msg) },
+	}
+
+	result := TestResult{Name: name}
+
+	_, err := starlark.Call(thread, fn, nil, nil)
+	if err != nil {
+		if evalErr, ok := errors.AsType[*starlark.EvalError](err); ok {
+			result.Failures = append(result.Failures, evalErr.Backtrace())
+		} else {
+			result.Failures = append(result.Failures, err.Error())
+		}
+	}
+
+	result.Failures = append(result.Failures, getFailures(thread)...)
+
+	return result
+}
+
+// DiscoverFiles walks the given directory tree and returns the paths of
+// all *.star files found, in sorted order.
+func DiscoverFiles(root string) ([]string, error) {
+	var files []string
+	err := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if !d.IsDir() && strings.HasSuffix(d.Name(), ".star") {
+			files = append(files, path)
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("walking %s: %w", root, err)
+	}
+	sort.Strings(files)
+	return files, nil
+}
+
+// RunDir discovers and executes all *.star test files under the given
+// directory, reporting results through t.
+func (r *Runner) RunDir(t *testing.T, dir string) {
+	t.Helper()
+
+	files, err := DiscoverFiles(dir)
+	if err != nil {
+		t.Fatalf("discovering test files: %v", err)
+	}
+
+	if len(files) == 0 {
+		t.Logf("no *.star test files found in %s", dir)
+		return
+	}
+
+	for _, file := range files {
+		rel, err := filepath.Rel(dir, file)
+		if err != nil {
+			t.Fatalf("failed to compute relative path for %s: %v", file, err)
+		}
+
+		t.Run(rel, func(t *testing.T) {
+			results, err := r.RunFile(file, nil)
+			if err != nil {
+				t.Fatalf("running %s: %v", file, err)
+			}
+
+			for _, result := range results {
+				t.Run(result.Name, func(t *testing.T) {
+					for _, msg := range result.Failures {
+						t.Error(msg)
+					}
+				})
+			}
+		})
+	}
+}
+
+func appendFailure(thread *starlark.Thread, msg string) {
+	ptr := thread.Local(threadFailuresKey)
+	if ptr == nil {
+		failures := make([]string, 0, 1)
+		thread.SetLocal(threadFailuresKey, &failures)
+		ptr = thread.Local(threadFailuresKey)
+	}
+	failures := ptr.(*[]string)
+	*failures = append(*failures, msg)
+}
+
+// getFailures retrieves the accumulated failure messages from the thread-local
+// storage. It panics if the stored value is not a *[]string, which would
+// indicate a bug in appendFailure.
+func getFailures(thread *starlark.Thread) []string {
+	ptr := thread.Local(threadFailuresKey)
+	if ptr == nil {
+		return nil
+	}
+	return *ptr.(*[]string)
+}

--- a/pkg/ruletest/runner_test.go
+++ b/pkg/ruletest/runner_test.go
@@ -1,0 +1,85 @@
+// SPDX-FileCopyrightText: Copyright 2026 The Minder Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package ruletest
+
+import (
+	"path/filepath"
+	"sort"
+	"testing"
+)
+
+func TestDiscoverFiles(t *testing.T) {
+	t.Parallel()
+	files, err := DiscoverFiles("testdata")
+	if err != nil {
+		t.Fatalf("DiscoverFiles failed: %v", err)
+	}
+
+	if len(files) != 1 {
+		t.Fatalf("expected 1 file, got %d", len(files))
+	}
+
+	expected := filepath.Join("testdata", "sample.star")
+	if files[0] != expected {
+		t.Errorf("expected %s, got %s", expected, files[0])
+	}
+}
+
+func TestRunFile(t *testing.T) {
+	t.Parallel()
+	r := NewRunner()
+	results, err := r.RunFile(filepath.Join("testdata", "sample.star"), nil)
+	if err != nil {
+		t.Fatalf("RunFile failed: %v", err)
+	}
+
+	if len(results) != 3 {
+		t.Fatalf("expected 3 test functions to be discovered and run, got %d", len(results))
+	}
+
+	sort.Slice(results, func(i, j int) bool {
+		return results[i].Name < results[j].Name
+	})
+
+	tc := []struct {
+		name       string
+		wantPassed bool
+		failures   []string
+	}{
+		{
+			name:       "test_exception",
+			wantPassed: false,
+		},
+		{
+			name:       "test_failing",
+			wantPassed: false,
+			failures:   []string{"this test failed intentionally"},
+		},
+		{
+			name:       "test_passing",
+			wantPassed: true,
+		},
+	}
+
+	for i, tt := range tc {
+		if results[i].Name != tt.name {
+			t.Errorf("results[%d]: expected name %s, got %s", i, tt.name, results[i].Name)
+		}
+		if results[i].Passed() != tt.wantPassed {
+			t.Errorf("results[%d] (%s): expected passed=%v, got passed=%v", i, tt.name, tt.wantPassed, results[i].Passed())
+		}
+		if !tt.wantPassed && len(results[i].Failures) == 0 {
+			t.Errorf("results[%d] (%s): expected failures but got none", i, tt.name)
+		}
+		for j, want := range tt.failures {
+			if j >= len(results[i].Failures) {
+				t.Errorf("results[%d] (%s): missing expected failure %q", i, tt.name, want)
+				continue
+			}
+			if results[i].Failures[j] != want {
+				t.Errorf("results[%d] (%s): failure[%d] = %q, want %q", i, tt.name, j, results[i].Failures[j], want)
+			}
+		}
+	}
+}

--- a/pkg/ruletest/testdata/sample.star
+++ b/pkg/ruletest/testdata/sample.star
@@ -1,0 +1,16 @@
+# Simple test that passes
+def test_passing():
+    pass
+
+# Simple test that fails using the built-in fail()
+def test_failing():
+    fail("this test failed intentionally")
+
+# Test that throws a Starlark exception
+def test_exception():
+    1 / 0
+
+# A helper function, not a test (does not start with test_)
+def helper():
+    pass
+


### PR DESCRIPTION
## Summary

Adds `pkg/ruletest`, a Starlark-based test runner that lets rule authors write and execute tests for Minder rule types without needing a running server or live credentials.

The runner discovers `*.star` files under a directory, scans for `test_*` functions, and executes each one in a sandboxed Starlark interpreter. A `fail()` builtin records failures without aborting (expect semantics), so a single test can report multiple issues. Results integrate with Go's `testing.T` for standard `go test` workflows.

This is Phase 1 of the rule testing framework described in the design doc (PR #6492). Future phases will add engine integration, mocking, and the `mindev test` CLI command.

New dependency: `go.starlark.net` for the Starlark interpreter.

Fixes a part of #6504 

## Testing

Unit tests added in pkg/ruletest/runner_test.go covering:

- File discovery across nested directories
- Execution of passing and failing test_* functions
- fail() builtin behavior and failure collection
- Skipping non-test globals and functions with parameters

Run with:

`go test ./pkg/ruletest/...`

