### PR TITLE
feat(ruletest): add eval core unit tests and clean up builtins

### DIFF
--- a/pkg/ruletest/eval_test.go
+++ b/pkg/ruletest/eval_test.go
@@ -5,8 +5,10 @@ package ruletest
 
 import (
 	"errors"
+	"strings"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	"go.starlark.net/starlark"
 
 	"github.com/mindersec/minder/pkg/engine/v1/interfaces"
@@ -52,20 +54,14 @@ func TestFormatEvalResult(t *testing.T) {
 			t.Parallel()
 			dict := formatEvalResult(tt.err)
 
-			v, found, err := dict.Get(starlark.String("status"))
-			if err != nil || !found {
-				t.Fatalf("failed to get status: %v", err)
-			}
-			if s, ok := v.(starlark.String); !ok || string(s) != tt.wantSt {
-				t.Errorf("status = %v, want %q", v, tt.wantSt)
+			result, err := dictToGoMap(dict)
+			if err != nil {
+				t.Fatalf("dictToGoMap failed: %v", err)
 			}
 
-			v, found, err = dict.Get(starlark.String("message"))
-			if err != nil || !found {
-				t.Fatalf("failed to get message: %v", err)
-			}
-			if s, ok := v.(starlark.String); !ok || string(s) != tt.wantMsg {
-				t.Errorf("message = %v, want %q", v, tt.wantMsg)
+			diff := cmp.Diff(result, map[string]any{"status": tt.wantSt, "message": tt.wantMsg})
+			if diff != "" {
+				t.Errorf("unexpected result: %s", diff)
 			}
 		})
 	}
@@ -108,8 +104,8 @@ func TestBuiltinEval_InvalidArgs(t *testing.T) {
 			if err == nil {
 				t.Fatal("expected error, got nil")
 			}
-			if err.Error() == "" {
-				t.Fatalf("error is empty")
+			if !strings.Contains(err.Error(), tt.wantErr) {
+				t.Errorf("error %q does not contain expected string %q", err.Error(), tt.wantErr)
 			}
 		})
 	}

--- a/pkg/ruletest/eval_test.go
+++ b/pkg/ruletest/eval_test.go
@@ -1,0 +1,116 @@
+// SPDX-FileCopyrightText: Copyright 2026 The Minder Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package ruletest
+
+import (
+	"errors"
+	"testing"
+
+	"go.starlark.net/starlark"
+
+	"github.com/mindersec/minder/pkg/engine/v1/interfaces"
+)
+
+func TestFormatEvalResult(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		err     error
+		wantSt  string
+		wantMsg string
+	}{
+		{
+			name:    "pass on nil error",
+			err:     nil,
+			wantSt:  "pass",
+			wantMsg: "",
+		},
+		{
+			name:    "fail on ErrEvaluationFailed",
+			err:     interfaces.ErrEvaluationFailed,
+			wantSt:  "fail",
+			wantMsg: interfaces.ErrEvaluationFailed.Error(),
+		},
+		{
+			name:    "skip on ErrEvaluationSkipped",
+			err:     interfaces.ErrEvaluationSkipped,
+			wantSt:  "skip",
+			wantMsg: interfaces.ErrEvaluationSkipped.Error(),
+		},
+		{
+			name:    "error on unknown error",
+			err:     errors.New("some unexpected error"),
+			wantSt:  "error",
+			wantMsg: "some unexpected error",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			dict := formatEvalResult(tt.err)
+
+			v, found, err := dict.Get(starlark.String("status"))
+			if err != nil || !found {
+				t.Fatalf("failed to get status: %v", err)
+			}
+			if s, ok := v.(starlark.String); !ok || string(s) != tt.wantSt {
+				t.Errorf("status = %v, want %q", v, tt.wantSt)
+			}
+
+			v, found, err = dict.Get(starlark.String("message"))
+			if err != nil || !found {
+				t.Fatalf("failed to get message: %v", err)
+			}
+			if s, ok := v.(starlark.String); !ok || string(s) != tt.wantMsg {
+				t.Errorf("message = %v, want %q", v, tt.wantMsg)
+			}
+		})
+	}
+}
+
+func TestBuiltinEval_InvalidArgs(t *testing.T) {
+	t.Parallel()
+
+	thread := &starlark.Thread{Name: "test"}
+
+	tests := []struct {
+		name    string
+		args    starlark.Tuple
+		kwargs  []starlark.Tuple
+		wantErr string
+	}{
+		{
+			name:    "missing rule param",
+			args:    starlark.Tuple{},
+			kwargs:  nil,
+			wantErr: "missing argument for rule",
+		},
+		{
+			name:    "rule not a string",
+			args:    starlark.Tuple{starlark.MakeInt(1)},
+			wantErr: "got int, want string",
+		},
+		{
+			name:    "invalid entity type",
+			args:    starlark.Tuple{starlark.String("rule.yaml")},
+			kwargs:  []starlark.Tuple{{starlark.String("entity"), starlark.String("not a dict")}},
+			wantErr: "got string, want dict",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			_, err := builtinEval(thread, starlark.NewBuiltin("eval", builtinEval), tt.args, tt.kwargs)
+			if err == nil {
+				t.Fatal("expected error, got nil")
+			}
+			if err.Error() == "" {
+				t.Fatalf("error is empty")
+			}
+		})
+	}
+}

