### PR TITLE
feat(ruletest): implement starlark eval built-in and assert module

### DIFF
--- a/pkg/ruletest/eval.go
+++ b/pkg/ruletest/eval.go
@@ -1,0 +1,100 @@
+// SPDX-FileCopyrightText: Copyright 2026 The Minder Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package ruletest
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"path/filepath"
+
+	"go.starlark.net/starlark"
+
+	minderv1 "github.com/mindersec/minder/pkg/api/protobuf/go/minder/v1"
+	"github.com/mindersec/minder/pkg/engine/v1/interfaces"
+	"github.com/mindersec/minder/pkg/engine/v1/rtengine"
+	"github.com/mindersec/minder/pkg/fileconvert"
+)
+
+func builtinEval(
+	thread *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple,
+) (starlark.Value, error) {
+	var rulePath string
+	var entityDict *starlark.Dict
+	var profileDict *starlark.Dict
+
+	err := starlark.UnpackArgs("eval", args, kwargs,
+		"rule", &rulePath, "entity?", &entityDict, "profile?", &profileDict)
+	if err != nil {
+		return nil, err
+	}
+
+	if !filepath.IsAbs(rulePath) {
+		callerFrame := thread.CallFrame(1)
+		if callerFile := callerFrame.Pos.Filename(); callerFile != "" {
+			rulePath = filepath.Join(filepath.Dir(callerFile), rulePath)
+		}
+	}
+
+	decoder, closer := fileconvert.DecoderForFile(rulePath)
+	if decoder == nil {
+		return nil, fmt.Errorf("error opening file: %s", rulePath)
+	}
+	defer closer.Close()
+
+	rt, err := fileconvert.ReadResourceTyped[*minderv1.RuleType](decoder)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse rule type: %w", err)
+	}
+
+	profileMap, err := dictToGoMap(profileDict)
+	if err != nil {
+		return nil, fmt.Errorf("invalid profile argument: %w", err)
+	}
+
+	entityMap, err := dictToGoMap(entityDict)
+	if err != nil {
+		return nil, fmt.Errorf("invalid entity argument: %w", err)
+	}
+
+	ctx := context.Background()
+	evaluator, err := rtengine.NewRuleEvaluator(ctx, rt, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to initialize rule evaluator: %w", err)
+	}
+
+	ingested := &interfaces.Ingested{Object: entityMap}
+	_, evalErr := evaluator.Eval(ctx, profileMap, nil, ingested)
+
+	return formatEvalResult(evalErr), nil
+}
+
+func formatEvalResult(evalErr error) *starlark.Dict {
+	result := starlark.NewDict(2)
+	status, msg := "", ""
+
+	switch {
+	case evalErr == nil:
+		status = "pass"
+	case errors.Is(evalErr, interfaces.ErrEvaluationFailed):
+		status = "fail"
+		msg = evalErr.Error()
+		var details interfaces.EvalError
+		if errors.As(evalErr, &details) {
+			msg = fmt.Sprintf("%s: %s", msg, details.Details())
+		}
+	case errors.Is(evalErr, interfaces.ErrEvaluationSkipped):
+		status = "skip"
+		msg = evalErr.Error()
+	default:
+		status = "error"
+		msg = evalErr.Error()
+	}
+
+	// We ignore the error from SetKey because result is a new Dict we just created
+	// and we know it's not frozen, and the keys are valid strings.
+	_ = result.SetKey(starlark.String("status"), starlark.String(status))
+	_ = result.SetKey(starlark.String("message"), starlark.String(msg))
+	return result
+}

--- a/pkg/ruletest/runner.go
+++ b/pkg/ruletest/runner.go
@@ -14,6 +14,7 @@ import (
 	"testing"
 
 	"go.starlark.net/starlark"
+	"go.starlark.net/starlarktest"
 	"go.starlark.net/syntax"
 )
 
