### PR TITLE
chore: minor cleanups from ruletest review

### DIFF
--- a/pkg/ruletest/builtins_file.go
+++ b/pkg/ruletest/builtins_file.go
@@ -6,7 +6,6 @@ package ruletest
 import (
 	"fmt"
 	"io/fs"
-	"strings"
 
 	"go.starlark.net/starlark"
 	"golang.org/x/tools/txtar"
@@ -26,9 +25,6 @@ func (tr *testCaseRunner) builtinReadFile(
 		return nil, err
 	}
 
-	if tr.fs == nil {
-		return nil, fmt.Errorf("read_file: no file system available in context")
-	}
 
 	// fs.ReadFile enforces unrooted, valid paths (preventing typical directory traversal)
 	data, err := fs.ReadFile(tr.fs, path)
@@ -57,7 +53,7 @@ func builtinTxtar(
 	dict := starlark.NewDict(len(archive.Files))
 
 	for _, f := range archive.Files {
-		key := starlark.String(strings.TrimSpace(f.Name))
+		key := starlark.String(f.Name)
 		val := starlark.String(string(f.Data))
 		if err := dict.SetKey(key, val); err != nil {
 			return nil, err

--- a/pkg/ruletest/runner.go
+++ b/pkg/ruletest/runner.go
@@ -29,6 +29,9 @@ type testCaseRunner struct {
 }
 
 func (r *Runner) newTestCaseRunner(name string, fileSystem fs.FS) *testCaseRunner {
+	if fileSystem == nil {
+		panic("fileSystem cannot be nil")
+	}
 	tr := &testCaseRunner{
 		fs:          fileSystem,
 		predeclared: starlark.StringDict{},
@@ -89,13 +92,14 @@ func NewRunner() *Runner {
 // for each test_* function found in it.
 // src may be nil, or a string, []byte, or io.Reader containing the file source.
 func (r *Runner) RunFile(filename string, src any) ([]TestResult, error) {
+	if filename == "" {
+		return nil, errors.New("filename cannot be empty")
+	}
+
 	baseDir := filepath.Dir(filename)
 	fileSystem := os.DirFS(baseDir)
 
-	name := "ruletest"
-	if filename != "" {
-		name = filepath.Base(filename)
-	}
+	name := filepath.Base(filename)
 	tr := r.newTestCaseRunner(name, fileSystem)
 
 	globals, err := tr.runFile(filename, src)


### PR DESCRIPTION
Addresses minor feedback from the ruletest PR review (#6530):
- Enforces `fileSystem != nil` invariant in `newTestCaseRunner`
- Returns error in `RunFile` if filename is empty
- Removes redundant `strings.TrimSpace` from `builtinTxtar`
- Removes unused `strings` import

Thanks @evankanderson for the review!