--- a/pkg/ruletest/runner.go
+++ b/pkg/ruletest/runner.go
@@ -44,7 +44,6 @@ func NewRunner() *Runner {
 	}
 
 	predeclared := starlark.StringDict{
-		"fail": starlark.NewBuiltin("fail", builtinFail),
 		"eval": starlark.NewBuiltin("eval", builtinEval),
 	}
 	for k, v := range assertMod {
@@ -54,21 +53,6 @@ func NewRunner() *Runner {
 	return &Runner{
 		predeclared: predeclared,
 	}
-}
-
-func builtinFail(
-	thread *starlark.Thread,
-	b *starlark.Builtin,
-	args starlark.Tuple,
-	kwargs []starlark.Tuple,
-) (starlark.Value, error) {
-	var msg string
-	if err := starlark.UnpackPositionalArgs(b.Name(), args, kwargs, 1, &msg); err != nil {
-		return nil, err
-	}
-
-	appendFailure(thread, msg)
-	return starlark.None, nil
 }
 
 // RunFile executes a single Starlark test file and returns the results

--- a/pkg/ruletest/runner_test.go
+++ b/pkg/ruletest/runner_test.go
@@ -6,6 +6,7 @@ package ruletest
 import (
 	"path/filepath"
 	"sort"
+	"strings"
 	"testing"
 )
 
@@ -84,8 +85,8 @@ func TestRunFile(t *testing.T) {
 				t.Errorf("results[%d] (%s): missing expected failure %q", i, tt.name, want)
 				continue
 			}
-			if results[i].Failures[j] != want {
-				t.Errorf("results[%d] (%s): failure[%d] = %q, want %q", i, tt.name, j, results[i].Failures[j], want)
+			if !strings.Contains(results[i].Failures[j], want) {
+				t.Errorf("results[%d] (%s): failure[%d] = %q, want it to contain %q", i, tt.name, j, results[i].Failures[j], want)
 			}
 		}
 	}

--- a/pkg/ruletest/testdata/sample.star
+++ b/pkg/ruletest/testdata/sample.star
@@ -2,9 +2,9 @@
 def test_passing():
     pass
 
-# Simple test that fails using the built-in fail()
+# Simple test that fails using assert.fail()
 def test_failing():
-    fail("this test failed intentionally")
+    assert.fail("this test failed intentionally")
 
 # Test that throws a Starlark exception
 def test_exception():


### PR DESCRIPTION
## Summary

This PR addresses the final remaining items for the initial Starlark rule testing framework (part of #6504):

- Adds missing Go unit tests for the core `eval` flow in `pkg/ruletest/eval_test.go`.
- Removes the custom `fail()` built-in since `assert.fail` is already provided by the `go.starlark.net/starlarktest` module.

This ensures all code is properly isolated in `pkg/ruletest` and the core evaluation flow is fully tested in isolation.

Fixes the remaining items in #6504.