@@ -37,10 +38,21 @@ type Runner struct {
 
 // NewRunner creates a new test runner with the default set of predeclared builtins.
 func NewRunner() *Runner {
+	assertMod, err := starlarktest.LoadAssertModule()
+	if err != nil {
+		panic(fmt.Errorf("failed to load starlarktest assert module: %w", err))
+	}
+
+	predeclared := starlark.StringDict{
+		"fail": starlark.NewBuiltin("fail", builtinFail),
+		"eval": starlark.NewBuiltin("eval", builtinEval),
+	}
+	for k, v := range assertMod {
+		predeclared[k] = v
+	}
+
 	return &Runner{
-		predeclared: starlark.StringDict{
-			"fail": starlark.NewBuiltin("fail", builtinFail),
-		},
+		predeclared: predeclared,
 	}
 }
 
@@ -63,10 +75,7 @@ func builtinFail(
 // for each test_* function found in it.
 // src may be nil, or a string, []byte, or io.Reader containing the file source.
 func (r *Runner) RunFile(filename string, src any) ([]TestResult, error) {
-	thread := &starlark.Thread{
-		Name:  "ruletest",
-		Print: func(_ *starlark.Thread, msg string) { fmt.Println(msg) },
-	}
+	thread := r.newThread("ruletest")
 
 	globals, err := starlark.ExecFileOptions(&syntax.FileOptions{}, thread, filename, src, r.predeclared)
 	if err != nil {
@@ -93,18 +102,24 @@ func (r *Runner) RunFile(filename string, src any) ([]TestResult, error) {
 
 	var results []TestResult
 	for name, fn := range testFns {
-		result := runOneTest(name, fn)
+		result := r.runOneTest(name, fn)
 		results = append(results, result)
 	}
 
 	return results, nil
 }
 
-func runOneTest(name string, fn *starlark.Function) TestResult {
+func (*Runner) newThread(name string) *starlark.Thread {
 	thread := &starlark.Thread{
 		Name:  name,
 		Print: func(_ *starlark.Thread, msg string) { fmt.Println(msg) },
 	}
+	starlarktest.SetReporter(thread, threadReporter{thread})
+	return thread
+}
+
+func (r *Runner) runOneTest(name string, fn *starlark.Function) TestResult {
+	thread := r.newThread(name)
 
 	result := TestResult{Name: name}
 
@@ -189,6 +204,14 @@ func appendFailure(thread *starlark.Thread, msg string) {
 	}
 	failures := ptr.(*[]string)
 	*failures = append(*failures, msg)
+}
+
+type threadReporter struct {
+	thread *starlark.Thread
+}
+
+func (r threadReporter) Error(args ...any) {
+	appendFailure(r.thread, fmt.Sprint(args...))
 }
 
 // getFailures retrieves the accumulated failure messages from the thread-local

--- a/pkg/ruletest/runner_test.go
+++ b/pkg/ruletest/runner_test.go
@@ -16,13 +16,20 @@ func TestDiscoverFiles(t *testing.T) {
 		t.Fatalf("DiscoverFiles failed: %v", err)
 	}
 
-	if len(files) != 1 {
-		t.Fatalf("expected 1 file, got %d", len(files))
+	found := make(map[string]bool)
+	for _, f := range files {
+		found[f] = true
 	}
 
-	expected := filepath.Join("testdata", "sample.star")
-	if files[0] != expected {
-		t.Errorf("expected %s, got %s", expected, files[0])
+	expected := []string{
+		filepath.Join("testdata", "eval.star"),
+		filepath.Join("testdata", "sample.star"),
+	}
+
+	for _, exp := range expected {
+		if !found[exp] {
+			t.Errorf("expected to find %s, but it was missing", exp)
+		}
 	}
 }
 
@@ -81,5 +88,32 @@ func TestRunFile(t *testing.T) {
 				t.Errorf("results[%d] (%s): failure[%d] = %q, want %q", i, tt.name, j, results[i].Failures[j], want)
 			}
 		}
+	}
+}
+
+func TestRunEvalFile(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		file string
+	}{
+		{name: "eval", file: "eval.star"},
+	}
+
+	r := NewRunner()
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			results, err := r.RunFile(filepath.Join("testdata", tt.file), nil)
+			if err != nil {
+				t.Fatalf("RunFile failed for %s: %v", tt.file, err)
+			}
+			for _, res := range results {
+				if !res.Passed() {
+					t.Errorf("test %s failed: %v", res.Name, res.Failures)
+				}
+			}
+		})
 	}
 }

