### PR TITLE
fix(oci): resolve artifact created time from image config

### DIFF
--- a/internal/providers/oci/oci.go
+++ b/internal/providers/oci/oci.go
@@ -126,9 +126,8 @@ func (o *OCI) GetReferrer(ctx context.Context, contname, tag, artifactType strin
 	return refer, nil
 }
 
-// GetManifest returns the manifest for the given tag of the given container in the given namespace
-// for the OCI provider. It returns the manifest as a golang struct given the OCI spec.
-func (o *OCI) GetManifest(ctx context.Context, contname, tag string) (*v1.Manifest, error) {
+// getImage returns the remote image for the given tag of the given container.
+func (o *OCI) getImage(ctx context.Context, contname, tag string) (v1.Image, error) {
 	ref, err := o.getReference(contname, tag)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get reference: %w", err)
@@ -137,6 +136,17 @@ func (o *OCI) GetManifest(ctx context.Context, contname, tag string) (*v1.Manife
 	img, err := remote.Image(ref, remote.WithContext(ctx), remote.WithUserAgent(constants.ServerUserAgent))
 	if err != nil {
 		return nil, fmt.Errorf("failed to get image: %w", err)
+	}
+
+	return img, nil
+}
+
+// GetManifest returns the manifest for the given tag of the given container in the given namespace
+// for the OCI provider. It returns the manifest as a golang struct given the OCI spec.
+func (o *OCI) GetManifest(ctx context.Context, contname, tag string) (*v1.Manifest, error) {
+	img, err := o.getImage(ctx, contname, tag)
+	if err != nil {
+		return nil, err
 	}
 
 	man, err := img.Manifest()
@@ -186,27 +196,19 @@ func (ov *OCI) GetArtifactVersions(
 	for _, t := range tags {
 		// TODO: We probably should try to surface errors while returning a subset
 		// of manifests.
-		man, err := ov.GetManifest(ctx, artifact.GetName(), t)
+		img, err := ov.getImage(ctx, artifact.GetName(), t)
 		if err != nil {
 			return nil, err
 		}
 
-		// NOTE/FIXME: This is going to be a hassle as not a lot of
-		// container images have the needed annotations. We'd need
-		// go down to a specific image configuration (e.g. for _some_
-		// architecture) to actually verify the creation date...
-		// Anybody has other ideas?
-		strcreated, ok := man.Annotations[imgspecv1.AnnotationCreated]
-		var createdAt time.Time
-		if ok {
-			// TODO: Verify if this is correct
-			createdAt, err = time.Parse(time.RFC3339, strcreated)
-			if err != nil {
-				return nil, fmt.Errorf("unable to get creation time for tag %s: %w", t, err)
-			}
-		} else {
-			// FIXME: This is a hack
-			createdAt = time.Now()
+		man, err := img.Manifest()
+		if err != nil {
+			return nil, fmt.Errorf("failed to get manifest for tag %s: %w", t, err)
+		}
+
+		createdAt, err := resolveCreatedAt(man, img.ConfigFile)
+		if err != nil {
+			return nil, fmt.Errorf("unable to get creation time for tag %s: %w", t, err)
 		}
 
 		if err := filter.IsSkippable(createdAt, []string{t}); err != nil {
@@ -229,6 +231,33 @@ func (ov *OCI) GetArtifactVersions(
 	}
 
 	return out, nil
+}
+
+// resolveCreatedAt determines the creation time of an artifact version. It
+// prefers the org.opencontainers.image.created manifest annotation and, when
+// that annotation is absent, falls back to the Created field of the image
+// configuration, which records the real build time. Unlike the previous
+// time.Now() fallback, the resolved value always reflects the image itself: a
+// zero or Unix-epoch timestamp is a legitimate reproducible-build value and is
+// preserved as-is rather than being overwritten with the current time. The
+// image config is passed as a getter so that the config blob is fetched only
+// when the annotation is absent, and so the resolution logic stays testable
+// without a registry.
+func resolveCreatedAt(man *v1.Manifest, configFile func() (*v1.ConfigFile, error)) (time.Time, error) {
+	if strcreated, ok := man.Annotations[imgspecv1.AnnotationCreated]; ok {
+		createdAt, err := time.Parse(time.RFC3339, strcreated)
+		if err != nil {
+			return time.Time{}, fmt.Errorf("parsing created annotation %q: %w", strcreated, err)
+		}
+		return createdAt, nil
+	}
+
+	cfg, err := configFile()
+	if err != nil {
+		return time.Time{}, fmt.Errorf("reading image config: %w", err)
+	}
+
+	return cfg.Created.Time, nil
 }
 
 // getReferenceString returns the reference string for a given container name and tag

--- a/internal/providers/oci/oci.go
+++ b/internal/providers/oci/oci.go
@@ -236,13 +236,11 @@ func (ov *OCI) GetArtifactVersions(
 // resolveCreatedAt determines the creation time of an artifact version. It
 // prefers the org.opencontainers.image.created manifest annotation and, when
 // that annotation is absent, falls back to the Created field of the image
-// configuration, which records the real build time. Unlike the previous
-// time.Now() fallback, the resolved value always reflects the image itself: a
-// zero or Unix-epoch timestamp is a legitimate reproducible-build value and is
-// preserved as-is rather than being overwritten with the current time. The
-// image config is passed as a getter so that the config blob is fetched only
-// when the annotation is absent, and so the resolution logic stays testable
-// without a registry.
+// configuration, which records the real build time. The resolved value always
+// reflects the image itself: a zero or Unix-epoch timestamp is a legitimate
+// reproducible-build value and is preserved as-is. The image config is passed
+// as a getter so that the config blob is fetched only when the annotation is
+// absent, and so the resolution logic stays testable without a registry.
 func resolveCreatedAt(man *v1.Manifest, configFile func() (*v1.ConfigFile, error)) (time.Time, error) {
 	if strcreated, ok := man.Annotations[imgspecv1.AnnotationCreated]; ok {
 		createdAt, err := time.Parse(time.RFC3339, strcreated)

--- a/internal/providers/oci/oci_test.go
+++ b/internal/providers/oci/oci_test.go
@@ -1,0 +1,98 @@
+// SPDX-FileCopyrightText: Copyright 2026 The Minder Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package oci
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	v1 "github.com/google/go-containerregistry/pkg/v1"
+	imgspecv1 "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestResolveCreatedAt(t *testing.T) {
+	t.Parallel()
+
+	buildTime := time.Date(2024, time.January, 2, 3, 4, 5, 0, time.UTC)
+	// poison is returned by the config getter for cases where the annotation is
+	// present: if the implementation wrongly consulted the config, the assertion
+	// against buildTime (or the expected error) would fail.
+	poison := time.Date(1999, time.December, 31, 23, 59, 59, 0, time.UTC)
+	epoch := time.Unix(0, 0).UTC()
+
+	configReturning := func(created time.Time) func() (*v1.ConfigFile, error) {
+		return func() (*v1.ConfigFile, error) {
+			return &v1.ConfigFile{Created: v1.Time{Time: created}}, nil
+		}
+	}
+	configFailing := func() (*v1.ConfigFile, error) {
+		return nil, errors.New("config blob unavailable")
+	}
+
+	tests := []struct {
+		name       string
+		man        *v1.Manifest
+		configFile func() (*v1.ConfigFile, error)
+		want       time.Time
+		wantErr    bool
+	}{
+		{
+			name: "annotation present is preferred over config",
+			man: &v1.Manifest{Annotations: map[string]string{
+				imgspecv1.AnnotationCreated: buildTime.Format(time.RFC3339),
+			}},
+			configFile: configReturning(poison),
+			want:       buildTime,
+		},
+		{
+			name: "invalid annotation returns error and does not use config",
+			man: &v1.Manifest{Annotations: map[string]string{
+				imgspecv1.AnnotationCreated: "not-a-timestamp",
+			}},
+			configFile: configReturning(poison),
+			wantErr:    true,
+		},
+		{
+			name:       "missing annotation falls back to config created",
+			man:        &v1.Manifest{},
+			configFile: configReturning(buildTime),
+			want:       buildTime,
+		},
+		{
+			name:       "epoch config timestamp is preserved",
+			man:        &v1.Manifest{Annotations: map[string]string{}},
+			configFile: configReturning(epoch),
+			want:       epoch,
+		},
+		{
+			name:       "zero config timestamp is preserved",
+			man:        &v1.Manifest{},
+			configFile: configReturning(time.Time{}),
+			want:       time.Time{},
+		},
+		{
+			name:       "config fetch error is propagated",
+			man:        &v1.Manifest{},
+			configFile: configFailing,
+			wantErr:    true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := resolveCreatedAt(tc.man, tc.configFile)
+			if tc.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Truef(t, got.Equal(tc.want), "got %s, want %s", got, tc.want)
+		})
+	}
+}


### PR DESCRIPTION
# Summary

`GetArtifactVersions` fell back to `time.Now()` when an image manifest lacked the
`org.opencontainers.image.created` annotation (a `// FIXME: This is a hack`), so
artifacts without that annotation were recorded as "created right now", silently
breaking age-based filtering and lifecycle policies.

This reads the real build time from the image config blob instead: it prefers the
manifest annotation and, when absent, falls back to the image config's `Created`
field (`img.ConfigFile().Created`). A zero or Unix-epoch timestamp is a legitimate
reproducible-build value and is preserved as-is rather than overwritten with the
current time.

The created-date resolution is extracted into a pure helper (`resolveCreatedAt`) so
it is unit-testable without a registry, and a `getImage` helper lets the same fetched
image serve both the manifest and the config lookup.

Note: for a multi-arch image index lacking the annotation, the config now resolves to
the default platform's build time (or surfaces a config-read error) where the old hack
always returned `time.Now()`.

Fixes #6490

# Testing

- Added `internal/providers/oci/oci_test.go`: table-driven unit test for `resolveCreatedAt`
  (annotation present / invalid / absent→config / epoch preserved / zero preserved / config error).
- `go test ./internal/providers/oci/...` — pass
- `go vet ./internal/providers/oci/...` — clean
- `golangci-lint run ./internal/providers/oci/...` — 0 issues