--- a/pkg/ruletest/starlark_util.go
+++ b/pkg/ruletest/starlark_util.go
@@ -1,0 +1,73 @@
+// SPDX-FileCopyrightText: Copyright 2026 The Minder Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package ruletest
+
+import (
+	"fmt"
+
+	"go.starlark.net/starlark"
+)
+
+// starlarkValueToGo converts a starlark.Value into its Go equivalent.
+func starlarkValueToGo(val starlark.Value) (any, error) {
+	switch v := val.(type) {
+	case starlark.NoneType:
+		return nil, nil
+	case starlark.Bool:
+		return bool(v), nil
+	case starlark.Int:
+		i, ok := v.Int64()
+		if !ok {
+			return nil, fmt.Errorf("starlark Int out of range")
+		}
+		return i, nil
+	case starlark.Float:
+		return float64(v), nil
+	case starlark.String:
+		return string(v), nil
+	case *starlark.List:
+		result := make([]any, v.Len())
+		for i := range v.Len() {
+			elem, err := starlarkValueToGo(v.Index(i))
+			if err != nil {
+				return nil, err
+			}
+			result[i] = elem
+		}
+		return result, nil
+	case *starlark.Dict:
+		result := make(map[string]any, v.Len())
+		for _, item := range v.Items() {
+			keyStr, ok := item[0].(starlark.String)
+			if !ok {
+				return nil, fmt.Errorf("dictionary key must be a string, got %s", item[0].Type())
+			}
+			goVal, err := starlarkValueToGo(item[1])
+			if err != nil {
+				return nil, fmt.Errorf("key %q: %w", keyStr, err)
+			}
+			result[string(keyStr)] = goVal
+		}
+		return result, nil
+	default:
+		return nil, fmt.Errorf("unsupported starlark type: %s", v.Type())
+	}
+}
+
+// dictToGoMap converts a starlark.Dict to map[string]any, defaulting to
+// an empty map when d is nil.
+func dictToGoMap(d *starlark.Dict) (map[string]any, error) {
+	if d == nil {
+		return map[string]any{}, nil
+	}
+	v, err := starlarkValueToGo(d)
+	if err != nil {
+		return nil, err
+	}
+	m, ok := v.(map[string]any)
+	if !ok {
+		return nil, fmt.Errorf("expected map[string]any, got %T", v)
+	}
+	return m, nil
+}

--- a/pkg/ruletest/starlark_util_test.go
+++ b/pkg/ruletest/starlark_util_test.go
@@ -1,0 +1,122 @@
+// SPDX-FileCopyrightText: Copyright 2026 The Minder Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package ruletest
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.starlark.net/starlark"
+)
+
+func TestStarlarkValueToGo(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name     string
+		input    starlark.Value
+		expected any
+		err      bool
+	}{
+		{
+			name:     "none",
+			input:    starlark.None,
+			expected: nil,
+		},
+		{
+			name:     "bool true",
+			input:    starlark.True,
+			expected: true,
+		},
+		{
+			name:     "bool false",
+			input:    starlark.False,
+			expected: false,
+		},
+		{
+			name:     "int",
+			input:    starlark.MakeInt(42),
+			expected: int64(42),
+		},
+		{
+			name:     "float",
+			input:    starlark.Float(3.14),
+			expected: float64(3.14),
+		},
+		{
+			name:     "string",
+			input:    starlark.String("hello"),
+			expected: "hello",
+		},
+		{
+			name: "list",
+			input: starlark.NewList([]starlark.Value{
+				starlark.String("a"),
+				starlark.MakeInt(1),
+			}),
+			expected: []any{"a", int64(1)},
+		},
+		{
+			name: "dict",
+			input: func() starlark.Value {
+				d := starlark.NewDict(2)
+				_ = d.SetKey(starlark.String("key1"), starlark.String("val1"))
+				_ = d.SetKey(starlark.String("key2"), starlark.MakeInt(2))
+				return d
+			}(),
+			expected: map[string]any{
+				"key1": "val1",
+				"key2": int64(2),
+			},
+		},
+		{
+			name: "nested dict",
+			input: func() starlark.Value {
+				inner := starlark.NewDict(1)
+				_ = inner.SetKey(starlark.String("innerKey"), starlark.String("innerVal"))
+
+				outer := starlark.NewDict(1)
+				_ = outer.SetKey(starlark.String("outerKey"), inner)
+				return outer
+			}(),
+			expected: map[string]any{
+				"outerKey": map[string]any{
+					"innerKey": "innerVal",
+				},
+			},
+		},
+		{
+			name: "dict with non-string key",
+			input: func() starlark.Value {
+				d := starlark.NewDict(1)
+				_ = d.SetKey(starlark.MakeInt(1), starlark.String("val"))
+				return d
+			}(),
+			expected: nil,
+			err:      true,
+		},
+		{
+			name:     "bytes unsupported",
+			input:    starlark.Bytes("unsupported"),
+			expected: nil,
+			err:      true,
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			res, err := starlarkValueToGo(tc.input)
+			if tc.err {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, tc.expected, res)
+			}
+		})
+	}
+}

--- a/pkg/ruletest/testdata/eval.star
+++ b/pkg/ruletest/testdata/eval.star
@@ -1,0 +1,19 @@
+# SPDX-FileCopyrightText: Copyright 2026 The Minder Authors
+# SPDX-License-Identifier: Apache-2.0
+
+def test_eval_success():
+    res = eval(
+        rule="rule_type_sample.yaml",
+        entity={"required_pull_request_reviews": {"required_approving_review_count": 2}},
+        profile={"required_reviews": 2},
+    )
+    assert.eq(res["status"], "pass")
+
+def test_eval_fail():
+    res = eval(
+        rule="rule_type_sample.yaml",
+        entity={"required_pull_request_reviews": {"required_approving_review_count": 1}},
+        profile={"required_reviews": 2},
+    )
+    assert.eq(res["status"], "fail")
+    assert.true(res["message"] != "")

--- a/pkg/ruletest/testdata/rule_type_sample.yaml
+++ b/pkg/ruletest/testdata/rule_type_sample.yaml
@@ -1,0 +1,43 @@
+# SPDX-FileCopyrightText: Copyright 2026 The Minder Authors
+# SPDX-License-Identifier: Apache-2.0
+
+version: v1
+type: rule-type
+name: branch_protection_reviews
+context:
+  project: 00000000-0000-0000-0000-000000000000
+description: 'Ensures that branch protection requires at least two approved reviews.'
+display_name: 'Require Branch Protection Reviews'
+release_phase: beta
+severity:
+  value: high
+guidance: |
+  To comply with this rule, you must enable branch protection on your main branch
+  and set the 'Required approving reviews' count to 2 or higher.
+def:
+  in_entity: repository
+  rule_schema:
+    properties:
+      required_reviews:
+        type: integer
+        default: 2
+  ingest:
+    type: rest
+    rest:
+      endpoint: '/repos/{{.Entity.Owner}}/{{.Entity.Name}}/branches/main/protection'
+      parse: 'json'
+  eval:
+    type: rego
+    rego:
+      type: 'deny-by-default'
+      def: |
+        package minder
+
+        import rego.v1
+
+        default allow := false
+
+        allow if {
+          # Check if the required review count meets our minimum
+          input.ingested.required_pull_request_reviews.required_approving_review_count >= input.profile.required_reviews
+        }


### PR DESCRIPTION
## Summary

This PR introduces the `eval` built-in function to the ruletest Starlark environment, allowing rule execution directly from test scripts using `eval(rule="...", profile={...}, entity={...})`. It also implements robust type conversion (`starlarkValueToGo`) to map Starlark dictionaries and lists back to native Go types, enabling proper execution of the underlying rule logic.

Additionally, while exploring the Starlark ecosystem to implement the `kwargs` design, I discovered and integrated the official `starlarktest` module (`go.starlark.net/starlarktest`). This replaces our manual `if/fail()` checks with the idiomatic `assert.eq()` and `assert.true()` testing pattern, making the Starlark test scripts much cleaner and more maintainable.

Adds 2nd part of #6504 

## Testing

- Added comprehensive table-driven unit tests in `starlark_util_test.go` to verify all type conversions (strings, ints, floats, bools, nested dicts, and lists).
- Updated `eval.star` and `sample.star` test fixtures to utilize the new `assert` module.
- Ran `go test -v ./pkg/ruletest/...` ensuring all 14 tests and sub-tests pass.
- Verified that Starlark thread errors (from failed assertions) are correctly surfaced as Go test failures via a custom `threadReporter`.