### PR TITLE
Introduce issue provider facet and issue remediation configuration

### DIFF
--- a/docs/docs/ref/proto.mdx
+++ b/docs/docs/ref/proto.mdx
@@ -2933,6 +2933,7 @@ Ingest defines how the data is ingested.
 | gh_branch_protection | <TypeLink type="minder-v1-RuleType-Definition-Remediate-GhBranchProtectionType">RuleType.Definition.Remediate.GhBranchProtectionType</TypeLink> | optional |  |
 | pull_request | <TypeLink type="minder-v1-RuleType-Definition-Remediate-PullRequestRemediation">RuleType.Definition.Remediate.PullRequestRemediation</TypeLink> | optional |  |
 | pull_request_comment | <TypeLink type="minder-v1-RuleType-Definition-Alert-AlertTypePRComment">RuleType.Definition.Alert.AlertTypePRComment</TypeLink> | optional |  |
+| issue | <TypeLink type="minder-v1-RuleType-Definition-Remediate-IssueRemediation">RuleType.Definition.Remediate.IssueRemediation</TypeLink> | optional |  |
 
 
 
@@ -2944,6 +2945,20 @@ Ingest defines how the data is ingested.
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
 | patch | <TypeLink type="string">string</TypeLink> |  |  |
+
+
+
+<Message id="minder-v1-RuleType-Definition-Remediate-IssueRemediation">RuleType.Definition.Remediate.IssueRemediation</Message>
+
+NOTE: Issue remediation is not yet implemented.
+This configuration is reserved for future support.
+"issue" is intentionally not a supported remediation type yet.
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| title | <TypeLink type="string">string</TypeLink> |  | the title of the issue Supports Minder's template interpolation syntax. This is not validated here as it will be validated by the repository provider, i.e. GitHub upon creation of the issue |
+| body | <TypeLink type="string">string</TypeLink> |  | the body of the issue Supports Minder's template interpolation syntax The rendered body is interpreted as Markdown by repository providers that support Markdown (e.g. Github) This is not validated here as it will be validated by the repository provider, i.e. GitHub upon creation of the issue |
 
 
 

--- a/internal/providers/github/common.go
+++ b/internal/providers/github/common.go
@@ -85,6 +85,9 @@ var _ provifv1.CommitStatusPublisher = (*GitHub)(nil)
 // Ensure that the GitHub client implements the ReviewPublisher interface
 var _ provifv1.ReviewPublisher = (*GitHub)(nil)
 
+// Ensure that the Github client implements the IssuePublisher interface
+var _ provifv1.IssuePublisher = (*GitHub)(nil)
+
 // ClientService is an interface for GitHub operations
 // It is used to mock GitHub operations in tests, but in order to generate
 // mocks, the interface must be exported
@@ -734,6 +737,78 @@ func (c *GitHub) ListPullRequests(
 	}
 
 	return prs, nil
+}
+
+// GetIssue get a single issue in repository
+func (c *GitHub) GetIssue(
+	ctx context.Context,
+	owner, repo string,
+	number int,
+) (*github.Issue, error) {
+	issue, _, err := c.client.Issues.Get(ctx, owner, repo, number)
+	if err != nil {
+		return nil, err
+	}
+	return issue, nil
+}
+
+// CreateIssue creates an issue in a repository
+func (c *GitHub) CreateIssue(
+	ctx context.Context,
+	owner, repo string,
+	title string,
+	body string,
+	labels []string,
+	assignees []string,
+) (*github.Issue, error) {
+	req := &github.IssueRequest{
+		Title: github.String(title),
+		Body:  github.String(body),
+	}
+	if len(labels) > 0 {
+		req.Labels = &labels
+	}
+	if len(assignees) > 0 {
+		req.Assignees = &assignees
+	}
+	issue, _, err := c.client.Issues.Create(ctx, owner, repo, req)
+	if err != nil {
+		return nil, err
+	}
+	return issue, nil
+}
+
+// CloseIssue closes an issue in a repository
+func (c *GitHub) CloseIssue(
+	ctx context.Context,
+	owner, repo string,
+	number int,
+	comment string,
+) (*github.Issue, error) {
+	_ = comment
+	// TODO: If comment is provided, create an issue comment before closing the issue.
+	issue, _, err := c.client.Issues.Edit(ctx, owner, repo, number, &github.IssueRequest{
+		State: github.String("closed"),
+	})
+	if err != nil {
+		return nil, err
+	}
+	return issue, nil
+}
+
+// ReopenIssue reopens an issue in a repository
+func (c *GitHub) ReopenIssue(
+	ctx context.Context,
+	owner, repo string,
+	number int,
+) (*github.Issue, error) {
+	issue, _, err := c.client.Issues.Edit(ctx, owner, repo, number, &github.IssueRequest{
+		State: github.String("open"),
+	})
+	if err != nil {
+		return nil, err
+	}
+	return issue, nil
 }
 
 // CreateIssueComment creates a comment on a pull request or an issue

--- a/internal/providers/github/mock/github.go
+++ b/internal/providers/github/mock/github.go
@@ -1107,6 +1107,206 @@ func (mr *MockReviewPublisherMockRecorder) UpdateReview(ctx, owner, repo, prNumb
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateReview", reflect.TypeOf((*MockReviewPublisher)(nil).UpdateReview), ctx, owner, repo, prNumber, reviewID, body)
 }
 
+// MockIssuePublisher is a mock of IssuePublisher interface.
+type MockIssuePublisher struct {
+	ctrl     *gomock.Controller
+	recorder *MockIssuePublisherMockRecorder
+	isgomock struct{}
+}
+
+// MockIssuePublisherMockRecorder is the mock recorder for MockIssuePublisher.
+type MockIssuePublisherMockRecorder struct {
+	mock *MockIssuePublisher
+}
+
+// NewMockIssuePublisher creates a new mock instance.
+func NewMockIssuePublisher(ctrl *gomock.Controller) *MockIssuePublisher {
+	mock := &MockIssuePublisher{ctrl: ctrl}
+	mock.recorder = &MockIssuePublisherMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MockIssuePublisher) EXPECT() *MockIssuePublisherMockRecorder {
+	return m.recorder
+}
+
+// CloseIssue mocks base method.
+func (m *MockIssuePublisher) CloseIssue(ctx context.Context, owner, repo string, number int, comment string) (*github.Issue, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CloseIssue", ctx, owner, repo, number, comment)
+	ret0, _ := ret[0].(*github.Issue)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// CloseIssue indicates an expected call of CloseIssue.
+func (mr *MockIssuePublisherMockRecorder) CloseIssue(ctx, owner, repo, number, comment any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CloseIssue", reflect.TypeOf((*MockIssuePublisher)(nil).CloseIssue), ctx, owner, repo, number, comment)
+}
+
+// CreateIssue mocks base method.
+func (m *MockIssuePublisher) CreateIssue(ctx context.Context, owner, repo, title, body string, labels, assignees []string) (*github.Issue, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CreateIssue", ctx, owner, repo, title, body, labels, assignees)
+	ret0, _ := ret[0].(*github.Issue)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// CreateIssue indicates an expected call of CreateIssue.
+func (mr *MockIssuePublisherMockRecorder) CreateIssue(ctx, owner, repo, title, body, labels, assignees any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateIssue", reflect.TypeOf((*MockIssuePublisher)(nil).CreateIssue), ctx, owner, repo, title, body, labels, assignees)
+}
+
+// CreationOptions mocks base method.
+func (m *MockIssuePublisher) CreationOptions(entType v10.Entity) *v11.EntityCreationOptions {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CreationOptions", entType)
+	ret0, _ := ret[0].(*v11.EntityCreationOptions)
+	return ret0
+}
+
+// CreationOptions indicates an expected call of CreationOptions.
+func (mr *MockIssuePublisherMockRecorder) CreationOptions(entType any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreationOptions", reflect.TypeOf((*MockIssuePublisher)(nil).CreationOptions), entType)
+}
+
+// DeregisterEntity mocks base method.
+func (m *MockIssuePublisher) DeregisterEntity(ctx context.Context, entType v10.Entity, props *properties.Properties) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeregisterEntity", ctx, entType, props)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DeregisterEntity indicates an expected call of DeregisterEntity.
+func (mr *MockIssuePublisherMockRecorder) DeregisterEntity(ctx, entType, props any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeregisterEntity", reflect.TypeOf((*MockIssuePublisher)(nil).DeregisterEntity), ctx, entType, props)
+}
+
+// FetchAllProperties mocks base method.
+func (m *MockIssuePublisher) FetchAllProperties(ctx context.Context, getByProps *properties.Properties, entType v10.Entity, cachedProps *properties.Properties) (*properties.Properties, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "FetchAllProperties", ctx, getByProps, entType, cachedProps)
+	ret0, _ := ret[0].(*properties.Properties)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// FetchAllProperties indicates an expected call of FetchAllProperties.
+func (mr *MockIssuePublisherMockRecorder) FetchAllProperties(ctx, getByProps, entType, cachedProps any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FetchAllProperties", reflect.TypeOf((*MockIssuePublisher)(nil).FetchAllProperties), ctx, getByProps, entType, cachedProps)
+}
+
+// GetEntityName mocks base method.
+func (m *MockIssuePublisher) GetEntityName(entType v10.Entity, props *properties.Properties) (string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetEntityName", entType, props)
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetEntityName indicates an expected call of GetEntityName.
+func (mr *MockIssuePublisherMockRecorder) GetEntityName(entType, props any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetEntityName", reflect.TypeOf((*MockIssuePublisher)(nil).GetEntityName), entType, props)
+}
+
+// GetIssue mocks base method.
+func (m *MockIssuePublisher) GetIssue(ctx context.Context, owner, repo string, number int) (*github.Issue, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetIssue", ctx, owner, repo, number)
+	ret0, _ := ret[0].(*github.Issue)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetIssue indicates an expected call of GetIssue.
+func (mr *MockIssuePublisherMockRecorder) GetIssue(ctx, owner, repo, number any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetIssue", reflect.TypeOf((*MockIssuePublisher)(nil).GetIssue), ctx, owner, repo, number)
+}
+
+// PropertiesToProtoMessage mocks base method.
+func (m *MockIssuePublisher) PropertiesToProtoMessage(entType v10.Entity, props *properties.Properties) (protoreflect.ProtoMessage, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "PropertiesToProtoMessage", entType, props)
+	ret0, _ := ret[0].(protoreflect.ProtoMessage)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// PropertiesToProtoMessage indicates an expected call of PropertiesToProtoMessage.
+func (mr *MockIssuePublisherMockRecorder) PropertiesToProtoMessage(entType, props any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PropertiesToProtoMessage", reflect.TypeOf((*MockIssuePublisher)(nil).PropertiesToProtoMessage), entType, props)
+}
+
+// ProviderClassInfo mocks base method.
+func (m *MockIssuePublisher) ProviderClassInfo() *v10.ProviderClassInfo {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ProviderClassInfo")
+	ret0, _ := ret[0].(*v10.ProviderClassInfo)
+	return ret0
+}
+
+// ProviderClassInfo indicates an expected call of ProviderClassInfo.
+func (mr *MockIssuePublisherMockRecorder) ProviderClassInfo() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ProviderClassInfo", reflect.TypeOf((*MockIssuePublisher)(nil).ProviderClassInfo))
+}
+
+// RegisterEntity mocks base method.
+func (m *MockIssuePublisher) RegisterEntity(ctx context.Context, entType v10.Entity, props *properties.Properties) (*properties.Properties, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "RegisterEntity", ctx, entType, props)
+	ret0, _ := ret[0].(*properties.Properties)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// RegisterEntity indicates an expected call of RegisterEntity.
+func (mr *MockIssuePublisherMockRecorder) RegisterEntity(ctx, entType, props any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RegisterEntity", reflect.TypeOf((*MockIssuePublisher)(nil).RegisterEntity), ctx, entType, props)
+}
+
+// ReopenIssue mocks base method.
+func (m *MockIssuePublisher) ReopenIssue(ctx context.Context, owner, repo string, number int) (*github.Issue, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ReopenIssue", ctx, owner, repo, number)
+	ret0, _ := ret[0].(*github.Issue)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ReopenIssue indicates an expected call of ReopenIssue.
+func (mr *MockIssuePublisherMockRecorder) ReopenIssue(ctx, owner, repo, number any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReopenIssue", reflect.TypeOf((*MockIssuePublisher)(nil).ReopenIssue), ctx, owner, repo, number)
+}
+
+// SupportsEntity mocks base method.
+func (m *MockIssuePublisher) SupportsEntity(entType v10.Entity) bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SupportsEntity", entType)
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// SupportsEntity indicates an expected call of SupportsEntity.
+func (mr *MockIssuePublisherMockRecorder) SupportsEntity(entType any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SupportsEntity", reflect.TypeOf((*MockIssuePublisher)(nil).SupportsEntity), entType)
+}
+
 // MockGitHub is a mock of GitHub interface.
 type MockGitHub struct {
 	ctrl     *gomock.Controller
@@ -1160,6 +1360,21 @@ func (mr *MockGitHubMockRecorder) Clone(ctx, url, branch any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Clone", reflect.TypeOf((*MockGitHub)(nil).Clone), ctx, url, branch)
 }
 
+// CloseIssue mocks base method.
+func (m *MockGitHub) CloseIssue(ctx context.Context, owner, repo string, number int, comment string) (*github.Issue, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CloseIssue", ctx, owner, repo, number, comment)
+	ret0, _ := ret[0].(*github.Issue)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// CloseIssue indicates an expected call of CloseIssue.
+func (mr *MockGitHubMockRecorder) CloseIssue(ctx, owner, repo, number, comment any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CloseIssue", reflect.TypeOf((*MockGitHub)(nil).CloseIssue), ctx, owner, repo, number, comment)
+}
+
 // ClosePullRequest mocks base method.
 func (m *MockGitHub) ClosePullRequest(ctx context.Context, owner, repo string, number int) (*github.PullRequest, error) {
 	m.ctrl.T.Helper()
@@ -1202,6 +1417,21 @@ func (m *MockGitHub) CreateHook(ctx context.Context, owner, repo string, hook *g
 func (mr *MockGitHubMockRecorder) CreateHook(ctx, owner, repo, hook any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateHook", reflect.TypeOf((*MockGitHub)(nil).CreateHook), ctx, owner, repo, hook)
+}
+
+// CreateIssue mocks base method.
+func (m *MockGitHub) CreateIssue(ctx context.Context, owner, repo, title, body string, labels, assignees []string) (*github.Issue, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CreateIssue", ctx, owner, repo, title, body, labels, assignees)
+	ret0, _ := ret[0].(*github.Issue)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// CreateIssue indicates an expected call of CreateIssue.
+func (mr *MockGitHubMockRecorder) CreateIssue(ctx, owner, repo, title, body, labels, assignees any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateIssue", reflect.TypeOf((*MockGitHub)(nil).CreateIssue), ctx, owner, repo, title, body, labels, assignees)
 }
 
 // CreateIssueComment mocks base method.
@@ -1437,6 +1667,21 @@ func (m *MockGitHub) GetEntityName(entType v10.Entity, props *properties.Propert
 func (mr *MockGitHubMockRecorder) GetEntityName(entType, props any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetEntityName", reflect.TypeOf((*MockGitHub)(nil).GetEntityName), entType, props)
+}
+
+// GetIssue mocks base method.
+func (m *MockGitHub) GetIssue(ctx context.Context, owner, repo string, number int) (*github.Issue, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetIssue", ctx, owner, repo, number)
+	ret0, _ := ret[0].(*github.Issue)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetIssue indicates an expected call of GetIssue.
+func (mr *MockGitHubMockRecorder) GetIssue(ctx, owner, repo, number any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetIssue", reflect.TypeOf((*MockGitHub)(nil).GetIssue), ctx, owner, repo, number)
 }
 
 // GetLogin mocks base method.
@@ -1765,6 +2010,21 @@ func (m *MockGitHub) RegisterEntity(ctx context.Context, entType v10.Entity, pro
 func (mr *MockGitHubMockRecorder) RegisterEntity(ctx, entType, props any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RegisterEntity", reflect.TypeOf((*MockGitHub)(nil).RegisterEntity), ctx, entType, props)
+}
+
+// ReopenIssue mocks base method.
+func (m *MockGitHub) ReopenIssue(ctx context.Context, owner, repo string, number int) (*github.Issue, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ReopenIssue", ctx, owner, repo, number)
+	ret0, _ := ret[0].(*github.Issue)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ReopenIssue indicates an expected call of ReopenIssue.
+func (mr *MockGitHubMockRecorder) ReopenIssue(ctx, owner, repo, number any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReopenIssue", reflect.TypeOf((*MockGitHub)(nil).ReopenIssue), ctx, owner, repo, number)
 }
 
 // SetCommitStatus mocks base method.

--- a/pkg/api/openapi/minder/v1/minder.swagger.json
+++ b/pkg/api/openapi/minder/v1/minder.swagger.json
@@ -3612,6 +3612,9 @@
         },
         "pullRequestComment": {
           "$ref": "#/definitions/AlertAlertTypePRComment"
+        },
+        "issue": {
+          "$ref": "#/definitions/RemediateIssueRemediation"
         }
       }
     },
@@ -3851,6 +3854,20 @@
           "type": "string"
         }
       }
+    },
+    "RemediateIssueRemediation": {
+      "type": "object",
+      "properties": {
+        "title": {
+          "type": "string",
+          "title": "the title of the issue\nSupports Minder's template interpolation syntax.\nThis is not validated here as it will be validated by the repository provider, i.e. GitHub upon\ncreation of the issue"
+        },
+        "body": {
+          "type": "string",
+          "title": "the body of the issue\nSupports Minder's template interpolation syntax\nThe rendered body is interpreted as Markdown by repository providers that\nsupport Markdown (e.g. Github)\nThis is not validated here as it will be validated by the repository provider, i.e. GitHub upon\ncreation of the issue"
+        }
+      },
+      "description": "NOTE: Issue remediation is not yet implemented.\nThis configuration is reserved for future support.\n\"issue\" is intentionally not a supported remediation type yet."
     },
     "RemediatePullRequestRemediation": {
       "type": "object",

--- a/pkg/api/protobuf/go/minder/v1/minder.pb.go
+++ b/pkg/api/protobuf/go/minder/v1/minder.pb.go
@@ -15102,7 +15102,7 @@ var File_minder_v1_minder_proto protoreflect.FileDescriptor
 
 const file_minder_v1_minder_proto_rawDesc = "" +
 	"\n" +
-	"\x16minder/v1/minder.proto\x12\tminder.v1\x1a\x1bbuf/validate/validate.proto\x1a\x1cgoogle/api/annotations.proto\x1a\x1fgoogle/api/field_behavior.proto\x1a google/protobuf/descriptor.proto\x1a google/protobuf/field_mask.proto\x1a\x1cgoogle/protobuf/struct.proto\x1a\x1fgoogle/protobuf/timestamp.proto\"\xb0\x01\n" +
+	"\x16minder/v1/minder.proto\x12\tminder.v1\x1a\x1cgoogle/api/annotations.proto\x1a\x1fgoogle/api/field_behavior.proto\x1a google/protobuf/descriptor.proto\x1a\x1fgoogle/protobuf/timestamp.proto\x1a\x1cgoogle/protobuf/struct.proto\x1a google/protobuf/field_mask.proto\x1a\x1bbuf/validate/validate.proto\"\xb0\x01\n" +
 	"\n" +
 	"RpcOptions\x12\x15\n" +
 	"\x06no_log\x18\x02 \x01(\bR\x05noLog\x12B\n" +

--- a/pkg/api/protobuf/go/minder/v1/minder.pb.go
+++ b/pkg/api/protobuf/go/minder/v1/minder.pb.go
@@ -13710,6 +13710,7 @@ type RuleType_Definition_Remediate struct {
 	GhBranchProtection *RuleType_Definition_Remediate_GhBranchProtectionType `protobuf:"bytes,3,opt,name=gh_branch_protection,json=ghBranchProtection,proto3,oneof" json:"gh_branch_protection,omitempty"`
 	PullRequest        *RuleType_Definition_Remediate_PullRequestRemediation `protobuf:"bytes,4,opt,name=pull_request,json=pullRequest,proto3,oneof" json:"pull_request,omitempty"`
 	PullRequestComment *RuleType_Definition_Alert_AlertTypePRComment         `protobuf:"bytes,5,opt,name=pull_request_comment,json=pullRequestComment,proto3,oneof" json:"pull_request_comment,omitempty"`
+	Issue              *RuleType_Definition_Remediate_IssueRemediation       `protobuf:"bytes,6,opt,name=issue,proto3,oneof" json:"issue,omitempty"`
 	unknownFields      protoimpl.UnknownFields
 	sizeCache          protoimpl.SizeCache
 }
@@ -13775,6 +13776,13 @@ func (x *RuleType_Definition_Remediate) GetPullRequest() *RuleType_Definition_Re
 func (x *RuleType_Definition_Remediate) GetPullRequestComment() *RuleType_Definition_Alert_AlertTypePRComment {
 	if x != nil {
 		return x.PullRequestComment
+	}
+	return nil
+}
+
+func (x *RuleType_Definition_Remediate) GetIssue() *RuleType_Definition_Remediate_IssueRemediation {
+	if x != nil {
+		return x.Issue
 	}
 	return nil
 }
@@ -14301,6 +14309,71 @@ func (x *RuleType_Definition_Remediate_PullRequestRemediation) GetActionsReplace
 	return nil
 }
 
+// NOTE: Issue remediation is not yet implemented.
+// This configuration is reserved for future support.
+// "issue" is intentionally not a supported remediation type yet.
+type RuleType_Definition_Remediate_IssueRemediation struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// the title of the issue
+	// Supports Minder's template interpolation syntax.
+	// This is not validated here as it will be validated by the repository provider, i.e. GitHub upon
+	// creation of the issue
+	Title string `protobuf:"bytes,1,opt,name=title,proto3" json:"title,omitempty"`
+	// the body of the issue
+	// Supports Minder's template interpolation syntax
+	// The rendered body is interpreted as Markdown by repository providers that
+	// support Markdown (e.g. Github)
+	// This is not validated here as it will be validated by the repository provider, i.e. GitHub upon
+	// creation of the issue
+	Body          string `protobuf:"bytes,2,opt,name=body,proto3" json:"body,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *RuleType_Definition_Remediate_IssueRemediation) Reset() {
+	*x = RuleType_Definition_Remediate_IssueRemediation{}
+	mi := &file_minder_v1_minder_proto_msgTypes[229]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *RuleType_Definition_Remediate_IssueRemediation) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*RuleType_Definition_Remediate_IssueRemediation) ProtoMessage() {}
+
+func (x *RuleType_Definition_Remediate_IssueRemediation) ProtoReflect() protoreflect.Message {
+	mi := &file_minder_v1_minder_proto_msgTypes[229]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use RuleType_Definition_Remediate_IssueRemediation.ProtoReflect.Descriptor instead.
+func (*RuleType_Definition_Remediate_IssueRemediation) Descriptor() ([]byte, []int) {
+	return file_minder_v1_minder_proto_rawDescGZIP(), []int{128, 0, 2, 2}
+}
+
+func (x *RuleType_Definition_Remediate_IssueRemediation) GetTitle() string {
+	if x != nil {
+		return x.Title
+	}
+	return ""
+}
+
+func (x *RuleType_Definition_Remediate_IssueRemediation) GetBody() string {
+	if x != nil {
+		return x.Body
+	}
+	return ""
+}
+
 type RuleType_Definition_Remediate_PullRequestRemediation_Content struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// the file to patch
@@ -14320,7 +14393,7 @@ type RuleType_Definition_Remediate_PullRequestRemediation_Content struct {
 
 func (x *RuleType_Definition_Remediate_PullRequestRemediation_Content) Reset() {
 	*x = RuleType_Definition_Remediate_PullRequestRemediation_Content{}
-	mi := &file_minder_v1_minder_proto_msgTypes[229]
+	mi := &file_minder_v1_minder_proto_msgTypes[230]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -14332,7 +14405,7 @@ func (x *RuleType_Definition_Remediate_PullRequestRemediation_Content) String() 
 func (*RuleType_Definition_Remediate_PullRequestRemediation_Content) ProtoMessage() {}
 
 func (x *RuleType_Definition_Remediate_PullRequestRemediation_Content) ProtoReflect() protoreflect.Message {
-	mi := &file_minder_v1_minder_proto_msgTypes[229]
+	mi := &file_minder_v1_minder_proto_msgTypes[230]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -14386,7 +14459,7 @@ type RuleType_Definition_Remediate_PullRequestRemediation_ActionsReplaceTagsWith
 
 func (x *RuleType_Definition_Remediate_PullRequestRemediation_ActionsReplaceTagsWithSha) Reset() {
 	*x = RuleType_Definition_Remediate_PullRequestRemediation_ActionsReplaceTagsWithSha{}
-	mi := &file_minder_v1_minder_proto_msgTypes[230]
+	mi := &file_minder_v1_minder_proto_msgTypes[231]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -14399,7 +14472,7 @@ func (*RuleType_Definition_Remediate_PullRequestRemediation_ActionsReplaceTagsWi
 }
 
 func (x *RuleType_Definition_Remediate_PullRequestRemediation_ActionsReplaceTagsWithSha) ProtoReflect() protoreflect.Message {
-	mi := &file_minder_v1_minder_proto_msgTypes[230]
+	mi := &file_minder_v1_minder_proto_msgTypes[231]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -14431,7 +14504,7 @@ type RuleType_Definition_Alert_AlertTypeSA struct {
 
 func (x *RuleType_Definition_Alert_AlertTypeSA) Reset() {
 	*x = RuleType_Definition_Alert_AlertTypeSA{}
-	mi := &file_minder_v1_minder_proto_msgTypes[231]
+	mi := &file_minder_v1_minder_proto_msgTypes[232]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -14443,7 +14516,7 @@ func (x *RuleType_Definition_Alert_AlertTypeSA) String() string {
 func (*RuleType_Definition_Alert_AlertTypeSA) ProtoMessage() {}
 
 func (x *RuleType_Definition_Alert_AlertTypeSA) ProtoReflect() protoreflect.Message {
-	mi := &file_minder_v1_minder_proto_msgTypes[231]
+	mi := &file_minder_v1_minder_proto_msgTypes[232]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -14479,7 +14552,7 @@ type RuleType_Definition_Alert_AlertTypePRComment struct {
 
 func (x *RuleType_Definition_Alert_AlertTypePRComment) Reset() {
 	*x = RuleType_Definition_Alert_AlertTypePRComment{}
-	mi := &file_minder_v1_minder_proto_msgTypes[232]
+	mi := &file_minder_v1_minder_proto_msgTypes[233]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -14491,7 +14564,7 @@ func (x *RuleType_Definition_Alert_AlertTypePRComment) String() string {
 func (*RuleType_Definition_Alert_AlertTypePRComment) ProtoMessage() {}
 
 func (x *RuleType_Definition_Alert_AlertTypePRComment) ProtoReflect() protoreflect.Message {
-	mi := &file_minder_v1_minder_proto_msgTypes[232]
+	mi := &file_minder_v1_minder_proto_msgTypes[233]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -14540,7 +14613,7 @@ type Profile_Rule struct {
 
 func (x *Profile_Rule) Reset() {
 	*x = Profile_Rule{}
-	mi := &file_minder_v1_minder_proto_msgTypes[233]
+	mi := &file_minder_v1_minder_proto_msgTypes[234]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -14552,7 +14625,7 @@ func (x *Profile_Rule) String() string {
 func (*Profile_Rule) ProtoMessage() {}
 
 func (x *Profile_Rule) ProtoReflect() protoreflect.Message {
-	mi := &file_minder_v1_minder_proto_msgTypes[233]
+	mi := &file_minder_v1_minder_proto_msgTypes[234]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -14612,7 +14685,7 @@ type Profile_Selector struct {
 
 func (x *Profile_Selector) Reset() {
 	*x = Profile_Selector{}
-	mi := &file_minder_v1_minder_proto_msgTypes[234]
+	mi := &file_minder_v1_minder_proto_msgTypes[235]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -14624,7 +14697,7 @@ func (x *Profile_Selector) String() string {
 func (*Profile_Selector) ProtoMessage() {}
 
 func (x *Profile_Selector) ProtoReflect() protoreflect.Message {
-	mi := &file_minder_v1_minder_proto_msgTypes[234]
+	mi := &file_minder_v1_minder_proto_msgTypes[235]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -14678,7 +14751,7 @@ type StructDataSource_Def struct {
 
 func (x *StructDataSource_Def) Reset() {
 	*x = StructDataSource_Def{}
-	mi := &file_minder_v1_minder_proto_msgTypes[236]
+	mi := &file_minder_v1_minder_proto_msgTypes[237]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -14690,7 +14763,7 @@ func (x *StructDataSource_Def) String() string {
 func (*StructDataSource_Def) ProtoMessage() {}
 
 func (x *StructDataSource_Def) ProtoReflect() protoreflect.Message {
-	mi := &file_minder_v1_minder_proto_msgTypes[236]
+	mi := &file_minder_v1_minder_proto_msgTypes[237]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -14723,7 +14796,7 @@ type StructDataSource_Def_Path struct {
 
 func (x *StructDataSource_Def_Path) Reset() {
 	*x = StructDataSource_Def_Path{}
-	mi := &file_minder_v1_minder_proto_msgTypes[238]
+	mi := &file_minder_v1_minder_proto_msgTypes[239]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -14735,7 +14808,7 @@ func (x *StructDataSource_Def_Path) String() string {
 func (*StructDataSource_Def_Path) ProtoMessage() {}
 
 func (x *StructDataSource_Def_Path) ProtoReflect() protoreflect.Message {
-	mi := &file_minder_v1_minder_proto_msgTypes[238]
+	mi := &file_minder_v1_minder_proto_msgTypes[239]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -14803,7 +14876,7 @@ type RestDataSource_Def struct {
 
 func (x *RestDataSource_Def) Reset() {
 	*x = RestDataSource_Def{}
-	mi := &file_minder_v1_minder_proto_msgTypes[239]
+	mi := &file_minder_v1_minder_proto_msgTypes[240]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -14815,7 +14888,7 @@ func (x *RestDataSource_Def) String() string {
 func (*RestDataSource_Def) ProtoMessage() {}
 
 func (x *RestDataSource_Def) ProtoReflect() protoreflect.Message {
-	mi := &file_minder_v1_minder_proto_msgTypes[239]
+	mi := &file_minder_v1_minder_proto_msgTypes[240]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -14952,7 +15025,7 @@ type RestDataSource_Def_Fallback struct {
 
 func (x *RestDataSource_Def_Fallback) Reset() {
 	*x = RestDataSource_Def_Fallback{}
-	mi := &file_minder_v1_minder_proto_msgTypes[242]
+	mi := &file_minder_v1_minder_proto_msgTypes[243]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -14964,7 +15037,7 @@ func (x *RestDataSource_Def_Fallback) String() string {
 func (*RestDataSource_Def_Fallback) ProtoMessage() {}
 
 func (x *RestDataSource_Def_Fallback) ProtoReflect() protoreflect.Message {
-	mi := &file_minder_v1_minder_proto_msgTypes[242]
+	mi := &file_minder_v1_minder_proto_msgTypes[243]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -15029,7 +15102,7 @@ var File_minder_v1_minder_proto protoreflect.FileDescriptor
 
 const file_minder_v1_minder_proto_rawDesc = "" +
 	"\n" +
-	"\x16minder/v1/minder.proto\x12\tminder.v1\x1a\x1cgoogle/api/annotations.proto\x1a\x1fgoogle/api/field_behavior.proto\x1a google/protobuf/descriptor.proto\x1a\x1fgoogle/protobuf/timestamp.proto\x1a\x1cgoogle/protobuf/struct.proto\x1a google/protobuf/field_mask.proto\x1a\x1bbuf/validate/validate.proto\"\xb0\x01\n" +
+	"\x16minder/v1/minder.proto\x12\tminder.v1\x1a\x1bbuf/validate/validate.proto\x1a\x1cgoogle/api/annotations.proto\x1a\x1fgoogle/api/field_behavior.proto\x1a google/protobuf/descriptor.proto\x1a google/protobuf/field_mask.proto\x1a\x1cgoogle/protobuf/struct.proto\x1a\x1fgoogle/protobuf/timestamp.proto\"\xb0\x01\n" +
 	"\n" +
 	"RpcOptions\x12\x15\n" +
 	"\x06no_log\x18\x02 \x01(\bR\x05noLog\x12B\n" +
@@ -15563,7 +15636,7 @@ const file_minder_v1_minder_proto_rawDesc = "" +
 	"\xea\xdc\x14\x06medium\x12\x18\n" +
 	"\n" +
 	"VALUE_HIGH\x10\x05\x1a\b\xea\xdc\x14\x04high\x12 \n" +
-	"\x0eVALUE_CRITICAL\x10\x06\x1a\f\xea\xdc\x14\bcritical\"\xed%\n" +
+	"\x0eVALUE_CRITICAL\x10\x06\x1a\f\xea\xdc\x14\bcritical\"\xa3'\n" +
 	"\bRuleType\x12&\n" +
 	"\aversion\x18\v \x01(\tB\f\xbaH\tr\a2\x05^v\\d$R\aversion\x12$\n" +
 	"\x04type\x18\f \x01(\tB\x10\xbaH\rr\v2\trule-typeR\x04type\x12 \n" +
@@ -15577,7 +15650,7 @@ const file_minder_v1_minder_proto_rawDesc = "" +
 	"\vdescription\x18\x05 \x01(\tB\r\xe0A\x02\xbaH\ar\x05\x10\x01\x18\xdc\vR\vdescription\x12)\n" +
 	"\bguidance\x18\x06 \x01(\tB\r\xe0A\x02\xbaH\ar\x05\x10\x01\x18\xe8\aR\bguidance\x12/\n" +
 	"\bseverity\x18\a \x01(\v2\x13.minder.v1.SeverityR\bseverity\x12D\n" +
-	"\rrelease_phase\x18\t \x01(\x0e2\x1f.minder.v1.RuleTypeReleasePhaseR\freleasePhase\x1a\xe8 \n" +
+	"\rrelease_phase\x18\t \x01(\x0e2\x1f.minder.v1.RuleTypeReleasePhaseR\freleasePhase\x1a\x9e\"\n" +
 	"\n" +
 	"Definition\x12;\n" +
 	"\tin_entity\x18\x01 \x01(\tB\x1e\xbaH\x1br\x19\x10\x01\x18\xc8\x012\x12^[a-z]+(_[a-z]+)*$R\binEntity\x128\n" +
@@ -15635,13 +15708,14 @@ const file_minder_v1_minder_proto_rawDesc = "" +
 	"\n" +
 	"_vulncheckB\t\n" +
 	"\a_trustyB\r\n" +
-	"\v_homoglyphs\x1a\xb8\v\n" +
+	"\v_homoglyphs\x1a\xee\f\n" +
 	"\tRemediate\x12\\\n" +
 	"\x04type\x18\x01 \x01(\tBH\xbaHE\xd8\x01\x01r@R\x04restR\x14gh_branch_protectionR\fpull_requestR\x14pull_request_commentR\x04type\x12,\n" +
 	"\x04rest\x18\x02 \x01(\v2\x13.minder.v1.RestTypeH\x00R\x04rest\x88\x01\x01\x12v\n" +
 	"\x14gh_branch_protection\x18\x03 \x01(\v2?.minder.v1.RuleType.Definition.Remediate.GhBranchProtectionTypeH\x01R\x12ghBranchProtection\x88\x01\x01\x12g\n" +
 	"\fpull_request\x18\x04 \x01(\v2?.minder.v1.RuleType.Definition.Remediate.PullRequestRemediationH\x02R\vpullRequest\x88\x01\x01\x12n\n" +
-	"\x14pull_request_comment\x18\x05 \x01(\v27.minder.v1.RuleType.Definition.Alert.AlertTypePRCommentH\x03R\x12pullRequestComment\x88\x01\x01\x1a;\n" +
+	"\x14pull_request_comment\x18\x05 \x01(\v27.minder.v1.RuleType.Definition.Alert.AlertTypePRCommentH\x03R\x12pullRequestComment\x88\x01\x01\x12T\n" +
+	"\x05issue\x18\x06 \x01(\v29.minder.v1.RuleType.Definition.Remediate.IssueRemediationH\x04R\x05issue\x88\x01\x01\x1a;\n" +
 	"\x16GhBranchProtectionType\x12!\n" +
 	"\x05patch\x18\x01 \x01(\tB\v\xbaH\b\xd8\x01\x01r\x03\x18\xe8\aR\x05patch\x1a\xc4\x06\n" +
 	"\x16PullRequestRemediation\x12\x1f\n" +
@@ -15660,11 +15734,15 @@ const file_minder_v1_minder_proto_rawDesc = "" +
 	"\x05_mode\x1a}\n" +
 	"\x19ActionsReplaceTagsWithSha\x12`\n" +
 	"\aexclude\x18\x01 \x03(\tBF\xbaHC\x92\x01@\">r<\x18\xc8\x0127^\\.?([[:word:].-]+\\/)*[[:word:].-]+(?:\\.[[:alnum:]]+)?$R\aexcludeB \n" +
-	"\x1e_actions_replace_tags_with_shaB\a\n" +
+	"\x1e_actions_replace_tags_with_sha\x1aT\n" +
+	"\x10IssueRemediation\x12\x1f\n" +
+	"\x05title\x18\x01 \x01(\tB\t\xbaH\x06r\x04\x10\x01\x18KR\x05title\x12\x1f\n" +
+	"\x04body\x18\x02 \x01(\tB\v\xbaH\br\x06\x10\x01\x18\x80\x80\x04R\x04bodyB\a\n" +
 	"\x05_restB\x17\n" +
 	"\x15_gh_branch_protectionB\x0f\n" +
 	"\r_pull_requestB\x17\n" +
-	"\x15_pull_request_comment\x1a\xc7\x04\n" +
+	"\x15_pull_request_commentB\b\n" +
+	"\x06_issue\x1a\xc7\x04\n" +
 	"\x05Alert\x12E\n" +
 	"\x04type\x18\x01 \x01(\tB1\xbaH.\xd8\x01\x01r)R\x11security_advisoryR\x14pull_request_commentR\x04type\x12b\n" +
 	"\x11security_advisory\x18\x02 \x01(\v20.minder.v1.RuleType.Definition.Alert.AlertTypeSAH\x00R\x10securityAdvisory\x88\x01\x01\x12n\n" +
@@ -16288,7 +16366,7 @@ func file_minder_v1_minder_proto_rawDescGZIP() []byte {
 }
 
 var file_minder_v1_minder_proto_enumTypes = make([]protoimpl.EnumInfo, 10)
-var file_minder_v1_minder_proto_msgTypes = make([]protoimpl.MessageInfo, 243)
+var file_minder_v1_minder_proto_msgTypes = make([]protoimpl.MessageInfo, 244)
 var file_minder_v1_minder_proto_goTypes = []any{
 	(ObjectOwner)(0),                                   // 0: minder.v1.ObjectOwner
 	(Relation)(0),                                      // 1: minder.v1.Relation
@@ -16529,26 +16607,27 @@ var file_minder_v1_minder_proto_goTypes = []any{
 	(*RuleType_Definition_Eval_JQComparison_Operator)(nil),                                 // 236: minder.v1.RuleType.Definition.Eval.JQComparison.Operator
 	(*RuleType_Definition_Remediate_GhBranchProtectionType)(nil),                           // 237: minder.v1.RuleType.Definition.Remediate.GhBranchProtectionType
 	(*RuleType_Definition_Remediate_PullRequestRemediation)(nil),                           // 238: minder.v1.RuleType.Definition.Remediate.PullRequestRemediation
-	(*RuleType_Definition_Remediate_PullRequestRemediation_Content)(nil),                   // 239: minder.v1.RuleType.Definition.Remediate.PullRequestRemediation.Content
-	(*RuleType_Definition_Remediate_PullRequestRemediation_ActionsReplaceTagsWithSha)(nil), // 240: minder.v1.RuleType.Definition.Remediate.PullRequestRemediation.ActionsReplaceTagsWithSha
-	(*RuleType_Definition_Alert_AlertTypeSA)(nil),                                          // 241: minder.v1.RuleType.Definition.Alert.AlertTypeSA
-	(*RuleType_Definition_Alert_AlertTypePRComment)(nil),                                   // 242: minder.v1.RuleType.Definition.Alert.AlertTypePRComment
-	(*Profile_Rule)(nil),                                                                   // 243: minder.v1.Profile.Rule
-	(*Profile_Selector)(nil),                                                               // 244: minder.v1.Profile.Selector
-	nil,                                                                                    // 245: minder.v1.RegisterEntityRequest.IdentifyingPropertiesEntry
-	(*StructDataSource_Def)(nil),                                                           // 246: minder.v1.StructDataSource.Def
-	nil,                                                                                    // 247: minder.v1.StructDataSource.DefEntry
-	(*StructDataSource_Def_Path)(nil),                                                      // 248: minder.v1.StructDataSource.Def.Path
-	(*RestDataSource_Def)(nil),                                                             // 249: minder.v1.RestDataSource.Def
-	nil,                                                                                    // 250: minder.v1.RestDataSource.DefEntry
-	nil,                                                                                    // 251: minder.v1.RestDataSource.Def.HeadersEntry
-	(*RestDataSource_Def_Fallback)(nil),                                                    // 252: minder.v1.RestDataSource.Def.Fallback
-	(*timestamppb.Timestamp)(nil),                                                          // 253: google.protobuf.Timestamp
-	(*structpb.Struct)(nil),                                                                // 254: google.protobuf.Struct
-	(*fieldmaskpb.FieldMask)(nil),                                                          // 255: google.protobuf.FieldMask
-	(*structpb.Value)(nil),                                                                 // 256: google.protobuf.Value
-	(*descriptorpb.EnumValueOptions)(nil),                                                  // 257: google.protobuf.EnumValueOptions
-	(*descriptorpb.MethodOptions)(nil),                                                     // 258: google.protobuf.MethodOptions
+	(*RuleType_Definition_Remediate_IssueRemediation)(nil),                                 // 239: minder.v1.RuleType.Definition.Remediate.IssueRemediation
+	(*RuleType_Definition_Remediate_PullRequestRemediation_Content)(nil),                   // 240: minder.v1.RuleType.Definition.Remediate.PullRequestRemediation.Content
+	(*RuleType_Definition_Remediate_PullRequestRemediation_ActionsReplaceTagsWithSha)(nil), // 241: minder.v1.RuleType.Definition.Remediate.PullRequestRemediation.ActionsReplaceTagsWithSha
+	(*RuleType_Definition_Alert_AlertTypeSA)(nil),                                          // 242: minder.v1.RuleType.Definition.Alert.AlertTypeSA
+	(*RuleType_Definition_Alert_AlertTypePRComment)(nil),                                   // 243: minder.v1.RuleType.Definition.Alert.AlertTypePRComment
+	(*Profile_Rule)(nil),                                                                   // 244: minder.v1.Profile.Rule
+	(*Profile_Selector)(nil),                                                               // 245: minder.v1.Profile.Selector
+	nil,                                                                                    // 246: minder.v1.RegisterEntityRequest.IdentifyingPropertiesEntry
+	(*StructDataSource_Def)(nil),                                                           // 247: minder.v1.StructDataSource.Def
+	nil,                                                                                    // 248: minder.v1.StructDataSource.DefEntry
+	(*StructDataSource_Def_Path)(nil),                                                      // 249: minder.v1.StructDataSource.Def.Path
+	(*RestDataSource_Def)(nil),                                                             // 250: minder.v1.RestDataSource.Def
+	nil,                                                                                    // 251: minder.v1.RestDataSource.DefEntry
+	nil,                                                                                    // 252: minder.v1.RestDataSource.Def.HeadersEntry
+	(*RestDataSource_Def_Fallback)(nil),                                                    // 253: minder.v1.RestDataSource.Def.Fallback
+	(*timestamppb.Timestamp)(nil),                                                          // 254: google.protobuf.Timestamp
+	(*structpb.Struct)(nil),                                                                // 255: google.protobuf.Struct
+	(*fieldmaskpb.FieldMask)(nil),                                                          // 256: google.protobuf.FieldMask
+	(*structpb.Value)(nil),                                                                 // 257: google.protobuf.Value
+	(*descriptorpb.EnumValueOptions)(nil),                                                  // 258: google.protobuf.EnumValueOptions
+	(*descriptorpb.MethodOptions)(nil),                                                     // 259: google.protobuf.MethodOptions
 }
 var file_minder_v1_minder_proto_depIdxs = []int32{
 	2,   // 0: minder.v1.RpcOptions.target_resource:type_name -> minder.v1.TargetResource
@@ -16558,30 +16637,30 @@ var file_minder_v1_minder_proto_depIdxs = []int32{
 	115, // 4: minder.v1.ListArtifactsRequest.context:type_name -> minder.v1.Context
 	17,  // 5: minder.v1.ListArtifactsResponse.results:type_name -> minder.v1.Artifact
 	18,  // 6: minder.v1.Artifact.versions:type_name -> minder.v1.ArtifactVersion
-	253, // 7: minder.v1.Artifact.created_at:type_name -> google.protobuf.Timestamp
+	254, // 7: minder.v1.Artifact.created_at:type_name -> google.protobuf.Timestamp
 	115, // 8: minder.v1.Artifact.context:type_name -> minder.v1.Context
-	253, // 9: minder.v1.ArtifactVersion.created_at:type_name -> google.protobuf.Timestamp
+	254, // 9: minder.v1.ArtifactVersion.created_at:type_name -> google.protobuf.Timestamp
 	115, // 10: minder.v1.GetArtifactByIdRequest.context:type_name -> minder.v1.Context
 	17,  // 11: minder.v1.GetArtifactByIdResponse.artifact:type_name -> minder.v1.Artifact
 	18,  // 12: minder.v1.GetArtifactByIdResponse.versions:type_name -> minder.v1.ArtifactVersion
 	115, // 13: minder.v1.GetArtifactByNameRequest.context:type_name -> minder.v1.Context
 	17,  // 14: minder.v1.GetArtifactByNameResponse.artifact:type_name -> minder.v1.Artifact
 	18,  // 15: minder.v1.GetArtifactByNameResponse.versions:type_name -> minder.v1.ArtifactVersion
-	253, // 16: minder.v1.GetInviteDetailsResponse.expires_at:type_name -> google.protobuf.Timestamp
+	254, // 16: minder.v1.GetInviteDetailsResponse.expires_at:type_name -> google.protobuf.Timestamp
 	115, // 17: minder.v1.GetAuthorizationURLRequest.context:type_name -> minder.v1.Context
-	254, // 18: minder.v1.GetAuthorizationURLRequest.config:type_name -> google.protobuf.Struct
+	255, // 18: minder.v1.GetAuthorizationURLRequest.config:type_name -> google.protobuf.Struct
 	115, // 19: minder.v1.StoreProviderTokenRequest.context:type_name -> minder.v1.Context
-	253, // 20: minder.v1.Project.created_at:type_name -> google.protobuf.Timestamp
-	253, // 21: minder.v1.Project.updated_at:type_name -> google.protobuf.Timestamp
+	254, // 20: minder.v1.Project.created_at:type_name -> google.protobuf.Timestamp
+	254, // 21: minder.v1.Project.updated_at:type_name -> google.protobuf.Timestamp
 	115, // 22: minder.v1.ListRemoteRepositoriesFromProviderRequest.context:type_name -> minder.v1.Context
 	39,  // 23: minder.v1.ListRemoteRepositoriesFromProviderResponse.results:type_name -> minder.v1.UpstreamRepositoryRef
 	38,  // 24: minder.v1.ListRemoteRepositoriesFromProviderResponse.entities:type_name -> minder.v1.RegistrableUpstreamEntityRef
 	212, // 25: minder.v1.RegistrableUpstreamEntityRef.entity:type_name -> minder.v1.UpstreamEntityRef
 	115, // 26: minder.v1.UpstreamRepositoryRef.context:type_name -> minder.v1.Context
 	115, // 27: minder.v1.Repository.context:type_name -> minder.v1.Context
-	253, // 28: minder.v1.Repository.created_at:type_name -> google.protobuf.Timestamp
-	253, // 29: minder.v1.Repository.updated_at:type_name -> google.protobuf.Timestamp
-	254, // 30: minder.v1.Repository.properties:type_name -> google.protobuf.Struct
+	254, // 28: minder.v1.Repository.created_at:type_name -> google.protobuf.Timestamp
+	254, // 29: minder.v1.Repository.updated_at:type_name -> google.protobuf.Timestamp
+	255, // 30: minder.v1.Repository.properties:type_name -> google.protobuf.Struct
 	39,  // 31: minder.v1.RegisterRepositoryRequest.repository:type_name -> minder.v1.UpstreamRepositoryRef
 	115, // 32: minder.v1.RegisterRepositoryRequest.context:type_name -> minder.v1.Context
 	212, // 33: minder.v1.RegisterRepositoryRequest.entity:type_name -> minder.v1.UpstreamEntityRef
@@ -16597,13 +16676,13 @@ var file_minder_v1_minder_proto_depIdxs = []int32{
 	115, // 43: minder.v1.ListRepositoriesRequest.context:type_name -> minder.v1.Context
 	40,  // 44: minder.v1.ListRepositoriesResponse.results:type_name -> minder.v1.Repository
 	115, // 45: minder.v1.ReconcileEntityRegistrationRequest.context:type_name -> minder.v1.Context
-	253, // 46: minder.v1.VerifyProviderTokenFromRequest.timestamp:type_name -> google.protobuf.Timestamp
+	254, // 46: minder.v1.VerifyProviderTokenFromRequest.timestamp:type_name -> google.protobuf.Timestamp
 	115, // 47: minder.v1.VerifyProviderTokenFromRequest.context:type_name -> minder.v1.Context
 	115, // 48: minder.v1.VerifyProviderCredentialRequest.context:type_name -> minder.v1.Context
-	253, // 49: minder.v1.CreateUserResponse.created_at:type_name -> google.protobuf.Timestamp
+	254, // 49: minder.v1.CreateUserResponse.created_at:type_name -> google.protobuf.Timestamp
 	115, // 50: minder.v1.CreateUserResponse.context:type_name -> minder.v1.Context
-	253, // 51: minder.v1.UserRecord.created_at:type_name -> google.protobuf.Timestamp
-	253, // 52: minder.v1.UserRecord.updated_at:type_name -> google.protobuf.Timestamp
+	254, // 51: minder.v1.UserRecord.created_at:type_name -> google.protobuf.Timestamp
+	254, // 52: minder.v1.UserRecord.updated_at:type_name -> google.protobuf.Timestamp
 	165, // 53: minder.v1.ProjectRole.role:type_name -> minder.v1.Role
 	35,  // 54: minder.v1.ProjectRole.project:type_name -> minder.v1.Project
 	64,  // 55: minder.v1.GetUserResponse.user:type_name -> minder.v1.UserRecord
@@ -16627,7 +16706,7 @@ var file_minder_v1_minder_proto_depIdxs = []int32{
 	139, // 73: minder.v1.UpdateProfileResponse.profile:type_name -> minder.v1.Profile
 	115, // 74: minder.v1.PatchProfileRequest.context:type_name -> minder.v1.Context
 	139, // 75: minder.v1.PatchProfileRequest.patch:type_name -> minder.v1.Profile
-	255, // 76: minder.v1.PatchProfileRequest.update_mask:type_name -> google.protobuf.FieldMask
+	256, // 76: minder.v1.PatchProfileRequest.update_mask:type_name -> google.protobuf.FieldMask
 	139, // 77: minder.v1.PatchProfileResponse.profile:type_name -> minder.v1.Profile
 	115, // 78: minder.v1.DeleteProfileRequest.context:type_name -> minder.v1.Context
 	115, // 79: minder.v1.ListProfilesRequest.context:type_name -> minder.v1.Context
@@ -16636,15 +16715,15 @@ var file_minder_v1_minder_proto_depIdxs = []int32{
 	139, // 82: minder.v1.GetProfileByIdResponse.profile:type_name -> minder.v1.Profile
 	115, // 83: minder.v1.GetProfileByNameRequest.context:type_name -> minder.v1.Context
 	139, // 84: minder.v1.GetProfileByNameResponse.profile:type_name -> minder.v1.Profile
-	253, // 85: minder.v1.ProfileStatus.last_updated:type_name -> google.protobuf.Timestamp
-	253, // 86: minder.v1.EvalResultAlert.last_updated:type_name -> google.protobuf.Timestamp
-	253, // 87: minder.v1.RuleEvaluationStatus.last_updated:type_name -> google.protobuf.Timestamp
+	254, // 85: minder.v1.ProfileStatus.last_updated:type_name -> google.protobuf.Timestamp
+	254, // 86: minder.v1.EvalResultAlert.last_updated:type_name -> google.protobuf.Timestamp
+	254, // 87: minder.v1.RuleEvaluationStatus.last_updated:type_name -> google.protobuf.Timestamp
 	218, // 88: minder.v1.RuleEvaluationStatus.entity_info:type_name -> minder.v1.RuleEvaluationStatus.EntityInfoEntry
-	253, // 89: minder.v1.RuleEvaluationStatus.remediation_last_updated:type_name -> google.protobuf.Timestamp
+	254, // 89: minder.v1.RuleEvaluationStatus.remediation_last_updated:type_name -> google.protobuf.Timestamp
 	97,  // 90: minder.v1.RuleEvaluationStatus.alert:type_name -> minder.v1.EvalResultAlert
 	137, // 91: minder.v1.RuleEvaluationStatus.severity:type_name -> minder.v1.Severity
 	4,   // 92: minder.v1.RuleEvaluationStatus.release_phase:type_name -> minder.v1.RuleTypeReleasePhase
-	256, // 93: minder.v1.RuleEvaluationStatus.output:type_name -> google.protobuf.Value
+	257, // 93: minder.v1.RuleEvaluationStatus.output:type_name -> google.protobuf.Value
 	3,   // 94: minder.v1.EntityTypedId.type:type_name -> minder.v1.Entity
 	115, // 95: minder.v1.GetProfileStatusByNameRequest.context:type_name -> minder.v1.Context
 	99,  // 96: minder.v1.GetProfileStatusByNameRequest.entity:type_name -> minder.v1.EntityTypedId
@@ -16682,15 +16761,15 @@ var file_minder_v1_minder_proto_depIdxs = []int32{
 	137, // 128: minder.v1.RuleType.severity:type_name -> minder.v1.Severity
 	4,   // 129: minder.v1.RuleType.release_phase:type_name -> minder.v1.RuleTypeReleasePhase
 	115, // 130: minder.v1.Profile.context:type_name -> minder.v1.Context
-	243, // 131: minder.v1.Profile.repository:type_name -> minder.v1.Profile.Rule
-	243, // 132: minder.v1.Profile.build_environment:type_name -> minder.v1.Profile.Rule
-	243, // 133: minder.v1.Profile.artifact:type_name -> minder.v1.Profile.Rule
-	243, // 134: minder.v1.Profile.pull_request:type_name -> minder.v1.Profile.Rule
-	243, // 135: minder.v1.Profile.release:type_name -> minder.v1.Profile.Rule
-	243, // 136: minder.v1.Profile.pipeline_run:type_name -> minder.v1.Profile.Rule
-	243, // 137: minder.v1.Profile.task_run:type_name -> minder.v1.Profile.Rule
-	243, // 138: minder.v1.Profile.build:type_name -> minder.v1.Profile.Rule
-	244, // 139: minder.v1.Profile.selection:type_name -> minder.v1.Profile.Selector
+	244, // 131: minder.v1.Profile.repository:type_name -> minder.v1.Profile.Rule
+	244, // 132: minder.v1.Profile.build_environment:type_name -> minder.v1.Profile.Rule
+	244, // 133: minder.v1.Profile.artifact:type_name -> minder.v1.Profile.Rule
+	244, // 134: minder.v1.Profile.pull_request:type_name -> minder.v1.Profile.Rule
+	244, // 135: minder.v1.Profile.release:type_name -> minder.v1.Profile.Rule
+	244, // 136: minder.v1.Profile.pipeline_run:type_name -> minder.v1.Profile.Rule
+	244, // 137: minder.v1.Profile.task_run:type_name -> minder.v1.Profile.Rule
+	244, // 138: minder.v1.Profile.build:type_name -> minder.v1.Profile.Rule
+	245, // 139: minder.v1.Profile.selection:type_name -> minder.v1.Profile.Selector
 	35,  // 140: minder.v1.ListProjectsResponse.projects:type_name -> minder.v1.Project
 	115, // 141: minder.v1.CreateProjectRequest.context:type_name -> minder.v1.Context
 	35,  // 142: minder.v1.CreateProjectResponse.project:type_name -> minder.v1.Project
@@ -16699,7 +16778,7 @@ var file_minder_v1_minder_proto_depIdxs = []int32{
 	35,  // 145: minder.v1.UpdateProjectResponse.project:type_name -> minder.v1.Project
 	115, // 146: minder.v1.PatchProjectRequest.context:type_name -> minder.v1.Context
 	148, // 147: minder.v1.PatchProjectRequest.patch:type_name -> minder.v1.ProjectPatch
-	255, // 148: minder.v1.PatchProjectRequest.update_mask:type_name -> google.protobuf.FieldMask
+	256, // 148: minder.v1.PatchProjectRequest.update_mask:type_name -> google.protobuf.FieldMask
 	35,  // 149: minder.v1.PatchProjectResponse.project:type_name -> minder.v1.Project
 	116, // 150: minder.v1.ListChildProjectsRequest.context:type_name -> minder.v1.ContextV2
 	35,  // 151: minder.v1.ListChildProjectsResponse.projects:type_name -> minder.v1.Project
@@ -16722,8 +16801,8 @@ var file_minder_v1_minder_proto_depIdxs = []int32{
 	166, // 168: minder.v1.RemoveRoleResponse.role_assignment:type_name -> minder.v1.RoleAssignment
 	171, // 169: minder.v1.RemoveRoleResponse.invitation:type_name -> minder.v1.Invitation
 	171, // 170: minder.v1.ListInvitationsResponse.invitations:type_name -> minder.v1.Invitation
-	253, // 171: minder.v1.Invitation.created_at:type_name -> google.protobuf.Timestamp
-	253, // 172: minder.v1.Invitation.expires_at:type_name -> google.protobuf.Timestamp
+	254, // 171: minder.v1.Invitation.created_at:type_name -> google.protobuf.Timestamp
+	254, // 172: minder.v1.Invitation.expires_at:type_name -> google.protobuf.Timestamp
 	115, // 173: minder.v1.GetProviderRequest.context:type_name -> minder.v1.Context
 	190, // 174: minder.v1.GetProviderResponse.provider:type_name -> minder.v1.Provider
 	115, // 175: minder.v1.ListProvidersRequest.context:type_name -> minder.v1.Context
@@ -16741,17 +16820,17 @@ var file_minder_v1_minder_proto_depIdxs = []int32{
 	183, // 187: minder.v1.ListProviderClassesResponse.provider_class_infos:type_name -> minder.v1.ProviderClassInfo
 	115, // 188: minder.v1.PatchProviderRequest.context:type_name -> minder.v1.Context
 	190, // 189: minder.v1.PatchProviderRequest.patch:type_name -> minder.v1.Provider
-	255, // 190: minder.v1.PatchProviderRequest.update_mask:type_name -> google.protobuf.FieldMask
+	256, // 190: minder.v1.PatchProviderRequest.update_mask:type_name -> google.protobuf.FieldMask
 	190, // 191: minder.v1.PatchProviderResponse.provider:type_name -> minder.v1.Provider
 	189, // 192: minder.v1.ProviderParameter.github_app:type_name -> minder.v1.GitHubAppParams
 	5,   // 193: minder.v1.Provider.implements:type_name -> minder.v1.ProviderType
-	254, // 194: minder.v1.Provider.config:type_name -> google.protobuf.Struct
+	255, // 194: minder.v1.Provider.config:type_name -> google.protobuf.Struct
 	7,   // 195: minder.v1.Provider.auth_flows:type_name -> minder.v1.AuthorizationFlow
 	188, // 196: minder.v1.Provider.parameters:type_name -> minder.v1.ProviderParameter
 	115, // 197: minder.v1.GetEvaluationHistoryRequest.context:type_name -> minder.v1.Context
 	115, // 198: minder.v1.ListEvaluationHistoryRequest.context:type_name -> minder.v1.Context
-	253, // 199: minder.v1.ListEvaluationHistoryRequest.from:type_name -> google.protobuf.Timestamp
-	253, // 200: minder.v1.ListEvaluationHistoryRequest.to:type_name -> google.protobuf.Timestamp
+	254, // 199: minder.v1.ListEvaluationHistoryRequest.from:type_name -> google.protobuf.Timestamp
+	254, // 200: minder.v1.ListEvaluationHistoryRequest.to:type_name -> google.protobuf.Timestamp
 	11,  // 201: minder.v1.ListEvaluationHistoryRequest.cursor:type_name -> minder.v1.Cursor
 	195, // 202: minder.v1.GetEvaluationHistoryResponse.evaluation:type_name -> minder.v1.EvaluationHistory
 	195, // 203: minder.v1.ListEvaluationHistoryResponse.data:type_name -> minder.v1.EvaluationHistory
@@ -16761,13 +16840,13 @@ var file_minder_v1_minder_proto_depIdxs = []int32{
 	198, // 207: minder.v1.EvaluationHistory.status:type_name -> minder.v1.EvaluationHistoryStatus
 	200, // 208: minder.v1.EvaluationHistory.alert:type_name -> minder.v1.EvaluationHistoryAlert
 	199, // 209: minder.v1.EvaluationHistory.remediation:type_name -> minder.v1.EvaluationHistoryRemediation
-	253, // 210: minder.v1.EvaluationHistory.evaluated_at:type_name -> google.protobuf.Timestamp
+	254, // 210: minder.v1.EvaluationHistory.evaluated_at:type_name -> google.protobuf.Timestamp
 	3,   // 211: minder.v1.EvaluationHistoryEntity.type:type_name -> minder.v1.Entity
 	137, // 212: minder.v1.EvaluationHistoryRule.severity:type_name -> minder.v1.Severity
-	256, // 213: minder.v1.EvaluationHistoryStatus.output:type_name -> google.protobuf.Value
+	257, // 213: minder.v1.EvaluationHistoryStatus.output:type_name -> google.protobuf.Value
 	116, // 214: minder.v1.EntityInstance.context:type_name -> minder.v1.ContextV2
 	3,   // 215: minder.v1.EntityInstance.type:type_name -> minder.v1.Entity
-	254, // 216: minder.v1.EntityInstance.properties:type_name -> google.protobuf.Struct
+	255, // 216: minder.v1.EntityInstance.properties:type_name -> google.protobuf.Struct
 	116, // 217: minder.v1.ListEntitiesRequest.context:type_name -> minder.v1.ContextV2
 	3,   // 218: minder.v1.ListEntitiesRequest.entity_type:type_name -> minder.v1.Entity
 	11,  // 219: minder.v1.ListEntitiesRequest.cursor:type_name -> minder.v1.Cursor
@@ -16781,23 +16860,23 @@ var file_minder_v1_minder_proto_depIdxs = []int32{
 	116, // 227: minder.v1.DeleteEntityByIdRequest.context:type_name -> minder.v1.ContextV2
 	116, // 228: minder.v1.RegisterEntityRequest.context:type_name -> minder.v1.ContextV2
 	3,   // 229: minder.v1.RegisterEntityRequest.entity_type:type_name -> minder.v1.Entity
-	245, // 230: minder.v1.RegisterEntityRequest.identifying_properties:type_name -> minder.v1.RegisterEntityRequest.IdentifyingPropertiesEntry
+	246, // 230: minder.v1.RegisterEntityRequest.identifying_properties:type_name -> minder.v1.RegisterEntityRequest.IdentifyingPropertiesEntry
 	201, // 231: minder.v1.RegisterEntityResponse.entity:type_name -> minder.v1.EntityInstance
 	116, // 232: minder.v1.UpstreamEntityRef.context:type_name -> minder.v1.ContextV2
 	3,   // 233: minder.v1.UpstreamEntityRef.type:type_name -> minder.v1.Entity
-	254, // 234: minder.v1.UpstreamEntityRef.properties:type_name -> google.protobuf.Struct
+	255, // 234: minder.v1.UpstreamEntityRef.properties:type_name -> google.protobuf.Struct
 	116, // 235: minder.v1.DataSource.context:type_name -> minder.v1.ContextV2
 	214, // 236: minder.v1.DataSource.structured:type_name -> minder.v1.StructDataSource
 	215, // 237: minder.v1.DataSource.rest:type_name -> minder.v1.RestDataSource
-	247, // 238: minder.v1.StructDataSource.def:type_name -> minder.v1.StructDataSource.DefEntry
-	250, // 239: minder.v1.RestDataSource.def:type_name -> minder.v1.RestDataSource.DefEntry
+	248, // 238: minder.v1.StructDataSource.def:type_name -> minder.v1.StructDataSource.DefEntry
+	251, // 239: minder.v1.RestDataSource.def:type_name -> minder.v1.RestDataSource.DefEntry
 	106, // 240: minder.v1.AutoRegistration.EntitiesEntry.value:type_name -> minder.v1.EntityAutoRegistrationConfig
 	96,  // 241: minder.v1.ListEvaluationResultsResponse.EntityProfileEvaluationResults.profile_status:type_name -> minder.v1.ProfileStatus
 	98,  // 242: minder.v1.ListEvaluationResultsResponse.EntityProfileEvaluationResults.results:type_name -> minder.v1.RuleEvaluationStatus
 	99,  // 243: minder.v1.ListEvaluationResultsResponse.EntityEvaluationResults.entity:type_name -> minder.v1.EntityTypedId
 	220, // 244: minder.v1.ListEvaluationResultsResponse.EntityEvaluationResults.profiles:type_name -> minder.v1.ListEvaluationResultsResponse.EntityProfileEvaluationResults
-	254, // 245: minder.v1.RuleType.Definition.rule_schema:type_name -> google.protobuf.Struct
-	254, // 246: minder.v1.RuleType.Definition.param_schema:type_name -> google.protobuf.Struct
+	255, // 245: minder.v1.RuleType.Definition.rule_schema:type_name -> google.protobuf.Struct
+	255, // 246: minder.v1.RuleType.Definition.param_schema:type_name -> google.protobuf.Struct
 	227, // 247: minder.v1.RuleType.Definition.ingest:type_name -> minder.v1.RuleType.Definition.Ingest
 	228, // 248: minder.v1.RuleType.Definition.eval:type_name -> minder.v1.RuleType.Definition.Eval
 	229, // 249: minder.v1.RuleType.Definition.remediate:type_name -> minder.v1.RuleType.Definition.Remediate
@@ -16817,179 +16896,180 @@ var file_minder_v1_minder_proto_depIdxs = []int32{
 	131, // 263: minder.v1.RuleType.Definition.Remediate.rest:type_name -> minder.v1.RestType
 	237, // 264: minder.v1.RuleType.Definition.Remediate.gh_branch_protection:type_name -> minder.v1.RuleType.Definition.Remediate.GhBranchProtectionType
 	238, // 265: minder.v1.RuleType.Definition.Remediate.pull_request:type_name -> minder.v1.RuleType.Definition.Remediate.PullRequestRemediation
-	242, // 266: minder.v1.RuleType.Definition.Remediate.pull_request_comment:type_name -> minder.v1.RuleType.Definition.Alert.AlertTypePRComment
-	241, // 267: minder.v1.RuleType.Definition.Alert.security_advisory:type_name -> minder.v1.RuleType.Definition.Alert.AlertTypeSA
-	242, // 268: minder.v1.RuleType.Definition.Alert.pull_request_comment:type_name -> minder.v1.RuleType.Definition.Alert.AlertTypePRComment
-	236, // 269: minder.v1.RuleType.Definition.Eval.JQComparison.ingested:type_name -> minder.v1.RuleType.Definition.Eval.JQComparison.Operator
-	236, // 270: minder.v1.RuleType.Definition.Eval.JQComparison.profile:type_name -> minder.v1.RuleType.Definition.Eval.JQComparison.Operator
-	256, // 271: minder.v1.RuleType.Definition.Eval.JQComparison.constant:type_name -> google.protobuf.Value
-	239, // 272: minder.v1.RuleType.Definition.Remediate.PullRequestRemediation.contents:type_name -> minder.v1.RuleType.Definition.Remediate.PullRequestRemediation.Content
-	254, // 273: minder.v1.RuleType.Definition.Remediate.PullRequestRemediation.params:type_name -> google.protobuf.Struct
-	240, // 274: minder.v1.RuleType.Definition.Remediate.PullRequestRemediation.actions_replace_tags_with_sha:type_name -> minder.v1.RuleType.Definition.Remediate.PullRequestRemediation.ActionsReplaceTagsWithSha
-	254, // 275: minder.v1.Profile.Rule.params:type_name -> google.protobuf.Struct
-	254, // 276: minder.v1.Profile.Rule.def:type_name -> google.protobuf.Struct
-	256, // 277: minder.v1.RegisterEntityRequest.IdentifyingPropertiesEntry.value:type_name -> google.protobuf.Value
-	248, // 278: minder.v1.StructDataSource.Def.path:type_name -> minder.v1.StructDataSource.Def.Path
-	246, // 279: minder.v1.StructDataSource.DefEntry.value:type_name -> minder.v1.StructDataSource.Def
-	251, // 280: minder.v1.RestDataSource.Def.headers:type_name -> minder.v1.RestDataSource.Def.HeadersEntry
-	254, // 281: minder.v1.RestDataSource.Def.bodyobj:type_name -> google.protobuf.Struct
-	252, // 282: minder.v1.RestDataSource.Def.fallback:type_name -> minder.v1.RestDataSource.Def.Fallback
-	254, // 283: minder.v1.RestDataSource.Def.input_schema:type_name -> google.protobuf.Struct
-	249, // 284: minder.v1.RestDataSource.DefEntry.value:type_name -> minder.v1.RestDataSource.Def
-	257, // 285: minder.v1.name:extendee -> google.protobuf.EnumValueOptions
-	258, // 286: minder.v1.rpc_options:extendee -> google.protobuf.MethodOptions
-	10,  // 287: minder.v1.rpc_options:type_name -> minder.v1.RpcOptions
-	29,  // 288: minder.v1.HealthService.CheckHealth:input_type -> minder.v1.CheckHealthRequest
-	13,  // 289: minder.v1.HealthService.GetVersion:input_type -> minder.v1.GetVersionRequest
-	15,  // 290: minder.v1.ArtifactService.ListArtifacts:input_type -> minder.v1.ListArtifactsRequest
-	19,  // 291: minder.v1.ArtifactService.GetArtifactById:input_type -> minder.v1.GetArtifactByIdRequest
-	21,  // 292: minder.v1.ArtifactService.GetArtifactByName:input_type -> minder.v1.GetArtifactByNameRequest
-	31,  // 293: minder.v1.OAuthService.GetAuthorizationURL:input_type -> minder.v1.GetAuthorizationURLRequest
-	33,  // 294: minder.v1.OAuthService.StoreProviderToken:input_type -> minder.v1.StoreProviderTokenRequest
-	56,  // 295: minder.v1.OAuthService.VerifyProviderTokenFrom:input_type -> minder.v1.VerifyProviderTokenFromRequest
-	58,  // 296: minder.v1.OAuthService.VerifyProviderCredential:input_type -> minder.v1.VerifyProviderCredentialRequest
-	41,  // 297: minder.v1.RepositoryService.RegisterRepository:input_type -> minder.v1.RegisterRepositoryRequest
-	36,  // 298: minder.v1.RepositoryService.ListRemoteRepositoriesFromProvider:input_type -> minder.v1.ListRemoteRepositoriesFromProviderRequest
-	52,  // 299: minder.v1.RepositoryService.ListRepositories:input_type -> minder.v1.ListRepositoriesRequest
-	44,  // 300: minder.v1.RepositoryService.GetRepositoryById:input_type -> minder.v1.GetRepositoryByIdRequest
-	48,  // 301: minder.v1.RepositoryService.GetRepositoryByName:input_type -> minder.v1.GetRepositoryByNameRequest
-	46,  // 302: minder.v1.RepositoryService.DeleteRepositoryById:input_type -> minder.v1.DeleteRepositoryByIdRequest
-	50,  // 303: minder.v1.RepositoryService.DeleteRepositoryByName:input_type -> minder.v1.DeleteRepositoryByNameRequest
-	60,  // 304: minder.v1.UserService.CreateUser:input_type -> minder.v1.CreateUserRequest
-	62,  // 305: minder.v1.UserService.DeleteUser:input_type -> minder.v1.DeleteUserRequest
-	66,  // 306: minder.v1.UserService.GetUser:input_type -> minder.v1.GetUserRequest
-	167, // 307: minder.v1.UserService.ListInvitations:input_type -> minder.v1.ListInvitationsRequest
-	169, // 308: minder.v1.UserService.ResolveInvitation:input_type -> minder.v1.ResolveInvitationRequest
-	82,  // 309: minder.v1.ProfileService.CreateProfile:input_type -> minder.v1.CreateProfileRequest
-	84,  // 310: minder.v1.ProfileService.UpdateProfile:input_type -> minder.v1.UpdateProfileRequest
-	86,  // 311: minder.v1.ProfileService.PatchProfile:input_type -> minder.v1.PatchProfileRequest
-	88,  // 312: minder.v1.ProfileService.DeleteProfile:input_type -> minder.v1.DeleteProfileRequest
-	90,  // 313: minder.v1.ProfileService.ListProfiles:input_type -> minder.v1.ListProfilesRequest
-	92,  // 314: minder.v1.ProfileService.GetProfileById:input_type -> minder.v1.GetProfileByIdRequest
-	94,  // 315: minder.v1.ProfileService.GetProfileByName:input_type -> minder.v1.GetProfileByNameRequest
-	100, // 316: minder.v1.ProfileService.GetProfileStatusByName:input_type -> minder.v1.GetProfileStatusByNameRequest
-	102, // 317: minder.v1.ProfileService.GetProfileStatusById:input_type -> minder.v1.GetProfileStatusByIdRequest
-	104, // 318: minder.v1.ProfileService.GetProfileStatusByProject:input_type -> minder.v1.GetProfileStatusByProjectRequest
-	68,  // 319: minder.v1.DataSourceService.CreateDataSource:input_type -> minder.v1.CreateDataSourceRequest
-	70,  // 320: minder.v1.DataSourceService.GetDataSourceById:input_type -> minder.v1.GetDataSourceByIdRequest
-	72,  // 321: minder.v1.DataSourceService.GetDataSourceByName:input_type -> minder.v1.GetDataSourceByNameRequest
-	74,  // 322: minder.v1.DataSourceService.ListDataSources:input_type -> minder.v1.ListDataSourcesRequest
-	76,  // 323: minder.v1.DataSourceService.UpdateDataSource:input_type -> minder.v1.UpdateDataSourceRequest
-	78,  // 324: minder.v1.DataSourceService.DeleteDataSourceById:input_type -> minder.v1.DeleteDataSourceByIdRequest
-	80,  // 325: minder.v1.DataSourceService.DeleteDataSourceByName:input_type -> minder.v1.DeleteDataSourceByNameRequest
-	117, // 326: minder.v1.RuleTypeService.ListRuleTypes:input_type -> minder.v1.ListRuleTypesRequest
-	119, // 327: minder.v1.RuleTypeService.GetRuleTypeByName:input_type -> minder.v1.GetRuleTypeByNameRequest
-	121, // 328: minder.v1.RuleTypeService.GetRuleTypeById:input_type -> minder.v1.GetRuleTypeByIdRequest
-	123, // 329: minder.v1.RuleTypeService.CreateRuleType:input_type -> minder.v1.CreateRuleTypeRequest
-	125, // 330: minder.v1.RuleTypeService.UpdateRuleType:input_type -> minder.v1.UpdateRuleTypeRequest
-	127, // 331: minder.v1.RuleTypeService.DeleteRuleType:input_type -> minder.v1.DeleteRuleTypeRequest
-	129, // 332: minder.v1.EvalResultsService.ListEvaluationResults:input_type -> minder.v1.ListEvaluationResultsRequest
-	192, // 333: minder.v1.EvalResultsService.ListEvaluationHistory:input_type -> minder.v1.ListEvaluationHistoryRequest
-	191, // 334: minder.v1.EvalResultsService.GetEvaluationHistory:input_type -> minder.v1.GetEvaluationHistoryRequest
-	155, // 335: minder.v1.PermissionsService.ListRoles:input_type -> minder.v1.ListRolesRequest
-	157, // 336: minder.v1.PermissionsService.ListRoleAssignments:input_type -> minder.v1.ListRoleAssignmentsRequest
-	159, // 337: minder.v1.PermissionsService.AssignRole:input_type -> minder.v1.AssignRoleRequest
-	161, // 338: minder.v1.PermissionsService.UpdateRole:input_type -> minder.v1.UpdateRoleRequest
-	163, // 339: minder.v1.PermissionsService.RemoveRole:input_type -> minder.v1.RemoveRoleRequest
-	140, // 340: minder.v1.ProjectsService.ListProjects:input_type -> minder.v1.ListProjectsRequest
-	142, // 341: minder.v1.ProjectsService.CreateProject:input_type -> minder.v1.CreateProjectRequest
-	151, // 342: minder.v1.ProjectsService.ListChildProjects:input_type -> minder.v1.ListChildProjectsRequest
-	144, // 343: minder.v1.ProjectsService.DeleteProject:input_type -> minder.v1.DeleteProjectRequest
-	146, // 344: minder.v1.ProjectsService.UpdateProject:input_type -> minder.v1.UpdateProjectRequest
-	149, // 345: minder.v1.ProjectsService.PatchProject:input_type -> minder.v1.PatchProjectRequest
-	153, // 346: minder.v1.ProjectsService.CreateEntityReconciliationTask:input_type -> minder.v1.CreateEntityReconciliationTaskRequest
-	185, // 347: minder.v1.ProvidersService.PatchProvider:input_type -> minder.v1.PatchProviderRequest
-	172, // 348: minder.v1.ProvidersService.GetProvider:input_type -> minder.v1.GetProviderRequest
-	174, // 349: minder.v1.ProvidersService.ListProviders:input_type -> minder.v1.ListProvidersRequest
-	176, // 350: minder.v1.ProvidersService.CreateProvider:input_type -> minder.v1.CreateProviderRequest
-	178, // 351: minder.v1.ProvidersService.DeleteProvider:input_type -> minder.v1.DeleteProviderRequest
-	180, // 352: minder.v1.ProvidersService.DeleteProviderByID:input_type -> minder.v1.DeleteProviderByIDRequest
-	182, // 353: minder.v1.ProvidersService.ListProviderClasses:input_type -> minder.v1.ListProviderClassesRequest
-	54,  // 354: minder.v1.ProvidersService.ReconcileEntityRegistration:input_type -> minder.v1.ReconcileEntityRegistrationRequest
-	27,  // 355: minder.v1.InviteService.GetInviteDetails:input_type -> minder.v1.GetInviteDetailsRequest
-	202, // 356: minder.v1.EntityInstanceService.ListEntities:input_type -> minder.v1.ListEntitiesRequest
-	204, // 357: minder.v1.EntityInstanceService.GetEntityById:input_type -> minder.v1.GetEntityByIdRequest
-	206, // 358: minder.v1.EntityInstanceService.GetEntityByName:input_type -> minder.v1.GetEntityByNameRequest
-	208, // 359: minder.v1.EntityInstanceService.DeleteEntityById:input_type -> minder.v1.DeleteEntityByIdRequest
-	210, // 360: minder.v1.EntityInstanceService.RegisterEntity:input_type -> minder.v1.RegisterEntityRequest
-	30,  // 361: minder.v1.HealthService.CheckHealth:output_type -> minder.v1.CheckHealthResponse
-	14,  // 362: minder.v1.HealthService.GetVersion:output_type -> minder.v1.GetVersionResponse
-	16,  // 363: minder.v1.ArtifactService.ListArtifacts:output_type -> minder.v1.ListArtifactsResponse
-	20,  // 364: minder.v1.ArtifactService.GetArtifactById:output_type -> minder.v1.GetArtifactByIdResponse
-	22,  // 365: minder.v1.ArtifactService.GetArtifactByName:output_type -> minder.v1.GetArtifactByNameResponse
-	32,  // 366: minder.v1.OAuthService.GetAuthorizationURL:output_type -> minder.v1.GetAuthorizationURLResponse
-	34,  // 367: minder.v1.OAuthService.StoreProviderToken:output_type -> minder.v1.StoreProviderTokenResponse
-	57,  // 368: minder.v1.OAuthService.VerifyProviderTokenFrom:output_type -> minder.v1.VerifyProviderTokenFromResponse
-	59,  // 369: minder.v1.OAuthService.VerifyProviderCredential:output_type -> minder.v1.VerifyProviderCredentialResponse
-	43,  // 370: minder.v1.RepositoryService.RegisterRepository:output_type -> minder.v1.RegisterRepositoryResponse
-	37,  // 371: minder.v1.RepositoryService.ListRemoteRepositoriesFromProvider:output_type -> minder.v1.ListRemoteRepositoriesFromProviderResponse
-	53,  // 372: minder.v1.RepositoryService.ListRepositories:output_type -> minder.v1.ListRepositoriesResponse
-	45,  // 373: minder.v1.RepositoryService.GetRepositoryById:output_type -> minder.v1.GetRepositoryByIdResponse
-	49,  // 374: minder.v1.RepositoryService.GetRepositoryByName:output_type -> minder.v1.GetRepositoryByNameResponse
-	47,  // 375: minder.v1.RepositoryService.DeleteRepositoryById:output_type -> minder.v1.DeleteRepositoryByIdResponse
-	51,  // 376: minder.v1.RepositoryService.DeleteRepositoryByName:output_type -> minder.v1.DeleteRepositoryByNameResponse
-	61,  // 377: minder.v1.UserService.CreateUser:output_type -> minder.v1.CreateUserResponse
-	63,  // 378: minder.v1.UserService.DeleteUser:output_type -> minder.v1.DeleteUserResponse
-	67,  // 379: minder.v1.UserService.GetUser:output_type -> minder.v1.GetUserResponse
-	168, // 380: minder.v1.UserService.ListInvitations:output_type -> minder.v1.ListInvitationsResponse
-	170, // 381: minder.v1.UserService.ResolveInvitation:output_type -> minder.v1.ResolveInvitationResponse
-	83,  // 382: minder.v1.ProfileService.CreateProfile:output_type -> minder.v1.CreateProfileResponse
-	85,  // 383: minder.v1.ProfileService.UpdateProfile:output_type -> minder.v1.UpdateProfileResponse
-	87,  // 384: minder.v1.ProfileService.PatchProfile:output_type -> minder.v1.PatchProfileResponse
-	89,  // 385: minder.v1.ProfileService.DeleteProfile:output_type -> minder.v1.DeleteProfileResponse
-	91,  // 386: minder.v1.ProfileService.ListProfiles:output_type -> minder.v1.ListProfilesResponse
-	93,  // 387: minder.v1.ProfileService.GetProfileById:output_type -> minder.v1.GetProfileByIdResponse
-	95,  // 388: minder.v1.ProfileService.GetProfileByName:output_type -> minder.v1.GetProfileByNameResponse
-	101, // 389: minder.v1.ProfileService.GetProfileStatusByName:output_type -> minder.v1.GetProfileStatusByNameResponse
-	103, // 390: minder.v1.ProfileService.GetProfileStatusById:output_type -> minder.v1.GetProfileStatusByIdResponse
-	105, // 391: minder.v1.ProfileService.GetProfileStatusByProject:output_type -> minder.v1.GetProfileStatusByProjectResponse
-	69,  // 392: minder.v1.DataSourceService.CreateDataSource:output_type -> minder.v1.CreateDataSourceResponse
-	71,  // 393: minder.v1.DataSourceService.GetDataSourceById:output_type -> minder.v1.GetDataSourceByIdResponse
-	73,  // 394: minder.v1.DataSourceService.GetDataSourceByName:output_type -> minder.v1.GetDataSourceByNameResponse
-	75,  // 395: minder.v1.DataSourceService.ListDataSources:output_type -> minder.v1.ListDataSourcesResponse
-	77,  // 396: minder.v1.DataSourceService.UpdateDataSource:output_type -> minder.v1.UpdateDataSourceResponse
-	79,  // 397: minder.v1.DataSourceService.DeleteDataSourceById:output_type -> minder.v1.DeleteDataSourceByIdResponse
-	81,  // 398: minder.v1.DataSourceService.DeleteDataSourceByName:output_type -> minder.v1.DeleteDataSourceByNameResponse
-	118, // 399: minder.v1.RuleTypeService.ListRuleTypes:output_type -> minder.v1.ListRuleTypesResponse
-	120, // 400: minder.v1.RuleTypeService.GetRuleTypeByName:output_type -> minder.v1.GetRuleTypeByNameResponse
-	122, // 401: minder.v1.RuleTypeService.GetRuleTypeById:output_type -> minder.v1.GetRuleTypeByIdResponse
-	124, // 402: minder.v1.RuleTypeService.CreateRuleType:output_type -> minder.v1.CreateRuleTypeResponse
-	126, // 403: minder.v1.RuleTypeService.UpdateRuleType:output_type -> minder.v1.UpdateRuleTypeResponse
-	128, // 404: minder.v1.RuleTypeService.DeleteRuleType:output_type -> minder.v1.DeleteRuleTypeResponse
-	130, // 405: minder.v1.EvalResultsService.ListEvaluationResults:output_type -> minder.v1.ListEvaluationResultsResponse
-	194, // 406: minder.v1.EvalResultsService.ListEvaluationHistory:output_type -> minder.v1.ListEvaluationHistoryResponse
-	193, // 407: minder.v1.EvalResultsService.GetEvaluationHistory:output_type -> minder.v1.GetEvaluationHistoryResponse
-	156, // 408: minder.v1.PermissionsService.ListRoles:output_type -> minder.v1.ListRolesResponse
-	158, // 409: minder.v1.PermissionsService.ListRoleAssignments:output_type -> minder.v1.ListRoleAssignmentsResponse
-	160, // 410: minder.v1.PermissionsService.AssignRole:output_type -> minder.v1.AssignRoleResponse
-	162, // 411: minder.v1.PermissionsService.UpdateRole:output_type -> minder.v1.UpdateRoleResponse
-	164, // 412: minder.v1.PermissionsService.RemoveRole:output_type -> minder.v1.RemoveRoleResponse
-	141, // 413: minder.v1.ProjectsService.ListProjects:output_type -> minder.v1.ListProjectsResponse
-	143, // 414: minder.v1.ProjectsService.CreateProject:output_type -> minder.v1.CreateProjectResponse
-	152, // 415: minder.v1.ProjectsService.ListChildProjects:output_type -> minder.v1.ListChildProjectsResponse
-	145, // 416: minder.v1.ProjectsService.DeleteProject:output_type -> minder.v1.DeleteProjectResponse
-	147, // 417: minder.v1.ProjectsService.UpdateProject:output_type -> minder.v1.UpdateProjectResponse
-	150, // 418: minder.v1.ProjectsService.PatchProject:output_type -> minder.v1.PatchProjectResponse
-	154, // 419: minder.v1.ProjectsService.CreateEntityReconciliationTask:output_type -> minder.v1.CreateEntityReconciliationTaskResponse
-	186, // 420: minder.v1.ProvidersService.PatchProvider:output_type -> minder.v1.PatchProviderResponse
-	173, // 421: minder.v1.ProvidersService.GetProvider:output_type -> minder.v1.GetProviderResponse
-	175, // 422: minder.v1.ProvidersService.ListProviders:output_type -> minder.v1.ListProvidersResponse
-	177, // 423: minder.v1.ProvidersService.CreateProvider:output_type -> minder.v1.CreateProviderResponse
-	179, // 424: minder.v1.ProvidersService.DeleteProvider:output_type -> minder.v1.DeleteProviderResponse
-	181, // 425: minder.v1.ProvidersService.DeleteProviderByID:output_type -> minder.v1.DeleteProviderByIDResponse
-	184, // 426: minder.v1.ProvidersService.ListProviderClasses:output_type -> minder.v1.ListProviderClassesResponse
-	55,  // 427: minder.v1.ProvidersService.ReconcileEntityRegistration:output_type -> minder.v1.ReconcileEntityRegistrationResponse
-	28,  // 428: minder.v1.InviteService.GetInviteDetails:output_type -> minder.v1.GetInviteDetailsResponse
-	203, // 429: minder.v1.EntityInstanceService.ListEntities:output_type -> minder.v1.ListEntitiesResponse
-	205, // 430: minder.v1.EntityInstanceService.GetEntityById:output_type -> minder.v1.GetEntityByIdResponse
-	207, // 431: minder.v1.EntityInstanceService.GetEntityByName:output_type -> minder.v1.GetEntityByNameResponse
-	209, // 432: minder.v1.EntityInstanceService.DeleteEntityById:output_type -> minder.v1.DeleteEntityByIdResponse
-	211, // 433: minder.v1.EntityInstanceService.RegisterEntity:output_type -> minder.v1.RegisterEntityResponse
-	361, // [361:434] is the sub-list for method output_type
-	288, // [288:361] is the sub-list for method input_type
-	287, // [287:288] is the sub-list for extension type_name
-	285, // [285:287] is the sub-list for extension extendee
-	0,   // [0:285] is the sub-list for field type_name
+	243, // 266: minder.v1.RuleType.Definition.Remediate.pull_request_comment:type_name -> minder.v1.RuleType.Definition.Alert.AlertTypePRComment
+	239, // 267: minder.v1.RuleType.Definition.Remediate.issue:type_name -> minder.v1.RuleType.Definition.Remediate.IssueRemediation
+	242, // 268: minder.v1.RuleType.Definition.Alert.security_advisory:type_name -> minder.v1.RuleType.Definition.Alert.AlertTypeSA
+	243, // 269: minder.v1.RuleType.Definition.Alert.pull_request_comment:type_name -> minder.v1.RuleType.Definition.Alert.AlertTypePRComment
+	236, // 270: minder.v1.RuleType.Definition.Eval.JQComparison.ingested:type_name -> minder.v1.RuleType.Definition.Eval.JQComparison.Operator
+	236, // 271: minder.v1.RuleType.Definition.Eval.JQComparison.profile:type_name -> minder.v1.RuleType.Definition.Eval.JQComparison.Operator
+	257, // 272: minder.v1.RuleType.Definition.Eval.JQComparison.constant:type_name -> google.protobuf.Value
+	240, // 273: minder.v1.RuleType.Definition.Remediate.PullRequestRemediation.contents:type_name -> minder.v1.RuleType.Definition.Remediate.PullRequestRemediation.Content
+	255, // 274: minder.v1.RuleType.Definition.Remediate.PullRequestRemediation.params:type_name -> google.protobuf.Struct
+	241, // 275: minder.v1.RuleType.Definition.Remediate.PullRequestRemediation.actions_replace_tags_with_sha:type_name -> minder.v1.RuleType.Definition.Remediate.PullRequestRemediation.ActionsReplaceTagsWithSha
+	255, // 276: minder.v1.Profile.Rule.params:type_name -> google.protobuf.Struct
+	255, // 277: minder.v1.Profile.Rule.def:type_name -> google.protobuf.Struct
+	257, // 278: minder.v1.RegisterEntityRequest.IdentifyingPropertiesEntry.value:type_name -> google.protobuf.Value
+	249, // 279: minder.v1.StructDataSource.Def.path:type_name -> minder.v1.StructDataSource.Def.Path
+	247, // 280: minder.v1.StructDataSource.DefEntry.value:type_name -> minder.v1.StructDataSource.Def
+	252, // 281: minder.v1.RestDataSource.Def.headers:type_name -> minder.v1.RestDataSource.Def.HeadersEntry
+	255, // 282: minder.v1.RestDataSource.Def.bodyobj:type_name -> google.protobuf.Struct
+	253, // 283: minder.v1.RestDataSource.Def.fallback:type_name -> minder.v1.RestDataSource.Def.Fallback
+	255, // 284: minder.v1.RestDataSource.Def.input_schema:type_name -> google.protobuf.Struct
+	250, // 285: minder.v1.RestDataSource.DefEntry.value:type_name -> minder.v1.RestDataSource.Def
+	258, // 286: minder.v1.name:extendee -> google.protobuf.EnumValueOptions
+	259, // 287: minder.v1.rpc_options:extendee -> google.protobuf.MethodOptions
+	10,  // 288: minder.v1.rpc_options:type_name -> minder.v1.RpcOptions
+	29,  // 289: minder.v1.HealthService.CheckHealth:input_type -> minder.v1.CheckHealthRequest
+	13,  // 290: minder.v1.HealthService.GetVersion:input_type -> minder.v1.GetVersionRequest
+	15,  // 291: minder.v1.ArtifactService.ListArtifacts:input_type -> minder.v1.ListArtifactsRequest
+	19,  // 292: minder.v1.ArtifactService.GetArtifactById:input_type -> minder.v1.GetArtifactByIdRequest
+	21,  // 293: minder.v1.ArtifactService.GetArtifactByName:input_type -> minder.v1.GetArtifactByNameRequest
+	31,  // 294: minder.v1.OAuthService.GetAuthorizationURL:input_type -> minder.v1.GetAuthorizationURLRequest
+	33,  // 295: minder.v1.OAuthService.StoreProviderToken:input_type -> minder.v1.StoreProviderTokenRequest
+	56,  // 296: minder.v1.OAuthService.VerifyProviderTokenFrom:input_type -> minder.v1.VerifyProviderTokenFromRequest
+	58,  // 297: minder.v1.OAuthService.VerifyProviderCredential:input_type -> minder.v1.VerifyProviderCredentialRequest
+	41,  // 298: minder.v1.RepositoryService.RegisterRepository:input_type -> minder.v1.RegisterRepositoryRequest
+	36,  // 299: minder.v1.RepositoryService.ListRemoteRepositoriesFromProvider:input_type -> minder.v1.ListRemoteRepositoriesFromProviderRequest
+	52,  // 300: minder.v1.RepositoryService.ListRepositories:input_type -> minder.v1.ListRepositoriesRequest
+	44,  // 301: minder.v1.RepositoryService.GetRepositoryById:input_type -> minder.v1.GetRepositoryByIdRequest
+	48,  // 302: minder.v1.RepositoryService.GetRepositoryByName:input_type -> minder.v1.GetRepositoryByNameRequest
+	46,  // 303: minder.v1.RepositoryService.DeleteRepositoryById:input_type -> minder.v1.DeleteRepositoryByIdRequest
+	50,  // 304: minder.v1.RepositoryService.DeleteRepositoryByName:input_type -> minder.v1.DeleteRepositoryByNameRequest
+	60,  // 305: minder.v1.UserService.CreateUser:input_type -> minder.v1.CreateUserRequest
+	62,  // 306: minder.v1.UserService.DeleteUser:input_type -> minder.v1.DeleteUserRequest
+	66,  // 307: minder.v1.UserService.GetUser:input_type -> minder.v1.GetUserRequest
+	167, // 308: minder.v1.UserService.ListInvitations:input_type -> minder.v1.ListInvitationsRequest
+	169, // 309: minder.v1.UserService.ResolveInvitation:input_type -> minder.v1.ResolveInvitationRequest
+	82,  // 310: minder.v1.ProfileService.CreateProfile:input_type -> minder.v1.CreateProfileRequest
+	84,  // 311: minder.v1.ProfileService.UpdateProfile:input_type -> minder.v1.UpdateProfileRequest
+	86,  // 312: minder.v1.ProfileService.PatchProfile:input_type -> minder.v1.PatchProfileRequest
+	88,  // 313: minder.v1.ProfileService.DeleteProfile:input_type -> minder.v1.DeleteProfileRequest
+	90,  // 314: minder.v1.ProfileService.ListProfiles:input_type -> minder.v1.ListProfilesRequest
+	92,  // 315: minder.v1.ProfileService.GetProfileById:input_type -> minder.v1.GetProfileByIdRequest
+	94,  // 316: minder.v1.ProfileService.GetProfileByName:input_type -> minder.v1.GetProfileByNameRequest
+	100, // 317: minder.v1.ProfileService.GetProfileStatusByName:input_type -> minder.v1.GetProfileStatusByNameRequest
+	102, // 318: minder.v1.ProfileService.GetProfileStatusById:input_type -> minder.v1.GetProfileStatusByIdRequest
+	104, // 319: minder.v1.ProfileService.GetProfileStatusByProject:input_type -> minder.v1.GetProfileStatusByProjectRequest
+	68,  // 320: minder.v1.DataSourceService.CreateDataSource:input_type -> minder.v1.CreateDataSourceRequest
+	70,  // 321: minder.v1.DataSourceService.GetDataSourceById:input_type -> minder.v1.GetDataSourceByIdRequest
+	72,  // 322: minder.v1.DataSourceService.GetDataSourceByName:input_type -> minder.v1.GetDataSourceByNameRequest
+	74,  // 323: minder.v1.DataSourceService.ListDataSources:input_type -> minder.v1.ListDataSourcesRequest
+	76,  // 324: minder.v1.DataSourceService.UpdateDataSource:input_type -> minder.v1.UpdateDataSourceRequest
+	78,  // 325: minder.v1.DataSourceService.DeleteDataSourceById:input_type -> minder.v1.DeleteDataSourceByIdRequest
+	80,  // 326: minder.v1.DataSourceService.DeleteDataSourceByName:input_type -> minder.v1.DeleteDataSourceByNameRequest
+	117, // 327: minder.v1.RuleTypeService.ListRuleTypes:input_type -> minder.v1.ListRuleTypesRequest
+	119, // 328: minder.v1.RuleTypeService.GetRuleTypeByName:input_type -> minder.v1.GetRuleTypeByNameRequest
+	121, // 329: minder.v1.RuleTypeService.GetRuleTypeById:input_type -> minder.v1.GetRuleTypeByIdRequest
+	123, // 330: minder.v1.RuleTypeService.CreateRuleType:input_type -> minder.v1.CreateRuleTypeRequest
+	125, // 331: minder.v1.RuleTypeService.UpdateRuleType:input_type -> minder.v1.UpdateRuleTypeRequest
+	127, // 332: minder.v1.RuleTypeService.DeleteRuleType:input_type -> minder.v1.DeleteRuleTypeRequest
+	129, // 333: minder.v1.EvalResultsService.ListEvaluationResults:input_type -> minder.v1.ListEvaluationResultsRequest
+	192, // 334: minder.v1.EvalResultsService.ListEvaluationHistory:input_type -> minder.v1.ListEvaluationHistoryRequest
+	191, // 335: minder.v1.EvalResultsService.GetEvaluationHistory:input_type -> minder.v1.GetEvaluationHistoryRequest
+	155, // 336: minder.v1.PermissionsService.ListRoles:input_type -> minder.v1.ListRolesRequest
+	157, // 337: minder.v1.PermissionsService.ListRoleAssignments:input_type -> minder.v1.ListRoleAssignmentsRequest
+	159, // 338: minder.v1.PermissionsService.AssignRole:input_type -> minder.v1.AssignRoleRequest
+	161, // 339: minder.v1.PermissionsService.UpdateRole:input_type -> minder.v1.UpdateRoleRequest
+	163, // 340: minder.v1.PermissionsService.RemoveRole:input_type -> minder.v1.RemoveRoleRequest
+	140, // 341: minder.v1.ProjectsService.ListProjects:input_type -> minder.v1.ListProjectsRequest
+	142, // 342: minder.v1.ProjectsService.CreateProject:input_type -> minder.v1.CreateProjectRequest
+	151, // 343: minder.v1.ProjectsService.ListChildProjects:input_type -> minder.v1.ListChildProjectsRequest
+	144, // 344: minder.v1.ProjectsService.DeleteProject:input_type -> minder.v1.DeleteProjectRequest
+	146, // 345: minder.v1.ProjectsService.UpdateProject:input_type -> minder.v1.UpdateProjectRequest
+	149, // 346: minder.v1.ProjectsService.PatchProject:input_type -> minder.v1.PatchProjectRequest
+	153, // 347: minder.v1.ProjectsService.CreateEntityReconciliationTask:input_type -> minder.v1.CreateEntityReconciliationTaskRequest
+	185, // 348: minder.v1.ProvidersService.PatchProvider:input_type -> minder.v1.PatchProviderRequest
+	172, // 349: minder.v1.ProvidersService.GetProvider:input_type -> minder.v1.GetProviderRequest
+	174, // 350: minder.v1.ProvidersService.ListProviders:input_type -> minder.v1.ListProvidersRequest
+	176, // 351: minder.v1.ProvidersService.CreateProvider:input_type -> minder.v1.CreateProviderRequest
+	178, // 352: minder.v1.ProvidersService.DeleteProvider:input_type -> minder.v1.DeleteProviderRequest
+	180, // 353: minder.v1.ProvidersService.DeleteProviderByID:input_type -> minder.v1.DeleteProviderByIDRequest
+	182, // 354: minder.v1.ProvidersService.ListProviderClasses:input_type -> minder.v1.ListProviderClassesRequest
+	54,  // 355: minder.v1.ProvidersService.ReconcileEntityRegistration:input_type -> minder.v1.ReconcileEntityRegistrationRequest
+	27,  // 356: minder.v1.InviteService.GetInviteDetails:input_type -> minder.v1.GetInviteDetailsRequest
+	202, // 357: minder.v1.EntityInstanceService.ListEntities:input_type -> minder.v1.ListEntitiesRequest
+	204, // 358: minder.v1.EntityInstanceService.GetEntityById:input_type -> minder.v1.GetEntityByIdRequest
+	206, // 359: minder.v1.EntityInstanceService.GetEntityByName:input_type -> minder.v1.GetEntityByNameRequest
+	208, // 360: minder.v1.EntityInstanceService.DeleteEntityById:input_type -> minder.v1.DeleteEntityByIdRequest
+	210, // 361: minder.v1.EntityInstanceService.RegisterEntity:input_type -> minder.v1.RegisterEntityRequest
+	30,  // 362: minder.v1.HealthService.CheckHealth:output_type -> minder.v1.CheckHealthResponse
+	14,  // 363: minder.v1.HealthService.GetVersion:output_type -> minder.v1.GetVersionResponse
+	16,  // 364: minder.v1.ArtifactService.ListArtifacts:output_type -> minder.v1.ListArtifactsResponse
+	20,  // 365: minder.v1.ArtifactService.GetArtifactById:output_type -> minder.v1.GetArtifactByIdResponse
+	22,  // 366: minder.v1.ArtifactService.GetArtifactByName:output_type -> minder.v1.GetArtifactByNameResponse
+	32,  // 367: minder.v1.OAuthService.GetAuthorizationURL:output_type -> minder.v1.GetAuthorizationURLResponse
+	34,  // 368: minder.v1.OAuthService.StoreProviderToken:output_type -> minder.v1.StoreProviderTokenResponse
+	57,  // 369: minder.v1.OAuthService.VerifyProviderTokenFrom:output_type -> minder.v1.VerifyProviderTokenFromResponse
+	59,  // 370: minder.v1.OAuthService.VerifyProviderCredential:output_type -> minder.v1.VerifyProviderCredentialResponse
+	43,  // 371: minder.v1.RepositoryService.RegisterRepository:output_type -> minder.v1.RegisterRepositoryResponse
+	37,  // 372: minder.v1.RepositoryService.ListRemoteRepositoriesFromProvider:output_type -> minder.v1.ListRemoteRepositoriesFromProviderResponse
+	53,  // 373: minder.v1.RepositoryService.ListRepositories:output_type -> minder.v1.ListRepositoriesResponse
+	45,  // 374: minder.v1.RepositoryService.GetRepositoryById:output_type -> minder.v1.GetRepositoryByIdResponse
+	49,  // 375: minder.v1.RepositoryService.GetRepositoryByName:output_type -> minder.v1.GetRepositoryByNameResponse
+	47,  // 376: minder.v1.RepositoryService.DeleteRepositoryById:output_type -> minder.v1.DeleteRepositoryByIdResponse
+	51,  // 377: minder.v1.RepositoryService.DeleteRepositoryByName:output_type -> minder.v1.DeleteRepositoryByNameResponse
+	61,  // 378: minder.v1.UserService.CreateUser:output_type -> minder.v1.CreateUserResponse
+	63,  // 379: minder.v1.UserService.DeleteUser:output_type -> minder.v1.DeleteUserResponse
+	67,  // 380: minder.v1.UserService.GetUser:output_type -> minder.v1.GetUserResponse
+	168, // 381: minder.v1.UserService.ListInvitations:output_type -> minder.v1.ListInvitationsResponse
+	170, // 382: minder.v1.UserService.ResolveInvitation:output_type -> minder.v1.ResolveInvitationResponse
+	83,  // 383: minder.v1.ProfileService.CreateProfile:output_type -> minder.v1.CreateProfileResponse
+	85,  // 384: minder.v1.ProfileService.UpdateProfile:output_type -> minder.v1.UpdateProfileResponse
+	87,  // 385: minder.v1.ProfileService.PatchProfile:output_type -> minder.v1.PatchProfileResponse
+	89,  // 386: minder.v1.ProfileService.DeleteProfile:output_type -> minder.v1.DeleteProfileResponse
+	91,  // 387: minder.v1.ProfileService.ListProfiles:output_type -> minder.v1.ListProfilesResponse
+	93,  // 388: minder.v1.ProfileService.GetProfileById:output_type -> minder.v1.GetProfileByIdResponse
+	95,  // 389: minder.v1.ProfileService.GetProfileByName:output_type -> minder.v1.GetProfileByNameResponse
+	101, // 390: minder.v1.ProfileService.GetProfileStatusByName:output_type -> minder.v1.GetProfileStatusByNameResponse
+	103, // 391: minder.v1.ProfileService.GetProfileStatusById:output_type -> minder.v1.GetProfileStatusByIdResponse
+	105, // 392: minder.v1.ProfileService.GetProfileStatusByProject:output_type -> minder.v1.GetProfileStatusByProjectResponse
+	69,  // 393: minder.v1.DataSourceService.CreateDataSource:output_type -> minder.v1.CreateDataSourceResponse
+	71,  // 394: minder.v1.DataSourceService.GetDataSourceById:output_type -> minder.v1.GetDataSourceByIdResponse
+	73,  // 395: minder.v1.DataSourceService.GetDataSourceByName:output_type -> minder.v1.GetDataSourceByNameResponse
+	75,  // 396: minder.v1.DataSourceService.ListDataSources:output_type -> minder.v1.ListDataSourcesResponse
+	77,  // 397: minder.v1.DataSourceService.UpdateDataSource:output_type -> minder.v1.UpdateDataSourceResponse
+	79,  // 398: minder.v1.DataSourceService.DeleteDataSourceById:output_type -> minder.v1.DeleteDataSourceByIdResponse
+	81,  // 399: minder.v1.DataSourceService.DeleteDataSourceByName:output_type -> minder.v1.DeleteDataSourceByNameResponse
+	118, // 400: minder.v1.RuleTypeService.ListRuleTypes:output_type -> minder.v1.ListRuleTypesResponse
+	120, // 401: minder.v1.RuleTypeService.GetRuleTypeByName:output_type -> minder.v1.GetRuleTypeByNameResponse
+	122, // 402: minder.v1.RuleTypeService.GetRuleTypeById:output_type -> minder.v1.GetRuleTypeByIdResponse
+	124, // 403: minder.v1.RuleTypeService.CreateRuleType:output_type -> minder.v1.CreateRuleTypeResponse
+	126, // 404: minder.v1.RuleTypeService.UpdateRuleType:output_type -> minder.v1.UpdateRuleTypeResponse
+	128, // 405: minder.v1.RuleTypeService.DeleteRuleType:output_type -> minder.v1.DeleteRuleTypeResponse
+	130, // 406: minder.v1.EvalResultsService.ListEvaluationResults:output_type -> minder.v1.ListEvaluationResultsResponse
+	194, // 407: minder.v1.EvalResultsService.ListEvaluationHistory:output_type -> minder.v1.ListEvaluationHistoryResponse
+	193, // 408: minder.v1.EvalResultsService.GetEvaluationHistory:output_type -> minder.v1.GetEvaluationHistoryResponse
+	156, // 409: minder.v1.PermissionsService.ListRoles:output_type -> minder.v1.ListRolesResponse
+	158, // 410: minder.v1.PermissionsService.ListRoleAssignments:output_type -> minder.v1.ListRoleAssignmentsResponse
+	160, // 411: minder.v1.PermissionsService.AssignRole:output_type -> minder.v1.AssignRoleResponse
+	162, // 412: minder.v1.PermissionsService.UpdateRole:output_type -> minder.v1.UpdateRoleResponse
+	164, // 413: minder.v1.PermissionsService.RemoveRole:output_type -> minder.v1.RemoveRoleResponse
+	141, // 414: minder.v1.ProjectsService.ListProjects:output_type -> minder.v1.ListProjectsResponse
+	143, // 415: minder.v1.ProjectsService.CreateProject:output_type -> minder.v1.CreateProjectResponse
+	152, // 416: minder.v1.ProjectsService.ListChildProjects:output_type -> minder.v1.ListChildProjectsResponse
+	145, // 417: minder.v1.ProjectsService.DeleteProject:output_type -> minder.v1.DeleteProjectResponse
+	147, // 418: minder.v1.ProjectsService.UpdateProject:output_type -> minder.v1.UpdateProjectResponse
+	150, // 419: minder.v1.ProjectsService.PatchProject:output_type -> minder.v1.PatchProjectResponse
+	154, // 420: minder.v1.ProjectsService.CreateEntityReconciliationTask:output_type -> minder.v1.CreateEntityReconciliationTaskResponse
+	186, // 421: minder.v1.ProvidersService.PatchProvider:output_type -> minder.v1.PatchProviderResponse
+	173, // 422: minder.v1.ProvidersService.GetProvider:output_type -> minder.v1.GetProviderResponse
+	175, // 423: minder.v1.ProvidersService.ListProviders:output_type -> minder.v1.ListProvidersResponse
+	177, // 424: minder.v1.ProvidersService.CreateProvider:output_type -> minder.v1.CreateProviderResponse
+	179, // 425: minder.v1.ProvidersService.DeleteProvider:output_type -> minder.v1.DeleteProviderResponse
+	181, // 426: minder.v1.ProvidersService.DeleteProviderByID:output_type -> minder.v1.DeleteProviderByIDResponse
+	184, // 427: minder.v1.ProvidersService.ListProviderClasses:output_type -> minder.v1.ListProviderClassesResponse
+	55,  // 428: minder.v1.ProvidersService.ReconcileEntityRegistration:output_type -> minder.v1.ReconcileEntityRegistrationResponse
+	28,  // 429: minder.v1.InviteService.GetInviteDetails:output_type -> minder.v1.GetInviteDetailsResponse
+	203, // 430: minder.v1.EntityInstanceService.ListEntities:output_type -> minder.v1.ListEntitiesResponse
+	205, // 431: minder.v1.EntityInstanceService.GetEntityById:output_type -> minder.v1.GetEntityByIdResponse
+	207, // 432: minder.v1.EntityInstanceService.GetEntityByName:output_type -> minder.v1.GetEntityByNameResponse
+	209, // 433: minder.v1.EntityInstanceService.DeleteEntityById:output_type -> minder.v1.DeleteEntityByIdResponse
+	211, // 434: minder.v1.EntityInstanceService.RegisterEntity:output_type -> minder.v1.RegisterEntityResponse
+	362, // [362:435] is the sub-list for method output_type
+	289, // [289:362] is the sub-list for method input_type
+	288, // [288:289] is the sub-list for extension type_name
+	286, // [286:288] is the sub-list for extension extendee
+	0,   // [0:286] is the sub-list for field type_name
 }
 
 func init() { file_minder_v1_minder_proto_init() }
@@ -17038,9 +17118,9 @@ func file_minder_v1_minder_proto_init() {
 	file_minder_v1_minder_proto_msgTypes[220].OneofWrappers = []any{}
 	file_minder_v1_minder_proto_msgTypes[222].OneofWrappers = []any{}
 	file_minder_v1_minder_proto_msgTypes[228].OneofWrappers = []any{}
-	file_minder_v1_minder_proto_msgTypes[229].OneofWrappers = []any{}
-	file_minder_v1_minder_proto_msgTypes[232].OneofWrappers = []any{}
-	file_minder_v1_minder_proto_msgTypes[239].OneofWrappers = []any{
+	file_minder_v1_minder_proto_msgTypes[230].OneofWrappers = []any{}
+	file_minder_v1_minder_proto_msgTypes[233].OneofWrappers = []any{}
+	file_minder_v1_minder_proto_msgTypes[240].OneofWrappers = []any{
 		(*RestDataSource_Def_Bodyobj)(nil),
 		(*RestDataSource_Def_Bodystr)(nil),
 		(*RestDataSource_Def_BodyFromField)(nil),
@@ -17051,7 +17131,7 @@ func file_minder_v1_minder_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_minder_v1_minder_proto_rawDesc), len(file_minder_v1_minder_proto_rawDesc)),
 			NumEnums:      10,
-			NumMessages:   243,
+			NumMessages:   244,
 			NumExtensions: 2,
 			NumServices:   14,
 		},

--- a/pkg/providers/v1/mock/providers.go
+++ b/pkg/providers/v1/mock/providers.go
@@ -1107,6 +1107,206 @@ func (mr *MockReviewPublisherMockRecorder) UpdateReview(ctx, owner, repo, prNumb
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateReview", reflect.TypeOf((*MockReviewPublisher)(nil).UpdateReview), ctx, owner, repo, prNumber, reviewID, body)
 }
 
+// MockIssuePublisher is a mock of IssuePublisher interface.
+type MockIssuePublisher struct {
+	ctrl     *gomock.Controller
+	recorder *MockIssuePublisherMockRecorder
+	isgomock struct{}
+}
+
+// MockIssuePublisherMockRecorder is the mock recorder for MockIssuePublisher.
+type MockIssuePublisherMockRecorder struct {
+	mock *MockIssuePublisher
+}
+
+// NewMockIssuePublisher creates a new mock instance.
+func NewMockIssuePublisher(ctrl *gomock.Controller) *MockIssuePublisher {
+	mock := &MockIssuePublisher{ctrl: ctrl}
+	mock.recorder = &MockIssuePublisherMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MockIssuePublisher) EXPECT() *MockIssuePublisherMockRecorder {
+	return m.recorder
+}
+
+// CloseIssue mocks base method.
+func (m *MockIssuePublisher) CloseIssue(ctx context.Context, owner, repo string, number int, comment string) (*github.Issue, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CloseIssue", ctx, owner, repo, number, comment)
+	ret0, _ := ret[0].(*github.Issue)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// CloseIssue indicates an expected call of CloseIssue.
+func (mr *MockIssuePublisherMockRecorder) CloseIssue(ctx, owner, repo, number, comment any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CloseIssue", reflect.TypeOf((*MockIssuePublisher)(nil).CloseIssue), ctx, owner, repo, number, comment)
+}
+
+// CreateIssue mocks base method.
+func (m *MockIssuePublisher) CreateIssue(ctx context.Context, owner, repo, title, body string, labels, assignees []string) (*github.Issue, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CreateIssue", ctx, owner, repo, title, body, labels, assignees)
+	ret0, _ := ret[0].(*github.Issue)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// CreateIssue indicates an expected call of CreateIssue.
+func (mr *MockIssuePublisherMockRecorder) CreateIssue(ctx, owner, repo, title, body, labels, assignees any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateIssue", reflect.TypeOf((*MockIssuePublisher)(nil).CreateIssue), ctx, owner, repo, title, body, labels, assignees)
+}
+
+// CreationOptions mocks base method.
+func (m *MockIssuePublisher) CreationOptions(entType v10.Entity) *v11.EntityCreationOptions {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CreationOptions", entType)
+	ret0, _ := ret[0].(*v11.EntityCreationOptions)
+	return ret0
+}
+
+// CreationOptions indicates an expected call of CreationOptions.
+func (mr *MockIssuePublisherMockRecorder) CreationOptions(entType any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreationOptions", reflect.TypeOf((*MockIssuePublisher)(nil).CreationOptions), entType)
+}
+
+// DeregisterEntity mocks base method.
+func (m *MockIssuePublisher) DeregisterEntity(ctx context.Context, entType v10.Entity, props *properties.Properties) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeregisterEntity", ctx, entType, props)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DeregisterEntity indicates an expected call of DeregisterEntity.
+func (mr *MockIssuePublisherMockRecorder) DeregisterEntity(ctx, entType, props any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeregisterEntity", reflect.TypeOf((*MockIssuePublisher)(nil).DeregisterEntity), ctx, entType, props)
+}
+
+// FetchAllProperties mocks base method.
+func (m *MockIssuePublisher) FetchAllProperties(ctx context.Context, getByProps *properties.Properties, entType v10.Entity, cachedProps *properties.Properties) (*properties.Properties, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "FetchAllProperties", ctx, getByProps, entType, cachedProps)
+	ret0, _ := ret[0].(*properties.Properties)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// FetchAllProperties indicates an expected call of FetchAllProperties.
+func (mr *MockIssuePublisherMockRecorder) FetchAllProperties(ctx, getByProps, entType, cachedProps any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FetchAllProperties", reflect.TypeOf((*MockIssuePublisher)(nil).FetchAllProperties), ctx, getByProps, entType, cachedProps)
+}
+
+// GetEntityName mocks base method.
+func (m *MockIssuePublisher) GetEntityName(entType v10.Entity, props *properties.Properties) (string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetEntityName", entType, props)
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetEntityName indicates an expected call of GetEntityName.
+func (mr *MockIssuePublisherMockRecorder) GetEntityName(entType, props any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetEntityName", reflect.TypeOf((*MockIssuePublisher)(nil).GetEntityName), entType, props)
+}
+
+// GetIssue mocks base method.
+func (m *MockIssuePublisher) GetIssue(ctx context.Context, owner, repo string, number int) (*github.Issue, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetIssue", ctx, owner, repo, number)
+	ret0, _ := ret[0].(*github.Issue)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetIssue indicates an expected call of GetIssue.
+func (mr *MockIssuePublisherMockRecorder) GetIssue(ctx, owner, repo, number any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetIssue", reflect.TypeOf((*MockIssuePublisher)(nil).GetIssue), ctx, owner, repo, number)
+}
+
+// PropertiesToProtoMessage mocks base method.
+func (m *MockIssuePublisher) PropertiesToProtoMessage(entType v10.Entity, props *properties.Properties) (protoreflect.ProtoMessage, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "PropertiesToProtoMessage", entType, props)
+	ret0, _ := ret[0].(protoreflect.ProtoMessage)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// PropertiesToProtoMessage indicates an expected call of PropertiesToProtoMessage.
+func (mr *MockIssuePublisherMockRecorder) PropertiesToProtoMessage(entType, props any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PropertiesToProtoMessage", reflect.TypeOf((*MockIssuePublisher)(nil).PropertiesToProtoMessage), entType, props)
+}
+
+// ProviderClassInfo mocks base method.
+func (m *MockIssuePublisher) ProviderClassInfo() *v10.ProviderClassInfo {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ProviderClassInfo")
+	ret0, _ := ret[0].(*v10.ProviderClassInfo)
+	return ret0
+}
+
+// ProviderClassInfo indicates an expected call of ProviderClassInfo.
+func (mr *MockIssuePublisherMockRecorder) ProviderClassInfo() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ProviderClassInfo", reflect.TypeOf((*MockIssuePublisher)(nil).ProviderClassInfo))
+}
+
+// RegisterEntity mocks base method.
+func (m *MockIssuePublisher) RegisterEntity(ctx context.Context, entType v10.Entity, props *properties.Properties) (*properties.Properties, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "RegisterEntity", ctx, entType, props)
+	ret0, _ := ret[0].(*properties.Properties)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// RegisterEntity indicates an expected call of RegisterEntity.
+func (mr *MockIssuePublisherMockRecorder) RegisterEntity(ctx, entType, props any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RegisterEntity", reflect.TypeOf((*MockIssuePublisher)(nil).RegisterEntity), ctx, entType, props)
+}
+
+// ReopenIssue mocks base method.
+func (m *MockIssuePublisher) ReopenIssue(ctx context.Context, owner, repo string, number int) (*github.Issue, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ReopenIssue", ctx, owner, repo, number)
+	ret0, _ := ret[0].(*github.Issue)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ReopenIssue indicates an expected call of ReopenIssue.
+func (mr *MockIssuePublisherMockRecorder) ReopenIssue(ctx, owner, repo, number any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReopenIssue", reflect.TypeOf((*MockIssuePublisher)(nil).ReopenIssue), ctx, owner, repo, number)
+}
+
+// SupportsEntity mocks base method.
+func (m *MockIssuePublisher) SupportsEntity(entType v10.Entity) bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SupportsEntity", entType)
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// SupportsEntity indicates an expected call of SupportsEntity.
+func (mr *MockIssuePublisherMockRecorder) SupportsEntity(entType any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SupportsEntity", reflect.TypeOf((*MockIssuePublisher)(nil).SupportsEntity), entType)
+}
+
 // MockGitHub is a mock of GitHub interface.
 type MockGitHub struct {
 	ctrl     *gomock.Controller
@@ -1160,6 +1360,21 @@ func (mr *MockGitHubMockRecorder) Clone(ctx, url, branch any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Clone", reflect.TypeOf((*MockGitHub)(nil).Clone), ctx, url, branch)
 }
 
+// CloseIssue mocks base method.
+func (m *MockGitHub) CloseIssue(ctx context.Context, owner, repo string, number int, comment string) (*github.Issue, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CloseIssue", ctx, owner, repo, number, comment)
+	ret0, _ := ret[0].(*github.Issue)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// CloseIssue indicates an expected call of CloseIssue.
+func (mr *MockGitHubMockRecorder) CloseIssue(ctx, owner, repo, number, comment any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CloseIssue", reflect.TypeOf((*MockGitHub)(nil).CloseIssue), ctx, owner, repo, number, comment)
+}
+
 // ClosePullRequest mocks base method.
 func (m *MockGitHub) ClosePullRequest(ctx context.Context, owner, repo string, number int) (*github.PullRequest, error) {
 	m.ctrl.T.Helper()
@@ -1202,6 +1417,21 @@ func (m *MockGitHub) CreateHook(ctx context.Context, owner, repo string, hook *g
 func (mr *MockGitHubMockRecorder) CreateHook(ctx, owner, repo, hook any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateHook", reflect.TypeOf((*MockGitHub)(nil).CreateHook), ctx, owner, repo, hook)
+}
+
+// CreateIssue mocks base method.
+func (m *MockGitHub) CreateIssue(ctx context.Context, owner, repo, title, body string, labels, assignees []string) (*github.Issue, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CreateIssue", ctx, owner, repo, title, body, labels, assignees)
+	ret0, _ := ret[0].(*github.Issue)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// CreateIssue indicates an expected call of CreateIssue.
+func (mr *MockGitHubMockRecorder) CreateIssue(ctx, owner, repo, title, body, labels, assignees any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateIssue", reflect.TypeOf((*MockGitHub)(nil).CreateIssue), ctx, owner, repo, title, body, labels, assignees)
 }
 
 // CreateIssueComment mocks base method.
@@ -1437,6 +1667,21 @@ func (m *MockGitHub) GetEntityName(entType v10.Entity, props *properties.Propert
 func (mr *MockGitHubMockRecorder) GetEntityName(entType, props any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetEntityName", reflect.TypeOf((*MockGitHub)(nil).GetEntityName), entType, props)
+}
+
+// GetIssue mocks base method.
+func (m *MockGitHub) GetIssue(ctx context.Context, owner, repo string, number int) (*github.Issue, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetIssue", ctx, owner, repo, number)
+	ret0, _ := ret[0].(*github.Issue)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetIssue indicates an expected call of GetIssue.
+func (mr *MockGitHubMockRecorder) GetIssue(ctx, owner, repo, number any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetIssue", reflect.TypeOf((*MockGitHub)(nil).GetIssue), ctx, owner, repo, number)
 }
 
 // GetLogin mocks base method.
@@ -1765,6 +2010,21 @@ func (m *MockGitHub) RegisterEntity(ctx context.Context, entType v10.Entity, pro
 func (mr *MockGitHubMockRecorder) RegisterEntity(ctx, entType, props any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RegisterEntity", reflect.TypeOf((*MockGitHub)(nil).RegisterEntity), ctx, entType, props)
+}
+
+// ReopenIssue mocks base method.
+func (m *MockGitHub) ReopenIssue(ctx context.Context, owner, repo string, number int) (*github.Issue, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ReopenIssue", ctx, owner, repo, number)
+	ret0, _ := ret[0].(*github.Issue)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ReopenIssue indicates an expected call of ReopenIssue.
+func (mr *MockGitHubMockRecorder) ReopenIssue(ctx, owner, repo, number any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReopenIssue", reflect.TypeOf((*MockGitHub)(nil).ReopenIssue), ctx, owner, repo, number)
 }
 
 // SetCommitStatus mocks base method.

--- a/pkg/providers/v1/providers.go
+++ b/pkg/providers/v1/providers.go
@@ -201,6 +201,43 @@ type ReviewPublisher interface {
 	GetPullRequest(ctx context.Context, owner, repo string, prNumber int) (*github.PullRequest, error)
 }
 
+// IssuePublisher is the interface for providers that can publish issues.
+type IssuePublisher interface {
+	Provider
+
+	// CreateIssue creates an issue in the given repository.
+	CreateIssue(
+		ctx context.Context,
+		owner, repo string,
+		title string,
+		body string,
+		labels []string,
+		assignees []string,
+	) (*github.Issue, error)
+
+	// GetIssue gets an issue from the given repository
+	GetIssue(
+		ctx context.Context,
+		owner, repo string,
+		number int,
+	) (*github.Issue, error)
+
+	// CloseIssue closes an existing issue
+	CloseIssue(
+		ctx context.Context,
+		owner, repo string,
+		number int,
+		comment string,
+	) (*github.Issue, error)
+
+	// ReopenIssue reopens an existing issue
+	ReopenIssue(
+		ctx context.Context,
+		owner, repo string,
+		number int,
+	) (*github.Issue, error)
+}
+
 // GitHub is the interface for interacting with the GitHub REST API
 // Add methods here for interacting with the GitHub Rest API
 type GitHub interface {
@@ -238,6 +275,11 @@ type GitHub interface {
 	CreatePullRequest(ctx context.Context, owner, repo, title, body, head, base string) (*github.PullRequest, error)
 	ClosePullRequest(ctx context.Context, owner, repo string, number int) (*github.PullRequest, error)
 	ListPullRequests(ctx context.Context, owner, repo string, opt *github.PullRequestListOptions) ([]*github.PullRequest, error)
+	CreateIssue(ctx context.Context, owner, repo string, title string, body string, labels []string,
+		assignees []string) (*github.Issue, error)
+	GetIssue(ctx context.Context, owner, repo string, number int) (*github.Issue, error)
+	CloseIssue(ctx context.Context, owner, repo string, number int, comment string) (*github.Issue, error)
+	ReopenIssue(ctx context.Context, owner, repo string, number int) (*github.Issue, error)
 	GetUserId(ctx context.Context) (int64, error)
 	GetName(ctx context.Context) (string, error)
 	GetLogin(ctx context.Context) (string, error)

--- a/proto/minder/v1/minder.proto
+++ b/proto/minder/v1/minder.proto
@@ -1,95 +1,95 @@
 // SPDX-FileCopyrightText: Copyright 2023 The Minder Authors
 // SPDX-License-Identifier: Apache-2.0
 
-
 syntax = "proto3";
 package minder.v1;
+
+import "buf/validate/validate.proto";
 import "google/api/annotations.proto";
 import "google/api/field_behavior.proto";
 import "google/protobuf/descriptor.proto";
-import "google/protobuf/timestamp.proto";
-import "google/protobuf/struct.proto";
 import "google/protobuf/field_mask.proto";
-import "buf/validate/validate.proto";
+import "google/protobuf/struct.proto";
+import "google/protobuf/timestamp.proto";
 
 option go_package = "github.com/mindersec/minder/pkg/api/protobuf/go/minder/v1";
 
 enum ObjectOwner {
-    OBJECT_OWNER_UNSPECIFIED = 0;
-    OBJECT_OWNER_PROJECT = 2;
-    OBJECT_OWNER_USER = 3;
-    reserved 1; // deprecated OBJECT_OWNER_ORGANIZATION
+  OBJECT_OWNER_UNSPECIFIED = 0;
+  OBJECT_OWNER_PROJECT = 2;
+  OBJECT_OWNER_USER = 3;
+  reserved 1; // deprecated OBJECT_OWNER_ORGANIZATION
 }
 
 enum Relation {
-    RELATION_UNSPECIFIED = 0;
-    RELATION_CREATE = 1 [(name) = "create"];
-    RELATION_GET = 2 [(name) = "get"];
-    RELATION_UPDATE = 3 [(name) = "update"];
-    RELATION_DELETE = 4 [(name) = "delete"];
-    RELATION_ROLE_LIST = 5 [(name) = "role_list"];
-    RELATION_ROLE_ASSIGNMENT_LIST = 6 [(name) = "role_assignment_list"];
-    RELATION_ROLE_ASSIGNMENT_CREATE = 7 [(name) = "role_assignment_create"];
-    RELATION_ROLE_ASSIGNMENT_REMOVE = 8 [(name) = "role_assignment_remove"];
-    RELATION_REPO_GET = 9 [(name) = "repo_get"];
-    RELATION_REPO_CREATE = 10 [(name) = "repo_create"];
-    RELATION_REPO_UPDATE = 11 [(name) = "repo_update"];
-    RELATION_REPO_DELETE = 12 [(name) = "repo_delete"];
-    RELATION_ARTIFACT_GET = 13 [(name) = "artifact_get"];
-    RELATION_ARTIFACT_CREATE = 14 [(name) = "artifact_create"];
-    RELATION_ARTIFACT_UPDATE = 15 [(name) = "artifact_update"];
-    RELATION_ARTIFACT_DELETE = 16 [(name) = "artifact_delete"];
-    RELATION_PR_GET = 17 [(name) = "pr_get"];
-    RELATION_PR_CREATE = 18 [(name) = "pr_create"];
-    RELATION_PR_UPDATE = 19 [(name) = "pr_update"];
-    RELATION_PR_DELETE = 20 [(name) = "pr_delete"];
-    RELATION_PROVIDER_GET = 21 [(name) = "provider_get"];
-    RELATION_PROVIDER_CREATE = 22 [(name) = "provider_create"];
-    RELATION_PROVIDER_UPDATE = 23 [(name) = "provider_update"];
-    RELATION_PROVIDER_DELETE = 24 [(name) = "provider_delete"];
-    RELATION_RULE_TYPE_GET = 25 [(name) = "rule_type_get"];
-    RELATION_RULE_TYPE_CREATE = 26 [(name) = "rule_type_create"];
-    RELATION_RULE_TYPE_UPDATE = 27 [(name) = "rule_type_update"];
-    RELATION_RULE_TYPE_DELETE = 28 [(name) = "rule_type_delete"];
-    RELATION_PROFILE_GET = 29 [(name) = "profile_get"];
-    RELATION_PROFILE_CREATE = 30 [(name) = "profile_create"];
-    RELATION_PROFILE_UPDATE = 31 [(name) = "profile_update"];
-    RELATION_PROFILE_DELETE = 32 [(name) = "profile_delete"];
-    RELATION_PROFILE_STATUS_GET = 33 [(name) = "profile_status_get"];
-    RELATION_REMOTE_REPO_GET = 34 [(name) = "remote_repo_get"];
-    RELATION_ENTITY_RECONCILIATION_TASK_CREATE = 35 [(name) = "entity_reconciliation_task_create"];
-    RELATION_ENTITY_RECONCILE = 36 [(name) = "entity_reconcile"];
-    RELATION_ROLE_ASSIGNMENT_UPDATE = 37 [(name) = "role_assignment_update"];
-    RELATION_DATA_SOURCE_GET = 38 [(name) = "data_source_get"];
-    RELATION_DATA_SOURCE_CREATE = 39 [(name) = "data_source_create"];
-    RELATION_DATA_SOURCE_UPDATE = 40 [(name) = "data_source_update"];
-    RELATION_DATA_SOURCE_DELETE = 41 [(name) = "data_source_delete"];
-    RELATION_ENTITY_GET = 42 [(name) = "entity_get"];
-    RELATION_ENTITY_REGISTER = 43 [(name) = "entity_register"];
-    RELATION_ENTITY_UPDATE = 44 [(name) = "entity_update"];
-    RELATION_ENTITY_DELETE = 45 [(name) = "entity_delete"];
+  RELATION_UNSPECIFIED = 0;
+  RELATION_CREATE = 1 [(name) = "create"];
+  RELATION_GET = 2 [(name) = "get"];
+  RELATION_UPDATE = 3 [(name) = "update"];
+  RELATION_DELETE = 4 [(name) = "delete"];
+  RELATION_ROLE_LIST = 5 [(name) = "role_list"];
+  RELATION_ROLE_ASSIGNMENT_LIST = 6 [(name) = "role_assignment_list"];
+  RELATION_ROLE_ASSIGNMENT_CREATE = 7 [(name) = "role_assignment_create"];
+  RELATION_ROLE_ASSIGNMENT_REMOVE = 8 [(name) = "role_assignment_remove"];
+  RELATION_REPO_GET = 9 [(name) = "repo_get"];
+  RELATION_REPO_CREATE = 10 [(name) = "repo_create"];
+  RELATION_REPO_UPDATE = 11 [(name) = "repo_update"];
+  RELATION_REPO_DELETE = 12 [(name) = "repo_delete"];
+  RELATION_ARTIFACT_GET = 13 [(name) = "artifact_get"];
+  RELATION_ARTIFACT_CREATE = 14 [(name) = "artifact_create"];
+  RELATION_ARTIFACT_UPDATE = 15 [(name) = "artifact_update"];
+  RELATION_ARTIFACT_DELETE = 16 [(name) = "artifact_delete"];
+  RELATION_PR_GET = 17 [(name) = "pr_get"];
+  RELATION_PR_CREATE = 18 [(name) = "pr_create"];
+  RELATION_PR_UPDATE = 19 [(name) = "pr_update"];
+  RELATION_PR_DELETE = 20 [(name) = "pr_delete"];
+  RELATION_PROVIDER_GET = 21 [(name) = "provider_get"];
+  RELATION_PROVIDER_CREATE = 22 [(name) = "provider_create"];
+  RELATION_PROVIDER_UPDATE = 23 [(name) = "provider_update"];
+  RELATION_PROVIDER_DELETE = 24 [(name) = "provider_delete"];
+  RELATION_RULE_TYPE_GET = 25 [(name) = "rule_type_get"];
+  RELATION_RULE_TYPE_CREATE = 26 [(name) = "rule_type_create"];
+  RELATION_RULE_TYPE_UPDATE = 27 [(name) = "rule_type_update"];
+  RELATION_RULE_TYPE_DELETE = 28 [(name) = "rule_type_delete"];
+  RELATION_PROFILE_GET = 29 [(name) = "profile_get"];
+  RELATION_PROFILE_CREATE = 30 [(name) = "profile_create"];
+  RELATION_PROFILE_UPDATE = 31 [(name) = "profile_update"];
+  RELATION_PROFILE_DELETE = 32 [(name) = "profile_delete"];
+  RELATION_PROFILE_STATUS_GET = 33 [(name) = "profile_status_get"];
+  RELATION_REMOTE_REPO_GET = 34 [(name) = "remote_repo_get"];
+  RELATION_ENTITY_RECONCILIATION_TASK_CREATE = 35 [(name) = "entity_reconciliation_task_create"];
+  RELATION_ENTITY_RECONCILE = 36 [(name) = "entity_reconcile"];
+  RELATION_ROLE_ASSIGNMENT_UPDATE = 37 [(name) = "role_assignment_update"];
+  RELATION_DATA_SOURCE_GET = 38 [(name) = "data_source_get"];
+  RELATION_DATA_SOURCE_CREATE = 39 [(name) = "data_source_create"];
+  RELATION_DATA_SOURCE_UPDATE = 40 [(name) = "data_source_update"];
+  RELATION_DATA_SOURCE_DELETE = 41 [(name) = "data_source_delete"];
+  RELATION_ENTITY_GET = 42 [(name) = "entity_get"];
+  RELATION_ENTITY_REGISTER = 43 [(name) = "entity_register"];
+  RELATION_ENTITY_UPDATE = 44 [(name) = "entity_update"];
+  RELATION_ENTITY_DELETE = 45 [(name) = "entity_delete"];
 }
 
 extend google.protobuf.EnumValueOptions {
-    optional string name = 42445;
+  optional string name = 42445;
 }
 
 enum TargetResource {
-    TARGET_RESOURCE_UNSPECIFIED = 0;
-    TARGET_RESOURCE_NONE = 1;
-    TARGET_RESOURCE_USER = 2;
-    TARGET_RESOURCE_PROJECT = 3;
+  TARGET_RESOURCE_UNSPECIFIED = 0;
+  TARGET_RESOURCE_NONE = 1;
+  TARGET_RESOURCE_USER = 2;
+  TARGET_RESOURCE_PROJECT = 3;
 }
 
 message RpcOptions {
-    bool no_log = 2;
-    TargetResource target_resource = 6;
-    Relation relation = 7;
-    reserved 1, 3, 4, 5; // deprecated anonymous, owner_only, root_admin_only and auth_scope
+  bool no_log = 2;
+  TargetResource target_resource = 6;
+  Relation relation = 7;
+  reserved 1, 3, 4, 5; // deprecated anonymous, owner_only, root_admin_only and auth_scope
 }
 
 extend google.protobuf.MethodOptions {
-    RpcOptions rpc_options = 51077;
+  RpcOptions rpc_options = 51077;
 }
 
 // Cursor message to be used in request messages. Its purpose is to
@@ -97,216 +97,190 @@ extend google.protobuf.MethodOptions {
 // of index within a collection, along with the number of items to
 // retrieve.
 message Cursor {
-    // cursor is the index to start from within the collection being
-    // retrieved. It's an opaque payload specified and interpreted on
-    // an per-rpc basis. An empty string is used to indicate the first
-    // item in the collection.
-    string cursor = 1 [
-        (buf.validate.field).string = {
-            pattern: "^[[:word:]=]*$",
-            max_len: 200,
-        }
-    ];
-    // size is the number of items to retrieve from the collection.
-    // 0 uses a server-defined default.
-    uint32 size = 2 [
-        (buf.validate.field).uint32 = { gte: 0, lte: 100 },
-        (google.api.field_behavior) = REQUIRED
-    ];
+  // cursor is the index to start from within the collection being
+  // retrieved. It's an opaque payload specified and interpreted on
+  // an per-rpc basis. An empty string is used to indicate the first
+  // item in the collection.
+  string cursor = 1 [(buf.validate.field).string = {
+    pattern: "^[[:word:]=]*$"
+    max_len: 200
+  }];
+  // size is the number of items to retrieve from the collection.
+  // 0 uses a server-defined default.
+  uint32 size = 2 [
+    (buf.validate.field).uint32 = {
+      gte: 0
+      lte: 100
+    },
+    (google.api.field_behavior) = REQUIRED
+  ];
 }
 
 // CursorPage message used in response messages. Its purpose is to
 // send to clients links pointing to next and/or previous collection
 // subsets with respect to the one containing this struct.
 message CursorPage {
-    // Total number of records matching the request. This is optional.
-    uint32 total_records = 1;
-    // Cursor pointing to retrieve results logically placed after the
-    // ones shipped with the message containing this struct. This is optional.
-    Cursor next = 2;
-    // Cursor pointing to retrieve results logically placed before the
-    // ones shipped with the message containing this struct. This is optional.
-    Cursor prev = 3;
+  // Total number of records matching the request. This is optional.
+  uint32 total_records = 1;
+  // Cursor pointing to retrieve results logically placed after the
+  // ones shipped with the message containing this struct. This is optional.
+  Cursor next = 2;
+  // Cursor pointing to retrieve results logically placed before the
+  // ones shipped with the message containing this struct. This is optional.
+  Cursor prev = 3;
 }
 
 // Simple Health Check Service
 // replies with OK
 service HealthService {
-    rpc CheckHealth (CheckHealthRequest) returns (CheckHealthResponse) {
-        option (google.api.http) = {
-            get: "/api/v1/health"
-        };
-
-        option (rpc_options) = {
-            target_resource: TARGET_RESOURCE_NONE
-            no_log: true
-        };
-    }
-
-    rpc GetVersion(GetVersionRequest) returns (GetVersionResponse) {
-    option (google.api.http) = {
-        get: "/api/v1/version"
-    };
+  rpc CheckHealth(CheckHealthRequest) returns (CheckHealthResponse) {
+    option (google.api.http) = {get: "/api/v1/health"};
 
     option (rpc_options) = {
-        target_resource: TARGET_RESOURCE_NONE
-        no_log: true
+      target_resource: TARGET_RESOURCE_NONE
+      no_log: true
     };
-}
+  }
+
+  rpc GetVersion(GetVersionRequest) returns (GetVersionResponse) {
+    option (google.api.http) = {get: "/api/v1/version"};
+
+    option (rpc_options) = {
+      target_resource: TARGET_RESOURCE_NONE
+      no_log: true
+    };
+  }
 }
 
 service ArtifactService {
-    rpc ListArtifacts (ListArtifactsRequest) returns (ListArtifactsResponse) {
-        option (google.api.http) = {
-            get: "/api/v1/artifacts/{provider}"
-            additional_bindings {
-                get: "/api/v1/artifacts"
-            }
-        };
+  rpc ListArtifacts(ListArtifactsRequest) returns (ListArtifactsResponse) {
+    option (google.api.http) = {
+      get: "/api/v1/artifacts/{provider}"
+      additional_bindings: {get: "/api/v1/artifacts"}
+    };
 
-        option (rpc_options) = {
-            target_resource: TARGET_RESOURCE_PROJECT
-            relation: RELATION_ARTIFACT_GET
-        };
-    }
+    option (rpc_options) = {
+      target_resource: TARGET_RESOURCE_PROJECT
+      relation: RELATION_ARTIFACT_GET
+    };
+  }
 
-    rpc GetArtifactById (GetArtifactByIdRequest) returns (GetArtifactByIdResponse) {
-        option (google.api.http) = {
-            get: "/api/v1/artifact/{id}"
-        };
+  rpc GetArtifactById(GetArtifactByIdRequest) returns (GetArtifactByIdResponse) {
+    option (google.api.http) = {get: "/api/v1/artifact/{id}"};
 
-        option (rpc_options) = {
-            target_resource: TARGET_RESOURCE_PROJECT
-            relation: RELATION_ARTIFACT_GET
-        };
-    }
+    option (rpc_options) = {
+      target_resource: TARGET_RESOURCE_PROJECT
+      relation: RELATION_ARTIFACT_GET
+    };
+  }
 
-    rpc GetArtifactByName (GetArtifactByNameRequest) returns (GetArtifactByNameResponse) {
-        option (google.api.http) = {
-            get: "/api/v1/artifact/name/{name=**}"
-        };
+  rpc GetArtifactByName(GetArtifactByNameRequest) returns (GetArtifactByNameResponse) {
+    option (google.api.http) = {get: "/api/v1/artifact/name/{name=**}"};
 
-        option (rpc_options) = {
-            target_resource: TARGET_RESOURCE_PROJECT
-            relation: RELATION_ARTIFACT_GET
-        };
-    }
-
+    option (rpc_options) = {
+      target_resource: TARGET_RESOURCE_PROJECT
+      relation: RELATION_ARTIFACT_GET
+    };
+  }
 }
 
 message GetVersionRequest {}
 
 // GetVersionResponse returns the build and version info of the Minder server
 message GetVersionResponse {
-    string version = 1;
-    string commit = 2;
+  string version = 1;
+  string commit = 2;
 }
 
 message ListArtifactsRequest {
-    string provider = 1 [deprecated=true];
-    Context context = 3;
-    // from is the filter to apply to the list of artifacts.
-    // An example is "repository=org1/repo1,org2/repo2"
-    // to filter by repository names. This is optional.
-    string from = 4 [
-        (buf.validate.field).string = {
-            pattern: "^[[:word:]]+=[-,/[:word:]]+$",
-            max_len: 200,
-        },
-        (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE
-    ];
+  string provider = 1 [deprecated = true];
+  Context context = 3;
+  // from is the filter to apply to the list of artifacts.
+  // An example is "repository=org1/repo1,org2/repo2"
+  // to filter by repository names. This is optional.
+  string from = 4 [
+    (buf.validate.field).string = {
+      pattern: "^[[:word:]]+=[-,/[:word:]]+$"
+      max_len: 200
+    },
+    (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE
+  ];
 
-    reserved 2; // deprecated project_id
+  reserved 2; // deprecated project_id
 }
 
 message ListArtifactsResponse {
-    repeated Artifact results = 1 [
-        (google.api.field_behavior) = REQUIRED
-    ];
+  repeated Artifact results = 1 [(google.api.field_behavior) = REQUIRED];
 }
 
 message Artifact {
-    string artifact_pk = 1 [
-        (google.api.field_behavior) = REQUIRED
-    ];
-    // owner is the artifact owner. This is optional.
-    string owner = 2;
-    string name = 3 [
-        (google.api.field_behavior) = REQUIRED
-    ];
-    string type = 4 [
-        (google.api.field_behavior) = REQUIRED
-    ];
-    string visibility = 5 [
-        (google.api.field_behavior) = REQUIRED
-    ];
-    // repository is the repository the artifact originated from.
-    // This is optional.
-    string repository = 6;
-    repeated ArtifactVersion versions = 7;
-    google.protobuf.Timestamp created_at = 8  [
-        (google.api.field_behavior) = REQUIRED
-    ];
-    Context context = 9;
+  string artifact_pk = 1 [(google.api.field_behavior) = REQUIRED];
+  // owner is the artifact owner. This is optional.
+  string owner = 2;
+  string name = 3 [(google.api.field_behavior) = REQUIRED];
+  string type = 4 [(google.api.field_behavior) = REQUIRED];
+  string visibility = 5 [(google.api.field_behavior) = REQUIRED];
+  // repository is the repository the artifact originated from.
+  // This is optional.
+  string repository = 6;
+  repeated ArtifactVersion versions = 7;
+  google.protobuf.Timestamp created_at = 8 [(google.api.field_behavior) = REQUIRED];
+  Context context = 9;
 }
 
 // ArtifactVersion is a version of an artifact.
 // This is currently not populated in any requests or responses.
 message ArtifactVersion {
-    int64 version_id = 1 [
-        (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE,
-        (buf.validate.field).int64 = { gte: 1 }
-    ];
-    repeated string tags = 2;
-    string sha = 3;
-    google.protobuf.Timestamp created_at = 6;
+  int64 version_id = 1 [
+    (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE,
+    (buf.validate.field).int64 = {gte: 1}
+  ];
+  repeated string tags = 2;
+  string sha = 3;
+  google.protobuf.Timestamp created_at = 6;
 
-    reserved 4, 5;
-    reserved "github_workflow", "signature_verification";
+  reserved 4, 5;
+  reserved "github_workflow", "signature_verification";
 }
 
 message GetArtifactByIdRequest {
-    string id = 1 [
-        (buf.validate.field).string = {uuid: true},
-        (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE,
-        (google.api.field_behavior) = REQUIRED
-    ];
+  string id = 1 [
+    (buf.validate.field).string = {uuid: true},
+    (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE,
+    (google.api.field_behavior) = REQUIRED
+  ];
 
-    Context context = 7;
+  Context context = 7;
 
-    reserved 5, 6; // deprecated latest_versions, tag
-    reserved "latest_versions", "tag";
+  reserved 5, 6; // deprecated latest_versions, tag
+  reserved "latest_versions", "tag";
 }
 
 message GetArtifactByIdResponse {
-    Artifact artifact = 1 [
-        (google.api.field_behavior) = REQUIRED
-    ];
-    // This is optional and currently always nil.
-    repeated ArtifactVersion versions = 2;
+  Artifact artifact = 1 [(google.api.field_behavior) = REQUIRED];
+  // This is optional and currently always nil.
+  repeated ArtifactVersion versions = 2;
 }
 
 message GetArtifactByNameRequest {
-    string name = 1 [
-        (buf.validate.field).string = {
-            pattern: "^[-./[:word:]]*$",
-            max_len: 200,
-        },
-        (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE,
-        (google.api.field_behavior) = REQUIRED
-    ];
-    Context context = 4;
+  string name = 1 [
+    (buf.validate.field).string = {
+      pattern: "^[-./[:word:]]*$"
+      max_len: 200
+    },
+    (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE,
+    (google.api.field_behavior) = REQUIRED
+  ];
+  Context context = 4;
 
-    reserved 2, 3; // deprecated latest_versions, tag
-    reserved "latest_versions", "tag";
+  reserved 2, 3; // deprecated latest_versions, tag
+  reserved "latest_versions", "tag";
 }
 
 message GetArtifactByNameResponse {
-    Artifact artifact = 1 [
-        (google.api.field_behavior) = REQUIRED
-    ];
-    // This is optional and currently always nil.
-    repeated ArtifactVersion versions = 2;
+  Artifact artifact = 1 [(google.api.field_behavior) = REQUIRED];
+  // This is optional and currently always nil.
+  repeated ArtifactVersion versions = 2;
 }
 
 // Stubs for the SDLC entities
@@ -316,1768 +290,1527 @@ message TaskRun {}
 message Build {}
 
 service OAuthService {
-    rpc GetAuthorizationURL (GetAuthorizationURLRequest) returns (GetAuthorizationURLResponse) {
-        option (google.api.http) = {
-            get: "/api/v1/auth/url"
-        };
+  rpc GetAuthorizationURL(GetAuthorizationURLRequest) returns (GetAuthorizationURLResponse) {
+    option (google.api.http) = {get: "/api/v1/auth/url"};
 
-        option (rpc_options) = {
-            target_resource: TARGET_RESOURCE_PROJECT
-            relation: RELATION_PROVIDER_UPDATE
-        };
-    }
+    option (rpc_options) = {
+      target_resource: TARGET_RESOURCE_PROJECT
+      relation: RELATION_PROVIDER_UPDATE
+    };
+  }
 
-    rpc StoreProviderToken (StoreProviderTokenRequest) returns (StoreProviderTokenResponse) {
-        option (google.api.http) = {
-            post: "/api/v1/auth/{provider}/token"
-            additional_bindings {
-                post: "/api/v1/auth/token"
-                body: "*"
-            }
-            body: "*"
-        };
+  rpc StoreProviderToken(StoreProviderTokenRequest) returns (StoreProviderTokenResponse) {
+    option (google.api.http) = {
+      post: "/api/v1/auth/{provider}/token"
+      additional_bindings: {
+        post: "/api/v1/auth/token"
+        body: "*"
+      }
+      body: "*"
+    };
 
-        option (rpc_options) = {
-            target_resource: TARGET_RESOURCE_PROJECT
-            relation: RELATION_PROVIDER_UPDATE
-        };
-    }
+    option (rpc_options) = {
+      target_resource: TARGET_RESOURCE_PROJECT
+      relation: RELATION_PROVIDER_UPDATE
+    };
+  }
 
-    // VerifyProviderTokenFrom verifies that a token has been created for a provider since given timestamp
-    rpc VerifyProviderTokenFrom (VerifyProviderTokenFromRequest) returns (VerifyProviderTokenFromResponse) {
-        option deprecated = true;
-        option (google.api.http) = {
-            get: "/api/v1/auth/verify/{provider}/{timestamp}"
-            additional_bindings {
-                get: "/api/v1/auth/verify/{timestamp}"
-            }
-        };
+  // VerifyProviderTokenFrom verifies that a token has been created for a provider since given timestamp
+  rpc VerifyProviderTokenFrom(VerifyProviderTokenFromRequest) returns (VerifyProviderTokenFromResponse) {
+    option deprecated = true;
+    option (google.api.http) = {
+      get: "/api/v1/auth/verify/{provider}/{timestamp}"
+      additional_bindings: {get: "/api/v1/auth/verify/{timestamp}"}
+    };
 
-        option (rpc_options) = {
-            target_resource: TARGET_RESOURCE_PROJECT
-            relation: RELATION_PROVIDER_UPDATE
-        };
-    }
+    option (rpc_options) = {
+      target_resource: TARGET_RESOURCE_PROJECT
+      relation: RELATION_PROVIDER_UPDATE
+    };
+  }
 
-    // VerifyProviderCredential verifies that a credential has been created matching the enrollment nonce
-    rpc VerifyProviderCredential (VerifyProviderCredentialRequest) returns (VerifyProviderCredentialResponse) {
-        option (google.api.http) = {
-            get: "/api/v1/auth/verify"
-        };
+  // VerifyProviderCredential verifies that a credential has been created matching the enrollment nonce
+  rpc VerifyProviderCredential(VerifyProviderCredentialRequest) returns (VerifyProviderCredentialResponse) {
+    option (google.api.http) = {get: "/api/v1/auth/verify"};
 
-        option (rpc_options) = {
-            target_resource: TARGET_RESOURCE_PROJECT
-            relation: RELATION_PROVIDER_UPDATE
-        };
-    }
-
+    option (rpc_options) = {
+      target_resource: TARGET_RESOURCE_PROJECT
+      relation: RELATION_PROVIDER_UPDATE
+    };
+  }
 }
 
 service RepositoryService {
-    rpc RegisterRepository (RegisterRepositoryRequest) returns (RegisterRepositoryResponse) {
-        option (google.api.http) = {
-            post: "/api/v1/repository/provider/{provider}/register"
-            additional_bindings {
-                post: "/api/v1/repository/register",
-                body: "*"
-            }
-            body: "*"
-        };
+  rpc RegisterRepository(RegisterRepositoryRequest) returns (RegisterRepositoryResponse) {
+    option (google.api.http) = {
+      post: "/api/v1/repository/provider/{provider}/register"
+      additional_bindings: {
+        post: "/api/v1/repository/register"
+        body: "*"
+      }
+      body: "*"
+    };
 
-        option (rpc_options) = {
-            target_resource: TARGET_RESOURCE_PROJECT
-            relation: RELATION_REPO_CREATE
-        };
-    }
-    rpc ListRemoteRepositoriesFromProvider(ListRemoteRepositoriesFromProviderRequest) returns (ListRemoteRepositoriesFromProviderResponse) {
-        option (google.api.http) = {
-            get: "/api/v1/repositories/provider/{provider}/remote"
-            additional_bindings {
-                get: "/api/v1/repositories/remote"
-            }
-        };
+    option (rpc_options) = {
+      target_resource: TARGET_RESOURCE_PROJECT
+      relation: RELATION_REPO_CREATE
+    };
+  }
+  rpc ListRemoteRepositoriesFromProvider(ListRemoteRepositoriesFromProviderRequest) returns (ListRemoteRepositoriesFromProviderResponse) {
+    option (google.api.http) = {
+      get: "/api/v1/repositories/provider/{provider}/remote"
+      additional_bindings: {get: "/api/v1/repositories/remote"}
+    };
 
-        option (rpc_options) = {
-            target_resource: TARGET_RESOURCE_PROJECT
-            relation: RELATION_REMOTE_REPO_GET
-        };
-    }
-    rpc ListRepositories (ListRepositoriesRequest) returns (ListRepositoriesResponse) {
-        option (google.api.http) = {
-            get: "/api/v1/repositories/provider/{provider}"
-            additional_bindings {
-                get: "/api/v1/repositories"
-            }
-        };
+    option (rpc_options) = {
+      target_resource: TARGET_RESOURCE_PROJECT
+      relation: RELATION_REMOTE_REPO_GET
+    };
+  }
+  rpc ListRepositories(ListRepositoriesRequest) returns (ListRepositoriesResponse) {
+    option (google.api.http) = {
+      get: "/api/v1/repositories/provider/{provider}"
+      additional_bindings: {get: "/api/v1/repositories"}
+    };
 
-        option (rpc_options) = {
-            target_resource: TARGET_RESOURCE_PROJECT
-            relation: RELATION_REPO_GET
-        };
-    }
-    rpc GetRepositoryById (GetRepositoryByIdRequest) returns (GetRepositoryByIdResponse) {
-        option (google.api.http) = {
-            get: "/api/v1/repository/id/{repository_id}"
-        };
+    option (rpc_options) = {
+      target_resource: TARGET_RESOURCE_PROJECT
+      relation: RELATION_REPO_GET
+    };
+  }
+  rpc GetRepositoryById(GetRepositoryByIdRequest) returns (GetRepositoryByIdResponse) {
+    option (google.api.http) = {get: "/api/v1/repository/id/{repository_id}"};
 
-        option (rpc_options) = {
-            target_resource: TARGET_RESOURCE_PROJECT
-            relation: RELATION_REPO_GET
-        };
-    }
+    option (rpc_options) = {
+      target_resource: TARGET_RESOURCE_PROJECT
+      relation: RELATION_REPO_GET
+    };
+  }
 
-    rpc GetRepositoryByName (GetRepositoryByNameRequest) returns (GetRepositoryByNameResponse) {
-        option (google.api.http) = {
-            get: "/api/v1/repository/provider/{provider}/name/{name=**}"
-            additional_bindings {
-                get: "/api/v1/repository/name/{name=**}"
-            }
-        };
+  rpc GetRepositoryByName(GetRepositoryByNameRequest) returns (GetRepositoryByNameResponse) {
+    option (google.api.http) = {
+      get: "/api/v1/repository/provider/{provider}/name/{name=**}"
+      additional_bindings: {get: "/api/v1/repository/name/{name=**}"}
+    };
 
-        option (rpc_options) = {
-            target_resource: TARGET_RESOURCE_PROJECT
-            relation: RELATION_REPO_GET
-        };
-    }
+    option (rpc_options) = {
+      target_resource: TARGET_RESOURCE_PROJECT
+      relation: RELATION_REPO_GET
+    };
+  }
 
-    rpc DeleteRepositoryById (DeleteRepositoryByIdRequest) returns (DeleteRepositoryByIdResponse) {
-        option (google.api.http) = {
-            delete: "/api/v1/repository/id/{repository_id}"
-        };
+  rpc DeleteRepositoryById(DeleteRepositoryByIdRequest) returns (DeleteRepositoryByIdResponse) {
+    option (google.api.http) = {delete: "/api/v1/repository/id/{repository_id}"};
 
-        option (minder.v1.rpc_options) = {
-            target_resource: TARGET_RESOURCE_PROJECT
-            relation: RELATION_REPO_DELETE
-        };
-    }
+    option (minder.v1.rpc_options) = {
+      target_resource: TARGET_RESOURCE_PROJECT
+      relation: RELATION_REPO_DELETE
+    };
+  }
 
-    rpc DeleteRepositoryByName (DeleteRepositoryByNameRequest) returns (DeleteRepositoryByNameResponse) {
-        option (google.api.http) = {
-            delete: "/api/v1/repository/provider/{provider}/name/{name=**}"
-            additional_bindings {
-                delete: "/api/v1/repository/name/{name=**}"
-            }
-        };
+  rpc DeleteRepositoryByName(DeleteRepositoryByNameRequest) returns (DeleteRepositoryByNameResponse) {
+    option (google.api.http) = {
+      delete: "/api/v1/repository/provider/{provider}/name/{name=**}"
+      additional_bindings: {delete: "/api/v1/repository/name/{name=**}"}
+    };
 
-        option (minder.v1.rpc_options) = {
-            target_resource: TARGET_RESOURCE_PROJECT
-            relation: RELATION_REPO_DELETE
-        };
-    }
+    option (minder.v1.rpc_options) = {
+      target_resource: TARGET_RESOURCE_PROJECT
+      relation: RELATION_REPO_DELETE
+    };
+  }
 }
 
 // manage Users CRUD
 service UserService {
-    rpc CreateUser (CreateUserRequest) returns (CreateUserResponse) {
-        option (google.api.http) = {
-            post: "/api/v1/user"
-            body: "*"
-        };
+  rpc CreateUser(CreateUserRequest) returns (CreateUserResponse) {
+    option (google.api.http) = {
+      post: "/api/v1/user"
+      body: "*"
+    };
 
-        option (rpc_options) = {
-            target_resource: TARGET_RESOURCE_USER
-        };
-    }
+    option (rpc_options) = {target_resource: TARGET_RESOURCE_USER};
+  }
 
-    rpc DeleteUser (DeleteUserRequest) returns (DeleteUserResponse) {
-        option (google.api.http) = {
-            delete: "/api/v1/user"
-        };
+  rpc DeleteUser(DeleteUserRequest) returns (DeleteUserResponse) {
+    option (google.api.http) = {delete: "/api/v1/user"};
 
-        option (rpc_options) = {
-            target_resource: TARGET_RESOURCE_USER
-        };
-    }
+    option (rpc_options) = {target_resource: TARGET_RESOURCE_USER};
+  }
 
-    rpc GetUser (GetUserRequest) returns (GetUserResponse) {
-        option (google.api.http) = {
-            get: "/api/v1/user"
-        };
+  rpc GetUser(GetUserRequest) returns (GetUserResponse) {
+    option (google.api.http) = {get: "/api/v1/user"};
 
-        option (rpc_options) = {
-            target_resource: TARGET_RESOURCE_USER
-        };
-    }
+    option (rpc_options) = {target_resource: TARGET_RESOURCE_USER};
+  }
 
-    // ListInvitations returns a list of invitations for the user
-    // based on the user's registered email address.  Note that a
-    // user who receives an invitation code may still accept the
-    // invitation even if the code was directed to a different
-    // email address.  This is because understanding the routing of
-    // email messages is beyond the scope of Minder.
-    //
-    // This API endpoint may be called without the logged-in user
-    // previously having called `CreateUser`.
-    rpc ListInvitations (ListInvitationsRequest) returns (ListInvitationsResponse) {
-        option (google.api.http) = {
-            get: "/api/v1/user/invitations"
-        };
+  // ListInvitations returns a list of invitations for the user
+  // based on the user's registered email address.  Note that a
+  // user who receives an invitation code may still accept the
+  // invitation even if the code was directed to a different
+  // email address.  This is because understanding the routing of
+  // email messages is beyond the scope of Minder.
+  //
+  // This API endpoint may be called without the logged-in user
+  // previously having called `CreateUser`.
+  rpc ListInvitations(ListInvitationsRequest) returns (ListInvitationsResponse) {
+    option (google.api.http) = {get: "/api/v1/user/invitations"};
 
-        option (rpc_options) = {
-            target_resource: TARGET_RESOURCE_USER
-        };
-    }
+    option (rpc_options) = {target_resource: TARGET_RESOURCE_USER};
+  }
 
-    // ResolveInvitation allows a user to accept or decline an
-    // invitation to a project given the code for the invitation.
-    // A user may call ResolveInvitation to accept or decline an
-    // invitation even if they have not called CreateUser.  If a
-    // user accepts an invitation via this call before calling
-    // CreateUser, a Minder user record will be created, but no
-    // additional projects will be created (unlike CreateUser,
-    // which will also create a default project).
-    rpc ResolveInvitation (ResolveInvitationRequest) returns (ResolveInvitationResponse) {
-        option (google.api.http) = {
-            post: "/api/v1/user/invitation/{code}"
-        };
+  // ResolveInvitation allows a user to accept or decline an
+  // invitation to a project given the code for the invitation.
+  // A user may call ResolveInvitation to accept or decline an
+  // invitation even if they have not called CreateUser.  If a
+  // user accepts an invitation via this call before calling
+  // CreateUser, a Minder user record will be created, but no
+  // additional projects will be created (unlike CreateUser,
+  // which will also create a default project).
+  rpc ResolveInvitation(ResolveInvitationRequest) returns (ResolveInvitationResponse) {
+    option (google.api.http) = {post: "/api/v1/user/invitation/{code}"};
 
-        option (rpc_options) = {
-            target_resource: TARGET_RESOURCE_USER
-        };
-    }
+    option (rpc_options) = {target_resource: TARGET_RESOURCE_USER};
+  }
 }
 
 service ProfileService {
-    rpc CreateProfile (CreateProfileRequest) returns (CreateProfileResponse) {
-        option (google.api.http) = {
-            post: "/api/v1/profile"
-            body: "*"
-        };
+  rpc CreateProfile(CreateProfileRequest) returns (CreateProfileResponse) {
+    option (google.api.http) = {
+      post: "/api/v1/profile"
+      body: "*"
+    };
 
-        option (rpc_options) = {
-            target_resource: TARGET_RESOURCE_PROJECT
-            relation: RELATION_PROFILE_CREATE
-        };
-    }
+    option (rpc_options) = {
+      target_resource: TARGET_RESOURCE_PROJECT
+      relation: RELATION_PROFILE_CREATE
+    };
+  }
 
-    rpc UpdateProfile (UpdateProfileRequest) returns (UpdateProfileResponse) {
-        option (google.api.http) = {
-            put: "/api/v1/profile"
-            body: "*"
-        };
+  rpc UpdateProfile(UpdateProfileRequest) returns (UpdateProfileResponse) {
+    option (google.api.http) = {
+      put: "/api/v1/profile"
+      body: "*"
+    };
 
-        option (rpc_options) = {
-            target_resource: TARGET_RESOURCE_PROJECT
-            relation: RELATION_PROFILE_UPDATE
-        };
-    }
+    option (rpc_options) = {
+      target_resource: TARGET_RESOURCE_PROJECT
+      relation: RELATION_PROFILE_UPDATE
+    };
+  }
 
-    rpc PatchProfile (PatchProfileRequest) returns (PatchProfileResponse) {
-        option (google.api.http) = {
-            patch: "/api/v1/profile/{id}"
-            body: "patch"
-        };
+  rpc PatchProfile(PatchProfileRequest) returns (PatchProfileResponse) {
+    option (google.api.http) = {
+      patch: "/api/v1/profile/{id}"
+      body: "patch"
+    };
 
-        option (rpc_options) = {
-            target_resource: TARGET_RESOURCE_PROJECT
-            relation: RELATION_PROFILE_UPDATE
-        };
-    }
+    option (rpc_options) = {
+      target_resource: TARGET_RESOURCE_PROJECT
+      relation: RELATION_PROFILE_UPDATE
+    };
+  }
 
-    rpc DeleteProfile (DeleteProfileRequest) returns (DeleteProfileResponse) {
-        option (google.api.http) = {
-            delete: "/api/v1/profile/{id}"
-        };
+  rpc DeleteProfile(DeleteProfileRequest) returns (DeleteProfileResponse) {
+    option (google.api.http) = {delete: "/api/v1/profile/{id}"};
 
-        option (rpc_options) = {
-            target_resource: TARGET_RESOURCE_PROJECT
-            relation: RELATION_PROFILE_DELETE
-        };
-    }
+    option (rpc_options) = {
+      target_resource: TARGET_RESOURCE_PROJECT
+      relation: RELATION_PROFILE_DELETE
+    };
+  }
 
-    rpc ListProfiles (ListProfilesRequest) returns (ListProfilesResponse) {
-        option (google.api.http) = {
-            get: "/api/v1/profiles"
-        };
+  rpc ListProfiles(ListProfilesRequest) returns (ListProfilesResponse) {
+    option (google.api.http) = {get: "/api/v1/profiles"};
 
-        option (rpc_options) = {
-            target_resource: TARGET_RESOURCE_PROJECT
-            relation: RELATION_PROFILE_GET
-        };
-    }
+    option (rpc_options) = {
+      target_resource: TARGET_RESOURCE_PROJECT
+      relation: RELATION_PROFILE_GET
+    };
+  }
 
-    rpc GetProfileById (GetProfileByIdRequest) returns (GetProfileByIdResponse) {
-        option (google.api.http) = {
-            get: "/api/v1/profile/{id}"
-        };
+  rpc GetProfileById(GetProfileByIdRequest) returns (GetProfileByIdResponse) {
+    option (google.api.http) = {get: "/api/v1/profile/{id}"};
 
-        option (rpc_options) = {
-            target_resource: TARGET_RESOURCE_PROJECT
-            relation: RELATION_PROFILE_GET
-        };
-    }
+    option (rpc_options) = {
+      target_resource: TARGET_RESOURCE_PROJECT
+      relation: RELATION_PROFILE_GET
+    };
+  }
 
-    rpc GetProfileByName (GetProfileByNameRequest) returns (GetProfileByNameResponse) {
-        option (google.api.http) = {
-            get: "/api/v1/profile/name/{name=**}"
-        };
+  rpc GetProfileByName(GetProfileByNameRequest) returns (GetProfileByNameResponse) {
+    option (google.api.http) = {get: "/api/v1/profile/name/{name=**}"};
 
-        option (rpc_options) = {
-            target_resource: TARGET_RESOURCE_PROJECT
-            relation: RELATION_PROFILE_GET
-        };
-    }
+    option (rpc_options) = {
+      target_resource: TARGET_RESOURCE_PROJECT
+      relation: RELATION_PROFILE_GET
+    };
+  }
 
-    rpc GetProfileStatusByName (GetProfileStatusByNameRequest) returns (GetProfileStatusByNameResponse) {
-        option (google.api.http) = {
-            get: "/api/v1/profile/name/{name=**}/status"
-        };
+  rpc GetProfileStatusByName(GetProfileStatusByNameRequest) returns (GetProfileStatusByNameResponse) {
+    option (google.api.http) = {get: "/api/v1/profile/name/{name=**}/status"};
 
-        option (rpc_options) = {
-            target_resource: TARGET_RESOURCE_PROJECT
-            relation: RELATION_PROFILE_STATUS_GET
-        };
-    }
+    option (rpc_options) = {
+      target_resource: TARGET_RESOURCE_PROJECT
+      relation: RELATION_PROFILE_STATUS_GET
+    };
+  }
 
-    rpc GetProfileStatusById (GetProfileStatusByIdRequest) returns (GetProfileStatusByIdResponse) {
-        option (google.api.http) = {
-            get: "/api/v1/profile/{id}/status"
-        };
+  rpc GetProfileStatusById(GetProfileStatusByIdRequest) returns (GetProfileStatusByIdResponse) {
+    option (google.api.http) = {get: "/api/v1/profile/{id}/status"};
 
-        option (rpc_options) = {
-            target_resource: TARGET_RESOURCE_PROJECT
-            relation: RELATION_PROFILE_STATUS_GET
-        };
-    }
+    option (rpc_options) = {
+      target_resource: TARGET_RESOURCE_PROJECT
+      relation: RELATION_PROFILE_STATUS_GET
+    };
+  }
 
-    rpc GetProfileStatusByProject (GetProfileStatusByProjectRequest) returns (GetProfileStatusByProjectResponse) {
-        option (google.api.http) = {
-            get: "/api/v1/profile_status"
-        };
+  rpc GetProfileStatusByProject(GetProfileStatusByProjectRequest) returns (GetProfileStatusByProjectResponse) {
+    option (google.api.http) = {get: "/api/v1/profile_status"};
 
-        option (rpc_options) = {
-            target_resource: TARGET_RESOURCE_PROJECT
-            relation: RELATION_PROFILE_STATUS_GET
-        };
-    }
+    option (rpc_options) = {
+      target_resource: TARGET_RESOURCE_PROJECT
+      relation: RELATION_PROFILE_STATUS_GET
+    };
+  }
 }
 
 service DataSourceService {
-    rpc CreateDataSource (CreateDataSourceRequest) returns (CreateDataSourceResponse) {
-        option (google.api.http) = {
-            post: "/api/v1/data_source"
-            body: "*"
-        };
+  rpc CreateDataSource(CreateDataSourceRequest) returns (CreateDataSourceResponse) {
+    option (google.api.http) = {
+      post: "/api/v1/data_source"
+      body: "*"
+    };
 
-        option (rpc_options) = {
-            target_resource: TARGET_RESOURCE_PROJECT
-            relation: RELATION_DATA_SOURCE_CREATE
-        };
-    }
+    option (rpc_options) = {
+      target_resource: TARGET_RESOURCE_PROJECT
+      relation: RELATION_DATA_SOURCE_CREATE
+    };
+  }
 
-    rpc GetDataSourceById (GetDataSourceByIdRequest) returns (GetDataSourceByIdResponse) {
-        option (google.api.http) = {
-            get: "/api/v1/data_source/{id}"
-        };
+  rpc GetDataSourceById(GetDataSourceByIdRequest) returns (GetDataSourceByIdResponse) {
+    option (google.api.http) = {get: "/api/v1/data_source/{id}"};
 
-        option (rpc_options) = {
-            target_resource: TARGET_RESOURCE_PROJECT
-            relation: RELATION_DATA_SOURCE_GET
-        };
-    }
+    option (rpc_options) = {
+      target_resource: TARGET_RESOURCE_PROJECT
+      relation: RELATION_DATA_SOURCE_GET
+    };
+  }
 
-    rpc GetDataSourceByName(GetDataSourceByNameRequest) returns (GetDataSourceByNameResponse) {
-        option (google.api.http) = {
-            get: "/api/v1/data_source/name/{name=**}"
-        };
+  rpc GetDataSourceByName(GetDataSourceByNameRequest) returns (GetDataSourceByNameResponse) {
+    option (google.api.http) = {get: "/api/v1/data_source/name/{name=**}"};
 
-        option (rpc_options) = {
-            target_resource: TARGET_RESOURCE_PROJECT
-            relation: RELATION_DATA_SOURCE_GET
-        };
-    }
+    option (rpc_options) = {
+      target_resource: TARGET_RESOURCE_PROJECT
+      relation: RELATION_DATA_SOURCE_GET
+    };
+  }
 
-    rpc ListDataSources (ListDataSourcesRequest) returns (ListDataSourcesResponse) {
-        option (google.api.http) = {
-            get: "/api/v1/data_sources"
-        };
+  rpc ListDataSources(ListDataSourcesRequest) returns (ListDataSourcesResponse) {
+    option (google.api.http) = {get: "/api/v1/data_sources"};
 
-        option (rpc_options) = {
-            target_resource: TARGET_RESOURCE_PROJECT
-            relation: RELATION_DATA_SOURCE_GET
-        };
-    }
+    option (rpc_options) = {
+      target_resource: TARGET_RESOURCE_PROJECT
+      relation: RELATION_DATA_SOURCE_GET
+    };
+  }
 
-    rpc UpdateDataSource (UpdateDataSourceRequest) returns (UpdateDataSourceResponse) {
-        option (google.api.http) = {
-            put: "/api/v1/data_source"
-            body: "*"
-        };
+  rpc UpdateDataSource(UpdateDataSourceRequest) returns (UpdateDataSourceResponse) {
+    option (google.api.http) = {
+      put: "/api/v1/data_source"
+      body: "*"
+    };
 
-        option (rpc_options) = {
-            target_resource: TARGET_RESOURCE_PROJECT
-            relation: RELATION_DATA_SOURCE_UPDATE
-        };
-    }
+    option (rpc_options) = {
+      target_resource: TARGET_RESOURCE_PROJECT
+      relation: RELATION_DATA_SOURCE_UPDATE
+    };
+  }
 
-    rpc DeleteDataSourceById(DeleteDataSourceByIdRequest) returns (DeleteDataSourceByIdResponse) {
-        option (google.api.http) = {
-            delete: "/api/v1/data_source/{id}"
-        };
+  rpc DeleteDataSourceById(DeleteDataSourceByIdRequest) returns (DeleteDataSourceByIdResponse) {
+    option (google.api.http) = {delete: "/api/v1/data_source/{id}"};
 
-        option (rpc_options) = {
-            target_resource: TARGET_RESOURCE_PROJECT
-            relation: RELATION_DATA_SOURCE_DELETE
-        };
-    }
+    option (rpc_options) = {
+      target_resource: TARGET_RESOURCE_PROJECT
+      relation: RELATION_DATA_SOURCE_DELETE
+    };
+  }
 
-    rpc DeleteDataSourceByName(DeleteDataSourceByNameRequest) returns (DeleteDataSourceByNameResponse) {
-        option (google.api.http) = {
-            delete: "/api/v1/data_source/name/{name=**}"
-        };
+  rpc DeleteDataSourceByName(DeleteDataSourceByNameRequest) returns (DeleteDataSourceByNameResponse) {
+    option (google.api.http) = {delete: "/api/v1/data_source/name/{name=**}"};
 
-        option (rpc_options) = {
-            target_resource: TARGET_RESOURCE_PROJECT
-            relation: RELATION_DATA_SOURCE_DELETE
-        };
-    }
+    option (rpc_options) = {
+      target_resource: TARGET_RESOURCE_PROJECT
+      relation: RELATION_DATA_SOURCE_DELETE
+    };
+  }
 }
 
 service RuleTypeService {
+  rpc ListRuleTypes(ListRuleTypesRequest) returns (ListRuleTypesResponse) {
+    option (google.api.http) = {get: "/api/v1/rule_types"};
 
-    rpc ListRuleTypes (ListRuleTypesRequest) returns (ListRuleTypesResponse) {
-        option (google.api.http) = {
-            get: "/api/v1/rule_types"
-        };
+    option (rpc_options) = {
+      target_resource: TARGET_RESOURCE_PROJECT
+      relation: RELATION_RULE_TYPE_GET
+    };
+  }
 
-        option (rpc_options) = {
-            target_resource: TARGET_RESOURCE_PROJECT
-            relation: RELATION_RULE_TYPE_GET
-        };
-    }
+  rpc GetRuleTypeByName(GetRuleTypeByNameRequest) returns (GetRuleTypeByNameResponse) {
+    option (google.api.http) = {get: "/api/v1/rule_type/name/{name=**}"};
 
-    rpc GetRuleTypeByName (GetRuleTypeByNameRequest) returns (GetRuleTypeByNameResponse) {
-        option (google.api.http) = {
-            get: "/api/v1/rule_type/name/{name=**}"
-        };
+    option (rpc_options) = {
+      target_resource: TARGET_RESOURCE_PROJECT
+      relation: RELATION_RULE_TYPE_GET
+    };
+  }
 
-        option (rpc_options) = {
-            target_resource: TARGET_RESOURCE_PROJECT
-            relation: RELATION_RULE_TYPE_GET
-        };
-    }
+  rpc GetRuleTypeById(GetRuleTypeByIdRequest) returns (GetRuleTypeByIdResponse) {
+    option (google.api.http) = {get: "/api/v1/rule_type/{id}"};
 
-    rpc GetRuleTypeById (GetRuleTypeByIdRequest) returns (GetRuleTypeByIdResponse) {
-        option (google.api.http) = {
-            get: "/api/v1/rule_type/{id}"
-        };
+    option (rpc_options) = {
+      target_resource: TARGET_RESOURCE_PROJECT
+      relation: RELATION_RULE_TYPE_GET
+    };
+  }
 
-        option (rpc_options) = {
-            target_resource: TARGET_RESOURCE_PROJECT
-            relation: RELATION_RULE_TYPE_GET
-        };
-    }
+  rpc CreateRuleType(CreateRuleTypeRequest) returns (CreateRuleTypeResponse) {
+    option (google.api.http) = {
+      post: "/api/v1/rule_type"
+      body: "*"
+    };
 
-    rpc CreateRuleType (CreateRuleTypeRequest) returns (CreateRuleTypeResponse) {
-        option (google.api.http) = {
-            post: "/api/v1/rule_type"
-            body: "*"
-        };
+    option (rpc_options) = {
+      target_resource: TARGET_RESOURCE_PROJECT
+      relation: RELATION_RULE_TYPE_CREATE
+    };
+  }
 
-        option (rpc_options) = {
-            target_resource: TARGET_RESOURCE_PROJECT
-            relation: RELATION_RULE_TYPE_CREATE
-        };
-    }
+  rpc UpdateRuleType(UpdateRuleTypeRequest) returns (UpdateRuleTypeResponse) {
+    option (google.api.http) = {
+      put: "/api/v1/rule_type"
+      body: "*"
+    };
 
-    rpc UpdateRuleType (UpdateRuleTypeRequest) returns (UpdateRuleTypeResponse) {
-        option (google.api.http) = {
-            put: "/api/v1/rule_type"
-            body: "*"
-        };
+    option (rpc_options) = {
+      target_resource: TARGET_RESOURCE_PROJECT
+      relation: RELATION_RULE_TYPE_UPDATE
+    };
+  }
 
-        option (rpc_options) = {
-            target_resource: TARGET_RESOURCE_PROJECT
-            relation: RELATION_RULE_TYPE_UPDATE
-        };
-    }
+  rpc DeleteRuleType(DeleteRuleTypeRequest) returns (DeleteRuleTypeResponse) {
+    option (google.api.http) = {delete: "/api/v1/rule_type/{id}"};
 
-    rpc DeleteRuleType (DeleteRuleTypeRequest) returns (DeleteRuleTypeResponse) {
-        option (google.api.http) = {
-            delete: "/api/v1/rule_type/{id}"
-        };
-
-        option (rpc_options) = {
-            target_resource: TARGET_RESOURCE_PROJECT
-            relation: RELATION_RULE_TYPE_DELETE
-        };
-    }
+    option (rpc_options) = {
+      target_resource: TARGET_RESOURCE_PROJECT
+      relation: RELATION_RULE_TYPE_DELETE
+    };
+  }
 }
 
 service EvalResultsService {
-    rpc ListEvaluationResults(ListEvaluationResultsRequest) returns (ListEvaluationResultsResponse) {
-        option (google.api.http) = {
-            // TODO: use
-            // get: "/api/v1/projects/{Context.project}/results"
-            // If we can promote Context.project to not be optional
-            get: "/api/v1/results"
-        };
+  rpc ListEvaluationResults(ListEvaluationResultsRequest) returns (ListEvaluationResultsResponse) {
+    option (google.api.http) = {
+      // TODO: use
+      // get: "/api/v1/projects/{Context.project}/results"
+      // If we can promote Context.project to not be optional
+      get: "/api/v1/results"
+    };
 
-        option (rpc_options) = {
-            target_resource: TARGET_RESOURCE_PROJECT
-            relation: RELATION_PROFILE_STATUS_GET
-        };
-    }
+    option (rpc_options) = {
+      target_resource: TARGET_RESOURCE_PROJECT
+      relation: RELATION_PROFILE_STATUS_GET
+    };
+  }
 
-    rpc ListEvaluationHistory(ListEvaluationHistoryRequest) returns (ListEvaluationHistoryResponse) {
-        option (google.api.http) = {
-            get: "/api/v1/history"
-        };
+  rpc ListEvaluationHistory(ListEvaluationHistoryRequest) returns (ListEvaluationHistoryResponse) {
+    option (google.api.http) = {get: "/api/v1/history"};
 
-        option (rpc_options) = {
-            target_resource: TARGET_RESOURCE_PROJECT
-            relation: RELATION_PROFILE_STATUS_GET
-        };
-    }
+    option (rpc_options) = {
+      target_resource: TARGET_RESOURCE_PROJECT
+      relation: RELATION_PROFILE_STATUS_GET
+    };
+  }
 
-    rpc GetEvaluationHistory(GetEvaluationHistoryRequest) returns (GetEvaluationHistoryResponse) {
-        option (google.api.http) = {
-            get: "/api/v1/history/{id}"
-        };
+  rpc GetEvaluationHistory(GetEvaluationHistoryRequest) returns (GetEvaluationHistoryResponse) {
+    option (google.api.http) = {get: "/api/v1/history/{id}"};
 
-        option (rpc_options) = {
-            target_resource: TARGET_RESOURCE_PROJECT
-            relation: RELATION_PROFILE_STATUS_GET
-        };
-    }
+    option (rpc_options) = {
+      target_resource: TARGET_RESOURCE_PROJECT
+      relation: RELATION_PROFILE_STATUS_GET
+    };
+  }
 }
 
 service PermissionsService {
-    rpc ListRoles (ListRolesRequest) returns (ListRolesResponse) {
-        option (google.api.http) = {
-            get: "/api/v1/permissions/roles"
-        };
+  rpc ListRoles(ListRolesRequest) returns (ListRolesResponse) {
+    option (google.api.http) = {get: "/api/v1/permissions/roles"};
 
-        option (rpc_options) = {
-            target_resource: TARGET_RESOURCE_PROJECT
-            relation: RELATION_ROLE_LIST
-        };
-    }
+    option (rpc_options) = {
+      target_resource: TARGET_RESOURCE_PROJECT
+      relation: RELATION_ROLE_LIST
+    };
+  }
 
-    rpc ListRoleAssignments (ListRoleAssignmentsRequest) returns (ListRoleAssignmentsResponse) {
-        option (google.api.http) = {
-            get: "/api/v1/permissions/assignments"
-        };
+  rpc ListRoleAssignments(ListRoleAssignmentsRequest) returns (ListRoleAssignmentsResponse) {
+    option (google.api.http) = {get: "/api/v1/permissions/assignments"};
 
-        option (rpc_options) = {
-            target_resource: TARGET_RESOURCE_PROJECT
-            relation: RELATION_ROLE_ASSIGNMENT_LIST
-        };
-    }
+    option (rpc_options) = {
+      target_resource: TARGET_RESOURCE_PROJECT
+      relation: RELATION_ROLE_ASSIGNMENT_LIST
+    };
+  }
 
-    rpc AssignRole (AssignRoleRequest) returns (AssignRoleResponse) {
-        option (google.api.http) = {
-            post: "/api/v1/permissions/assign"
-            body: "*"
-        };
+  rpc AssignRole(AssignRoleRequest) returns (AssignRoleResponse) {
+    option (google.api.http) = {
+      post: "/api/v1/permissions/assign"
+      body: "*"
+    };
 
-        option (rpc_options) = {
-            target_resource: TARGET_RESOURCE_PROJECT
-            relation: RELATION_ROLE_ASSIGNMENT_CREATE
-        };
-    }
+    option (rpc_options) = {
+      target_resource: TARGET_RESOURCE_PROJECT
+      relation: RELATION_ROLE_ASSIGNMENT_CREATE
+    };
+  }
 
-    rpc UpdateRole(UpdateRoleRequest) returns (UpdateRoleResponse) {
-        option (google.api.http) = {
-            post: "/api/v1/permissions/update"
-            body: "*"
-        };
+  rpc UpdateRole(UpdateRoleRequest) returns (UpdateRoleResponse) {
+    option (google.api.http) = {
+      post: "/api/v1/permissions/update"
+      body: "*"
+    };
 
-        option (rpc_options) = {
-            target_resource: TARGET_RESOURCE_PROJECT
-            relation: RELATION_ROLE_ASSIGNMENT_UPDATE
-        };
-    }
+    option (rpc_options) = {
+      target_resource: TARGET_RESOURCE_PROJECT
+      relation: RELATION_ROLE_ASSIGNMENT_UPDATE
+    };
+  }
 
-    rpc RemoveRole (RemoveRoleRequest) returns (RemoveRoleResponse) {
-        // The role name comes from the name field in the role object
-        option (google.api.http) = {
-            delete: "/api/v1/permissions/remove"
-        };
+  rpc RemoveRole(RemoveRoleRequest) returns (RemoveRoleResponse) {
+    // The role name comes from the name field in the role object
+    option (google.api.http) = {delete: "/api/v1/permissions/remove"};
 
-        option (rpc_options) = {
-            target_resource: TARGET_RESOURCE_PROJECT
-            relation: RELATION_ROLE_ASSIGNMENT_REMOVE
-        };
-    }
+    option (rpc_options) = {
+      target_resource: TARGET_RESOURCE_PROJECT
+      relation: RELATION_ROLE_ASSIGNMENT_REMOVE
+    };
+  }
 }
 
 service ProjectsService {
+  rpc ListProjects(ListProjectsRequest) returns (ListProjectsResponse) {
+    option (google.api.http) = {get: "/api/v1/projects"};
 
-    rpc ListProjects(ListProjectsRequest) returns (ListProjectsResponse) {
-        option (google.api.http) = {
-            get: "/api/v1/projects"
-        };
+    option (rpc_options) = {
+      target_resource: TARGET_RESOURCE_USER
+      relation: RELATION_GET
+    };
+  }
 
-        option (rpc_options) = {
-            target_resource: TARGET_RESOURCE_USER
-            relation: RELATION_GET
-        };
-    }
+  rpc CreateProject(CreateProjectRequest) returns (CreateProjectResponse) {
+    option (google.api.http) = {
+      post: "/api/v1/projects"
+      body: "*"
+    };
 
-    rpc CreateProject(CreateProjectRequest) returns (CreateProjectResponse) {
-        option (google.api.http) = {
-            post: "/api/v1/projects"
-            body: "*"
-        };
+    option (rpc_options) = {
+      // We use TARGET_RESOURCE_USER (no specific resource is checked for authz)
+      // here when creating top-level projects, and specifically check the
+      // RELATION_CREATE permission when creating sub-projects under a parent.
+      target_resource: TARGET_RESOURCE_USER
+      relation: RELATION_CREATE
+    };
+  }
 
-        option (rpc_options) = {
-            // We use TARGET_RESOURCE_USER (no specific resource is checked for authz)
-            // here when creating top-level projects, and specifically check the
-            // RELATION_CREATE permission when creating sub-projects under a parent.
-            target_resource: TARGET_RESOURCE_USER
-            relation: RELATION_CREATE
-        };
-    }
+  rpc ListChildProjects(ListChildProjectsRequest) returns (ListChildProjectsResponse) {
+    option (google.api.http) = {get: "/api/v1/projects/{context.project_id}/children"};
 
-    rpc ListChildProjects(ListChildProjectsRequest) returns (ListChildProjectsResponse) {
-        option (google.api.http) = {
-            get: "/api/v1/projects/{context.project_id}/children"
-        };
+    option (rpc_options) = {
+      target_resource: TARGET_RESOURCE_PROJECT
+      relation: RELATION_GET
+    };
+  }
 
-        option (rpc_options) = {
-            target_resource: TARGET_RESOURCE_PROJECT
-            relation: RELATION_GET
-        };
-    }
+  rpc DeleteProject(DeleteProjectRequest) returns (DeleteProjectResponse) {
+    option (google.api.http) = {delete: "/api/v1/projects"};
 
-    rpc DeleteProject(DeleteProjectRequest) returns (DeleteProjectResponse) {
-        option (google.api.http) = {
-            delete: "/api/v1/projects"
-        };
+    option (rpc_options) = {
+      target_resource: TARGET_RESOURCE_PROJECT
+      relation: RELATION_DELETE
+    };
+  }
 
-        option (rpc_options) = {
-            target_resource: TARGET_RESOURCE_PROJECT
-            relation: RELATION_DELETE
-        };
-    }
+  rpc UpdateProject(UpdateProjectRequest) returns (UpdateProjectResponse) {
+    option (google.api.http) = {
+      put: "/api/v1/projects"
+      body: "*"
+    };
 
-    rpc UpdateProject(UpdateProjectRequest) returns (UpdateProjectResponse) {
-        option (google.api.http) = {
-            put: "/api/v1/projects"
-            body: "*"
-        };
+    option (rpc_options) = {
+      target_resource: TARGET_RESOURCE_PROJECT
+      relation: RELATION_UPDATE
+    };
+  }
 
-        option (rpc_options) = {
-            target_resource: TARGET_RESOURCE_PROJECT
-            relation: RELATION_UPDATE
-        };
-    }
+  rpc PatchProject(PatchProjectRequest) returns (PatchProjectResponse) {
+    option (google.api.http) = {
+      patch: "/api/v1/projects"
+      body: "patch"
+    };
 
-    rpc PatchProject(PatchProjectRequest) returns (PatchProjectResponse) {
-        option (google.api.http) = {
-            patch: "/api/v1/projects"
-            body: "patch"
-        };
+    option (rpc_options) = {
+      target_resource: TARGET_RESOURCE_PROJECT
+      relation: RELATION_UPDATE
+    };
+  }
 
-        option (rpc_options) = {
-            target_resource: TARGET_RESOURCE_PROJECT
-            relation: RELATION_UPDATE
-        };
-    }
+  rpc CreateEntityReconciliationTask(CreateEntityReconciliationTaskRequest) returns (CreateEntityReconciliationTaskResponse) {
+    option (google.api.http) = {
+      post: "/api/v1/projects/entity/reconcile"
+      body: "*"
+    };
 
-    rpc CreateEntityReconciliationTask(CreateEntityReconciliationTaskRequest) returns (CreateEntityReconciliationTaskResponse) {
-        option (google.api.http) = {
-            post: "/api/v1/projects/entity/reconcile"
-            body: "*"
-        };
-
-        option (rpc_options) = {
-            target_resource: TARGET_RESOURCE_PROJECT
-            relation: RELATION_ENTITY_RECONCILIATION_TASK_CREATE
-        };
-    }
+    option (rpc_options) = {
+      target_resource: TARGET_RESOURCE_PROJECT
+      relation: RELATION_ENTITY_RECONCILIATION_TASK_CREATE
+    };
+  }
 }
 
 service ProvidersService {
-    rpc PatchProvider(PatchProviderRequest) returns (PatchProviderResponse) {
-        option (google.api.http) = {
-            patch: "/api/v1/providers"
-            body: "patch"
-        };
+  rpc PatchProvider(PatchProviderRequest) returns (PatchProviderResponse) {
+    option (google.api.http) = {
+      patch: "/api/v1/providers"
+      body: "patch"
+    };
 
-        option (rpc_options) = {
-            target_resource: TARGET_RESOURCE_PROJECT
-            relation: RELATION_PROVIDER_UPDATE
-        };
-    }
+    option (rpc_options) = {
+      target_resource: TARGET_RESOURCE_PROJECT
+      relation: RELATION_PROVIDER_UPDATE
+    };
+  }
 
-    rpc GetProvider(GetProviderRequest) returns (GetProviderResponse) {
-        option (google.api.http) = {
-            get: "/api/v1/providers/{name}"
-        };
+  rpc GetProvider(GetProviderRequest) returns (GetProviderResponse) {
+    option (google.api.http) = {get: "/api/v1/providers/{name}"};
 
-        option (rpc_options) = {
-            target_resource: TARGET_RESOURCE_PROJECT
-            relation: RELATION_PROVIDER_GET
-        };
-    }
+    option (rpc_options) = {
+      target_resource: TARGET_RESOURCE_PROJECT
+      relation: RELATION_PROVIDER_GET
+    };
+  }
 
-    rpc ListProviders (ListProvidersRequest) returns (ListProvidersResponse) {
-        option (google.api.http) = {
-            get: "/api/v1/providers"
-        };
+  rpc ListProviders(ListProvidersRequest) returns (ListProvidersResponse) {
+    option (google.api.http) = {get: "/api/v1/providers"};
 
-        option (rpc_options) = {
-            target_resource: TARGET_RESOURCE_PROJECT
-            relation: RELATION_PROVIDER_GET
-        };
-    }
+    option (rpc_options) = {
+      target_resource: TARGET_RESOURCE_PROJECT
+      relation: RELATION_PROVIDER_GET
+    };
+  }
 
-    rpc CreateProvider (CreateProviderRequest) returns (CreateProviderResponse) {
-        option (google.api.http) = {
-            post: "/api/v1/providers"
-            body: "*"
-        };
+  rpc CreateProvider(CreateProviderRequest) returns (CreateProviderResponse) {
+    option (google.api.http) = {
+      post: "/api/v1/providers"
+      body: "*"
+    };
 
-        option (rpc_options) = {
-            target_resource: TARGET_RESOURCE_PROJECT
-            relation: RELATION_PROVIDER_CREATE
-        };
-    }
+    option (rpc_options) = {
+      target_resource: TARGET_RESOURCE_PROJECT
+      relation: RELATION_PROVIDER_CREATE
+    };
+  }
 
-    rpc DeleteProvider (DeleteProviderRequest) returns (DeleteProviderResponse) {
-        option (google.api.http) = {
-            // TODO: it would be nice to be able to use context.project and
-            // context.provider here, but they are optional and cannot be used
-            // in the path.  Change this for v2.
-            delete: "/api/v1/providers"
-        };
+  rpc DeleteProvider(DeleteProviderRequest) returns (DeleteProviderResponse) {
+    option (google.api.http) = {
+      // TODO: it would be nice to be able to use context.project and
+      // context.provider here, but they are optional and cannot be used
+      // in the path.  Change this for v2.
+      delete: "/api/v1/providers"
+    };
 
-        option (rpc_options) = {
-            target_resource: TARGET_RESOURCE_PROJECT
-            relation: RELATION_PROVIDER_DELETE
-        };
-    }
+    option (rpc_options) = {
+      target_resource: TARGET_RESOURCE_PROJECT
+      relation: RELATION_PROVIDER_DELETE
+    };
+  }
 
-    rpc DeleteProviderByID (DeleteProviderByIDRequest) returns (DeleteProviderByIDResponse) {
-        option (google.api.http) = {
-            delete: "/api/v1/providers/{id}"
-        };
+  rpc DeleteProviderByID(DeleteProviderByIDRequest) returns (DeleteProviderByIDResponse) {
+    option (google.api.http) = {delete: "/api/v1/providers/{id}"};
 
-        option (minder.v1.rpc_options) = {
-            target_resource: TARGET_RESOURCE_PROJECT
-            relation: RELATION_REPO_DELETE
-        };
-    }
+    option (minder.v1.rpc_options) = {
+      target_resource: TARGET_RESOURCE_PROJECT
+      relation: RELATION_REPO_DELETE
+    };
+  }
 
-    rpc ListProviderClasses (ListProviderClassesRequest) returns (ListProviderClassesResponse) {
-        option (google.api.http) = {
-            get: "/api/v1/provider_classes"
-        };
+  rpc ListProviderClasses(ListProviderClassesRequest) returns (ListProviderClassesResponse) {
+    option (google.api.http) = {get: "/api/v1/provider_classes"};
 
-        option (rpc_options) = {
-            target_resource: TARGET_RESOURCE_PROJECT
-            relation: RELATION_PROVIDER_GET
-        };
-    }
+    option (rpc_options) = {
+      target_resource: TARGET_RESOURCE_PROJECT
+      relation: RELATION_PROVIDER_GET
+    };
+  }
 
-    rpc ReconcileEntityRegistration(ReconcileEntityRegistrationRequest) returns (ReconcileEntityRegistrationResponse) {
-        option (google.api.http) = {
-            post: "/api/v1/provider/register_all"
-            body: "*"
-        };
+  rpc ReconcileEntityRegistration(ReconcileEntityRegistrationRequest) returns (ReconcileEntityRegistrationResponse) {
+    option (google.api.http) = {
+      post: "/api/v1/provider/register_all"
+      body: "*"
+    };
 
-        option (rpc_options) = {
-            target_resource: TARGET_RESOURCE_PROJECT
-            relation: RELATION_ENTITY_RECONCILE
-        };
-    }
+    option (rpc_options) = {
+      target_resource: TARGET_RESOURCE_PROJECT
+      relation: RELATION_ENTITY_RECONCILE
+    };
+  }
 }
 
 service InviteService {
-    rpc GetInviteDetails(GetInviteDetailsRequest) returns (GetInviteDetailsResponse) {
-        option (google.api.http) = {
-            get: "/api/v1/invite/{code}"
-        };
+  rpc GetInviteDetails(GetInviteDetailsRequest) returns (GetInviteDetailsResponse) {
+    option (google.api.http) = {get: "/api/v1/invite/{code}"};
 
-        option (rpc_options) = {
-            target_resource: TARGET_RESOURCE_NONE
-        };
-    }
+    option (rpc_options) = {target_resource: TARGET_RESOURCE_NONE};
+  }
 }
 
 message GetInviteDetailsRequest {
-    // Invite nonce/code to retrieve details for
-    string code = 2 [
-        (buf.validate.field).string = {
-            pattern: "^[A-Za-z0-9_-]+$",
-            len: 64,
-        },
-        (google.api.field_behavior) = REQUIRED
-    ];
+  // Invite nonce/code to retrieve details for
+  string code = 2 [
+    (buf.validate.field).string = {
+      pattern: "^[A-Za-z0-9_-]+$"
+      len: 64
+    },
+    (google.api.field_behavior) = REQUIRED
+  ];
 
-    reserved 1; // deprecated Context context = 1;
-    reserved "context";
+  reserved 1; // deprecated Context context = 1;
+  reserved "context";
 }
 
 message GetInviteDetailsResponse {
-    // Project associated with the invite
-    string project_display = 1 [
-        (google.api.field_behavior) = REQUIRED
-    ];
-    // Sponsor of the invite
-    string sponsor_display = 2 [
-        (google.api.field_behavior) = REQUIRED
-    ];
-    // expires_at is the time at which the invitation expires.
-    google.protobuf.Timestamp expires_at = 3 [
-        (google.api.field_behavior) = REQUIRED
-    ];
-    // expired is true if the invitation has expired
-    bool expired = 4 [
-        (google.api.field_behavior) = REQUIRED
-    ];
+  // Project associated with the invite
+  string project_display = 1 [(google.api.field_behavior) = REQUIRED];
+  // Sponsor of the invite
+  string sponsor_display = 2 [(google.api.field_behavior) = REQUIRED];
+  // expires_at is the time at which the invitation expires.
+  google.protobuf.Timestamp expires_at = 3 [(google.api.field_behavior) = REQUIRED];
+  // expired is true if the invitation has expired
+  bool expired = 4 [(google.api.field_behavior) = REQUIRED];
 }
 
-message CheckHealthRequest {
-}
+message CheckHealthRequest {}
 
 message CheckHealthResponse {
-    string status = 1 [
-        (google.api.field_behavior) = REQUIRED
-    ];
+  string status = 1 [(google.api.field_behavior) = REQUIRED];
 }
 
 message GetAuthorizationURLRequest {
-    // cli is true if the request is being made from a CLI.
-    bool cli = 3;
+  // cli is true if the request is being made from a CLI.
+  bool cli = 3;
 
-    // owner is the owner (e.g GitHub org) that the provider is associated with.
-    // This is optional; we allow empty string because the client may set the
-    // field unconditionally, even though the field is marked as `optional`.
-    optional string owner = 5 [
-        (buf.validate.field).string = {
-            pattern: "^(?:[A-Za-z][-[:word:]]*)?$"
-            max_len: 200,
-        }
-    ];
-    Context context = 6;
+  // owner is the owner (e.g GitHub org) that the provider is associated with.
+  // This is optional; we allow empty string because the client may set the
+  // field unconditionally, even though the field is marked as `optional`.
+  optional string owner = 5 [(buf.validate.field).string = {
+    pattern: "^(?:[A-Za-z][-[:word:]]*)?$"
+    max_len: 200
+  }];
+  Context context = 6;
 
-    // redirect_url is the URL to redirect to after the authorization is complete.
-    optional string redirect_url = 7 [
-        (buf.validate.field).string = {
-            uri: true,
-            max_len: 600,
-        }
-    ];
+  // redirect_url is the URL to redirect to after the authorization is complete.
+  optional string redirect_url = 7 [(buf.validate.field).string = {
+    uri: true
+    max_len: 600
+  }];
 
-    // config is a JSON object that can be used to pass additional configuration
-    google.protobuf.Struct config = 8;
+  // config is a JSON object that can be used to pass additional configuration
+  google.protobuf.Struct config = 8;
 
-    string provider_class = 9 [
-        (buf.validate.field).string = {
-            pattern: "^(?:[A-Za-z][-[:word:]]*)?$",
-            max_len: 200,
-        },
-        (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE
-    ];
+  string provider_class = 9 [
+    (buf.validate.field).string = {
+      pattern: "^(?:[A-Za-z][-[:word:]]*)?$"
+      max_len: 200
+    },
+    (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE
+  ];
 
-    reserved 1, 2, 4;
-    reserved "provider", "project_id", "port";
+  reserved 1, 2, 4;
+  reserved "provider", "project_id", "port";
 }
 
 message GetAuthorizationURLResponse {
-    string url = 1 [
-        (google.api.field_behavior) = REQUIRED
-    ];
-    string state = 2 [
-        (google.api.field_behavior) = REQUIRED
-    ];
+  string url = 1 [(google.api.field_behavior) = REQUIRED];
+  string state = 2 [(google.api.field_behavior) = REQUIRED];
 }
 
 message StoreProviderTokenRequest {
-    string provider = 1 [deprecated=true];
+  string provider = 1 [deprecated = true];
 
-    // access_token is the token to store.
-    string access_token = 3 [
-        (buf.validate.field).string = {
-            pattern: "^[a-zA-Z0-9-_.]+$",
-            min_len: 10,
-            max_len: 200,
-        },
-        (google.api.field_behavior) = REQUIRED
-    ];
+  // access_token is the token to store.
+  string access_token = 3 [
+    (buf.validate.field).string = {
+      pattern: "^[a-zA-Z0-9-_.]+$"
+      min_len: 10
+      max_len: 200
+    },
+    (google.api.field_behavior) = REQUIRED
+  ];
 
-    // owner is the owner (e.g GitHub org) that the provider is associated with.
-    // This is optional, but an empty string is allowed as existing clients may
-    // set the field unconditionally.
-    optional string owner = 4 [
-        (buf.validate.field).string = {
-            pattern: "^(?:[A-Za-z][-[:word:]]*)?$"
-            max_len: 200,
-        }
-    ];
-    Context context = 5;
+  // owner is the owner (e.g GitHub org) that the provider is associated with.
+  // This is optional, but an empty string is allowed as existing clients may
+  // set the field unconditionally.
+  optional string owner = 4 [(buf.validate.field).string = {
+    pattern: "^(?:[A-Za-z][-[:word:]]*)?$"
+    max_len: 200
+  }];
+  Context context = 5;
 
-    reserved 2; // deprecated project_id
+  reserved 2; // deprecated project_id
 }
 
-message StoreProviderTokenResponse {
-}
+message StoreProviderTokenResponse {}
 
 // Project API Objects. This is only used in responses.
 message Project {
-    string project_id = 1 [
-        (google.api.field_behavior) = REQUIRED
-    ];
-    string name = 3 [
-        (google.api.field_behavior) = REQUIRED
-    ];
+  string project_id = 1 [(google.api.field_behavior) = REQUIRED];
+  string name = 3 [(google.api.field_behavior) = REQUIRED];
 
-    // description is a human-readable description of the project.
-    // This is optional.
-    string description = 4;
-    google.protobuf.Timestamp created_at = 6 [
-        (google.api.field_behavior) = REQUIRED
-    ];
-    google.protobuf.Timestamp updated_at = 7 [
-        (google.api.field_behavior) = REQUIRED
-    ];
-    // display_name allows for a human-readable name to be used.
-    // display_names are short *non-unique* strings to provide
-    // a user-friendly name for presentation in lists, etc.
-    // This is optional.
-    string display_name = 5;
+  // description is a human-readable description of the project.
+  // This is optional.
+  string description = 4;
+  google.protobuf.Timestamp created_at = 6 [(google.api.field_behavior) = REQUIRED];
+  google.protobuf.Timestamp updated_at = 7 [(google.api.field_behavior) = REQUIRED];
+  // display_name allows for a human-readable name to be used.
+  // display_names are short *non-unique* strings to provide
+  // a user-friendly name for presentation in lists, etc.
+  // This is optional.
+  string display_name = 5;
 }
 
 // Repositories API objects
 
 message ListRemoteRepositoriesFromProviderRequest {
-    string provider = 1 [deprecated=true];
-    Context context = 3;
+  string provider = 1 [deprecated = true];
+  Context context = 3;
 
-    reserved 2; // deprecated project_id
+  reserved 2; // deprecated project_id
 }
 
 message ListRemoteRepositoriesFromProviderResponse {
-    repeated UpstreamRepositoryRef results = 1 [
-        (google.api.field_behavior) = REQUIRED
-    ];
-    // entities is the same list as the repositories, but it
-    // uses the new UpstreamEntityRef message. This is what
-    // we'll migrate to eventually.
-    repeated RegistrableUpstreamEntityRef entities = 2 [
-        (google.api.field_behavior) = REQUIRED
-    ];
+  repeated UpstreamRepositoryRef results = 1 [(google.api.field_behavior) = REQUIRED];
+  // entities is the same list as the repositories, but it
+  // uses the new UpstreamEntityRef message. This is what
+  // we'll migrate to eventually.
+  repeated RegistrableUpstreamEntityRef entities = 2 [(google.api.field_behavior) = REQUIRED];
 }
 
 message RegistrableUpstreamEntityRef {
-    UpstreamEntityRef entity = 1 [
-        (google.api.field_behavior) = REQUIRED
-    ];
+  UpstreamEntityRef entity = 1 [(google.api.field_behavior) = REQUIRED];
 
-    // True if the entity is already registered in Minder.
-    bool registered = 2;
+  // True if the entity is already registered in Minder.
+  bool registered = 2;
 }
 
 message UpstreamRepositoryRef {
-    // owner is the owner (e.g GitHub org) that the provider is associated with.
-    // This is optional.
-    string owner = 1 [
-        (buf.validate.field).string = {
-            pattern: "^[A-Za-z][-[:word:]]*$"
-            max_len: 200,
-        },
-        (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE
-    ];
-    string name = 2 [
-        (buf.validate.field).string = {
-            pattern: "^[-.[:alnum:]_]+$",
-            max_len: 200,
-        },
-        (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE,
-        (google.api.field_behavior) = REQUIRED
-    ];
-    // The upstream identity of the repository, as an integer.
-    // This is only set on output, and is ignored on input.
-    int64 repo_id = 3 [
-        (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE, // Given it's ignored on input, we can ignore empty values
-        (buf.validate.field).int64 = { gte: 1 },
-        (google.api.field_behavior) = OUTPUT_ONLY
-    ];
-    Context context = 4;
-    // True if the repository is already registered in Minder.
-    // This is only set on output, and is ignored on input.
-    bool registered = 5 [
-        (google.api.field_behavior) = OUTPUT_ONLY
-    ];
+  // owner is the owner (e.g GitHub org) that the provider is associated with.
+  // This is optional.
+  string owner = 1 [
+    (buf.validate.field).string = {
+      pattern: "^[A-Za-z][-[:word:]]*$"
+      max_len: 200
+    },
+    (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE
+  ];
+  string name = 2 [
+    (buf.validate.field).string = {
+      pattern: "^[-.[:alnum:]_]+$"
+      max_len: 200
+    },
+    (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE,
+    (google.api.field_behavior) = REQUIRED
+  ];
+  // The upstream identity of the repository, as an integer.
+  // This is only set on output, and is ignored on input.
+  int64 repo_id = 3 [
+    (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE, // Given it's ignored on input, we can ignore empty values
+    (buf.validate.field).int64 = {gte: 1},
+    (google.api.field_behavior) = OUTPUT_ONLY
+  ];
+  Context context = 4;
+  // True if the repository is already registered in Minder.
+  // This is only set on output, and is ignored on input.
+  bool registered = 5 [(google.api.field_behavior) = OUTPUT_ONLY];
 }
 
 // Repository API objects. This is only used in responses.
 message Repository {
-    reserved 15;
-    reserved "registered";
-    // id is the unique identifier of the repository within Minder.
-    // It is always populated, but the optional keyword is used for
-    // backwards compatibility.
-    optional string id = 1 [
-        (google.api.field_behavior) = REQUIRED
-    ];
-    optional Context context = 2;
-    string owner = 3 [
-        (google.api.field_behavior) = REQUIRED
-    ];
-    string name = 4 [
-        (google.api.field_behavior) = REQUIRED
-    ];
-    int64 repo_id = 5;
-    int64 hook_id = 6;
-    string hook_url = 7;
-    string deploy_url = 8;
-    string clone_url = 9;
-    string hook_name = 10;
-    string hook_type = 11;
-    string hook_uuid = 12;
-    bool is_private = 13 [
-        (google.api.field_behavior) = REQUIRED
-    ];
-    bool is_fork = 14 [
-        (google.api.field_behavior) = REQUIRED
-    ];
-    google.protobuf.Timestamp created_at = 16;
-    google.protobuf.Timestamp updated_at = 17;
-    string default_branch = 18;
-    string license = 19;
-    // properties is a map of properties of the entity.
-    google.protobuf.Struct properties = 20;
+  reserved 15;
+  reserved "registered";
+  // id is the unique identifier of the repository within Minder.
+  // It is always populated, but the optional keyword is used for
+  // backwards compatibility.
+  optional string id = 1 [(google.api.field_behavior) = REQUIRED];
+  optional Context context = 2;
+  string owner = 3 [(google.api.field_behavior) = REQUIRED];
+  string name = 4 [(google.api.field_behavior) = REQUIRED];
+  int64 repo_id = 5;
+  int64 hook_id = 6;
+  string hook_url = 7;
+  string deploy_url = 8;
+  string clone_url = 9;
+  string hook_name = 10;
+  string hook_type = 11;
+  string hook_uuid = 12;
+  bool is_private = 13 [(google.api.field_behavior) = REQUIRED];
+  bool is_fork = 14 [(google.api.field_behavior) = REQUIRED];
+  google.protobuf.Timestamp created_at = 16;
+  google.protobuf.Timestamp updated_at = 17;
+  string default_branch = 18;
+  string license = 19;
+  // properties is a map of properties of the entity.
+  google.protobuf.Struct properties = 20;
 }
 
 message RegisterRepositoryRequest {
-    string provider = 1 [deprecated=true];
+  string provider = 1 [deprecated = true];
 
-    // repository is the repository to register. This is optional if entity
-    // is set.
-    UpstreamRepositoryRef repository = 3;
-    Context context = 4;
-    // entity is the entity to register. This is the same as the repository
-    // field, but uses the new UpstreamEntityRef message. This is what we'll
-    // migrate to eventually. This is optional if repository is set.
-    UpstreamEntityRef entity = 5;
+  // repository is the repository to register. This is optional if entity
+  // is set.
+  UpstreamRepositoryRef repository = 3;
+  Context context = 4;
+  // entity is the entity to register. This is the same as the repository
+  // field, but uses the new UpstreamEntityRef message. This is what we'll
+  // migrate to eventually. This is optional if repository is set.
+  UpstreamEntityRef entity = 5;
 
-    reserved 2; // deprecated project_id
+  reserved 2; // deprecated project_id
 }
 
 message RegisterRepoResult {
-    message Status {
-        bool success = 1;
-        optional string error = 2;
-    }
+  message Status {
+    bool success = 1;
+    optional string error = 2;
+  }
 
-    Repository repository = 1;
-    Status status = 2 [
-        (google.api.field_behavior) = REQUIRED
-    ];
+  Repository repository = 1;
+  Status status = 2 [(google.api.field_behavior) = REQUIRED];
 }
 
 message RegisterRepositoryResponse {
-    RegisterRepoResult result = 1 [
-        (google.api.field_behavior) = REQUIRED
-    ];
+  RegisterRepoResult result = 1 [(google.api.field_behavior) = REQUIRED];
 }
 
 message GetRepositoryByIdRequest {
-    string repository_id = 1 [
-        (buf.validate.field).string = {uuid: true},
-        (google.api.field_behavior) = REQUIRED
-    ];
-    Context context = 2;
+  string repository_id = 1 [
+    (buf.validate.field).string = {uuid: true},
+    (google.api.field_behavior) = REQUIRED
+  ];
+  Context context = 2;
 }
 
 message GetRepositoryByIdResponse {
-    Repository repository = 1 [
-        (google.api.field_behavior) = REQUIRED
-    ];
+  Repository repository = 1 [(google.api.field_behavior) = REQUIRED];
 }
 
 message DeleteRepositoryByIdRequest {
-    string repository_id = 1 [
-        (buf.validate.field).string = {uuid: true},
-        (google.api.field_behavior) = REQUIRED
-    ];
-    Context context = 2;
+  string repository_id = 1 [
+    (buf.validate.field).string = {uuid: true},
+    (google.api.field_behavior) = REQUIRED
+  ];
+  Context context = 2;
 }
 
 message DeleteRepositoryByIdResponse {
-    string repository_id = 1 [
-        (google.api.field_behavior) = REQUIRED
-    ];
+  string repository_id = 1 [(google.api.field_behavior) = REQUIRED];
 }
 
 message GetRepositoryByNameRequest {
-    string provider = 1 [deprecated=true];
-    string name = 3 [
-        (buf.validate.field).string = {
-            pattern: "^[A-Za-z][-[:word:]./]*$",
-            max_len: 200,
-        },
-        (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE,
-        (google.api.field_behavior) = REQUIRED
-    ];
-    Context context = 4;
+  string provider = 1 [deprecated = true];
+  string name = 3 [
+    (buf.validate.field).string = {
+      pattern: "^[A-Za-z][-[:word:]./]*$"
+      max_len: 200
+    },
+    (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE,
+    (google.api.field_behavior) = REQUIRED
+  ];
+  Context context = 4;
 
-    reserved 2; // deprecated project_id
+  reserved 2; // deprecated project_id
 }
 
 message GetRepositoryByNameResponse {
-    Repository repository = 1 [
-        (google.api.field_behavior) = REQUIRED
-    ];
+  Repository repository = 1 [(google.api.field_behavior) = REQUIRED];
 }
 
 message DeleteRepositoryByNameRequest {
-    string provider = 1 [deprecated=true];
-    string name = 3 [
-        (buf.validate.field).string = {
-            pattern: "^[A-Za-z][-[:word:]./]*$",
-            max_len: 200,
-        },
-        (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE,
-        (google.api.field_behavior) = REQUIRED
-    ];
-    Context context = 4;
+  string provider = 1 [deprecated = true];
+  string name = 3 [
+    (buf.validate.field).string = {
+      pattern: "^[A-Za-z][-[:word:]./]*$"
+      max_len: 200
+    },
+    (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE,
+    (google.api.field_behavior) = REQUIRED
+  ];
+  Context context = 4;
 
-    reserved 2; // deprecated project_id
+  reserved 2; // deprecated project_id
 }
 
 message DeleteRepositoryByNameResponse {
-    string name = 1 [
-        (google.api.field_behavior) = REQUIRED
-    ];
+  string name = 1 [(google.api.field_behavior) = REQUIRED];
 }
 
 message ListRepositoriesRequest {
-    string provider = 1 [deprecated=true];
+  string provider = 1 [deprecated = true];
 
-    // limit is the maximum number of results to return.
-    // This is optional.
-    int64 limit = 3 [
-        (buf.validate.field).int64 = { gte: 0, lte: 100 }
-    ];
-    Context context = 5;
+  // limit is the maximum number of results to return.
+  // This is optional.
+  int64 limit = 3 [(buf.validate.field).int64 = {
+    gte: 0
+    lte: 100
+  }];
+  Context context = 5;
 
-    // cursor is the cursor to use for the next page of results.
-    // This is optional.
-    string cursor = 6 [
-        (buf.validate.field).string = {
-            pattern: "^[[:word:]=]*$",
-            max_len: 200,
-        }
-    ];
+  // cursor is the cursor to use for the next page of results.
+  // This is optional.
+  string cursor = 6 [(buf.validate.field).string = {
+    pattern: "^[[:word:]=]*$"
+    max_len: 200
+  }];
 
-    reserved 2,4; // deprecated project_id, offset
-    reserved "project_id", "offset";
+  reserved 2, 4; // deprecated project_id, offset
+  reserved "project_id", "offset";
 }
 
 message ListRepositoriesResponse {
-    repeated Repository results = 1 [
-        (google.api.field_behavior) = REQUIRED
-    ];
+  repeated Repository results = 1 [(google.api.field_behavior) = REQUIRED];
 
-    // cursor is the cursor to use for the next page of results, empty if at the end
-    string cursor = 2;
+  // cursor is the cursor to use for the next page of results, empty if at the end
+  string cursor = 2;
 }
 
 message ReconcileEntityRegistrationRequest {
-    Context context = 1;
-    // entity is the entity type
-    string entity = 2 [
-        (buf.validate.field).string = {
-            pattern: "^[a-z]+(_[a-z]+)*$",
-            min_len: 1,
-            max_len: 200,
-        },
-        (google.api.field_behavior) = REQUIRED
-    ];
+  Context context = 1;
+  // entity is the entity type
+  string entity = 2 [
+    (buf.validate.field).string = {
+      pattern: "^[a-z]+(_[a-z]+)*$"
+      min_len: 1
+      max_len: 200
+    },
+    (google.api.field_behavior) = REQUIRED
+  ];
 }
 
-message ReconcileEntityRegistrationResponse {
-}
+message ReconcileEntityRegistrationResponse {}
 
 message VerifyProviderTokenFromRequest {
-    string provider = 1 [deprecated=true];
-    google.protobuf.Timestamp timestamp = 3;
-    Context context = 4;
+  string provider = 1 [deprecated = true];
+  google.protobuf.Timestamp timestamp = 3;
+  Context context = 4;
 
-    reserved 2; // deprecated project_id
+  reserved 2; // deprecated project_id
 }
 
 message VerifyProviderTokenFromResponse {
-    string status = 1 [
-        (google.api.field_behavior) = REQUIRED
-    ];
+  string status = 1 [(google.api.field_behavior) = REQUIRED];
 }
 
 // VerifyProviderCredentialRequest contains the enrollment nonce (aka state) that was used when enrolling the provider
 message VerifyProviderCredentialRequest {
-    Context context = 1;
+  Context context = 1;
 
-    // enrollment_nonce is the state parameter returned when enrolling the provider
-    string enrollment_nonce = 2 [
-        (buf.validate.field).string = {
-            pattern: "^[A-Za-z0-9_-]+$",
-            len: 54,
-        },
-        (google.api.field_behavior) = REQUIRED
-    ];
+  // enrollment_nonce is the state parameter returned when enrolling the provider
+  string enrollment_nonce = 2 [
+    (buf.validate.field).string = {
+      pattern: "^[A-Za-z0-9_-]+$"
+      len: 54
+    },
+    (google.api.field_behavior) = REQUIRED
+  ];
 }
 
 // VerifyProviderCredentialRequest responds with a boolean indicating if the provider has been created and the provider
 // name, if it has been created
 message VerifyProviderCredentialResponse {
+  // created is true if the provider was created.
+  bool created = 1 [(google.api.field_behavior) = REQUIRED];
 
-    // created is true if the provider was created.
-    bool created = 1 [
-        (google.api.field_behavior) = REQUIRED
-    ];
-
-    // provider_name is the name of the provider that was created.
-    // This is populated if creation was successful.
-    string provider_name = 2;
+  // provider_name is the name of the provider that was created.
+  // This is populated if creation was successful.
+  string provider_name = 2;
 }
 
 // User service
-message CreateUserRequest { }
+message CreateUserRequest {}
 
 message CreateUserResponse {
-    int32 id = 1 [
-        (google.api.field_behavior) = REQUIRED
-    ];
-    string organization_id = 2 [deprecated=true];
-    string organizatio_name =3 [deprecated=true];
-    string project_id = 4 [
-        (google.api.field_behavior) = REQUIRED
-    ];
-    string project_name = 5 [
-        (google.api.field_behavior) = REQUIRED
-    ];
-    string identity_subject = 6 [
-        (google.api.field_behavior) = REQUIRED
-    ];
-    google.protobuf.Timestamp created_at = 7 [
-        (google.api.field_behavior) = REQUIRED
-    ];
-    Context context = 8 [deprecated=true];
+  int32 id = 1 [(google.api.field_behavior) = REQUIRED];
+  string organization_id = 2 [deprecated = true];
+  string organizatio_name = 3 [deprecated = true];
+  string project_id = 4 [(google.api.field_behavior) = REQUIRED];
+  string project_name = 5 [(google.api.field_behavior) = REQUIRED];
+  string identity_subject = 6 [(google.api.field_behavior) = REQUIRED];
+  google.protobuf.Timestamp created_at = 7 [(google.api.field_behavior) = REQUIRED];
+  Context context = 8 [deprecated = true];
 }
 
 message DeleteUserRequest {
-    reserved 1; // deprecated context
+  reserved 1; // deprecated context
 }
 
-message DeleteUserResponse {
-}
+message DeleteUserResponse {}
 
 // user record to be returned
 message UserRecord {
-    int32 id = 1 [
-        (google.api.field_behavior) = REQUIRED
-    ];
-    string identity_subject = 3 [
-        (google.api.field_behavior) = REQUIRED
-    ];
-    google.protobuf.Timestamp created_at = 4 [
-        (google.api.field_behavior) = REQUIRED
-    ];
-    google.protobuf.Timestamp updated_at = 5 [
-        (google.api.field_behavior) = REQUIRED
-    ];
+  int32 id = 1 [(google.api.field_behavior) = REQUIRED];
+  string identity_subject = 3 [(google.api.field_behavior) = REQUIRED];
+  google.protobuf.Timestamp created_at = 4 [(google.api.field_behavior) = REQUIRED];
+  google.protobuf.Timestamp updated_at = 5 [(google.api.field_behavior) = REQUIRED];
 
-    reserved 2; // deprecated organization_id
-    reserved "organization_id";
+  reserved 2; // deprecated organization_id
+  reserved "organization_id";
 }
 
 // ProjectRole has the project along with the role the user has in the project
 message ProjectRole {
-    Role role = 1 [
-        (google.api.field_behavior) = REQUIRED
-    ];
-    Project project = 2 [
-        (google.api.field_behavior) = REQUIRED
-    ];
+  Role role = 1 [(google.api.field_behavior) = REQUIRED];
+  Project project = 2 [(google.api.field_behavior) = REQUIRED];
 }
 
 // get user
 message GetUserRequest {
-    reserved 1; // deprecated context
+  reserved 1; // deprecated context
 }
 
 message GetUserResponse {
-    optional UserRecord user = 1 [
-        (google.api.field_behavior) = REQUIRED
-    ];
-    // This will be deprecated in favor of the project_roles field
-    repeated Project projects = 2 [deprecated=true];
-    repeated ProjectRole project_roles = 3 [
-        (google.api.field_behavior) = REQUIRED
-    ];
+  optional UserRecord user = 1 [(google.api.field_behavior) = REQUIRED];
+  // This will be deprecated in favor of the project_roles field
+  repeated Project projects = 2 [deprecated = true];
+  repeated ProjectRole project_roles = 3 [(google.api.field_behavior) = REQUIRED];
 }
 
 // DataSource service
 message CreateDataSourceRequest {
-    DataSource data_source = 1;
+  DataSource data_source = 1;
 }
 
 message CreateDataSourceResponse {
-    DataSource data_source = 1;
+  DataSource data_source = 1;
 }
 
 message GetDataSourceByIdRequest {
-    ContextV2 context = 1;
-    string id = 2 [
-        (buf.validate.field).string = {uuid: true}
-    ];
+  ContextV2 context = 1;
+  string id = 2 [(buf.validate.field).string = {uuid: true}];
 }
 
 message GetDataSourceByIdResponse {
-    DataSource data_source = 1;
+  DataSource data_source = 1;
 }
 
 // GetDataSourceByNameRequest is the request message for the GetDataSourceByName RPC.
 message GetDataSourceByNameRequest {
-    ContextV2 context = 1;
+  ContextV2 context = 1;
 
-    string name = 2 [
-        (buf.validate.field).string = {
-            pattern: "^[A-Za-z][-[:word:]]*$",
-            max_len: 200,
-        },
-        (google.api.field_behavior) = REQUIRED
-    ];
+  string name = 2 [
+    (buf.validate.field).string = {
+      pattern: "^[A-Za-z][-[:word:]]*$"
+      max_len: 200
+    },
+    (google.api.field_behavior) = REQUIRED
+  ];
 }
 
 message GetDataSourceByNameResponse {
-    DataSource data_source = 1;
+  DataSource data_source = 1;
 }
 
 message ListDataSourcesRequest {
-    ContextV2 context = 1;
+  ContextV2 context = 1;
 }
 
 message ListDataSourcesResponse {
-    repeated DataSource data_sources = 1;
+  repeated DataSource data_sources = 1;
 }
 
 message UpdateDataSourceRequest {
-    DataSource data_source = 1;
+  DataSource data_source = 1;
 }
 
 message UpdateDataSourceResponse {
-    DataSource data_source = 1;
+  DataSource data_source = 1;
 }
 
 message DeleteDataSourceByIdRequest {
-    ContextV2 context = 1;
-    string id = 2 [
-        (buf.validate.field).string = {uuid: true}
-    ];
+  ContextV2 context = 1;
+  string id = 2 [(buf.validate.field).string = {uuid: true}];
 }
 
 message DeleteDataSourceByIdResponse {
-    string id = 1;
+  string id = 1;
 }
 
 message DeleteDataSourceByNameRequest {
-    ContextV2 context = 1;
-    string name = 2 [
-        (buf.validate.field).string = {
-            pattern: "^[A-Za-z][-[:word:]]*$",
-            max_len: 200,
-        },
-        (google.api.field_behavior) = REQUIRED
-    ];
+  ContextV2 context = 1;
+  string name = 2 [
+    (buf.validate.field).string = {
+      pattern: "^[A-Za-z][-[:word:]]*$"
+      max_len: 200
+    },
+    (google.api.field_behavior) = REQUIRED
+  ];
 }
 
 message DeleteDataSourceByNameResponse {
-    string name = 1;
+  string name = 1;
 }
 
 // Profile service
 message CreateProfileRequest {
-    Profile profile = 1 [
-        (google.api.field_behavior) = REQUIRED
-    ];
-    reserved 2; // deprecated context
+  Profile profile = 1 [(google.api.field_behavior) = REQUIRED];
+  reserved 2; // deprecated context
 }
 
 message CreateProfileResponse {
-    Profile profile = 1 [
-        (google.api.field_behavior) = REQUIRED
-    ];
+  Profile profile = 1 [(google.api.field_behavior) = REQUIRED];
 }
 
 message UpdateProfileRequest {
-    Profile profile = 1 [
-        (google.api.field_behavior) = REQUIRED
-    ];
-    reserved 2; // deprecated context
+  Profile profile = 1 [(google.api.field_behavior) = REQUIRED];
+  reserved 2; // deprecated context
 }
 
 message UpdateProfileResponse {
-    Profile profile = 1 [
-        (google.api.field_behavior) = REQUIRED
-    ];
+  Profile profile = 1 [(google.api.field_behavior) = REQUIRED];
 }
 
 message PatchProfileRequest {
-    // The context in which the patch is applied. Provided explicitly
-    // so that the patch itself can be minimal and contain only
-    // the attribute to set, e.g. remediate=true
-    Context context = 1;
-    // The id or name of the profile to patch. Same explanation about explicitness
-    // as for the context
-    string id = 2 [
-        (buf.validate.field).string = {
-            pattern: "^[A-Za-z0-9][-/[:word:]]*$",
-            max_len: 200,
-        },
-        (google.api.field_behavior) = REQUIRED
-    ];
-    // The patch to apply to the profile
-    Profile patch = 3;
-    // needed to enable PATCH, see https://grpc-ecosystem.github.io/grpc-gateway/docs/mapping/patch_feature/
-    // is not exposed to the API user
-    google.protobuf.FieldMask update_mask = 4;
+  // The context in which the patch is applied. Provided explicitly
+  // so that the patch itself can be minimal and contain only
+  // the attribute to set, e.g. remediate=true
+  Context context = 1;
+  // The id or name of the profile to patch. Same explanation about explicitness
+  // as for the context
+  string id = 2 [
+    (buf.validate.field).string = {
+      pattern: "^[A-Za-z0-9][-/[:word:]]*$"
+      max_len: 200
+    },
+    (google.api.field_behavior) = REQUIRED
+  ];
+  // The patch to apply to the profile
+  Profile patch = 3;
+  // needed to enable PATCH, see https://grpc-ecosystem.github.io/grpc-gateway/docs/mapping/patch_feature/
+  // is not exposed to the API user
+  google.protobuf.FieldMask update_mask = 4;
 }
 
 message PatchProfileResponse {
-    Profile profile = 1 [
-        (google.api.field_behavior) = REQUIRED
-    ];
+  Profile profile = 1 [(google.api.field_behavior) = REQUIRED];
 }
 
 message DeleteProfileRequest {
-    // context is the context in which the rule type is evaluated.
-    Context context = 1;
-    // id is the name or id of the profile to delete
-    string id = 2 [
-        (buf.validate.field).string = {
-            pattern: "^[A-Za-z0-9][-/[:word:]]*$",
-            max_len: 200,
-        },
-        (google.api.field_behavior) = REQUIRED
-    ];
+  // context is the context in which the rule type is evaluated.
+  Context context = 1;
+  // id is the name or id of the profile to delete
+  string id = 2 [
+    (buf.validate.field).string = {
+      pattern: "^[A-Za-z0-9][-/[:word:]]*$"
+      max_len: 200
+    },
+    (google.api.field_behavior) = REQUIRED
+  ];
 }
 
-message DeleteProfileResponse {
-}
+message DeleteProfileResponse {}
 
 // list profiles
 message ListProfilesRequest {
-    // context is the context which contains the profiles
-    Context context = 1;
-    // Filter profiles to only those matching the specified labels.
-    //
-    // The default is to return all user-created profiles; the string "*" can
-    // be used to select all profiles, including system profiles.  This syntax
-    // may be expanded in the future.
-    string label_filter = 2 [
-        (buf.validate.field).string = {
-            pattern: "^(\\*|[a-z][a-z0-9_]*)$",
-            max_len: 200,
-        },
-        (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE
-    ];
+  // context is the context which contains the profiles
+  Context context = 1;
+  // Filter profiles to only those matching the specified labels.
+  //
+  // The default is to return all user-created profiles; the string "*" can
+  // be used to select all profiles, including system profiles.  This syntax
+  // may be expanded in the future.
+  string label_filter = 2 [
+    (buf.validate.field).string = {
+      pattern: "^(\\*|[a-z][a-z0-9_]*)$"
+      max_len: 200
+    },
+    (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE
+  ];
 }
 
 message ListProfilesResponse {
-    repeated Profile profiles = 1 [
-        (google.api.field_behavior) = REQUIRED
-    ];
+  repeated Profile profiles = 1 [(google.api.field_behavior) = REQUIRED];
 }
 
 // get profile by id
 message GetProfileByIdRequest {
-    // context is the context which contains the profiles
-    Context context = 1;
-    // id is the id of the profile to get
-    string id = 2 [
-        (buf.validate.field).string = {uuid: true},
-        (google.api.field_behavior) = REQUIRED
-    ];
+  // context is the context which contains the profiles
+  Context context = 1;
+  // id is the id of the profile to get
+  string id = 2 [
+    (buf.validate.field).string = {uuid: true},
+    (google.api.field_behavior) = REQUIRED
+  ];
 }
 
 message GetProfileByIdResponse {
-    Profile profile = 1 [
-        (google.api.field_behavior) = REQUIRED
-    ];
+  Profile profile = 1 [(google.api.field_behavior) = REQUIRED];
 }
 
 // get profile by name
 message GetProfileByNameRequest {
-    // context is the context in which the rule type is evaluated.
-    Context context = 1;
-    // name is the name of the profile to get
-    string name = 2 [
-        (buf.validate.field).string = {
-            pattern: "^[A-Za-z][-/[:word:]]*$",
-            max_len: 200,
-        },
-        (google.api.field_behavior) = REQUIRED
-    ];
+  // context is the context in which the rule type is evaluated.
+  Context context = 1;
+  // name is the name of the profile to get
+  string name = 2 [
+    (buf.validate.field).string = {
+      pattern: "^[A-Za-z][-/[:word:]]*$"
+      max_len: 200
+    },
+    (google.api.field_behavior) = REQUIRED
+  ];
 }
 
 message GetProfileByNameResponse {
-    Profile profile = 1 [
-        (google.api.field_behavior) = REQUIRED
-    ];
+  Profile profile = 1 [(google.api.field_behavior) = REQUIRED];
 }
 
 // get the overall profile status as output
 message ProfileStatus {
-    // profile_id is the id of the profile.  One of profile_id or profile_name must be set.
-    string profile_id = 1;
-    // profile_name is the name of the profile.  One of profile_id or profile_name must be set.
-    string profile_name = 2;
-    // profile_status is the status of the profile
-    string profile_status = 3 [
-        (google.api.field_behavior) = REQUIRED
-    ];
-    // last_updated is the last time the profile was updated
-    google.protobuf.Timestamp last_updated = 4;
+  // profile_id is the id of the profile.  One of profile_id or profile_name must be set.
+  string profile_id = 1;
+  // profile_name is the name of the profile.  One of profile_id or profile_name must be set.
+  string profile_name = 2;
+  // profile_status is the status of the profile
+  string profile_status = 3 [(google.api.field_behavior) = REQUIRED];
+  // last_updated is the last time the profile was updated
+  google.protobuf.Timestamp last_updated = 4;
 
-    // profile_display_name is the display name of the profile
-    string profile_display_name = 5;
+  // profile_display_name is the display name of the profile
+  string profile_display_name = 5;
 }
 
 // EvalResultAlert holds the alert details for a given rule evaluation
 message EvalResultAlert {
-    // status is the status of the alert
-    string status = 1;
-    // last_updated is the last time the alert was performed or attempted
-    google.protobuf.Timestamp last_updated = 2;
-    // details is the description of the alert attempt if any
-    string details = 3;
-    // url is the URL to the alert
-    string url = 4;
+  // status is the status of the alert
+  string status = 1;
+  // last_updated is the last time the alert was performed or attempted
+  google.protobuf.Timestamp last_updated = 2;
+  // details is the description of the alert attempt if any
+  string details = 3;
+  // url is the URL to the alert
+  string url = 4;
 }
 
 // get the status of the rules for a given profile
 message RuleEvaluationStatus {
-    // profile_id is the id of the profile
-    string profile_id = 1;
-    // rule_id is the id of the rule
-    string rule_id = 2 [
-        (google.api.field_behavior) = REQUIRED
-    ];
-    // rule_name is the type of the rule. Deprecated in favor of rule_type_name
-    string rule_name = 3 [deprecated=true];
-    // entity is the entity that was evaluated
-    string entity = 4 [
-        (google.api.field_behavior) = REQUIRED
-    ];
-    // status is the status of the evaluation
-    string status = 5 [
-        (google.api.field_behavior) = REQUIRED
-    ];
-    // last_updated is the last time the profile was updated
-    google.protobuf.Timestamp last_updated = 6;
-    // entity_info is the information about the entity
-    map<string, string> entity_info = 7;
-    // details is the description of the evaluation if any
-    string details = 8;
-    // guidance is the guidance for the evaluation if any
-    string guidance = 9;
-    // remediation_status is the status of the remediation
-    string remediation_status = 10;
-    // remediation_last_updated is the last time the remediation was performed or attempted
-    optional google.protobuf.Timestamp remediation_last_updated = 11;
-    // remediation_details is the description of the remediation attempt if any
-    string remediation_details = 12;
-    // rule_type_name is the name of the rule
-    string rule_type_name = 13 [
-        (google.api.field_behavior) = REQUIRED
-    ];
-    // rule_description_name is the name to describe the rule
-    string rule_description_name = 14;
-    // alert holds the alert details if the rule generated an alert in an external system
-    EvalResultAlert alert = 15;
-    // severity is the severity of the rule. This may be empty.
-    Severity severity = 16;
-    // rule_evaluation_id is the id of the rule evaluation
-    string rule_evaluation_id = 17;
-    // remediation_url is a url to get more data about a remediation, for PRs is the link to the PR
-    string remediation_url = 18;
-    // rule_display_name captures the display name of the rule
-    string rule_display_name = 19;
-    // release_phase is the phase of the release
-    RuleTypeReleasePhase release_phase = 20 [
-        (google.api.field_behavior) = REQUIRED
-    ];
-    // output optionally contains the structured rule evaluation output.
-    // Because output may be multiple KB, it is only returned
-    // if include_outputs is set. Historical evaluations may
-    // discard structured output sooner than status results.
-    google.protobuf.Value output = 21;
+  // profile_id is the id of the profile
+  string profile_id = 1;
+  // rule_id is the id of the rule
+  string rule_id = 2 [(google.api.field_behavior) = REQUIRED];
+  // rule_name is the type of the rule. Deprecated in favor of rule_type_name
+  string rule_name = 3 [deprecated = true];
+  // entity is the entity that was evaluated
+  string entity = 4 [(google.api.field_behavior) = REQUIRED];
+  // status is the status of the evaluation
+  string status = 5 [(google.api.field_behavior) = REQUIRED];
+  // last_updated is the last time the profile was updated
+  google.protobuf.Timestamp last_updated = 6;
+  // entity_info is the information about the entity
+  map<string, string> entity_info = 7;
+  // details is the description of the evaluation if any
+  string details = 8;
+  // guidance is the guidance for the evaluation if any
+  string guidance = 9;
+  // remediation_status is the status of the remediation
+  string remediation_status = 10;
+  // remediation_last_updated is the last time the remediation was performed or attempted
+  optional google.protobuf.Timestamp remediation_last_updated = 11;
+  // remediation_details is the description of the remediation attempt if any
+  string remediation_details = 12;
+  // rule_type_name is the name of the rule
+  string rule_type_name = 13 [(google.api.field_behavior) = REQUIRED];
+  // rule_description_name is the name to describe the rule
+  string rule_description_name = 14;
+  // alert holds the alert details if the rule generated an alert in an external system
+  EvalResultAlert alert = 15;
+  // severity is the severity of the rule. This may be empty.
+  Severity severity = 16;
+  // rule_evaluation_id is the id of the rule evaluation
+  string rule_evaluation_id = 17;
+  // remediation_url is a url to get more data about a remediation, for PRs is the link to the PR
+  string remediation_url = 18;
+  // rule_display_name captures the display name of the rule
+  string rule_display_name = 19;
+  // release_phase is the phase of the release
+  RuleTypeReleasePhase release_phase = 20 [(google.api.field_behavior) = REQUIRED];
+  // output optionally contains the structured rule evaluation output.
+  // Because output may be multiple KB, it is only returned
+  // if include_outputs is set. Historical evaluations may
+  // discard structured output sooner than status results.
+  google.protobuf.Value output = 21;
 }
 
 // EntityTypedId is a message that carries an ID together with a type to uniquely identify an entity
 // such as (repo, 1), (artifact, 2), ...
 message EntityTypedId {
-    // entity is the entity to get status for. Incompatible with `all`
-    Entity type = 1 [
-        (google.api.field_behavior) = REQUIRED
-    ];
-    // On input, at least one of id and name must be set.  If both are set, they must both match.
-    // On output, both id and name will be set.
+  // entity is the entity to get status for. Incompatible with `all`
+  Entity type = 1 [(google.api.field_behavior) = REQUIRED];
+  // On input, at least one of id and name must be set.  If both are set, they must both match.
+  // On output, both id and name will be set.
 
-    // id is the ID of the entity to get status for. Incompatible with `all`
-    string id = 2 [
-        (buf.validate.field).string = {uuid: true},
-        (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE,
-        (google.api.field_behavior) = OPTIONAL
-    ];
-    // name is the name of the entity.  This name is unique within a given project, type, and provider, but may not be globally unique.
-    string name = 3 [
-        (buf.validate.field).string = {
-            max_bytes: 200
-            pattern: "^[[:alnum:]][-/[:word:]]*"
-        },
-        (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE,
-        (google.api.field_behavior) = OPTIONAL
-    ];
+  // id is the ID of the entity to get status for. Incompatible with `all`
+  string id = 2 [
+    (buf.validate.field).string = {uuid: true},
+    (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE,
+    (google.api.field_behavior) = OPTIONAL
+  ];
+  // name is the name of the entity.  This name is unique within a given project, type, and provider, but may not be globally unique.
+  string name = 3 [
+    (buf.validate.field).string = {
+      max_bytes: 200
+      pattern: "^[[:alnum:]][-/[:word:]]*"
+    },
+    (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE,
+    (google.api.field_behavior) = OPTIONAL
+  ];
 }
 
 message GetProfileStatusByNameRequest {
-    // context is the context in which the rule type is evaluated.
-    Context context = 1;
-    // name is the name of the profile to get
-    string name = 2 [
-        (buf.validate.field).string = {
-            pattern: "^[A-Za-z][-/[:word:]]*$",
-            max_len: 200,
-        },
-        (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE
-    ];
+  // context is the context in which the rule type is evaluated.
+  Context context = 1;
+  // name is the name of the profile to get
+  string name = 2 [
+    (buf.validate.field).string = {
+      pattern: "^[A-Za-z][-/[:word:]]*$"
+      max_len: 200
+    },
+    (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE
+  ];
 
-    // entity is the entity to get status for. Incompatible with `all`.
-    // This is optional.
-    EntityTypedId entity = 3;
+  // entity is the entity to get status for. Incompatible with `all`.
+  // This is optional.
+  EntityTypedId entity = 3;
 
-    // all is true if the status of all entities should be returned.
-    // Incompatible with `entity`. This is optional.
-    bool all = 4;
+  // all is true if the status of all entities should be returned.
+  // Incompatible with `entity`. This is optional.
+  bool all = 4;
 
-    // rule is the type of the rule. Deprecated in favor of rule_type
-    string rule = 5 [deprecated=true];
+  // rule is the type of the rule. Deprecated in favor of rule_type
+  string rule = 5 [deprecated = true];
 
-    // rule_type is the type of the rule to filter on.
-    // This is optional.
-    string rule_type = 6 [
-        (buf.validate.field).string = {
-            pattern: "^[A-Za-z][-/[:word:]]*$"
-            max_len: 200,
-        },
-        (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE
-    ];
+  // rule_type is the type of the rule to filter on.
+  // This is optional.
+  string rule_type = 6 [
+    (buf.validate.field).string = {
+      pattern: "^[A-Za-z][-/[:word:]]*$"
+      max_len: 200
+    },
+    (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE
+  ];
 
-    // rule_name is the name of the rule to filter on.
-    // This is optional.
-    string rule_name = 7 [
-        (buf.validate.field).string = {
-            pattern: "^[A-Za-z][-/'()[:word:] :]*$",
-            max_len: 200,
-        },
-        (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE
-    ];
+  // rule_name is the name of the rule to filter on.
+  // This is optional.
+  string rule_name = 7 [
+    (buf.validate.field).string = {
+      pattern: "^[A-Za-z][-/'()[:word:] :]*$"
+      max_len: 200
+    },
+    (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE
+  ];
 }
 
 message GetProfileStatusByNameResponse {
-    // profile_status is the status of the profile
-    ProfileStatus profile_status = 1[
-        (google.api.field_behavior) = REQUIRED
-    ];
+  // profile_status is the status of the profile
+  ProfileStatus profile_status = 1 [(google.api.field_behavior) = REQUIRED];
 
-    // rule_evaluation_status is the status of the rules
-    repeated RuleEvaluationStatus rule_evaluation_status = 2;
+  // rule_evaluation_status is the status of the rules
+  repeated RuleEvaluationStatus rule_evaluation_status = 2;
 }
 
 message GetProfileStatusByIdRequest {
-    // context is the context in which the rule type is evaluated.
-    Context context = 1;
-    // id is the id of the profile to get
-    string id = 2 [
-        (buf.validate.field).string = {uuid: true}
-    ];
+  // context is the context in which the rule type is evaluated.
+  Context context = 1;
+  // id is the id of the profile to get
+  string id = 2 [(buf.validate.field).string = {uuid: true}];
 
-    EntityTypedId entity = 3;
-    bool all = 4;
+  EntityTypedId entity = 3;
+  bool all = 4;
 
-    string rule_type = 5 [
-        (buf.validate.field).string = {
-            pattern: "^[A-Za-z][-/[:word:]]*$"
-            max_len: 200,
-        },
-        (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE
-    ];
-    string rule_name = 6 [
-        (buf.validate.field).string = {
-            pattern: "^[A-Za-z][-/'()[:word:] :]*$",
-            max_len: 200,
-        },
-        (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE
-    ];
+  string rule_type = 5 [
+    (buf.validate.field).string = {
+      pattern: "^[A-Za-z][-/[:word:]]*$"
+      max_len: 200
+    },
+    (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE
+  ];
+  string rule_name = 6 [
+    (buf.validate.field).string = {
+      pattern: "^[A-Za-z][-/'()[:word:] :]*$"
+      max_len: 200
+    },
+    (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE
+  ];
 }
 
 message GetProfileStatusByIdResponse {
-    // profile_status is the status of the profile
-    ProfileStatus profile_status = 1[
-        (google.api.field_behavior) = REQUIRED
-    ];
+  // profile_status is the status of the profile
+  ProfileStatus profile_status = 1 [(google.api.field_behavior) = REQUIRED];
 
-    // rule_evaluation_status is the status of the rules
-    repeated RuleEvaluationStatus rule_evaluation_status = 2;
+  // rule_evaluation_status is the status of the rules
+  repeated RuleEvaluationStatus rule_evaluation_status = 2;
 }
 
-
 message GetProfileStatusByProjectRequest {
-    // context is the context in which the rule type is evaluated.
-    Context context = 1;
+  // context is the context in which the rule type is evaluated.
+  Context context = 1;
 }
 
 message GetProfileStatusByProjectResponse {
-    // profile_status is the status of the profile
-    repeated ProfileStatus profile_status = 1 [
-        (google.api.field_behavior) = REQUIRED
-    ];
+  // profile_status is the status of the profile
+  repeated ProfileStatus profile_status = 1 [(google.api.field_behavior) = REQUIRED];
 }
 
 // Entity defines the entity that is supported by the provider.
 enum Entity {
-    ENTITY_UNSPECIFIED = 0;
-    ENTITY_REPOSITORIES = 1;
-    ENTITY_BUILD_ENVIRONMENTS = 2;
-    ENTITY_ARTIFACTS = 3;
-    ENTITY_PULL_REQUESTS = 4;
-    ENTITY_RELEASE = 5;
-    ENTITY_PIPELINE_RUN = 6;
-    ENTITY_TASK_RUN = 7;
-    ENTITY_BUILD = 8;
+  ENTITY_UNSPECIFIED = 0;
+  ENTITY_REPOSITORIES = 1;
+  ENTITY_BUILD_ENVIRONMENTS = 2;
+  ENTITY_ARTIFACTS = 3;
+  ENTITY_PULL_REQUESTS = 4;
+  ENTITY_RELEASE = 5;
+  ENTITY_PIPELINE_RUN = 6;
+  ENTITY_TASK_RUN = 7;
+  ENTITY_BUILD = 8;
 }
 
 message EntityAutoRegistrationConfig {
-   optional bool enabled = 1;
+  optional bool enabled = 1;
 }
 
 // AutoRegistration is the configuration for auto-registering entities.
 // When nothing is set, it means that auto-registration is disabled. There is no difference between disabled
 // and undefined so for the "let's not auto-register anything" case we'd just let the repeated string empty
 message AutoRegistration {
-    // enabled is the list of entities that are enabled for auto-registration.
-    map<string, EntityAutoRegistrationConfig> entities = 1 [
-        (google.api.field_behavior) = REQUIRED
-    ];
+  // enabled is the list of entities that are enabled for auto-registration.
+  map<string, EntityAutoRegistrationConfig> entities = 1 [(google.api.field_behavior) = REQUIRED];
 }
 
 // ProviderConfig contains the generic configuration for a provider.
 message ProviderConfig {
-    // auto_registration is the configuration for auto-registering entities.
-    optional AutoRegistration auto_registration = 1;
+  // auto_registration is the configuration for auto-registering entities.
+  optional AutoRegistration auto_registration = 1;
 }
 
 // RESTProviderConfig contains the configuration for the REST provider.
 message RESTProviderConfig {
-    // base_url is the base URL for the REST provider.
-	optional string base_url = 1;
+  // base_url is the base URL for the REST provider.
+  optional string base_url = 1;
 }
 
 // GitHubProviderConfig contains the configuration for the GitHub client
@@ -2088,8 +1821,8 @@ message RESTProviderConfig {
 // disable revive linting for this struct as there is nothing wrong with the
 // naming convention
 message GitHubProviderConfig {
-    // Endpoint is the GitHub API endpoint. If using the public GitHub API, Endpoint can be left blank.
-	optional string endpoint = 1;
+  // Endpoint is the GitHub API endpoint. If using the public GitHub API, Endpoint can be left blank.
+  optional string endpoint = 1;
 }
 
 // GitHubAppProviderConfig contains the configuration for the GitHub App provider
@@ -2106,11 +1839,11 @@ message GitHubAppProviderConfig {
 //
 // If using the public GitLab API, Endpoint can be left blank
 message GitLabProviderConfig {
-    // Endpoint is the GitLab API endpoint. If using the public GitLab API, Endpoint can be left blank.
-    string endpoint = 1;
+  // Endpoint is the GitLab API endpoint. If using the public GitLab API, Endpoint can be left blank.
+  string endpoint = 1;
 
-    // group is the GitLab group to use for the provider
-    string group = 2;
+  // group is the GitLab group to use for the provider
+  string group = 2;
 }
 
 // DockerHubProviderConfig contains the configuration for the DockerHub provider.
@@ -2118,8 +1851,8 @@ message GitLabProviderConfig {
 // Namespace: is the namespace for the DockerHub provider.
 //
 message DockerHubProviderConfig {
-    // namespace is the namespace for the DockerHub provider.
-    optional string namespace = 1;
+  // namespace is the namespace for the DockerHub provider.
+  optional string namespace = 1;
 }
 
 // GHCRProviderConfig contains the configuration for the GHCR provider.
@@ -2127,1766 +1860,1651 @@ message DockerHubProviderConfig {
 // Namespace: is the namespace for the GHCR provider.
 //
 message GHCRProviderConfig {
-    // namespace is the namespace for the GHCR provider.
-    optional string namespace = 1;
+  // namespace is the namespace for the GHCR provider.
+  optional string namespace = 1;
 }
 
 // Context defines the context in which a rule is evaluated.
 // this normally refers to a combination of the provider, organization and project.
 message Context {
-    // Removing the 'optional' keyword from the following two fields below will break
-    // buf compatibility checks.
+  // Removing the 'optional' keyword from the following two fields below will break
+  // buf compatibility checks.
 
-    // name of the provider
-    // This is optional, but some existing clients may set the field unconditionally,
-    // so an empty string is also an allowed value.
-    optional string provider = 1 [
-        (buf.validate.field).string = {
-            pattern: "^(?:[A-Za-z][-[:word:]]*)?$",
-            max_len: 200,
-        }
-    ];
-    // ID or name of the project.  If empty or unset, will select the user's default
-    // project if they only have one project.  Existing clients may unconditionally set
-    // this to the empty string rather than leaving this unset, so we allow "" as an
-    // alias for unset.
-    optional string project = 3 [
-        (buf.validate.field).string = {
-            pattern: "^[-a-zA-Z0-9.]{0,63}$"
-            max_len: 63
-        }
-    ];
+  // name of the provider
+  // This is optional, but some existing clients may set the field unconditionally,
+  // so an empty string is also an allowed value.
+  optional string provider = 1 [(buf.validate.field).string = {
+    pattern: "^(?:[A-Za-z][-[:word:]]*)?$"
+    max_len: 200
+  }];
+  // ID or name of the project.  If empty or unset, will select the user's default
+  // project if they only have one project.  Existing clients may unconditionally set
+  // this to the empty string rather than leaving this unset, so we allow "" as an
+  // alias for unset.
+  optional string project = 3 [(buf.validate.field).string = {
+    pattern: "^[-a-zA-Z0-9.]{0,63}$"
+    max_len: 63
+  }];
 
-    optional string retired_organization = 2;
+  optional string retired_organization = 2;
 }
 
 // ContextV2 defines the context in which a rule is evaluated.
 message ContextV2 {
-    // project is the project ID or name.  If empty or unset, will select the user's
-    // default project if they only have one project.
-    string project_id = 1 [
-        (buf.validate.field).string = {
-            pattern: "^[-a-zA-Z0-9.]{1,63}$"
-            max_len: 63
-        },
-        (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE
-    ];
+  // project is the project ID or name.  If empty or unset, will select the user's
+  // default project if they only have one project.
+  string project_id = 1 [
+    (buf.validate.field).string = {
+      pattern: "^[-a-zA-Z0-9.]{1,63}$"
+      max_len: 63
+    },
+    (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE
+  ];
 
-    // name of the provider. Set to empty string when not applicable.
-    string provider = 2 [
-        (buf.validate.field).string = {
-            pattern: "^[A-Za-z][-[:word:]]*$",
-            max_len: 200,
-        },
-        (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE
-    ];
+  // name of the provider. Set to empty string when not applicable.
+  string provider = 2 [
+    (buf.validate.field).string = {
+      pattern: "^[A-Za-z][-[:word:]]*$"
+      max_len: 200
+    },
+    (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE
+  ];
 }
 
 // --- START RuleType CRUD definitions
 
 // ListRuleTypesRequest is the request to list rule types.
 message ListRuleTypesRequest {
-    // context is the context in which the rule types are evaluated.
-    Context context = 1;
+  // context is the context in which the rule types are evaluated.
+  Context context = 1;
 }
 
 // ListRuleTypesResponse is the response to list rule types.
 message ListRuleTypesResponse {
-    // rule_types is the list of rule types.
-    repeated RuleType rule_types = 1 [
-        (google.api.field_behavior) = REQUIRED
-    ];
+  // rule_types is the list of rule types.
+  repeated RuleType rule_types = 1 [(google.api.field_behavior) = REQUIRED];
 }
 
 // GetRuleTypeByNameRequest is the request to get a rule type by name.
 message GetRuleTypeByNameRequest {
-    // context is the context in which the rule type is evaluated.
-    Context context = 1;
-    // name is the name of the rule type.
-    string name = 2 [
-        (buf.validate.field).string = {
-            pattern: "^[A-Za-z][-/[:word:]]*$",
-            max_len: 200,
-        },
-        (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE
-    ];
+  // context is the context in which the rule type is evaluated.
+  Context context = 1;
+  // name is the name of the rule type.
+  string name = 2 [
+    (buf.validate.field).string = {
+      pattern: "^[A-Za-z][-/[:word:]]*$"
+      max_len: 200
+    },
+    (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE
+  ];
 }
 
 // GetRuleTypeByNameResponse is the response to get a rule type by name.
 message GetRuleTypeByNameResponse {
-    // rule_type is the rule type.
-    RuleType rule_type = 1 [
-        (google.api.field_behavior) = REQUIRED
-    ];
+  // rule_type is the rule type.
+  RuleType rule_type = 1 [(google.api.field_behavior) = REQUIRED];
 }
 
 // GetRuleTypeByIdRequest is the request to get a rule type by id.
 message GetRuleTypeByIdRequest {
-    // context is the context in which the rule type is evaluated.
-    Context context = 1;
-    // id is the id of the rule type.
-    string id = 2 [
-        (buf.validate.field).string = {uuid: true},
-        (google.api.field_behavior) = REQUIRED
-    ];
+  // context is the context in which the rule type is evaluated.
+  Context context = 1;
+  // id is the id of the rule type.
+  string id = 2 [
+    (buf.validate.field).string = {uuid: true},
+    (google.api.field_behavior) = REQUIRED
+  ];
 }
 
 // GetRuleTypeByIdResponse is the response to get a rule type by id.
 message GetRuleTypeByIdResponse {
-    // rule_type is the rule type.
-    RuleType rule_type = 1 [
-        (google.api.field_behavior) = REQUIRED
-    ];
+  // rule_type is the rule type.
+  RuleType rule_type = 1 [(google.api.field_behavior) = REQUIRED];
 }
 
 // CreateRuleTypeRequest is the request to create a rule type.
 message CreateRuleTypeRequest {
-    // rule_type is the rule type to be created.
-    RuleType rule_type = 1 [
-        (google.api.field_behavior) = REQUIRED
-    ];
-    reserved 2; // deprecated context
+  // rule_type is the rule type to be created.
+  RuleType rule_type = 1 [(google.api.field_behavior) = REQUIRED];
+  reserved 2; // deprecated context
 }
 
 // CreateRuleTypeResponse is the response to create a rule type.
 message CreateRuleTypeResponse {
-    // rule_type is the rule type that was created.
-    RuleType rule_type = 1 [
-        (google.api.field_behavior) = REQUIRED
-    ];
+  // rule_type is the rule type that was created.
+  RuleType rule_type = 1 [(google.api.field_behavior) = REQUIRED];
 }
 
 // UpdateRuleTypeRequest is the request to update a rule type.
 message UpdateRuleTypeRequest {
-    // rule_type is the rule type to be updated.
-    RuleType rule_type = 2 [
-        (google.api.field_behavior) = REQUIRED
-    ];
-    reserved 3; // deprecated context
+  // rule_type is the rule type to be updated.
+  RuleType rule_type = 2 [(google.api.field_behavior) = REQUIRED];
+  reserved 3; // deprecated context
 }
 
 // UpdateRuleTypeResponse is the response to update a rule type.
 message UpdateRuleTypeResponse {
-    // rule_type is the rule type that was updated.
-    RuleType rule_type = 1 [
-        (google.api.field_behavior) = REQUIRED
-    ];
+  // rule_type is the rule type that was updated.
+  RuleType rule_type = 1 [(google.api.field_behavior) = REQUIRED];
 }
 
 // DeleteRuleTypeRequest is the request to delete a rule type.
 message DeleteRuleTypeRequest {
-    // context is the context in which the rule type is evaluated.
-    Context context = 1;
-    // id is the name or id of the rule type to be deleted.
-    string id = 2 [
-        (buf.validate.field).string = {
-            pattern: "^[A-Za-z0-9][-/[:word:]]*$",
-            max_len: 200,
-        },
-        (google.api.field_behavior) = REQUIRED
-    ];
+  // context is the context in which the rule type is evaluated.
+  Context context = 1;
+  // id is the name or id of the rule type to be deleted.
+  string id = 2 [
+    (buf.validate.field).string = {
+      pattern: "^[A-Za-z0-9][-/[:word:]]*$"
+      max_len: 200
+    },
+    (google.api.field_behavior) = REQUIRED
+  ];
 }
 
 // DeleteRuleTypeResponse is the response to delete a rule type.
-message DeleteRuleTypeResponse {
-}
+message DeleteRuleTypeResponse {}
 
 // --- END RuleType CRUD definitions
 
 // --- START EvaluationResults definitions
 
 message ListEvaluationResultsRequest {
-    // context is the context in which the evaluation results are evaluated.
-    Context context = 1;
+  // context is the context in which the evaluation results are evaluated.
+  Context context = 1;
 
-    // profile is the profile name or ID to retrieve results for.
-    // If empty, return evaluation results for profiles selected by
-    // an empty label_filter.
-    oneof profile_selector {
-        // ID can contain either a profile name or an ID.
-        string profile = 2 [
-            (buf.validate.field).string = {
-                pattern: "^([[:alnum:]][-[:word:]]*)?$"
-                max_len: 200,
-            }
-        ];
-        // Filter profiles to only those matching the specified labels.
-        //
-        // The default is to return all user-created profiles; the string "*" can
-        // be used to select all profiles, including system profiles.  This syntax
-        // may be expanded in the future.
-        string label_filter = 3 [
-            (buf.validate.field).string = {
-                pattern: "^(\\*|[a-zA-Z][a-zA-Z0-9_]*)$",
-                max_len: 200,
-            }
-        ];
+  // profile is the profile name or ID to retrieve results for.
+  // If empty, return evaluation results for profiles selected by
+  // an empty label_filter.
+  oneof profile_selector {
+    // ID can contain either a profile name or an ID.
+    string profile = 2 [(buf.validate.field).string = {
+      pattern: "^([[:alnum:]][-[:word:]]*)?$"
+      max_len: 200
+    }];
+    // Filter profiles to only those matching the specified labels.
+    //
+    // The default is to return all user-created profiles; the string "*" can
+    // be used to select all profiles, including system profiles.  This syntax
+    // may be expanded in the future.
+    string label_filter = 3 [(buf.validate.field).string = {
+      pattern: "^(\\*|[a-zA-Z][a-zA-Z0-9_]*)$"
+      max_len: 200
+    }];
+  }
+
+  // If set, only return evaluation results for the named entities.
+  // If empty, return evaluation results for all entities
+  repeated EntityTypedId entity = 4;
+
+  // If set, only return evaluation results for the named rules.
+  // If empty, return evaluation results for all rules
+  repeated string rule_name = 5 [(buf.validate.field).repeated = {
+    items: {
+      string: {
+        pattern: "^[A-Za-z][-/[:word:]]*$"
+        max_len: 200
+      }
     }
+  }];
 
-    // If set, only return evaluation results for the named entities.
-    // If empty, return evaluation results for all entities
-    repeated EntityTypedId entity = 4;
-
-    // If set, only return evaluation results for the named rules.
-    // If empty, return evaluation results for all rules
-    repeated string rule_name = 5 [
-        (buf.validate.field).repeated = {
-            items: {
-                string: {
-                    pattern: "^[A-Za-z][-/[:word:]]*$",
-                        max_len: 200,
-                    }
-            }
-        }
-    ];
-
-    // If true, include structured rule output for the matched evaluations.
-    // Not all ruletypes may generate structured outputs.
-    // Because the evaluation output may be large, it is only returned
-    // when explicitly requested.
-    bool include_outputs = 6;
+  // If true, include structured rule output for the matched evaluations.
+  // Not all ruletypes may generate structured outputs.
+  // Because the evaluation output may be large, it is only returned
+  // when explicitly requested.
+  bool include_outputs = 6;
 }
 
 message ListEvaluationResultsResponse {
-    reserved 1; // deprecated status
-    reserved "status";
+  reserved 1; // deprecated status
+  reserved "status";
 
-    message EntityProfileEvaluationResults {
-        // profile_status is the status of the profile - id, name, status, last_updated
-        ProfileStatus profile_status = 1;
+  message EntityProfileEvaluationResults {
+    // profile_status is the status of the profile - id, name, status, last_updated
+    ProfileStatus profile_status = 1;
 
-        // Note that some fields like profile_id and entity might be empty
-        // Eventually we might replace this type with another one that fits the API better
-        repeated RuleEvaluationStatus results = 2;
-    }
+    // Note that some fields like profile_id and entity might be empty
+    // Eventually we might replace this type with another one that fits the API better
+    repeated RuleEvaluationStatus results = 2;
+  }
 
-    message EntityEvaluationResults {
-        EntityTypedId entity = 1;
-        repeated EntityProfileEvaluationResults profiles = 2;
-    }
+  message EntityEvaluationResults {
+    EntityTypedId entity = 1;
+    repeated EntityProfileEvaluationResults profiles = 2;
+  }
 
-    // Each entity selected by the list request will have _single_ entry in entities which contains results of all evaluations for each profile.
-    repeated EntityEvaluationResults entities = 2 [
-        (google.api.field_behavior) = REQUIRED
-    ];
+  // Each entity selected by the list request will have _single_ entry in entities which contains results of all evaluations for each profile.
+  repeated EntityEvaluationResults entities = 2 [(google.api.field_behavior) = REQUIRED];
 }
 
 // --- END EvaluationResults definitions
 
-
-
 // RestType defines the rest data evaluation.
 // This is used to fetch data from a REST endpoint.
 message RestType {
-    message Fallback {
-        int32 http_code = 1 [(buf.validate.field).int32 = { gte: 100, lte: 599 }];
-        // This is expected to be a valid JSON string.
-        string body = 2 [
-            (buf.validate.field).string = {
-                max_len: 1000,
-            },
-            (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE
-        ];
+  message Fallback {
+    int32 http_code = 1 [(buf.validate.field).int32 = {
+      gte: 100
+      lte: 599
+    }];
+    // This is expected to be a valid JSON string.
+    string body = 2 [
+      (buf.validate.field).string = {max_len: 1000},
+      (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE
+    ];
+  }
+
+  // endpoint is the endpoint to fetch data from.
+  // This can be a URL or path on the API.
+  // This is a required field and must be set.
+  // This is also evaluated via a template which allows
+  // us dynamically fill in the values.
+  string endpoint = 1 [
+    (buf.validate.field).string = {max_len: 400},
+    (google.api.field_behavior) = REQUIRED
+  ];
+
+  // method is the method to use to fetch data.
+  // Go templates may be used to vary the method using the same parameters
+  // as the endpoint.
+  string method = 2 [
+    (buf.validate.field).string = {max_len: 50},
+    (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE
+  ];
+
+  // headers are the headers to be sent to the endpoint.
+  repeated string headers = 3 [(buf.validate.field).repeated = {
+    items: {
+      string: {
+        pattern: "^[a-zA-Z0-9-]+:[[:graph:][:blank:]]+$"
+        max_len: 400
+      }
     }
+  }];
 
-    // endpoint is the endpoint to fetch data from.
-    // This can be a URL or path on the API.
-    // This is a required field and must be set.
-    // This is also evaluated via a template which allows
-    // us dynamically fill in the values.
-    string endpoint = 1 [
-        (buf.validate.field).string = {
-            max_len: 400,
-        },
-        (google.api.field_behavior) = REQUIRED
-    ];
+  // body is the body to be sent to the endpoint, which must be valid JSON
+  // Go templates may be used to vary the method using the same parameters
+  // as the endpoint.
+  optional string body = 4 [(buf.validate.field).string = {max_len: 1000}];
 
-    // method is the method to use to fetch data.
-    // Go templates may be used to vary the method using the same parameters
-    // as the endpoint.
-    string method = 2 [
-        (buf.validate.field).string = {
-            max_len: 50
-        },
-        (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE
-    ];
+  // parse is the parsing mechanism to be used to parse the data.
+  string parse = 5 [
+    (buf.validate.field).string = {
+      pattern: "^[a-z_]+$"
+      max_len: 50
+    },
+    (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE
+  ];
 
-    // headers are the headers to be sent to the endpoint.
-    repeated string headers = 3 [
-        (buf.validate.field).repeated = {
-            items: {
-                string: {
-                    pattern: "^[a-zA-Z0-9-]+:[[:graph:][:blank:]]+$",
-                    max_len: 400,
-                }
-            }
-        }
-    ];
-
-    // body is the body to be sent to the endpoint, which must be valid JSON
-    // Go templates may be used to vary the method using the same parameters
-    // as the endpoint.
-    optional string body = 4 [
-        (buf.validate.field).string = {
-            max_len: 1000,
-        }
-    ];
-
-    // parse is the parsing mechanism to be used to parse the data.
-    string parse = 5 [
-        (buf.validate.field).string = {
-            pattern: "^[a-z_]+$",
-            max_len: 50,
-        },
-        (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE
-    ];
-
-    // fallback provides a body that the ingester would return in case
-    // the REST call returns a non-200 status code.
-    repeated Fallback fallback = 6;
+  // fallback provides a body that the ingester would return in case
+  // the REST call returns a non-200 status code.
+  repeated Fallback fallback = 6;
 }
 
 // BuiltinType defines the builtin data evaluation.
 message BuiltinType {
-    string method = 1;
+  string method = 1;
 }
 
 // ArtifactType defines the artifact data evaluation.
-message ArtifactType {
-}
+message ArtifactType {}
 
 // GitType defines the git data ingester.
 message GitType {
-    // clone_url is the url of the git repository.
-    string clone_url = 1 [
-        (buf.validate.field).string = {
-            uri: true,
-            max_len: 200,
-        },
-        (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE
-    ];
+  // clone_url is the url of the git repository.
+  string clone_url = 1 [
+    (buf.validate.field).string = {
+      uri: true
+      max_len: 200
+    },
+    (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE
+  ];
 
-    // branch is the branch of the git repository.
-    string branch = 2 [
-        (buf.validate.field).string = {
-            pattern: "^[[:word:]./-]+$",
-            max_len: 200,
-        },
-        (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE
-    ];
+  // branch is the branch of the git repository.
+  string branch = 2 [
+    (buf.validate.field).string = {
+      pattern: "^[[:word:]./-]+$"
+      max_len: 200
+    },
+    (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE
+  ];
 }
 
 // DiffType defines the diff data ingester.
 message DiffType {
-    message Ecosystem {
-        // name is the name of the ecosystem.
-        string name = 1 [
-            (buf.validate.field).string = {
-                pattern: "^[a-z]+(_[a-z]+)*$",
-                min_len: 1,
-                max_len: 200,
-            }
-        ];
-        // depfile is the file that contains the dependencies for this ecosystem
-        string depfile = 2 [
-            (buf.validate.field).string = {
-                pattern: "^(\\./)?([a-zA-Z0-9_\\-]+/)*[a-zA-Z0-9_\\-]+(\\.[a-zA-Z0-9]+)?$",
-                min_len: 1,
-                max_len: 200,
-            }
-        ];
-    }
+  message Ecosystem {
+    // name is the name of the ecosystem.
+    string name = 1 [(buf.validate.field).string = {
+      pattern: "^[a-z]+(_[a-z]+)*$"
+      min_len: 1
+      max_len: 200
+    }];
+    // depfile is the file that contains the dependencies for this ecosystem
+    string depfile = 2 [(buf.validate.field).string = {
+      pattern: "^(\\./)?([a-zA-Z0-9_\\-]+/)*[a-zA-Z0-9_\\-]+(\\.[a-zA-Z0-9]+)?$"
+      min_len: 1
+      max_len: 200
+    }];
+  }
 
-    // ecosystems is the list of ecosystems to be used
-    // for the "dep" diff type.
-    repeated Ecosystem ecosystems = 1;
+  // ecosystems is the list of ecosystems to be used
+  // for the "dep" diff type.
+  repeated Ecosystem ecosystems = 1;
 
-    // type is the type of diff ingestor to use.
-    // The default is "dep" which will leverage
-    // the ecosystems array.
-    string type = 2 [
-        (buf.validate.field).string = {
-            pattern: "^[a-z]+(_[a-z]+)*$",
-            max_len: 200,
-        },
-        (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE
-    ];
+  // type is the type of diff ingestor to use.
+  // The default is "dep" which will leverage
+  // the ecosystems array.
+  string type = 2 [
+    (buf.validate.field).string = {
+      pattern: "^[a-z]+(_[a-z]+)*$"
+      max_len: 200
+    },
+    (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE
+  ];
 }
 
 // DepsType defines the "deps" ingester which can extract depndencies in protobom
 // format for rule evaluation.
 message DepsType {
-    // branch is the branch of the git repository, when applied to repository entities.
-    // Has no meaning or effect on other entity types.
-    message RepoConfigs {
-        string branch = 1 [
-            (buf.validate.field).string = {
-                pattern: "^[[:word:]./-]+$",
-                max_len: 200,
-            },
-            (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE
-        ];
-    }
+  // branch is the branch of the git repository, when applied to repository entities.
+  // Has no meaning or effect on other entity types.
+  message RepoConfigs {
+    string branch = 1 [
+      (buf.validate.field).string = {
+        pattern: "^[[:word:]./-]+$"
+        max_len: 200
+      },
+      (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE
+    ];
+  }
 
-    message PullRequestConfigs {
-        // filter is the filter to apply to the PRs.  The default value is "NEW_AND_UPDATED".
-        string filter = 1 [
-            (buf.validate.field).string = {
-                in: ["NEW_AND_UPDATED", "NEW_ONLY"],
-            },
-            (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE
-        ];
-    }
+  message PullRequestConfigs {
+    // filter is the filter to apply to the PRs.  The default value is "NEW_AND_UPDATED".
+    string filter = 1 [
+      (buf.validate.field).string = {
+        in: [
+          "NEW_AND_UPDATED",
+          "NEW_ONLY"
+        ]
+      },
+      (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE
+    ];
+  }
 
-    oneof entity_type {
-        RepoConfigs repo = 1;
-        PullRequestConfigs pr = 2;
-    }
+  oneof entity_type {
+    RepoConfigs repo = 1;
+    PullRequestConfigs pr = 2;
+  }
 }
 
 // Severity defines the severity of the rule.
 message Severity {
-    // Value enumerates the severity values.
-    enum Value {
-        VALUE_UNSPECIFIED = 0;
-        // unknown severity means that the severity is unknown or hasn't
-        // been set.
-        VALUE_UNKNOWN = 1 [(name) = "unknown"];
-        // info severity means that the severity is informational and
-        // does not incur risk.
-        VALUE_INFO = 2 [(name) = "info"];
-        // low severity means that the severity is low and does not
-        // incur significant risk.
-        VALUE_LOW = 3 [(name) = "low"];
-        // medium severity means that the severity is medium and may
-        // incur some risk.
-        VALUE_MEDIUM = 4 [(name) = "medium"];
-        // high severity means that the severity is high and may incur
-        // significant risk.
-        VALUE_HIGH = 5 [(name) = "high"];
-        // critical severity means that the severity is critical and
-        // requires immediate attention.
-        VALUE_CRITICAL = 6 [(name) = "critical"];
-    }
+  // Value enumerates the severity values.
+  enum Value {
+    VALUE_UNSPECIFIED = 0;
+    // unknown severity means that the severity is unknown or hasn't
+    // been set.
+    VALUE_UNKNOWN = 1 [(name) = "unknown"];
+    // info severity means that the severity is informational and
+    // does not incur risk.
+    VALUE_INFO = 2 [(name) = "info"];
+    // low severity means that the severity is low and does not
+    // incur significant risk.
+    VALUE_LOW = 3 [(name) = "low"];
+    // medium severity means that the severity is medium and may
+    // incur some risk.
+    VALUE_MEDIUM = 4 [(name) = "medium"];
+    // high severity means that the severity is high and may incur
+    // significant risk.
+    VALUE_HIGH = 5 [(name) = "high"];
+    // critical severity means that the severity is critical and
+    // requires immediate attention.
+    VALUE_CRITICAL = 6 [(name) = "critical"];
+  }
 
-    // value is the severity value.
-    Value value = 1;
+  // value is the severity value.
+  Value value = 1;
 }
 
 // RuleTypeReleasePhase defines the release phase of the rule type.
 enum RuleTypeReleasePhase {
-    RULE_TYPE_RELEASE_PHASE_UNSPECIFIED = 0;
-    RULE_TYPE_RELEASE_PHASE_ALPHA = 1 [(name) = "alpha"];
-    RULE_TYPE_RELEASE_PHASE_BETA = 2 [(name) = "beta"];
-    RULE_TYPE_RELEASE_PHASE_GA = 3 [(name) = "ga"];
-    RULE_TYPE_RELEASE_PHASE_DEPRECATED = 4 [(name) = "deprecated"];
+  RULE_TYPE_RELEASE_PHASE_UNSPECIFIED = 0;
+  RULE_TYPE_RELEASE_PHASE_ALPHA = 1 [(name) = "alpha"];
+  RULE_TYPE_RELEASE_PHASE_BETA = 2 [(name) = "beta"];
+  RULE_TYPE_RELEASE_PHASE_GA = 3 [(name) = "ga"];
+  RULE_TYPE_RELEASE_PHASE_DEPRECATED = 4 [(name) = "deprecated"];
 }
 
 // RuleType defines rules that may or may not be user defined.
 // The version is assumed from the folder's version.
 message RuleType {
-    // version is the version of the rule type API.
-    string version = 11 [
-        (buf.validate.field).string = {
-            pattern: "^v\\d$",
-        }
-    ];
+  // version is the version of the rule type API.
+  string version = 11 [(buf.validate.field).string = {pattern: "^v\\d$"}];
 
-    // type is the type of the rule.
-    string type = 12 [
-        (buf.validate.field).string = {
-            pattern: "rule-type",
-        }
-    ];
+  // type is the type of the rule.
+  string type = 12 [(buf.validate.field).string = {pattern: "rule-type"}];
 
-    // id is the id of the rule type.
-    // This is mostly optional and is set by the server.
-    optional string id = 1 [
-        (buf.validate.field).string = {uuid: true},
-        (google.api.field_behavior) = OUTPUT_ONLY
-    ];
+  // id is the id of the rule type.
+  // This is mostly optional and is set by the server.
+  optional string id = 1 [
+    (buf.validate.field).string = {uuid: true},
+    (google.api.field_behavior) = OUTPUT_ONLY
+  ];
 
-    // name is the name of the rule type.
-    string name = 2 [
+  // name is the name of the rule type.
+  string name = 2 [
+    (buf.validate.field).string = {
+      pattern: "^[A-Za-z][-/[:word:]]*$"
+      max_len: 200
+    },
+    (google.api.field_behavior) = REQUIRED
+  ];
+
+  // display_name is the display name of the rule type.
+  string display_name = 8 [
+    (buf.validate.field).string = {
+      pattern: "^[A-Za-z][-/'()[:word:] :]*$"
+      max_len: 200
+    },
+    (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE
+  ];
+
+  // short_failure_message is the message to display when the evaluation fails.
+  string short_failure_message = 10 [
+    (buf.validate.field).string = {max_len: 400},
+    (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE
+  ];
+
+  // context is the context in which the rule is evaluated.
+  Context context = 3;
+
+  // Definition defines the rule type. It encompases the schema and the data evaluation.
+  message Definition {
+    // in_entity is the entity in which the rule is evaluated.
+    // This can be repository, build_environment or artifact.
+    string in_entity = 1 [(buf.validate.field).string = {
+      pattern: "^[a-z]+(_[a-z]+)*$"
+      min_len: 1
+      max_len: 200
+    }];
+
+    // rule_schema is the schema of the rule. This is expressed in JSON Schema.
+    google.protobuf.Struct rule_schema = 2;
+
+    // param_schema is the schema of the parameters that are passed to the rule.
+    // This is expressed in JSON Schema.
+    optional google.protobuf.Struct param_schema = 3;
+
+    // Ingest defines how the data is ingested.
+    message Ingest {
+      // type is the type of the data ingestion.
+      // we currently support rest, artifact and builtin.
+      string type = 1 [
         (buf.validate.field).string = {
-            pattern: "^[A-Za-z][-/[:word:]]*$",
-            max_len: 200,
+          in: [
+            "rest",
+            "artifact",
+            "builtin",
+            "git",
+            "diff",
+            "deps"
+          ]
         },
         (google.api.field_behavior) = REQUIRED
-    ];
+      ];
 
-    // display_name is the display name of the rule type.
-    string display_name = 8 [
-        (buf.validate.field).string = {
-            pattern: "^[A-Za-z][-/'()[:word:] :]*$",
-            max_len: 200,
-        },
-        (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE
-    ];
+      // NOTE: we should have used the "oneof" feature here rather than
+      // having both a string "type" and a series of optional messages.
+      // We can consider fixing this in a V2 API, but it's probably too
+      // to do in V1.
 
-    // short_failure_message is the message to display when the evaluation fails.
-    string short_failure_message = 10 [
-        (buf.validate.field).string = {
-            max_len: 400,
-        },
-        (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE
-    ];
+      // rest is the rest data ingestion.
+      // this is only used if the type is rest.
+      optional RestType rest = 3;
 
-    // context is the context in which the rule is evaluated.
-    Context context = 3;
+      // builtin is the builtin data ingestion.
+      optional BuiltinType builtin = 4;
 
-    // Definition defines the rule type. It encompases the schema and the data evaluation.
-    message Definition {
-        // in_entity is the entity in which the rule is evaluated.
-        // This can be repository, build_environment or artifact.
-        string in_entity = 1 [
-            (buf.validate.field).string = {
-                pattern: "^[a-z]+(_[a-z]+)*$",
-                min_len: 1,
-                max_len: 200,
-            }
-        ];
+      // artifact is the artifact data ingestion.
+      // artifact currently only applies to artifacts.
+      optional ArtifactType artifact = 5;
 
-        // rule_schema is the schema of the rule. This is expressed in JSON Schema.
-        google.protobuf.Struct rule_schema = 2;
+      // git is the git data ingestion.
+      // git currently only applies to repositories.
+      optional GitType git = 6;
 
-        // param_schema is the schema of the parameters that are passed to the rule.
-        // This is expressed in JSON Schema.
-        optional google.protobuf.Struct param_schema = 3;
+      // diff is the diff data ingestion.
+      // diff currently only applies to pull_requests.
+      optional DiffType diff = 7;
 
-        // Ingest defines how the data is ingested.
-        message Ingest {
-            // type is the type of the data ingestion.
-            // we currently support rest, artifact and builtin.
-            string type = 1 [
-                (buf.validate.field).string = {
-                    in: ["rest", "artifact", "builtin", "git", "diff", "deps"],
-                },
-                (google.api.field_behavior) = REQUIRED
-            ];
-
-            // NOTE: we should have used the "oneof" feature here rather than
-            // having both a string "type" and a series of optional messages.
-            // We can consider fixing this in a V2 API, but it's probably too
-            // to do in V1.
-
-            // rest is the rest data ingestion.
-            // this is only used if the type is rest.
-            optional RestType rest = 3;
-
-            // builtin is the builtin data ingestion.
-            optional BuiltinType builtin = 4;
-
-            // artifact is the artifact data ingestion.
-            // artifact currently only applies to artifacts.
-            optional ArtifactType artifact = 5;
-
-            // git is the git data ingestion.
-            // git currently only applies to repositories.
-            optional GitType git = 6;
-
-            // diff is the diff data ingestion.
-            // diff currently only applies to pull_requests.
-            optional DiffType diff = 7;
-
-            // deps is the deps data ingestion.
-            // deps currently only applies to repositories.
-            optional DepsType deps = 8;
-        }
-        Ingest ingest = 4 [
-            (google.api.field_behavior) = REQUIRED
-        ];
-
-        // Eval defines the data evaluation definition.
-        // This pertains to the way we traverse data from the upstream
-        // endpoint and how we compare it to the rule.
-        message Eval {
-            // type is the type of the data evaluation.
-            string type = 1 [
-                (buf.validate.field).string = {
-                    in: ["jq", "rego", "vulncheck", "trusty", "homoglyphs"],
-                },
-                (google.api.field_behavior) = REQUIRED
-            ];
-
-            message JQComparison {
-                message Operator {
-                    string def = 1 [
-                        (buf.validate.field).string = {
-                            pattern: "^\\.[a-zA-Z_]+(\\.[a-zA-Z_]+|\\[\\d+]|\\[\"[a-zA-Z_]+\"\\])*$",
-                            min_len: 1,
-                            max_len: 200,
-                        },
-                        (google.api.field_behavior) = REQUIRED
-                    ];
-                }
-
-                // Ingested points to the data retrieved in the `ingest` section
-                Operator ingested = 1 [
-                    (google.api.field_behavior) = REQUIRED
-                ];
-
-                // Profile points to the profile itself.
-                // This is mutually exclusive with the `constant` field.
-                Operator profile = 2;
-
-                // Constant points to a constant value.
-                // This is mutually exclusive with the `profile` field.
-                google.protobuf.Value constant = 3;
-            }
-
-            message Rego {
-                // type is the type of evaluation engine to use
-                // for rego. We currently have two modes of operation:
-                // - deny-by-default: this is the default mode of operation
-                //   where we deny access by default and allow access only
-                //   if the profile explicitly allows it. It expects the
-                //   profile to set an `allow` variable to true or false.
-                // - constraints: this is the mode of operation where we
-                //   allow access by default and deny access only if a
-                //   violation is found. It expects the profile to set a
-                //   `violations` variable with a "msg" field.
-                string type = 1 [
-                    (buf.validate.field).string = {
-                        pattern: "^[a-z]+([_-][a-z]+)*$",
-                        min_len: 1,
-                        max_len: 200,
-                    },
-                    (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE
-                ];
-                // def is the definition of the rego profile.
-                string def = 2 [
-                    (google.api.field_behavior) = REQUIRED
-                ];
-                // how are violations reported. This is only used if the
-                // `constraints` type is selected. The default is `text`
-                // which returns human-readable text. The other option is
-                // `json` which returns a JSON array containing the violations.
-                optional string violation_format = 3 [
-                    (buf.validate.field).string = {
-                        in: ["text", "json"],
-                    }
-                ];
-            }
-
-            message Vulncheck {
-                // no configuration for now
-            }
-
-            message Trusty {
-                // This is no longer used, but is still here for backwards
-                // compatibility with existing stored rules
-                string endpoint = 1 [
-                    (buf.validate.field).string = {
-                        uri: true,
-                    },
-                    (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE
-                ];
-            }
-
-            message Homoglyphs {
-                string type = 1 [
-                    (buf.validate.field).string = {
-                        in: ["invisible_characters", "mixed_scripts"]
-                    }
-                ];
-            }
-
-            // jq is only used if the `jq` type is selected.
-            // It defines the comparisons that are made between
-            // the ingested data and the profile rule.
-            repeated JQComparison jq = 2;
-
-            // rego is only used if the `rego` type is selected.
-            optional Rego rego = 3;
-
-            // vulncheck is only used if the `vulncheck` type is selected.
-            optional Vulncheck vulncheck = 4;
-
-            // The trusty type is no longer used, but is still here for backwards
-            // compatibility with existing stored rules
-            optional Trusty trusty = 5;
-
-            // homoglyphs is only used if the `homoglyphs` type is selected.
-            optional Homoglyphs homoglyphs = 6;
-
-            // Data sources that the rule refers to. These are used to
-            // instantiate the relevant data sources for the rule and keep
-            // track of them as dependencies.
-            //
-            // Note that the data source must exist in the project hierarchy
-            // in order to be used in the rule.
-            repeated DataSourceReference data_sources = 7;
-        }
-        Eval eval = 5 [
-            (google.api.field_behavior) = REQUIRED
-        ];
-
-        message Remediate {
-            // type is the type of the remediation.
-            // * 'rest' can be used with any entity type.
-            // * 'gh_branch_protection' and 'pull_request' can only be used with the 'repository' entity type.
-            // * 'pull_request_comment' can only be used with the 'pull_request' entity type.
-            string type = 1 [
-                (buf.validate.field).string = {
-                    in: ["rest", "gh_branch_protection", "pull_request", "pull_request_comment"],
-                },
-                (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE
-            ];
-
-            message GhBranchProtectionType {
-                string patch = 1 [
-                    (buf.validate.field).string = {
-                        max_len: 1000,
-                    },
-                    (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE
-                ];
-            }
-
-            // the name stutters a bit but we already use a PullRequest message for handling PR entities
-            message PullRequestRemediation {
-                message Content {
-                    // the file to patch
-                    string path = 1 [
-                        (buf.validate.field).string = {
-                            min_len: 1,
-                            max_len: 200,
-                        }
-                    ];
-                    // how to patch the file. For now, only replace is supported
-                    string action = 2 [
-                        (buf.validate.field).string = {
-                            in: ["replace"],
-                            min_len: 1,
-                            max_len: 50,
-                        }
-                    ];
-                    // the content of the file
-                    string content = 4;
-                    // the GIT mode of the file. Not UNIX mode! String because the GH API also uses strings
-                    // the usual modes are: 100644 for regular files, 100755 for executable files and
-                    // 040000 for submodules (which we don't use but now you know the meaning of the 1 in 100644)
-                    // see e.g. https://github.com/go-git/go-git/blob/32e0172851c35ae2fac495069c923330040903d2/plumbing/filemode/filemode.go#L16
-                    optional string mode = 3 [
-                        (buf.validate.field).string = {
-                            pattern: "^\\d+$",
-                            max_len: 6,
-                        }
-                    ];
-                }
-
-                message ActionsReplaceTagsWithSha {
-                    // List of actions to exclude from the replacement
-                    repeated string exclude = 1 [
-                        (buf.validate.field).repeated = {
-                            items: {
-                                string: {
-                                    pattern: "^\\.?([[:word:].-]+\\/)*[[:word:].-]+(?:\\.[[:alnum:]]+)?$",
-                                    max_len: 200,
-                                }
-                            }
-                        }
-                    ];
-                }
-
-                // the title of the PR
-                // This is not validated here as it will be validated by the repository provider, i.e. GitHub upon
-                // creation of the PR.
-                string title = 1 [
-                    (buf.validate.field).string = {
-                        min_len: 1,
-                        max_len: 75,
-                    }
-                ];
-                // the body of the PR
-                // This is not validated here as it will be validated by the repository provider, i.e. GitHub upon
-                // creation of the PR.
-                string body = 2 [
-                    (buf.validate.field).string = {
-                        min_len: 1,
-                        max_len: 65536,
-                    }
-                ];
-                repeated Content contents = 3;
-                // the method to use to create the PR. For now, these are supported:
-                // -- minder.content - ensures that the content of the file is exactly as specified
-                //                     refer to the Content message for more details
-                // -- minder.actions.replace_tags_with_sha - finds any github actions within a workflow
-                //                                           file and replaces the tag with the SHA
-                // -- minder.yq.evaluate - evaluates a yq expression on a file
-                string method = 4 [
-                    (buf.validate.field).string = {
-                        in: ["minder.content", "minder.actions.replace_tags_with_sha", "minder.yq.evaluate"],
-                    },
-                    (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE
-                ];
-                // params are unstructured parameters passed to the method. These are optional
-                // and evaluated by the method.
-                google.protobuf.Struct params = 6;
-
-                // If the method is minder.actions.replace_tags_with_sha, this is the configuration
-                // for that method
-                optional ActionsReplaceTagsWithSha actions_replace_tags_with_sha = 5;
-            }
-
-            optional RestType rest = 2;
-            optional GhBranchProtectionType gh_branch_protection = 3;
-            optional PullRequestRemediation pull_request = 4;
-            optional Alert.AlertTypePRComment pull_request_comment = 5;
-        }
-        Remediate remediate = 6;
-
-        message Alert {
-            // type is the type of the alert.
-            // * 'security_advisory' can only be used with the 'repository' entity type.
-            // * 'pull_request_comment' can only be used with the 'pull_request' entity type.
-            string type = 1 [
-                (buf.validate.field).string = {
-                    in: ["security_advisory", "pull_request_comment"],
-                },
-                (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE
-            ];
-
-            message AlertTypeSA {
-                string severity = 1 [
-                    (buf.validate.field).string = {
-                        in: ["unknown", "info", "low", "medium", "high", "critical"],
-                    },
-                    (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE
-                ];
-            }
-            optional AlertTypeSA security_advisory = 2;
-
-            message AlertTypePRComment {
-                // review_message is the message to post in the PR review.
-                string review_message = 1 [
-                    (buf.validate.field).string = {
-                        max_len: 65536,
-                    },
-                    (google.api.field_behavior) = REQUIRED
-                ];
-                // action is the action to use for the PR review (comment or request_changes).
-                // Default is comment.
-                optional string action = 2 [
-                    (buf.validate.field).string = {
-                        in: ["comment", "request_changes"],
-                    }
-                ];
-            }
-            optional AlertTypePRComment pull_request_comment = 3;
-        }
-        Alert alert = 7;
+      // deps is the deps data ingestion.
+      // deps currently only applies to repositories.
+      optional DepsType deps = 8;
     }
+    Ingest ingest = 4 [(google.api.field_behavior) = REQUIRED];
 
-    // def is the definition of the rule type.
-    Definition def = 4 [
-        (google.api.field_behavior) = REQUIRED
-    ];
-
-    // description is the description of the rule type.
-    // This is expected to be a valid markdown formatted string.
-    string description = 5 [
+    // Eval defines the data evaluation definition.
+    // This pertains to the way we traverse data from the upstream
+    // endpoint and how we compare it to the rule.
+    message Eval {
+      // type is the type of the data evaluation.
+      string type = 1 [
         (buf.validate.field).string = {
-            min_len: 1,
-            max_len: 1500,
+          in: [
+            "jq",
+            "rego",
+            "vulncheck",
+            "trusty",
+            "homoglyphs"
+          ]
         },
         (google.api.field_behavior) = REQUIRED
-    ];
+      ];
 
-    // guidance are instructions we give the user in case a rule fails.
-    // This is expected to be a valid markdown formatted string.
-    string guidance = 6 [
+      message JQComparison {
+        message Operator {
+          string def = 1 [
+            (buf.validate.field).string = {
+              pattern: "^\\.[a-zA-Z_]+(\\.[a-zA-Z_]+|\\[\\d+]|\\[\"[a-zA-Z_]+\"\\])*$"
+              min_len: 1
+              max_len: 200
+            },
+            (google.api.field_behavior) = REQUIRED
+          ];
+        }
+
+        // Ingested points to the data retrieved in the `ingest` section
+        Operator ingested = 1 [(google.api.field_behavior) = REQUIRED];
+
+        // Profile points to the profile itself.
+        // This is mutually exclusive with the `constant` field.
+        Operator profile = 2;
+
+        // Constant points to a constant value.
+        // This is mutually exclusive with the `profile` field.
+        google.protobuf.Value constant = 3;
+      }
+
+      message Rego {
+        // type is the type of evaluation engine to use
+        // for rego. We currently have two modes of operation:
+        // - deny-by-default: this is the default mode of operation
+        //   where we deny access by default and allow access only
+        //   if the profile explicitly allows it. It expects the
+        //   profile to set an `allow` variable to true or false.
+        // - constraints: this is the mode of operation where we
+        //   allow access by default and deny access only if a
+        //   violation is found. It expects the profile to set a
+        //   `violations` variable with a "msg" field.
+        string type = 1 [
+          (buf.validate.field).string = {
+            pattern: "^[a-z]+([_-][a-z]+)*$"
+            min_len: 1
+            max_len: 200
+          },
+          (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE
+        ];
+        // def is the definition of the rego profile.
+        string def = 2 [(google.api.field_behavior) = REQUIRED];
+        // how are violations reported. This is only used if the
+        // `constraints` type is selected. The default is `text`
+        // which returns human-readable text. The other option is
+        // `json` which returns a JSON array containing the violations.
+        optional string violation_format = 3 [(buf.validate.field).string = {
+          in: [
+            "text",
+            "json"
+          ]
+        }];
+      }
+
+      message Vulncheck {
+        // no configuration for now
+      }
+
+      message Trusty {
+        // This is no longer used, but is still here for backwards
+        // compatibility with existing stored rules
+        string endpoint = 1 [
+          (buf.validate.field).string = {uri: true},
+          (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE
+        ];
+      }
+
+      message Homoglyphs {
+        string type = 1 [(buf.validate.field).string = {
+          in: [
+            "invisible_characters",
+            "mixed_scripts"
+          ]
+        }];
+      }
+
+      // jq is only used if the `jq` type is selected.
+      // It defines the comparisons that are made between
+      // the ingested data and the profile rule.
+      repeated JQComparison jq = 2;
+
+      // rego is only used if the `rego` type is selected.
+      optional Rego rego = 3;
+
+      // vulncheck is only used if the `vulncheck` type is selected.
+      optional Vulncheck vulncheck = 4;
+
+      // The trusty type is no longer used, but is still here for backwards
+      // compatibility with existing stored rules
+      optional Trusty trusty = 5;
+
+      // homoglyphs is only used if the `homoglyphs` type is selected.
+      optional Homoglyphs homoglyphs = 6;
+
+      // Data sources that the rule refers to. These are used to
+      // instantiate the relevant data sources for the rule and keep
+      // track of them as dependencies.
+      //
+      // Note that the data source must exist in the project hierarchy
+      // in order to be used in the rule.
+      repeated DataSourceReference data_sources = 7;
+    }
+    Eval eval = 5 [(google.api.field_behavior) = REQUIRED];
+
+    message Remediate {
+      // type is the type of the remediation.
+      // * 'rest' can be used with any entity type.
+      // * 'gh_branch_protection' and 'pull_request' can only be used with the 'repository' entity type.
+      // * 'pull_request_comment' can only be used with the 'pull_request' entity type.
+      string type = 1 [
         (buf.validate.field).string = {
-            min_len: 1,
-            max_len: 1000,
+          in: [
+            "rest",
+            "gh_branch_protection",
+            "pull_request",
+            "pull_request_comment"
+          ]
         },
-        (google.api.field_behavior) = REQUIRED
-    ];
+        (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE
+      ];
 
-    // severity is the severity of the rule type.
-    Severity severity = 7;
+      message GhBranchProtectionType {
+        string patch = 1 [
+          (buf.validate.field).string = {max_len: 1000},
+          (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE
+        ];
+      }
 
-    // release_phase is the release phase of the rule type, i.e. alpha, beta, ga, deprecated.
-    RuleTypeReleasePhase release_phase = 9;
+      // the name stutters a bit but we already use a PullRequest message for handling PR entities
+      message PullRequestRemediation {
+        message Content {
+          // the file to patch
+          string path = 1 [(buf.validate.field).string = {
+            min_len: 1
+            max_len: 200
+          }];
+          // how to patch the file. For now, only replace is supported
+          string action = 2 [(buf.validate.field).string = {
+            in: ["replace"]
+            min_len: 1
+            max_len: 50
+          }];
+          // the content of the file
+          string content = 4;
+          // the GIT mode of the file. Not UNIX mode! String because the GH API also uses strings
+          // the usual modes are: 100644 for regular files, 100755 for executable files and
+          // 040000 for submodules (which we don't use but now you know the meaning of the 1 in 100644)
+          // see e.g. https://github.com/go-git/go-git/blob/32e0172851c35ae2fac495069c923330040903d2/plumbing/filemode/filemode.go#L16
+          optional string mode = 3 [(buf.validate.field).string = {
+            pattern: "^\\d+$"
+            max_len: 6
+          }];
+        }
+
+        message ActionsReplaceTagsWithSha {
+          // List of actions to exclude from the replacement
+          repeated string exclude = 1 [(buf.validate.field).repeated = {
+            items: {
+              string: {
+                pattern: "^\\.?([[:word:].-]+\\/)*[[:word:].-]+(?:\\.[[:alnum:]]+)?$"
+                max_len: 200
+              }
+            }
+          }];
+        }
+
+        // the title of the PR
+        // This is not validated here as it will be validated by the repository provider, i.e. GitHub upon
+        // creation of the PR.
+        string title = 1 [(buf.validate.field).string = {
+          min_len: 1
+          max_len: 75
+        }];
+        // the body of the PR
+        // This is not validated here as it will be validated by the repository provider, i.e. GitHub upon
+        // creation of the PR.
+        string body = 2 [(buf.validate.field).string = {
+          min_len: 1
+          max_len: 65536
+        }];
+        repeated Content contents = 3;
+        // the method to use to create the PR. For now, these are supported:
+        // -- minder.content - ensures that the content of the file is exactly as specified
+        //                     refer to the Content message for more details
+        // -- minder.actions.replace_tags_with_sha - finds any github actions within a workflow
+        //                                           file and replaces the tag with the SHA
+        // -- minder.yq.evaluate - evaluates a yq expression on a file
+        string method = 4 [
+          (buf.validate.field).string = {
+            in: [
+              "minder.content",
+              "minder.actions.replace_tags_with_sha",
+              "minder.yq.evaluate"
+            ]
+          },
+          (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE
+        ];
+        // params are unstructured parameters passed to the method. These are optional
+        // and evaluated by the method.
+        google.protobuf.Struct params = 6;
+
+        // If the method is minder.actions.replace_tags_with_sha, this is the configuration
+        // for that method
+        optional ActionsReplaceTagsWithSha actions_replace_tags_with_sha = 5;
+      }
+
+      // NOTE: Issue remediation is not yet implemented.
+      // This configuration is reserved for future support.
+      // "issue" is intentionally not a supported remediation type yet.
+      message IssueRemediation {
+        // the title of the issue
+        // Supports Minder's template interpolation syntax.
+        // This is not validated here as it will be validated by the repository provider, i.e. GitHub upon
+        // creation of the issue
+        string title = 1 [(buf.validate.field).string = {
+          min_len: 1
+          max_len: 75
+        }];
+        // the body of the issue
+        // Supports Minder's template interpolation syntax
+        // The rendered body is interpreted as Markdown by repository providers that
+        // support Markdown (e.g. Github)
+        // This is not validated here as it will be validated by the repository provider, i.e. GitHub upon
+        // creation of the issue
+        string body = 2 [(buf.validate.field).string = {
+          min_len: 1
+          max_len: 65536
+        }];
+      }
+
+      optional RestType rest = 2;
+      optional GhBranchProtectionType gh_branch_protection = 3;
+      optional PullRequestRemediation pull_request = 4;
+      optional Alert.AlertTypePRComment pull_request_comment = 5;
+      optional IssueRemediation issue = 6;
+    }
+    Remediate remediate = 6;
+
+    message Alert {
+      // type is the type of the alert.
+      // * 'security_advisory' can only be used with the 'repository' entity type.
+      // * 'pull_request_comment' can only be used with the 'pull_request' entity type.
+      string type = 1 [
+        (buf.validate.field).string = {
+          in: [
+            "security_advisory",
+            "pull_request_comment"
+          ]
+        },
+        (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE
+      ];
+
+      message AlertTypeSA {
+        string severity = 1 [
+          (buf.validate.field).string = {
+            in: [
+              "unknown",
+              "info",
+              "low",
+              "medium",
+              "high",
+              "critical"
+            ]
+          },
+          (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE
+        ];
+      }
+      optional AlertTypeSA security_advisory = 2;
+
+      message AlertTypePRComment {
+        // review_message is the message to post in the PR review.
+        string review_message = 1 [
+          (buf.validate.field).string = {max_len: 65536},
+          (google.api.field_behavior) = REQUIRED
+        ];
+        // action is the action to use for the PR review (comment or request_changes).
+        // Default is comment.
+        optional string action = 2 [(buf.validate.field).string = {
+          in: [
+            "comment",
+            "request_changes"
+          ]
+        }];
+      }
+      optional AlertTypePRComment pull_request_comment = 3;
+    }
+    Alert alert = 7;
+  }
+
+  // def is the definition of the rule type.
+  Definition def = 4 [(google.api.field_behavior) = REQUIRED];
+
+  // description is the description of the rule type.
+  // This is expected to be a valid markdown formatted string.
+  string description = 5 [
+    (buf.validate.field).string = {
+      min_len: 1
+      max_len: 1500
+    },
+    (google.api.field_behavior) = REQUIRED
+  ];
+
+  // guidance are instructions we give the user in case a rule fails.
+  // This is expected to be a valid markdown formatted string.
+  string guidance = 6 [
+    (buf.validate.field).string = {
+      min_len: 1
+      max_len: 1000
+    },
+    (google.api.field_behavior) = REQUIRED
+  ];
+
+  // severity is the severity of the rule type.
+  Severity severity = 7;
+
+  // release_phase is the release phase of the rule type, i.e. alpha, beta, ga, deprecated.
+  RuleTypeReleasePhase release_phase = 9;
 }
 
 // Profile defines a profile that is user defined.
 // All fields are optional because we want to allow partial updates.
 message Profile {
-    // context is the context in which the profile is evaluated.
-    Context context = 1;
+  // context is the context in which the profile is evaluated.
+  Context context = 1;
 
-    // id is the id of the profile.
-    // This is optional and is set by the system.
-    optional string id = 2 [
-        (buf.validate.field).string = {uuid: true},
-        (google.api.field_behavior) = OUTPUT_ONLY
-    ];
+  // id is the id of the profile.
+  // This is optional and is set by the system.
+  optional string id = 2 [
+    (buf.validate.field).string = {uuid: true},
+    (google.api.field_behavior) = OUTPUT_ONLY
+  ];
 
-    // name is the name of the profile instance.
-    string name = 3 [
-        (buf.validate.field).string = {
-            pattern: "^[A-Za-z][-/[:word:]]*$",
-            max_len: 200,
-        },
-        (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE
-    ];
+  // name is the name of the profile instance.
+  string name = 3 [
+    (buf.validate.field).string = {
+      pattern: "^[A-Za-z][-/[:word:]]*$"
+      max_len: 200
+    },
+    (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE
+  ];
 
-    // labels are a set of system-provided attributes which can be used to
-    // filter profiles and status results.  Labels cannot be set by the user,
-    // but are returned in ListProfiles.
-    //
-    // Labels use DNS label constraints, with a possible namespace prefix
-    // separated by a colon (:).  They are intended to allow filtering, but
-    // not to store arbitrary metadata.
-    // DNS labels are 1-63 character alphanumeric strings with internal hyphens.
-    // An RE2-style validation regex would be:
-    //
-    // DNS_STR = "[a-zA-Z0-9](?[-a-zA-Z0-9]{0,61}[a-zA-Z0-9])?"
-    // ($DNS_STR:)?$DNS_STR
-    repeated string labels = 12 [
-        (buf.validate.field) = {
-            repeated: {
-                items: {
-                    string: {
-                        // DNS label constraints extended to allow for underscores
-                        pattern: "^([a-zA-Z0-9_]([-a-zA-Z0-9_]{0,61}[a-zA-Z0-9_])?:)?[a-zA-Z0-9_]([-a-zA-Z0-9_]{0,61}[a-zA-Z0-9_])?$"
-                    }
-                },
-                unique: true
-            }
+  // labels are a set of system-provided attributes which can be used to
+  // filter profiles and status results.  Labels cannot be set by the user,
+  // but are returned in ListProfiles.
+  //
+  // Labels use DNS label constraints, with a possible namespace prefix
+  // separated by a colon (:).  They are intended to allow filtering, but
+  // not to store arbitrary metadata.
+  // DNS labels are 1-63 character alphanumeric strings with internal hyphens.
+  // An RE2-style validation regex would be:
+  //
+  // DNS_STR = "[a-zA-Z0-9](?[-a-zA-Z0-9]{0,61}[a-zA-Z0-9])?"
+  // ($DNS_STR:)?$DNS_STR
+  repeated string labels = 12 [(buf.validate.field) = {
+    repeated: {
+      items: {
+        string: {
+          // DNS label constraints extended to allow for underscores
+          pattern: "^([a-zA-Z0-9_]([-a-zA-Z0-9_]{0,61}[a-zA-Z0-9_])?:)?[a-zA-Z0-9_]([-a-zA-Z0-9_]{0,61}[a-zA-Z0-9_])?$"
         }
-    ];
-
-    // Rule defines the individual call of a certain rule type.
-    message Rule {
-        // type is the type of the rule to be instantiated.
-        string type = 1 [
-            (buf.validate.field).string = {
-                pattern: "^[A-Za-z][-/[:word:]]*$",
-                max_len: 200,
-            },
-            (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE
-        ];
-        // params are the parameters that are passed to the rule.
-        // This is optional and depends on the rule type.
-        google.protobuf.Struct params = 2;
-        // def is the definition of the rule.
-        // This depends on the rule type.
-        google.protobuf.Struct def = 3;
-
-        // name is the descriptive name of the rule, not to be confused with type
-        string name = 4 [
-            (buf.validate.field).string = {
-                pattern: "^[A-Za-z][-/'()[:word:] :]*$",
-                max_len: 200,
-            },
-            (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE
-        ];
+      }
+      unique: true
     }
+  }];
 
-    // These are the entities that one could set in the profile.
-    repeated Rule repository = 4;
-    repeated Rule build_environment = 5;
-    repeated Rule artifact = 6;
-    repeated Rule pull_request = 7;
-    repeated Rule release = 15;
-    repeated Rule pipeline_run = 16;
-    repeated Rule task_run = 17;
-    repeated Rule build = 18;
-
-    message Selector {
-        // id is optional and use for updates to match upserts as well as read operations. It is ignored for creates.
-        string id = 1;
-        // entity is the entity to select.
-        string entity = 2 [
-            (buf.validate.field).string = {
-                pattern: "^[a-z]+(_[a-z]+)*$",
-                min_len: 1,
-                max_len: 200,
-            },
-            (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE
-        ];
-        // expr is the expression to select the entity.
-        string selector = 4 [
-            (buf.validate.field).string = {
-                max_len: 200,
-            },
-            (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE
-        ];
-        reserved 5;
-        reserved "comment";
-        // description is the human-readable description of the selector.
-        string description = 6 [
-            (buf.validate.field).string = {
-                pattern: "^[A-Za-z][-/.!?,:;'[:word:] ]*$",
-                max_len: 1000,
-            },
-            (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE
-        ];
-    }
-
-    repeated Selector selection = 14;
-
-    // whether and how to remediate (on,off,dry_run)
-    // this is optional and defaults to "off"
-    optional string remediate = 8 [
-        (buf.validate.field).string = {
-            in: ["on", "off", "dry_run"]
-        }
+  // Rule defines the individual call of a certain rule type.
+  message Rule {
+    // type is the type of the rule to be instantiated.
+    string type = 1 [
+      (buf.validate.field).string = {
+        pattern: "^[A-Za-z][-/[:word:]]*$"
+        max_len: 200
+      },
+      (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE
     ];
+    // params are the parameters that are passed to the rule.
+    // This is optional and depends on the rule type.
+    google.protobuf.Struct params = 2;
+    // def is the definition of the rule.
+    // This depends on the rule type.
+    google.protobuf.Struct def = 3;
 
-    // whether and how to alert (on,off,dry_run)
-    // this is optional and defaults to "on"
-    optional string alert = 9 [
-        (buf.validate.field).string = {
-            in: ["on", "off", "dry_run"]
-        }
+    // name is the descriptive name of the rule, not to be confused with type
+    string name = 4 [
+      (buf.validate.field).string = {
+        pattern: "^[A-Za-z][-/'()[:word:] :]*$"
+        max_len: 200
+      },
+      (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE
     ];
+  }
 
-    // type is a placeholder for the object type. It should always be set to "profile".
-    string type = 10 [
-        (buf.validate.field).string = {
-            pattern: "profile",
-        }
-    ];
+  // These are the entities that one could set in the profile.
+  repeated Rule repository = 4;
+  repeated Rule build_environment = 5;
+  repeated Rule artifact = 6;
+  repeated Rule pull_request = 7;
+  repeated Rule release = 15;
+  repeated Rule pipeline_run = 16;
+  repeated Rule task_run = 17;
+  repeated Rule build = 18;
 
-    // version is the version of the profile type. In this case, it is "v1"
-    string version = 11 [
-        (buf.validate.field).string = {
-            pattern: "^v\\d$",
-        }
+  message Selector {
+    // id is optional and use for updates to match upserts as well as read operations. It is ignored for creates.
+    string id = 1;
+    // entity is the entity to select.
+    string entity = 2 [
+      (buf.validate.field).string = {
+        pattern: "^[a-z]+(_[a-z]+)*$"
+        min_len: 1
+        max_len: 200
+      },
+      (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE
     ];
+    // expr is the expression to select the entity.
+    string selector = 4 [
+      (buf.validate.field).string = {max_len: 200},
+      (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE
+    ];
+    reserved 5;
+    reserved "comment";
+    // description is the human-readable description of the selector.
+    string description = 6 [
+      (buf.validate.field).string = {
+        pattern: "^[A-Za-z][-/.!?,:;'[:word:] ]*$"
+        max_len: 1000
+      },
+      (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE
+    ];
+  }
 
-    // display_name is the display name of the profile.
-    string display_name = 13 [
-        (buf.validate.field).string = {
-            pattern: "^[A-Za-z][-/'()[:word:] :]*$",
-            max_len: 1000,
-        },
-        (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE
-    ];
+  repeated Selector selection = 14;
+
+  // whether and how to remediate (on,off,dry_run)
+  // this is optional and defaults to "off"
+  optional string remediate = 8 [(buf.validate.field).string = {
+    in: [
+      "on",
+      "off",
+      "dry_run"
+    ]
+  }];
+
+  // whether and how to alert (on,off,dry_run)
+  // this is optional and defaults to "on"
+  optional string alert = 9 [(buf.validate.field).string = {
+    in: [
+      "on",
+      "off",
+      "dry_run"
+    ]
+  }];
+
+  // type is a placeholder for the object type. It should always be set to "profile".
+  string type = 10 [(buf.validate.field).string = {pattern: "profile"}];
+
+  // version is the version of the profile type. In this case, it is "v1"
+  string version = 11 [(buf.validate.field).string = {pattern: "^v\\d$"}];
+
+  // display_name is the display name of the profile.
+  string display_name = 13 [
+    (buf.validate.field).string = {
+      pattern: "^[A-Za-z][-/'()[:word:] :]*$"
+      max_len: 1000
+    },
+    (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE
+  ];
 }
 
-message ListProjectsRequest {
-
-}
+message ListProjectsRequest {}
 
 message ListProjectsResponse {
-    repeated Project projects = 1 [
-        (google.api.field_behavior) = REQUIRED
-    ];
+  repeated Project projects = 1 [(google.api.field_behavior) = REQUIRED];
 }
 
 message CreateProjectRequest {
-    // context is the context in which the project is created.
-    Context context = 1;
+  // context is the context in which the project is created.
+  Context context = 1;
 
-    // name is the name of the project to create.
-    string name = 2 [
-        (buf.validate.field).string = {
-            pattern: "^[A-Za-z][-/[:word:]]*$",
-            max_len: 200,
-        },
-        (google.api.field_behavior) = REQUIRED
-    ];
+  // name is the name of the project to create.
+  string name = 2 [
+    (buf.validate.field).string = {
+      pattern: "^[A-Za-z][-/[:word:]]*$"
+      max_len: 200
+    },
+    (google.api.field_behavior) = REQUIRED
+  ];
 }
 
 message CreateProjectResponse {
-    // project is the project that was created.
-    Project project = 1 [
-        (google.api.field_behavior) = REQUIRED
-    ];
+  // project is the project that was created.
+  Project project = 1 [(google.api.field_behavior) = REQUIRED];
 }
 
 message DeleteProjectRequest {
-    // context is the context in which the project is deleted.
-    Context context = 1;
+  // context is the context in which the project is deleted.
+  Context context = 1;
 }
 
 message DeleteProjectResponse {
-    // project_id is the id of the project that was deleted.
-    string project_id = 1 [
-        (google.api.field_behavior) = REQUIRED
-    ];
+  // project_id is the id of the project that was deleted.
+  string project_id = 1 [(google.api.field_behavior) = REQUIRED];
 }
 
 message UpdateProjectRequest {
-    // context is the context in which the project is updated.
-    Context context = 1;
+  // context is the context in which the project is updated.
+  Context context = 1;
 
-    // display_name is the display name of the project to update.
-    // This is optional.
-    string display_name = 2 [
-        (buf.validate.field).string = {
-            pattern: "^[A-Za-z][-/'()[:word:] :]*$",
-            max_len: 200,
-        },
-        (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE
-    ];
+  // display_name is the display name of the project to update.
+  // This is optional.
+  string display_name = 2 [
+    (buf.validate.field).string = {
+      pattern: "^[A-Za-z][-/'()[:word:] :]*$"
+      max_len: 200
+    },
+    (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE
+  ];
 
-    // description is the description of the project to update.
-    // This is optional.
-    string description = 3 [
-        (buf.validate.field).string = {
-            pattern: "^[A-Za-z][-/.!?,:;'[:word:] ]*$",
-            min_len: 0,
-            max_len: 1000,
-        },
-        (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE
-    ];
+  // description is the description of the project to update.
+  // This is optional.
+  string description = 3 [
+    (buf.validate.field).string = {
+      pattern: "^[A-Za-z][-/.!?,:;'[:word:] ]*$"
+      min_len: 0
+      max_len: 1000
+    },
+    (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE
+  ];
 }
 
 message UpdateProjectResponse {
-    // project is the project that was updated.
-    Project project = 1 [
-        (google.api.field_behavior) = REQUIRED
-    ];
+  // project is the project that was updated.
+  Project project = 1 [(google.api.field_behavior) = REQUIRED];
 }
 
 message ProjectPatch {
-    // display_name is the display name of the project to update.
-    optional string display_name = 1 [
-        (buf.validate.field).string = {
-            pattern: "^[A-Za-z][-/'()[:word:] :]*$",
-            max_len: 200,
-        }
-    ];
+  // display_name is the display name of the project to update.
+  optional string display_name = 1 [(buf.validate.field).string = {
+    pattern: "^[A-Za-z][-/'()[:word:] :]*$"
+    max_len: 200
+  }];
 
-    // description is the description of the project to update.
-    optional string description = 2 [
-        (buf.validate.field).string = {
-            pattern: "^[A-Za-z][-/.!?,:;'[:word:] ]*$",
-            min_len: 0,
-            max_len: 1000,
-        }
-    ];
+  // description is the description of the project to update.
+  optional string description = 2 [(buf.validate.field).string = {
+    pattern: "^[A-Za-z][-/.!?,:;'[:word:] ]*$"
+    min_len: 0
+    max_len: 1000
+  }];
 }
 
 message PatchProjectRequest {
-    // context is the context in which the project is updated.
-    Context context = 1;
+  // context is the context in which the project is updated.
+  Context context = 1;
 
-    // patch is the patch to apply to the project
-    ProjectPatch patch = 3;
+  // patch is the patch to apply to the project
+  ProjectPatch patch = 3;
 
-    // needed to enable PATCH, see https://grpc-ecosystem.github.io/grpc-gateway/docs/mapping/patch_feature/
-    // is not exposed to the API user
-    google.protobuf.FieldMask update_mask = 4;
+  // needed to enable PATCH, see https://grpc-ecosystem.github.io/grpc-gateway/docs/mapping/patch_feature/
+  // is not exposed to the API user
+  google.protobuf.FieldMask update_mask = 4;
 }
 
 message PatchProjectResponse {
-    // project is the project that was updated.
-    Project project = 1 [
-        (google.api.field_behavior) = REQUIRED
-    ];
+  // project is the project that was updated.
+  Project project = 1 [(google.api.field_behavior) = REQUIRED];
 }
 
 message ListChildProjectsRequest {
-    // context is the context in which the child projects are listed.
-    ContextV2 context = 1;
+  // context is the context in which the child projects are listed.
+  ContextV2 context = 1;
 
-    // recursive is true if child projects should be listed recursively.
-    bool recursive = 2;
+  // recursive is true if child projects should be listed recursively.
+  bool recursive = 2;
 }
 
 message ListChildProjectsResponse {
-    repeated Project projects = 1 [
-        (google.api.field_behavior) = REQUIRED
-    ];
+  repeated Project projects = 1 [(google.api.field_behavior) = REQUIRED];
 }
 
 message CreateEntityReconciliationTaskRequest {
-    // entity is the entity to be reconciled.
-    EntityTypedId entity = 1 [
-        (google.api.field_behavior) = REQUIRED
-    ];
+  // entity is the entity to be reconciled.
+  EntityTypedId entity = 1 [(google.api.field_behavior) = REQUIRED];
 
-    // context is the context in which the entity reconciliation task is created.
-    Context context = 2;
+  // context is the context in which the entity reconciliation task is created.
+  Context context = 2;
 }
 
-message CreateEntityReconciliationTaskResponse {
-}
+message CreateEntityReconciliationTaskResponse {}
 
 message ListRolesRequest {
-    // context is the context in which the roles are evaluated.
-    Context context = 1;
+  // context is the context in which the roles are evaluated.
+  Context context = 1;
 }
 
 message ListRolesResponse {
-    repeated Role roles = 1 [
-        (google.api.field_behavior) = REQUIRED
-    ];
+  repeated Role roles = 1 [(google.api.field_behavior) = REQUIRED];
 }
 
 message ListRoleAssignmentsRequest {
-    // context is the context in which the role assignments are evaluated.
-    Context context = 1;
+  // context is the context in which the role assignments are evaluated.
+  Context context = 1;
 }
 
 message ListRoleAssignmentsResponse {
-    // role_assignments contains permission grants which have been accepted
-    // by a user.
-    repeated RoleAssignment role_assignments = 1 [
-        (google.api.field_behavior) = REQUIRED
-    ];
+  // role_assignments contains permission grants which have been accepted
+  // by a user.
+  repeated RoleAssignment role_assignments = 1 [(google.api.field_behavior) = REQUIRED];
 
-    // invitations contains outstanding role invitations which have not yet
-    // been accepted by a user.
-    repeated Invitation invitations = 2 [
-        (google.api.field_behavior) = REQUIRED
-    ];
+  // invitations contains outstanding role invitations which have not yet
+  // been accepted by a user.
+  repeated Invitation invitations = 2 [(google.api.field_behavior) = REQUIRED];
 }
 
 message AssignRoleRequest {
-    // context is the context in which the role assignment is evaluated.
-    Context context = 1;
-    // role_assignment is the role assignment to be created.
-    RoleAssignment role_assignment = 2 [
-        (google.api.field_behavior) = REQUIRED
-    ];
+  // context is the context in which the role assignment is evaluated.
+  Context context = 1;
+  // role_assignment is the role assignment to be created.
+  RoleAssignment role_assignment = 2 [(google.api.field_behavior) = REQUIRED];
 }
 
 message AssignRoleResponse {
-    // role_assignment is the role assignment that was created.
-    // This is optional.
-    RoleAssignment role_assignment = 1;
+  // role_assignment is the role assignment that was created.
+  // This is optional.
+  RoleAssignment role_assignment = 1;
 
-    // invitation contains the details of the invitation for the
-    // assigned user to join the project if the user is not already
-    // a member. This is optional.
-    Invitation invitation = 2;
+  // invitation contains the details of the invitation for the
+  // assigned user to join the project if the user is not already
+  // a member. This is optional.
+  Invitation invitation = 2;
 }
 
 message UpdateRoleRequest {
-    // context is the context in which the role assignment is evaluated.
-    Context context = 1;
-    // subject is the account to change permissions for.
-    // The account must already have permissions on the project
-    string subject = 2 [
-        (buf.validate.field).string = {uuid: true},
-        (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE
-    ];
-    // All subject roles are _replaced_ with the following role assignments.  Must be non-empty,
-    // use RemoveRole to remove permissions entirely from the project.
-    repeated string roles = 4 [
-        (buf.validate.field).repeated = {
-            items: {
-                string: {
-                    pattern: "^[a-z]+(_[a-z]+)*$",
-                    min_len: 1,
-                    max_len: 200,
-                }
-            }
-        },
-        (google.api.field_behavior) = REQUIRED
-    ];
-    // email is the email address of the subject used for updating invitations
-    string email = 5 [
-      (buf.validate.field) = {string: {email: true}},
-      (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE
-    ];
+  // context is the context in which the role assignment is evaluated.
+  Context context = 1;
+  // subject is the account to change permissions for.
+  // The account must already have permissions on the project
+  string subject = 2 [
+    (buf.validate.field).string = {uuid: true},
+    (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE
+  ];
+  // All subject roles are _replaced_ with the following role assignments.  Must be non-empty,
+  // use RemoveRole to remove permissions entirely from the project.
+  repeated string roles = 4 [
+    (buf.validate.field).repeated = {
+      items: {
+        string: {
+          pattern: "^[a-z]+(_[a-z]+)*$"
+          min_len: 1
+          max_len: 200
+        }
+      }
+    },
+    (google.api.field_behavior) = REQUIRED
+  ];
+  // email is the email address of the subject used for updating invitations
+  string email = 5 [
+    (buf.validate.field) = {
+      string: {email: true}
+    },
+    (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE
+  ];
 
-    reserved 3; // deprecated repeated string role = 3;
-    reserved "role";
+  reserved 3; // deprecated repeated string role = 3;
+  reserved "role";
 }
 
 message UpdateRoleResponse {
-    // role_assignments are the role assignments that were updated.
-    repeated RoleAssignment role_assignments = 1;
-    // invitations contains the details of the invitations that were updated.
-    repeated Invitation invitations = 2;
+  // role_assignments are the role assignments that were updated.
+  repeated RoleAssignment role_assignments = 1;
+  // invitations contains the details of the invitations that were updated.
+  repeated Invitation invitations = 2;
 }
 
-
 message RemoveRoleRequest {
-    // context is the context in which the role assignment is evaluated.
-    Context context = 1;
-    // role_assignment is the role assignment to be removed.
-    RoleAssignment role_assignment = 2 [
-        (google.api.field_behavior) = REQUIRED
-    ];
+  // context is the context in which the role assignment is evaluated.
+  Context context = 1;
+  // role_assignment is the role assignment to be removed.
+  RoleAssignment role_assignment = 2 [(google.api.field_behavior) = REQUIRED];
 }
 
 message RemoveRoleResponse {
-    // role_assignment is the role assignment that was removed.
-    RoleAssignment role_assignment = 1;
-    // invitation contains the details of the invitation that was removed.
-    Invitation invitation = 2;
+  // role_assignment is the role assignment that was removed.
+  RoleAssignment role_assignment = 1;
+  // invitation contains the details of the invitation that was removed.
+  Invitation invitation = 2;
 }
 
 message Role {
-    // name is the name of the role.
-    string name = 1 [
-        (google.api.field_behavior) = REQUIRED
-    ];
-    // display name of the role
-    string display_name = 3 [
-        (google.api.field_behavior) = REQUIRED
-    ];
-    // description is the description of the role.
-    string description = 2 [
-        (google.api.field_behavior) = REQUIRED
-    ];
+  // name is the name of the role.
+  string name = 1 [(google.api.field_behavior) = REQUIRED];
+  // display name of the role
+  string display_name = 3 [(google.api.field_behavior) = REQUIRED];
+  // description is the description of the role.
+  string description = 2 [(google.api.field_behavior) = REQUIRED];
 }
 
 message RoleAssignment {
-    // role is the role that is assigned.
-    string role = 1 [
-        (buf.validate.field).string = {
-            pattern: "^[a-z]+(_[a-z]+)*$",
-            min_len: 1,
-            max_len: 200,
-        },
-        (google.api.field_behavior) = REQUIRED
-    ];
-    // subject is the subject to which the role is assigned.
-    // Can be either a UUID or a providername/subject string.
-    string subject = 2 [
-        (buf.validate.field).string.pattern =
-            // Can be either a UUID or a providername/<subject> string
-            "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12})|([a-z]+/[-/[:word:]:]+)$",
-        (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE
-    ];
-    // display_name is the display name of the subject.
-    string display_name = 5 [
-        (buf.validate.field).string = {
-            pattern: "^[A-Za-z][-/'()[:word:] :]*$",
-            max_len: 200,
-        },
-        (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE
-    ];
-    // project is the project in which the role is assigned.
-    optional string project = 4 [
-        (buf.validate.field).string = {uuid: true}
-    ];
-    // email is the email address of the subject used for invitations.
-    string email = 6 [
-        (buf.validate.field) = {string: {email: true}},
-        (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE
-    ];
-    // first_name is the first name of the subject.
-    string first_name = 7 [
-        (buf.validate.field).string = {
-            pattern: "^[A-Za-z][- [:word:]\\[\\]\\(\\)]*$",
-            max_len: 200,
-        },
-        (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE
-    ];
-    // last_name is the last name of the subject.
-    string last_name = 8 [
-        (buf.validate.field).string = {
-            pattern: "^[A-Za-z][- [:word:]\\[\\]\\(\\)]*$",
-            max_len: 200,
-        },
-        (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE
-    ];
+  // role is the role that is assigned.
+  string role = 1 [
+    (buf.validate.field).string = {
+      pattern: "^[a-z]+(_[a-z]+)*$"
+      min_len: 1
+      max_len: 200
+    },
+    (google.api.field_behavior) = REQUIRED
+  ];
+  // subject is the subject to which the role is assigned.
+  // Can be either a UUID or a providername/subject string.
+  string subject = 2 [
+    (buf.validate.field).string.pattern = /* Can be either a UUID or a providername/<subject> string */ "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12})|([a-z]+/[-/[:word:]:]+)$",
+    (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE
+  ];
+  // display_name is the display name of the subject.
+  string display_name = 5 [
+    (buf.validate.field).string = {
+      pattern: "^[A-Za-z][-/'()[:word:] :]*$"
+      max_len: 200
+    },
+    (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE
+  ];
+  // project is the project in which the role is assigned.
+  optional string project = 4 [(buf.validate.field).string = {uuid: true}];
+  // email is the email address of the subject used for invitations.
+  string email = 6 [
+    (buf.validate.field) = {
+      string: {email: true}
+    },
+    (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE
+  ];
+  // first_name is the first name of the subject.
+  string first_name = 7 [
+    (buf.validate.field).string = {
+      pattern: "^[A-Za-z][- [:word:]\\[\\]\\(\\)]*$"
+      max_len: 200
+    },
+    (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE
+  ];
+  // last_name is the last name of the subject.
+  string last_name = 8 [
+    (buf.validate.field).string = {
+      pattern: "^[A-Za-z][- [:word:]\\[\\]\\(\\)]*$"
+      max_len: 200
+    },
+    (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE
+  ];
 
-    reserved 3; // deprecated context
+  reserved 3; // deprecated context
 }
 
-message ListInvitationsRequest {
-}
+message ListInvitationsRequest {}
 
 message ListInvitationsResponse {
-    repeated Invitation invitations = 1 [
-        (google.api.field_behavior) = REQUIRED
-    ];
+  repeated Invitation invitations = 1 [(google.api.field_behavior) = REQUIRED];
 }
 
 message ResolveInvitationRequest {
-    // code is the code of the invitation to resolve.
-    string code = 1 [
-        (buf.validate.field).string = {
-            pattern: "^[A-Za-z0-9_-]+$",
-            len: 64,
-        },
-        (google.api.field_behavior) = REQUIRED
-    ];
-    // accept is true if the invitation is accepted, false if it is rejected.
-    bool accept = 2;
+  // code is the code of the invitation to resolve.
+  string code = 1 [
+    (buf.validate.field).string = {
+      pattern: "^[A-Za-z0-9_-]+$"
+      len: 64
+    },
+    (google.api.field_behavior) = REQUIRED
+  ];
+  // accept is true if the invitation is accepted, false if it is rejected.
+  bool accept = 2;
 }
 
 message ResolveInvitationResponse {
-    // role is the role that would be assigned if the user
-    // accepts the invitation.
-    string role = 1 [
-        (google.api.field_behavior) = REQUIRED
-    ];
-    // email is the email address of the invited user.
-    string email = 2;
-    // project is the project to which the user is invited.
-    string project = 3 [
-        (google.api.field_behavior) = REQUIRED
-    ];
-    // is_accepted is the status of the invitation.
-    bool is_accepted = 4 [
-        (google.api.field_behavior) = REQUIRED
-    ];
-    // project_display is the display name of the project to which the user
-    // is invited.
-    string project_display = 5;
+  // role is the role that would be assigned if the user
+  // accepts the invitation.
+  string role = 1 [(google.api.field_behavior) = REQUIRED];
+  // email is the email address of the invited user.
+  string email = 2;
+  // project is the project to which the user is invited.
+  string project = 3 [(google.api.field_behavior) = REQUIRED];
+  // is_accepted is the status of the invitation.
+  bool is_accepted = 4 [(google.api.field_behavior) = REQUIRED];
+  // project_display is the display name of the project to which the user
+  // is invited.
+  string project_display = 5;
 }
 
 // Invitation is an invitation to join a project. This is only used in responses.
 message Invitation {
-    // role is the role that would be assigned if the user
-    // accepts the invitation.
-    string role = 1 [
-        (google.api.field_behavior) = REQUIRED
-    ];
-    // email is the email address of the invited user.  This is
-    // presented as a convenience for display purposes, and does
-    // not affect who can accept the invitation using the code.
-    string email = 2;
-    // project is the project to which the user is invited.
-    string project = 3 [
-        (google.api.field_behavior) = REQUIRED
-    ];
+  // role is the role that would be assigned if the user
+  // accepts the invitation.
+  string role = 1 [(google.api.field_behavior) = REQUIRED];
+  // email is the email address of the invited user.  This is
+  // presented as a convenience for display purposes, and does
+  // not affect who can accept the invitation using the code.
+  string email = 2;
+  // project is the project to which the user is invited.
+  string project = 3 [(google.api.field_behavior) = REQUIRED];
 
-    // code is a unique identifier for the invitation, which can
-    // be used by the recipient to accept or reject the invitation.
-    // The code is only transmitted in response to AssignRole or
-    // ListInvitations RPCs, and not transmitted in
-    // ListRoleAssignments or other calls.
-    string code = 4;
+  // code is a unique identifier for the invitation, which can
+  // be used by the recipient to accept or reject the invitation.
+  // The code is only transmitted in response to AssignRole or
+  // ListInvitations RPCs, and not transmitted in
+  // ListRoleAssignments or other calls.
+  string code = 4;
 
-    // created_at is the time at which the invitation was created.
-    google.protobuf.Timestamp created_at = 5;
-    // expires_at is the time at which the invitation expires.
-    google.protobuf.Timestamp expires_at = 6;
-    // expired is true if the invitation has expired.
-    bool expired = 9;
+  // created_at is the time at which the invitation was created.
+  google.protobuf.Timestamp created_at = 5;
+  // expires_at is the time at which the invitation expires.
+  google.protobuf.Timestamp expires_at = 6;
+  // expired is true if the invitation has expired.
+  bool expired = 9;
 
-    // sponsor is the account (ID) of the user who created the invitation.
-    string sponsor = 7;
-    // sponsor_display is the display name of the user who created the
-    // invitation.
-    string sponsor_display = 8;
-    // project_display is the display name of the project to which the user
-    // is invited.
-    string project_display = 10;
-    // inviteURL is the URL that can be used to accept the invitation.
-    string invite_url = 11;
-    // emailSkipped is true if the email was not sent to the invitee.
-    bool email_skipped = 12;
+  // sponsor is the account (ID) of the user who created the invitation.
+  string sponsor = 7;
+  // sponsor_display is the display name of the user who created the
+  // invitation.
+  string sponsor_display = 8;
+  // project_display is the display name of the project to which the user
+  // is invited.
+  string project_display = 10;
+  // inviteURL is the URL that can be used to accept the invitation.
+  string invite_url = 11;
+  // emailSkipped is true if the email was not sent to the invitee.
+  bool email_skipped = 12;
 }
 
 message GetProviderRequest {
-    // context is the context in which the provider is evaluated.
-    Context context = 1;
-    // name is the name of the provider to get.
-    string name = 2 [
-        (buf.validate.field).string = {
-            pattern: "^[-[:word:]]*$",
-            max_len: 200,
-        },
-        (google.api.field_behavior) = REQUIRED
-    ];
+  // context is the context in which the provider is evaluated.
+  Context context = 1;
+  // name is the name of the provider to get.
+  string name = 2 [
+    (buf.validate.field).string = {
+      pattern: "^[-[:word:]]*$"
+      max_len: 200
+    },
+    (google.api.field_behavior) = REQUIRED
+  ];
 }
 
 message GetProviderResponse {
-    // provider is the provider that was retrieved.
-    Provider provider = 1 [
-        (google.api.field_behavior) = REQUIRED
-    ];
+  // provider is the provider that was retrieved.
+  Provider provider = 1 [(google.api.field_behavior) = REQUIRED];
 }
 
 message ListProvidersRequest {
-    // context is the context in which the providers are evaluated.
-    Context context = 1;
+  // context is the context in which the providers are evaluated.
+  Context context = 1;
 
-    // limit is the maximum number of providers to return.
-    // 0 uses a server-defined default.
-    int32 limit = 2 [
-        (buf.validate.field).int32 = {gte: 0, lte: 100},
-        (google.api.field_behavior) = REQUIRED
-    ];
+  // limit is the maximum number of providers to return.
+  // 0 uses a server-defined default.
+  int32 limit = 2 [
+    (buf.validate.field).int32 = {
+      gte: 0
+      lte: 100
+    },
+    (google.api.field_behavior) = REQUIRED
+  ];
 
-    // cursor is the cursor to use for the page of results, empty if at the beginning
-    string cursor = 3 [
-        (buf.validate.field).string = {
-            pattern: "^[[:word:]=]*$",
-            max_len: 200,
-        }
-    ];
+  // cursor is the cursor to use for the page of results, empty if at the beginning
+  string cursor = 3 [(buf.validate.field).string = {
+    pattern: "^[[:word:]=]*$"
+    max_len: 200
+  }];
 }
 
 message ListProvidersResponse {
-    repeated Provider providers = 1 [
-        (google.api.field_behavior) = REQUIRED
-    ];
+  repeated Provider providers = 1 [(google.api.field_behavior) = REQUIRED];
 
-    // cursor is the cursor to use for the next page of results, empty if at the end
-    string cursor = 2;
+  // cursor is the cursor to use for the next page of results, empty if at the end
+  string cursor = 2;
 }
 
 message CreateProviderRequest {
-    // context is the context in which the provider is created.
-    Context context = 1;
-    // provider is the provider to be created.
-    Provider provider = 2 [
-        (google.api.field_behavior) = REQUIRED
-    ];
+  // context is the context in which the provider is created.
+  Context context = 1;
+  // provider is the provider to be created.
+  Provider provider = 2 [(google.api.field_behavior) = REQUIRED];
 }
 
 message CreateProviderResponse {
-    // provider is the provider that was created.
-    Provider provider = 1 [
-        (google.api.field_behavior) = REQUIRED
-    ];
+  // provider is the provider that was created.
+  Provider provider = 1 [(google.api.field_behavior) = REQUIRED];
 
-    // authorization provides additional authorization information needed
-    // to complete the initialization of the provider.
-    AuthorizationParams authorization = 2;
+  // authorization provides additional authorization information needed
+  // to complete the initialization of the provider.
+  AuthorizationParams authorization = 2;
 }
 
 message DeleteProviderRequest {
-    // context is the context in which the provider is deleted.  Both
-    // project and provider are required in this context.
-    Context context = 1 [
-        (google.api.field_behavior) = REQUIRED
-    ];
+  // context is the context in which the provider is deleted.  Both
+  // project and provider are required in this context.
+  Context context = 1 [(google.api.field_behavior) = REQUIRED];
 }
 
 message DeleteProviderResponse {
-    // name is the name of the provider that was deleted
-    string name = 1 [
-        (google.api.field_behavior) = REQUIRED
-    ];
+  // name is the name of the provider that was deleted
+  string name = 1 [(google.api.field_behavior) = REQUIRED];
 }
 
 message DeleteProviderByIDRequest {
-    // context is the context in which the provider is deleted. Only the project is required in this context.
-    Context context = 1;
-    // id is the id of the provider to delete
-    string id = 2 [
-        (buf.validate.field).string = {uuid: true},
-        (google.api.field_behavior) = REQUIRED
-    ];
+  // context is the context in which the provider is deleted. Only the project is required in this context.
+  Context context = 1;
+  // id is the id of the provider to delete
+  string id = 2 [
+    (buf.validate.field).string = {uuid: true},
+    (google.api.field_behavior) = REQUIRED
+  ];
 }
 
 message DeleteProviderByIDResponse {
-    // id is the id of the provider that was deleted
-    string id = 1 [
-        (google.api.field_behavior) = REQUIRED
-    ];
+  // id is the id of the provider that was deleted
+  string id = 1 [(google.api.field_behavior) = REQUIRED];
 }
 
 message ListProviderClassesRequest {
-    // context is the context in which the provider classes are evaluated.
-    Context context = 1;
+  // context is the context in which the provider classes are evaluated.
+  Context context = 1;
 }
 
 message ProviderClassInfo {
-    // class is the provider class identifier.
-    string class = 1 [
-        (google.api.field_behavior) = REQUIRED
-    ];
+  // class is the provider class identifier.
+  string class = 1 [(google.api.field_behavior) = REQUIRED];
 
-    // display_name is a human-friendly provider class name.
-    string display_name = 2 [
-        (google.api.field_behavior) = REQUIRED
-    ];
+  // display_name is a human-friendly provider class name.
+  string display_name = 2 [(google.api.field_behavior) = REQUIRED];
 
-    // description is a short plaintext summary of the provider class.
-    string description = 3;
+  // description is a short plaintext summary of the provider class.
+  string description = 3;
 
-    // supported_provider_types is the list of provider traits/interfaces supported by this class.
-    repeated ProviderType supported_provider_types = 4 [
-        (google.api.field_behavior) = REQUIRED
-    ];
+  // supported_provider_types is the list of provider traits/interfaces supported by this class.
+  repeated ProviderType supported_provider_types = 4 [(google.api.field_behavior) = REQUIRED];
 
-    // supported_auth_flows is the list of supported authorization flows.
-    repeated AuthorizationFlow supported_auth_flows = 5 [
-        (google.api.field_behavior) = REQUIRED
-    ];
+  // supported_auth_flows is the list of supported authorization flows.
+  repeated AuthorizationFlow supported_auth_flows = 5 [(google.api.field_behavior) = REQUIRED];
 
-    // supported_entities is the list of entity types supported by this provider class.
-    repeated Entity supported_entities = 6;
+  // supported_entities is the list of entity types supported by this provider class.
+  repeated Entity supported_entities = 6;
 
-    // documentation_url points to provider-specific or generic documentation.
-    string documentation_url = 7;
+  // documentation_url points to provider-specific or generic documentation.
+  string documentation_url = 7;
 
-    reserved 8;
-    reserved "creation_help";
+  reserved 8;
+  reserved "creation_help";
 }
 
 message ListProviderClassesResponse {
-    // provider_classes is the legacy list of provider class names.
-    // Deprecated: use provider_class_infos for rich metadata.
-    repeated string provider_classes = 1 [
-        (google.api.field_behavior) = REQUIRED,
-        deprecated = true
-    ];
+  // provider_classes is the legacy list of provider class names.
+  // Deprecated: use provider_class_infos for rich metadata.
+  repeated string provider_classes = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    deprecated = true
+  ];
 
-    // provider_class_infos is the rich metadata for each provider class.
-    repeated ProviderClassInfo provider_class_infos = 2 [
-        (google.api.field_behavior) = REQUIRED
-    ];
+  // provider_class_infos is the rich metadata for each provider class.
+  repeated ProviderClassInfo provider_class_infos = 2 [(google.api.field_behavior) = REQUIRED];
 }
 
 message PatchProviderRequest {
-    // context is the context in which the provider is updated.
-    // The provider name is required in this context.
-    Context context = 1 [
-        (google.api.field_behavior) = REQUIRED
-    ];
-    Provider patch = 2;
+  // context is the context in which the provider is updated.
+  // The provider name is required in this context.
+  Context context = 1 [(google.api.field_behavior) = REQUIRED];
+  Provider patch = 2;
 
-    google.protobuf.FieldMask update_mask = 3;
+  google.protobuf.FieldMask update_mask = 3;
 }
 
 message PatchProviderResponse {
-    Provider provider = 1 [
-        (google.api.field_behavior) = REQUIRED
-    ];
+  Provider provider = 1 [(google.api.field_behavior) = REQUIRED];
 }
 
 message AuthorizationParams {
-    // authorization_url is an external URL to use to authorize the provider.
-    string authorization_url = 1;
-
+  // authorization_url is an external URL to use to authorize the provider.
+  string authorization_url = 1;
 }
 
 message ProviderParameter {
-    oneof parameters {
-        GitHubAppParams github_app = 1;
-    }
+  oneof parameters {
+    GitHubAppParams github_app = 1;
+  }
 }
 
 // GitHubAppParams is the parameters for a GitHub App provider.
 message GitHubAppParams {
-    // The GitHub installation ID for the app.  On create, this is the only
-    // parameter used; the organization parameters are ignored.
-    int64 installation_id = 1 [
-        (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE,
-        (buf.validate.field).int64 = {gt: 0}
-    ];
+  // The GitHub installation ID for the app.  On create, this is the only
+  // parameter used; the organization parameters are ignored.
+  int64 installation_id = 1 [
+    (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE,
+    (buf.validate.field).int64 = {gt: 0}
+  ];
 
-    // The GitHub organization slug where the app is installed.  This is an
-    // output-only parameter, and is validated on input if set (i.e. the value
-    // must be either empty or match the org of the installation_id).
-    string organization = 2 [
-        (google.api.field_behavior) = OUTPUT_ONLY
-    ];
-    // The GitHub organization ID where the app is installed.  This is an
-    // output-only parameter, and is validated on input if set (i.e. the value
-    // must be either empty or match the org of the installation_id).
-    int64 organization_id = 3 [
-        (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE,
-        (buf.validate.field).int64 = {gt: 0},
-        (google.api.field_behavior) = OUTPUT_ONLY
-    ];
+  // The GitHub organization slug where the app is installed.  This is an
+  // output-only parameter, and is validated on input if set (i.e. the value
+  // must be either empty or match the org of the installation_id).
+  string organization = 2 [(google.api.field_behavior) = OUTPUT_ONLY];
+  // The GitHub organization ID where the app is installed.  This is an
+  // output-only parameter, and is validated on input if set (i.e. the value
+  // must be either empty or match the org of the installation_id).
+  int64 organization_id = 3 [
+    (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE,
+    (buf.validate.field).int64 = {gt: 0},
+    (google.api.field_behavior) = OUTPUT_ONLY
+  ];
 }
 
 // ProviderTrait is the type of the provider.
 enum ProviderType {
-    PROVIDER_TYPE_UNSPECIFIED = 0;
-    PROVIDER_TYPE_GITHUB = 1 [(name) = "github"];
-    PROVIDER_TYPE_REST = 2 [(name) = "rest"];
-    PROVIDER_TYPE_GIT = 3 [(name) = "git"];
-    PROVIDER_TYPE_OCI = 4 [(name) = "oci"];
-    PROVIDER_TYPE_REPO_LISTER = 5 [(name) = "repo-lister"];
-    PROVIDER_TYPE_IMAGE_LISTER = 6 [(name) = "image-lister"];
+  PROVIDER_TYPE_UNSPECIFIED = 0;
+  PROVIDER_TYPE_GITHUB = 1 [(name) = "github"];
+  PROVIDER_TYPE_REST = 2 [(name) = "rest"];
+  PROVIDER_TYPE_GIT = 3 [(name) = "git"];
+  PROVIDER_TYPE_OCI = 4 [(name) = "oci"];
+  PROVIDER_TYPE_REPO_LISTER = 5 [(name) = "repo-lister"];
+  PROVIDER_TYPE_IMAGE_LISTER = 6 [(name) = "image-lister"];
 }
 
 enum ProviderClass {
-    PROVIDER_CLASS_UNSPECIFIED = 0;
-    PROVIDER_CLASS_GITHUB = 1 [(name) = "github"];
-    PROVIDER_CLASS_GITHUB_APP = 2 [(name) = "github-app"];
-    PROVIDER_CLASS_GHCR = 3 [(name) = "ghcr"];
-    PROVIDER_CLASS_DOCKERHUB = 4 [(name) = "dockerhub"];
+  PROVIDER_CLASS_UNSPECIFIED = 0;
+  PROVIDER_CLASS_GITHUB = 1 [(name) = "github"];
+  PROVIDER_CLASS_GITHUB_APP = 2 [(name) = "github-app"];
+  PROVIDER_CLASS_GHCR = 3 [(name) = "ghcr"];
+  PROVIDER_CLASS_DOCKERHUB = 4 [(name) = "dockerhub"];
 }
 
 enum AuthorizationFlow {
-    AUTHORIZATION_FLOW_UNSPECIFIED = 0;
-    AUTHORIZATION_FLOW_NONE = 1 [(name) = "none"];
-    AUTHORIZATION_FLOW_USER_INPUT = 2 [(name) = "user_input"];
-    AUTHORIZATION_FLOW_OAUTH2_AUTHORIZATION_CODE_FLOW = 3 [(name) = "oauth2_authorization_code_flow"];
-    AUTHORIZATION_FLOW_GITHUB_APP_FLOW = 4 [(name) = "github_app_flow"];
+  AUTHORIZATION_FLOW_UNSPECIFIED = 0;
+  AUTHORIZATION_FLOW_NONE = 1 [(name) = "none"];
+  AUTHORIZATION_FLOW_USER_INPUT = 2 [(name) = "user_input"];
+  AUTHORIZATION_FLOW_OAUTH2_AUTHORIZATION_CODE_FLOW = 3 [(name) = "oauth2_authorization_code_flow"];
+  AUTHORIZATION_FLOW_GITHUB_APP_FLOW = 4 [(name) = "github_app_flow"];
 }
 
 enum CredentialsState {
-    CREDENTIALS_STATE_UNSPECIFIED = 0;
-    CREDENTIALS_STATE_SET = 1 [(name) = "set"];
-    CREDENTIALS_STATE_UNSET = 2 [(name) = "unset"];
-    CREDENTIALS_STATE_NOT_APPLICABLE = 3 [(name) = "not_applicable"];
+  CREDENTIALS_STATE_UNSPECIFIED = 0;
+  CREDENTIALS_STATE_SET = 1 [(name) = "set"];
+  CREDENTIALS_STATE_UNSET = 2 [(name) = "unset"];
+  CREDENTIALS_STATE_NOT_APPLICABLE = 3 [(name) = "not_applicable"];
 }
 
 // Provider represents a provider that is used to interact with external systems.
 // All fields are optional because we want to allow partial updates.
 message Provider {
-    // name is the name of the provider.
-    string name = 1 [
-        (buf.validate.field).string = {
-            pattern: "^[A-Za-z][-[:word:]]*$",
-            max_len: 200,
-        },
-        (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE
-    ];
-    // class is the name of the provider implementation, eg. 'github' or 'gh-app'.
-    string class = 7 [
-        (buf.validate.field).string = {
-            pattern: "^[a-z][a-z0-9_-]*$",
-            max_len: 200,
-        },
-        (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE
-    ];
-    // project is the project where the provider is.  This is ignored on input
-    // in favor of the context field in CreateProviderRequest.
-    string project = 2 [
-        (google.api.field_behavior) = OUTPUT_ONLY
-    ];
-    // version is the version of the provider.
-    // if unset, "v1" is assumed.
-    string version = 3 [
-        (buf.validate.field).string = {
-            pattern: "v1",
-        },
-        (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE
-    ];
+  // name is the name of the provider.
+  string name = 1 [
+    (buf.validate.field).string = {
+      pattern: "^[A-Za-z][-[:word:]]*$"
+      max_len: 200
+    },
+    (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE
+  ];
+  // class is the name of the provider implementation, eg. 'github' or 'gh-app'.
+  string class = 7 [
+    (buf.validate.field).string = {
+      pattern: "^[a-z][a-z0-9_-]*$"
+      max_len: 200
+    },
+    (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE
+  ];
+  // project is the project where the provider is.  This is ignored on input
+  // in favor of the context field in CreateProviderRequest.
+  string project = 2 [(google.api.field_behavior) = OUTPUT_ONLY];
+  // version is the version of the provider.
+  // if unset, "v1" is assumed.
+  string version = 3 [
+    (buf.validate.field).string = {pattern: "v1"},
+    (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE
+  ];
 
-    // implements is the list of interfaces that the provider implements.
-    repeated ProviderType implements = 4;
+  // implements is the list of interfaces that the provider implements.
+  repeated ProviderType implements = 4;
 
-    // config is the configuration of the provider.
-    google.protobuf.Struct config = 5;
+  // config is the configuration of the provider.
+  google.protobuf.Struct config = 5;
 
-    // auth_flows is the list of authorization flows that the provider supports.
-    repeated AuthorizationFlow auth_flows = 6;
+  // auth_flows is the list of authorization flows that the provider supports.
+  repeated AuthorizationFlow auth_flows = 6;
 
-    // parameters is the list of parameters that the provider requires.
-    ProviderParameter parameters = 8;
+  // parameters is the list of parameters that the provider requires.
+  ProviderParameter parameters = 8;
 
-    // credentials_state is the state of the credentials for the provider.
-    // This is an output-only field. It may be: "set", "unset", "not_applicable".
-    string credentials_state = 9 [
-        (google.api.field_behavior) = OUTPUT_ONLY
-    ];
+  // credentials_state is the state of the credentials for the provider.
+  // This is an output-only field. It may be: "set", "unset", "not_applicable".
+  string credentials_state = 9 [(google.api.field_behavior) = OUTPUT_ONLY];
 
-    // id is the unique identifier of the provider.
-    string id = 10 [
-        (buf.validate.field).string = {uuid: true},
-        (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE
-    ];
+  // id is the unique identifier of the provider.
+  string id = 10 [
+    (buf.validate.field).string = {uuid: true},
+    (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE
+  ];
 }
 
 // GetEvaluationHistoryRequest represents a request for the GetEvaluationHistory endpoint
 message GetEvaluationHistoryRequest {
-    string id = 1 [
-        (buf.validate.field).string = {uuid: true},
-        (google.api.field_behavior) = REQUIRED
-    ];
+  string id = 1 [
+    (buf.validate.field).string = {uuid: true},
+    (google.api.field_behavior) = REQUIRED
+  ];
 
-    Context context = 2;
+  Context context = 2;
 
-    // If true, include structured rule output for the matched evaluations.
-    // Not all ruletypes may generate structured outputs.
-    // Because the evaluation output may be large, it is only returned
-    // when explicitly requested.
-    bool include_outputs = 3;
+  // If true, include structured rule output for the matched evaluations.
+  // Not all ruletypes may generate structured outputs.
+  // Because the evaluation output may be large, it is only returned
+  // when explicitly requested.
+  bool include_outputs = 3;
 }
 
 // ListEvaluationHistoryRequest represents a request message for the
@@ -3895,112 +3513,96 @@ message GetEvaluationHistoryRequest {
 // Most of its fields are used for filtering, except for `cursor`
 // which is used for pagination.
 message ListEvaluationHistoryRequest {
-    Context context = 1;
+  Context context = 1;
 
-    // List of entity types to retrieve.
-    repeated string entity_type = 2 [
-        (buf.validate.field).repeated = {
-            items: {
-                string: {
-                    pattern: "^[,[:word:]]*$",
-                    max_len: 200,
-                }
-            }
-        }
-    ];
-    // List of entity names to retrieve.
-    repeated string entity_name = 3 [
-        (buf.validate.field).repeated = {
-            items: {
-                string: {
-                    pattern: "^[,-./[:word:]]*$",
-                    max_len: 200,
-                }
-            }
-        }
-    ];
-    // List of profile names to retrieve.
-    repeated string profile_name = 4 [
-        (buf.validate.field).repeated = {
-            items: {
-                string: {
-                    pattern: "^[A-Za-z][-/[:word:]]*$",
-                    max_len: 200,
-                }
-            }
-        }
-    ];
-    // List of evaluation statuses to retrieve.
-    repeated string status = 5 [
-        (buf.validate.field).repeated = {
-            items: {
-                string: {
-                    pattern: "^[,[:word:]]*$",
-                    max_len: 200,
-                }
-            }
-        }
-    ];
-    // List of remediation statuses to retrieve.
-    repeated string remediation = 6 [
-        (buf.validate.field).repeated = {
-            items: {
-                string: {
-                    pattern: "^[,[:word:]]*$",
-                    max_len: 200,
-                }
-            }
-        }
-    ];
-    // List of alert statuses to retrieve.
-    repeated string alert = 7 [
-        (buf.validate.field).repeated = {
-            items: {
-                string: {
-                    pattern: "^[,[:word:]]*$",
-                    max_len: 200,
-                }
-            }
-        }
-    ];
-    // Timestamp representing the start time of the selection window.
-    google.protobuf.Timestamp from = 8;
-    // Timestamp representing the end time of the selection window.
-    google.protobuf.Timestamp to = 9;
+  // List of entity types to retrieve.
+  repeated string entity_type = 2 [(buf.validate.field).repeated = {
+    items: {
+      string: {
+        pattern: "^[,[:word:]]*$"
+        max_len: 200
+      }
+    }
+  }];
+  // List of entity names to retrieve.
+  repeated string entity_name = 3 [(buf.validate.field).repeated = {
+    items: {
+      string: {
+        pattern: "^[,-./[:word:]]*$"
+        max_len: 200
+      }
+    }
+  }];
+  // List of profile names to retrieve.
+  repeated string profile_name = 4 [(buf.validate.field).repeated = {
+    items: {
+      string: {
+        pattern: "^[A-Za-z][-/[:word:]]*$"
+        max_len: 200
+      }
+    }
+  }];
+  // List of evaluation statuses to retrieve.
+  repeated string status = 5 [(buf.validate.field).repeated = {
+    items: {
+      string: {
+        pattern: "^[,[:word:]]*$"
+        max_len: 200
+      }
+    }
+  }];
+  // List of remediation statuses to retrieve.
+  repeated string remediation = 6 [(buf.validate.field).repeated = {
+    items: {
+      string: {
+        pattern: "^[,[:word:]]*$"
+        max_len: 200
+      }
+    }
+  }];
+  // List of alert statuses to retrieve.
+  repeated string alert = 7 [(buf.validate.field).repeated = {
+    items: {
+      string: {
+        pattern: "^[,[:word:]]*$"
+        max_len: 200
+      }
+    }
+  }];
+  // Timestamp representing the start time of the selection window.
+  google.protobuf.Timestamp from = 8;
+  // Timestamp representing the end time of the selection window.
+  google.protobuf.Timestamp to = 9;
 
-    // Filter evaluation history to only those matching the specified labels.
-    //
-    // The default is to return all user-created profiles; the string "*" can
-    // be used to select all profiles, including system profiles.  This syntax
-    // may be expanded in the future.
-    repeated string label_filter = 11 [
-        (buf.validate.field).repeated = {
-            items: {
-                string: {
-                    pattern: "^(\\*|[a-z][a-z0-9_]*)$",
-                    max_len: 200,
-                },
-            },
-        }
-    ];
+  // Filter evaluation history to only those matching the specified labels.
+  //
+  // The default is to return all user-created profiles; the string "*" can
+  // be used to select all profiles, including system profiles.  This syntax
+  // may be expanded in the future.
+  repeated string label_filter = 11 [(buf.validate.field).repeated = {
+    items: {
+      string: {
+        pattern: "^(\\*|[a-z][a-z0-9_]*)$"
+        max_len: 200
+      }
+    }
+  }];
 
-    // Cursor object to select the "page" of data to retrieve. This is optional.
-    Cursor cursor = 10;
+  // Cursor object to select the "page" of data to retrieve. This is optional.
+  Cursor cursor = 10;
 
-    // If true, include structured rule output for the matched evaluations.
-    // Not all ruletypes may generate structured outputs.
-    // Because the evaluation output may be large, it is only returned
-    // when explicitly requested.
-    bool include_outputs = 12;
+  // If true, include structured rule output for the matched evaluations.
+  // Not all ruletypes may generate structured outputs.
+  // Because the evaluation output may be large, it is only returned
+  // when explicitly requested.
+  bool include_outputs = 12;
 }
 
 // GetEvaluationHistoryResponse represents a response message for the
 // GetEvaluationHistory RPC.
 message GetEvaluationHistoryResponse {
-    // The requested record
-    EvaluationHistory evaluation = 1 [
-        (google.api.field_behavior) = REQUIRED
-    ];
+  // The requested record
+  EvaluationHistory evaluation = 1 [(google.api.field_behavior) = REQUIRED];
 }
 
 // ListEvaluationHistoryResponse represents a response message for the
@@ -4009,356 +3611,296 @@ message GetEvaluationHistoryResponse {
 // It ships a collection of records retrieved and pointers to get to
 // the next and/or previous pages of data.
 message ListEvaluationHistoryResponse {
-    // List of records retrieved.
-    repeated EvaluationHistory data = 1 [
-        (google.api.field_behavior) = REQUIRED
-    ];
-    // Metadata of the current page and pointers to next and/or
-    // previous pages.
-    CursorPage page = 2;
+  // List of records retrieved.
+  repeated EvaluationHistory data = 1 [(google.api.field_behavior) = REQUIRED];
+  // Metadata of the current page and pointers to next and/or
+  // previous pages.
+  CursorPage page = 2;
 }
 
 // EvaluationHistory represents the history of an entity evaluation.
 // This is only used in responses.
 message EvaluationHistory {
-    // entity contains details of the entity which was evaluated.
-    EvaluationHistoryEntity entity = 1 [
-        (google.api.field_behavior) = REQUIRED
-    ];
+  // entity contains details of the entity which was evaluated.
+  EvaluationHistoryEntity entity = 1 [(google.api.field_behavior) = REQUIRED];
 
-    // rule contains details of the rule which the entity was evaluated against.
-    EvaluationHistoryRule rule = 2 [
-        (google.api.field_behavior) = REQUIRED
-    ];
+  // rule contains details of the rule which the entity was evaluated against.
+  EvaluationHistoryRule rule = 2 [(google.api.field_behavior) = REQUIRED];
 
-    // status contains the evaluation status.
-    EvaluationHistoryStatus status = 3 [
-        (google.api.field_behavior) = REQUIRED
-    ];
+  // status contains the evaluation status.
+  EvaluationHistoryStatus status = 3 [(google.api.field_behavior) = REQUIRED];
 
-    // alert contains details of the alerts for this evaluation.
-    // This is optional.
-    EvaluationHistoryAlert alert = 4;
+  // alert contains details of the alerts for this evaluation.
+  // This is optional.
+  EvaluationHistoryAlert alert = 4;
 
-    // remediation contains details of the remediation for this evaluation.
-    // This is optional.
-    EvaluationHistoryRemediation remediation = 5;
+  // remediation contains details of the remediation for this evaluation.
+  // This is optional.
+  EvaluationHistoryRemediation remediation = 5;
 
-    // created_at is the timestamp of creation of this evaluation
-    google.protobuf.Timestamp evaluated_at = 6 [
-        (google.api.field_behavior) = REQUIRED
-    ];
+  // created_at is the timestamp of creation of this evaluation
+  google.protobuf.Timestamp evaluated_at = 6 [(google.api.field_behavior) = REQUIRED];
 
-    // id is the unique identifier of the evaluation.
-    string id = 7 [
-        (google.api.field_behavior) = REQUIRED
-    ];
+  // id is the unique identifier of the evaluation.
+  string id = 7 [(google.api.field_behavior) = REQUIRED];
 }
 
 message EvaluationHistoryEntity {
-    // id is the unique identifier of the entity.
-    string id = 1 [
-        (google.api.field_behavior) = REQUIRED
-    ];
+  // id is the unique identifier of the entity.
+  string id = 1 [(google.api.field_behavior) = REQUIRED];
 
-    // type is the entity type.
-    Entity type = 2 [
-        (google.api.field_behavior) = REQUIRED
-    ];
+  // type is the entity type.
+  Entity type = 2 [(google.api.field_behavior) = REQUIRED];
 
-    // name is the entity name.
-    string name = 3 [
-        (google.api.field_behavior) = REQUIRED
-    ];
+  // name is the entity name.
+  string name = 3 [(google.api.field_behavior) = REQUIRED];
 }
 
 message EvaluationHistoryRule {
-    // name is the name of the rule instance.
-    string name = 1 [
-        (google.api.field_behavior) = REQUIRED
-    ];
+  // name is the name of the rule instance.
+  string name = 1 [(google.api.field_behavior) = REQUIRED];
 
-    // type is the name of the rule type.
-    string rule_type = 2 [
-        (google.api.field_behavior) = REQUIRED
-    ];
+  // type is the name of the rule type.
+  string rule_type = 2 [(google.api.field_behavior) = REQUIRED];
 
-    // profile is the name of the profile which contains the rule.
-    string profile = 3 [
-        (google.api.field_behavior) = REQUIRED
-    ];
+  // profile is the name of the profile which contains the rule.
+  string profile = 3 [(google.api.field_behavior) = REQUIRED];
 
-    // severity is the severity of the rule type.
-    Severity severity = 4 [
-        (google.api.field_behavior) = REQUIRED
-    ];
+  // severity is the severity of the rule type.
+  Severity severity = 4 [(google.api.field_behavior) = REQUIRED];
 }
 
 message EvaluationHistoryStatus {
-    // status is one of (success, error, failure, skipped)
-    // not using enums to mirror the behaviour of the existing API contracts.
-    string status = 1 [
-        (google.api.field_behavior) = REQUIRED
-    ];
+  // status is one of (success, error, failure, skipped)
+  // not using enums to mirror the behaviour of the existing API contracts.
+  string status = 1 [(google.api.field_behavior) = REQUIRED];
 
-    // details contains optional details about the evaluation.
-    // the structure and contents are rule type specific, and are subject to change.
-    string details = 2 [
-        (google.api.field_behavior) = REQUIRED
-    ];
+  // details contains optional details about the evaluation.
+  // the structure and contents are rule type specific, and are subject to change.
+  string details = 2 [(google.api.field_behavior) = REQUIRED];
 
-    // output optionally contains the structured rule evaluation output.
-    // Because output may be multiple KB, it is only returned
-    // if include_outputs is set. Historical evaluations may
-    // discard structured output sooner than status results.
-    google.protobuf.Value output = 3;
+  // output optionally contains the structured rule evaluation output.
+  // Because output may be multiple KB, it is only returned
+  // if include_outputs is set. Historical evaluations may
+  // discard structured output sooner than status results.
+  google.protobuf.Value output = 3;
 }
 
 message EvaluationHistoryRemediation {
-    // status is one of (success, error, failure, skipped, not available)
-    // not using enums to mirror the behaviour of the existing API contracts.
-    string status = 1 [
-        (google.api.field_behavior) = REQUIRED
-    ];
+  // status is one of (success, error, failure, skipped, not available)
+  // not using enums to mirror the behaviour of the existing API contracts.
+  string status = 1 [(google.api.field_behavior) = REQUIRED];
 
-    // details contains optional details about the remediation.
-    // the structure and contents are remediation specific, and are subject to change.
-    string details = 2;
+  // details contains optional details about the remediation.
+  // the structure and contents are remediation specific, and are subject to change.
+  string details = 2;
 }
 
 message EvaluationHistoryAlert {
-    // status is one of (on, off, error, skipped, not available)
-    // not using enums to mirror the behaviour of the existing API contracts.
-    string status = 1 [
-        (google.api.field_behavior) = REQUIRED
-    ];
+  // status is one of (on, off, error, skipped, not available)
+  // not using enums to mirror the behaviour of the existing API contracts.
+  string status = 1 [(google.api.field_behavior) = REQUIRED];
 
-    // details contains optional details about the alert.
-    // the structure and contents are alert specific, and are subject to change.
-    string details = 2;
+  // details contains optional details about the alert.
+  // the structure and contents are alert specific, and are subject to change.
+  string details = 2;
 }
 
 // used for parsing resources in ruletypes
 message EntityInstance {
-    // id is the unique identifier of the entity.
-    string id = 1;
+  // id is the unique identifier of the entity.
+  string id = 1;
 
-    // context is the context in which the entity is evaluated.
-    ContextV2 context = 2;
+  // context is the context in which the entity is evaluated.
+  ContextV2 context = 2;
 
-    // name is the name of the entity.
-    string name = 3;
+  // name is the name of the entity.
+  string name = 3;
 
-    // type is the type of the entity.
-    // DISCUSSION: If we're aiming for a BYO entity type, we should probably
-    // have this be a string, and have the user provide the type.
-    Entity type = 4;
+  // type is the type of the entity.
+  // DISCUSSION: If we're aiming for a BYO entity type, we should probably
+  // have this be a string, and have the user provide the type.
+  Entity type = 4;
 
-    // properties is a map of properties of the entity.
-    google.protobuf.Struct properties = 5;
+  // properties is a map of properties of the entity.
+  google.protobuf.Struct properties = 5;
 }
 
 // EntityInstanceService provides API endpoints for managing entity instances
 service EntityInstanceService {
-    // ListEntities returns a list of entity instances for a given project and provider
-    rpc ListEntities (ListEntitiesRequest) returns (ListEntitiesResponse) {
-        option (google.api.http) = {
-            get: "/api/v1/entities"
-        };
+  // ListEntities returns a list of entity instances for a given project and provider
+  rpc ListEntities(ListEntitiesRequest) returns (ListEntitiesResponse) {
+    option (google.api.http) = {get: "/api/v1/entities"};
 
-        option (rpc_options) = {
-            target_resource: TARGET_RESOURCE_PROJECT
-            relation: RELATION_ENTITY_GET
-        };
-    }
+    option (rpc_options) = {
+      target_resource: TARGET_RESOURCE_PROJECT
+      relation: RELATION_ENTITY_GET
+    };
+  }
 
-    // GetEntityById returns an entity instance for a given entity ID
-    rpc GetEntityById (GetEntityByIdRequest) returns (GetEntityByIdResponse) {
-        option (google.api.http) = {
-            get: "/api/v1/entity/id/{id}"
-        };
+  // GetEntityById returns an entity instance for a given entity ID
+  rpc GetEntityById(GetEntityByIdRequest) returns (GetEntityByIdResponse) {
+    option (google.api.http) = {get: "/api/v1/entity/id/{id}"};
 
-        option (rpc_options) = {
-            target_resource: TARGET_RESOURCE_PROJECT
-            relation: RELATION_ENTITY_GET
-        };
-    }
+    option (rpc_options) = {
+      target_resource: TARGET_RESOURCE_PROJECT
+      relation: RELATION_ENTITY_GET
+    };
+  }
 
-    // GetEntityByName returns an entity instance for a given entity name
-    rpc GetEntityByName (GetEntityByNameRequest) returns (GetEntityByNameResponse) {
-        option (google.api.http) = {
-            get: "/api/v1/entity/{entity_type}/{name=**}"
-        };
+  // GetEntityByName returns an entity instance for a given entity name
+  rpc GetEntityByName(GetEntityByNameRequest) returns (GetEntityByNameResponse) {
+    option (google.api.http) = {get: "/api/v1/entity/{entity_type}/{name=**}"};
 
-        option (rpc_options) = {
-            target_resource: TARGET_RESOURCE_PROJECT
-            relation: RELATION_ENTITY_GET
-        };
-    }
+    option (rpc_options) = {
+      target_resource: TARGET_RESOURCE_PROJECT
+      relation: RELATION_ENTITY_GET
+    };
+  }
 
-    // DeleteEntityById deletes an entity instance for a given entity ID
-    rpc DeleteEntityById (DeleteEntityByIdRequest) returns (DeleteEntityByIdResponse) {
-        option (google.api.http) = {
-            delete: "/api/v1/entity/id/{id}"
-        };
+  // DeleteEntityById deletes an entity instance for a given entity ID
+  rpc DeleteEntityById(DeleteEntityByIdRequest) returns (DeleteEntityByIdResponse) {
+    option (google.api.http) = {delete: "/api/v1/entity/id/{id}"};
 
-        option (minder.v1.rpc_options) = {
-            target_resource: TARGET_RESOURCE_PROJECT
-            relation: RELATION_ENTITY_DELETE
-        };
-    }
+    option (minder.v1.rpc_options) = {
+      target_resource: TARGET_RESOURCE_PROJECT
+      relation: RELATION_ENTITY_DELETE
+    };
+  }
 
-    // RegisterEntity creates a new entity instance
-    rpc RegisterEntity (RegisterEntityRequest) returns (RegisterEntityResponse) {
-        option (google.api.http) = {
-            post: "/api/v1/entity"
-            body: "*"
-        };
+  // RegisterEntity creates a new entity instance
+  rpc RegisterEntity(RegisterEntityRequest) returns (RegisterEntityResponse) {
+    option (google.api.http) = {
+      post: "/api/v1/entity"
+      body: "*"
+    };
 
-        option (rpc_options) = {
-            target_resource: TARGET_RESOURCE_PROJECT
-            relation: RELATION_ENTITY_REGISTER
-        };
-    }
+    option (rpc_options) = {
+      target_resource: TARGET_RESOURCE_PROJECT
+      relation: RELATION_ENTITY_REGISTER
+    };
+  }
 }
 
 // ListEntitiesRequest is the request message for the ListEntities method
 message ListEntitiesRequest {
-    // context is the context in which the entities are listed
-    ContextV2 context = 1;
+  // context is the context in which the entities are listed
+  ContextV2 context = 1;
 
-    // entity_type is the type of entity to list
-    Entity entity_type = 2 [
-        (google.api.field_behavior) = REQUIRED
-    ];
+  // entity_type is the type of entity to list
+  Entity entity_type = 2 [(google.api.field_behavior) = REQUIRED];
 
-    // cursor is the pagination cursor
-    Cursor cursor = 3;
+  // cursor is the pagination cursor
+  Cursor cursor = 3;
 }
 
 // ListEntitiesResponse is the response message for the ListEntities method
 message ListEntitiesResponse {
-    // results is the list of entities
-    repeated EntityInstance results = 1 [
-        (google.api.field_behavior) = REQUIRED
-    ];
+  // results is the list of entities
+  repeated EntityInstance results = 1 [(google.api.field_behavior) = REQUIRED];
 
-    // page is the pagination information
-    CursorPage page = 2;
+  // page is the pagination information
+  CursorPage page = 2;
 }
 
 // GetEntityByIdRequest is the request message for the GetEntityById method
 message GetEntityByIdRequest {
-    // context is the context in which the entity is evaluated
-    ContextV2 context = 1;
+  // context is the context in which the entity is evaluated
+  ContextV2 context = 1;
 
-    // id is the ID of the entity to get
-    string id = 2 [
-        (buf.validate.field).string = {uuid: true},
-        (google.api.field_behavior) = REQUIRED
-    ];
+  // id is the ID of the entity to get
+  string id = 2 [
+    (buf.validate.field).string = {uuid: true},
+    (google.api.field_behavior) = REQUIRED
+  ];
 }
 
 // GetEntityByIdResponse is the response message for the GetEntityById method
 message GetEntityByIdResponse {
-    // entity is the entity that was retrieved
-    EntityInstance entity = 1 [
-        (google.api.field_behavior) = REQUIRED
-    ];
+  // entity is the entity that was retrieved
+  EntityInstance entity = 1 [(google.api.field_behavior) = REQUIRED];
 }
 
 // GetEntityByNameRequest is the request message for the GetEntityByName method
 message GetEntityByNameRequest {
-    // context is the context in which the entity is evaluated
-    ContextV2 context = 1;
+  // context is the context in which the entity is evaluated
+  ContextV2 context = 1;
 
-    // name is the name of the entity to get
-    string name = 2 [
-        (buf.validate.field).string = {
-            pattern: "^[A-Za-z][-/[:word:]]*$",
-            max_len: 200,
-        },
-        (google.api.field_behavior) = REQUIRED
-    ];
+  // name is the name of the entity to get
+  string name = 2 [
+    (buf.validate.field).string = {
+      pattern: "^[A-Za-z][-/[:word:]]*$"
+      max_len: 200
+    },
+    (google.api.field_behavior) = REQUIRED
+  ];
 
-    // entity_type is the type of entity to get
-    Entity entity_type = 3 [
-        (google.api.field_behavior) = REQUIRED
-    ];
+  // entity_type is the type of entity to get
+  Entity entity_type = 3 [(google.api.field_behavior) = REQUIRED];
 }
 
 // GetEntityByNameResponse is the response message for the GetEntityByName method
 message GetEntityByNameResponse {
-    // entity is the entity that was retrieved
-    EntityInstance entity = 1 [
-        (google.api.field_behavior) = REQUIRED
-    ];
+  // entity is the entity that was retrieved
+  EntityInstance entity = 1 [(google.api.field_behavior) = REQUIRED];
 }
 
 // DeleteEntityByIdRequest is the request message for the DeleteEntityById method
 message DeleteEntityByIdRequest {
-    // context is the context in which the entity is evaluated
-    ContextV2 context = 1;
+  // context is the context in which the entity is evaluated
+  ContextV2 context = 1;
 
-    // id is the ID of the entity to delete
-    string id = 2 [
-        (buf.validate.field).string = {uuid: true},
-        (google.api.field_behavior) = REQUIRED
-    ];
+  // id is the ID of the entity to delete
+  string id = 2 [
+    (buf.validate.field).string = {uuid: true},
+    (google.api.field_behavior) = REQUIRED
+  ];
 }
 
 // DeleteEntityByIdResponse is the response message for the DeleteEntityById method
 message DeleteEntityByIdResponse {
-    // id is the ID of the entity that was deleted
-    string id = 1 [
-        (google.api.field_behavior) = REQUIRED
-    ];
+  // id is the ID of the entity that was deleted
+  string id = 1 [(google.api.field_behavior) = REQUIRED];
 }
 
 // RegisterEntityRequest is the request message for the RegisterEntity method
 message RegisterEntityRequest {
-    // context is the context in which the entity is created
-    ContextV2 context = 1;
+  // context is the context in which the entity is created
+  ContextV2 context = 1;
 
-    // entity_type is the type of entity to create
-    Entity entity_type = 2 [
-        (google.api.field_behavior) = REQUIRED
-    ];
+  // entity_type is the type of entity to create
+  Entity entity_type = 2 [(google.api.field_behavior) = REQUIRED];
 
-    // identifying_properties uniquely identifies the entity in the provider.
-    // For example, for a GitHub repository use github/repo_owner and github/repo_name,
-    // or use upstream_id to identify by provider's internal ID.
-    // Each key maps to a value that can be a string, number, boolean, or nested structure.
-    map<string, google.protobuf.Value> identifying_properties = 3 [
-        (google.api.field_behavior) = REQUIRED
-    ];
+  // identifying_properties uniquely identifies the entity in the provider.
+  // For example, for a GitHub repository use github/repo_owner and github/repo_name,
+  // or use upstream_id to identify by provider's internal ID.
+  // Each key maps to a value that can be a string, number, boolean, or nested structure.
+  map<string, google.protobuf.Value> identifying_properties = 3 [(google.api.field_behavior) = REQUIRED];
 }
 
 // RegisterEntityResponse is the response message for the RegisterEntity method
 message RegisterEntityResponse {
-    // entity is the entity that was created
-    EntityInstance entity = 1 [
-        (google.api.field_behavior) = REQUIRED
-    ];
+  // entity is the entity that was created
+  EntityInstance entity = 1 [(google.api.field_behavior) = REQUIRED];
 }
 
 // UpstreamEntityRef providers enough information for the
 // provider to identify the entity in the upstream system.
 message UpstreamEntityRef {
-    // context is the context in which the entity is evaluated.
-    // Note that the context is included here since users of
-    // this message may return upstream references from
-    // multiple providers
-    ContextV2 context = 1;
+  // context is the context in which the entity is evaluated.
+  // Note that the context is included here since users of
+  // this message may return upstream references from
+  // multiple providers
+  ContextV2 context = 1;
 
-    // type is the type of the entity.
-    Entity type = 2;
+  // type is the type of the entity.
+  Entity type = 2;
 
-    // properties is a map of properties of the entity.
-    // This will be used to identify the entity in the upstream system
-    // and will be a subset of the properties of the entity that will
-    // be stored in Minder.
-    google.protobuf.Struct properties = 3;
+  // properties is a map of properties of the entity.
+  // This will be used to identify the entity in the upstream system
+  // and will be a subset of the properties of the entity that will
+  // be stored in Minder.
+  google.protobuf.Struct properties = 3;
 }
 
 // DataSource is a Data source instance. Data sources represent
@@ -4366,197 +3908,190 @@ message UpstreamEntityRef {
 // have explicit lifecycle objects (entities).  Integrations which
 // create entities are called Providers.
 message DataSource {
-    // version is the version of the data source API.
-    string version = 1 [
-        (buf.validate.field).string = {
-            pattern: "^v\\d$",
-        },
-        (google.api.field_behavior) = REQUIRED
-    ];
+  // version is the version of the data source API.
+  string version = 1 [
+    (buf.validate.field).string = {pattern: "^v\\d$"},
+    (google.api.field_behavior) = REQUIRED
+  ];
 
-    // type is the data source type
-    string type = 2 [
-        (buf.validate.field).string = {
-            in: ["data-source"],
-            max_len: 12,
-        }
-    ];
+  // type is the data source type
+  string type = 2 [(buf.validate.field).string = {
+    in: ["data-source"]
+    max_len: 12
+  }];
 
-    // context is the context in which the data source is evaluated.
-    // Note that in this case we only need the project in the
-    // context, since data sources are not provider-specific.
-    ContextV2 context = 3;
+  // context is the context in which the data source is evaluated.
+  // Note that in this case we only need the project in the
+  // context, since data sources are not provider-specific.
+  ContextV2 context = 3;
 
-    // name is the name of the data source.
-    // Note that this is unique within a project hierarchy.
-    // Names must be lowercase and can only contain letters, numbers,
-    // hyphens, and underscores.
-    string name = 4 [
-        (buf.validate.field).string = {
-            pattern: "^[a-z][-_[:word:]]*$",
-            max_len: 200,
-        },
-        (google.api.field_behavior) = REQUIRED
-    ];
+  // name is the name of the data source.
+  // Note that this is unique within a project hierarchy.
+  // Names must be lowercase and can only contain letters, numbers,
+  // hyphens, and underscores.
+  string name = 4 [
+    (buf.validate.field).string = {
+      pattern: "^[a-z][-_[:word:]]*$"
+      max_len: 200
+    },
+    (google.api.field_behavior) = REQUIRED
+  ];
 
-    // id is the unique identifier of the data source.
-    string id = 5 [
-        (buf.validate.field).string = {uuid: true},
-        (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE,
-        (google.api.field_behavior) = OUTPUT_ONLY
-    ];
+  // id is the unique identifier of the data source.
+  string id = 5 [
+    (buf.validate.field).string = {uuid: true},
+    (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE,
+    (google.api.field_behavior) = OUTPUT_ONLY
+  ];
 
-    oneof driver {
-        // structured is the structired data - data source.
-        StructDataSource structured = 8;
-        // rest is the REST data source driver.
-        RestDataSource rest = 6;
-    }
+  oneof driver {
+    // structured is the structired data - data source.
+    StructDataSource structured = 8;
+    // rest is the REST data source driver.
+    RestDataSource rest = 6;
+  }
 }
 
 // StructDataSource is the structured data source driver.
 message StructDataSource {
-    message Def {
-        // Path is the path specification for the structured data source.
-        Path path = 1 [
-              (google.api.field_behavior) = REQUIRED
-        ];
+  message Def {
+    // Path is the path specification for the structured data source.
+    Path path = 1 [(google.api.field_behavior) = REQUIRED];
 
-        message Path {
-            string file_name = 1;
-            repeated string alternatives = 2;
-        }
+    message Path {
+      string file_name = 1;
+      repeated string alternatives = 2;
     }
+  }
 
-    // defs is the list of definitions for the structured data API.
-    map<string, Def> def = 1;
+  // defs is the list of definitions for the structured data API.
+  map<string, Def> def = 1;
 }
 
 // RestDataSource is the REST data source driver.
 message RestDataSource {
-    message Def {
-        // endpoint is the URL of the REST API. Note that endpoints are
-        // templates that can be parameterized with variables. Parametrization
-        // is done using RFC 6570.
-        string endpoint = 1 [
-            (buf.validate.field).string = {
-                pattern: "^https?://.*$",
-                max_len: 800,
-            },
-            (google.api.field_behavior) = REQUIRED
-        ];
+  message Def {
+    // endpoint is the URL of the REST API. Note that endpoints are
+    // templates that can be parameterized with variables. Parametrization
+    // is done using RFC 6570.
+    string endpoint = 1 [
+      (buf.validate.field).string = {
+        pattern: "^https?://.*$"
+        max_len: 800
+      },
+      (google.api.field_behavior) = REQUIRED
+    ];
 
-        // method is the HTTP method to use for the request.
-        // If left unset, it will default to "GET".
-        string method = 2 [
-            (buf.validate.field).string = {
-                in: ["GET", "POST", "PUT", "PATCH", "DELETE"]
-            },
-            (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE
-        ];
+    // method is the HTTP method to use for the request.
+    // If left unset, it will default to "GET".
+    string method = 2 [
+      (buf.validate.field).string = {
+        in: [
+          "GET",
+          "POST",
+          "PUT",
+          "PATCH",
+          "DELETE"
+        ]
+      },
+      (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE
+    ];
 
-        // headers is a map of headers to send with the request.
-        map<string, string> headers = 3;
+    // headers is a map of headers to send with the request.
+    map<string, string> headers = 3;
 
-        oneof body {
-            // body is the body of the request.
-            google.protobuf.Struct bodyobj = 4;
-            // bodystr is the body of the request as a string.
-            string bodystr = 5 [
-                (buf.validate.field).string = {
-                    max_len: 1000,
-                }
-            ];
+    oneof body {
+      // body is the body of the request.
+      google.protobuf.Struct bodyobj = 4;
+      // bodystr is the body of the request as a string.
+      string bodystr = 5 [(buf.validate.field).string = {max_len: 1000}];
 
-            // body_from_field is the field in the input to use as the body.
-            // If the value is an string, it will be used as the body, as is.
-            // If the value is an object, it will be serialized as JSON.
-            // If the value is not found in the input, the request will fail.
-            string body_from_field = 10 [
-                (buf.validate.field).string = {
-                    // We're assuming fairly short field names here.
-                    max_len: 50,
-                }
-            ];
-        }
-
-        // parse is the parse configuration for the response.
-        // This allows us to serialize the response into a structured format,
-        // or not.
-        // If left unset, the response will be treated as a string.
-        // If set to "json", the response will be parsed as JSON.
-        string parse = 6 [
-            (buf.validate.field).string = {
-                in: ["json"]
-            },
-            (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE
-        ];
-
-        message Fallback {
-            int32 http_status = 1 [
-                (buf.validate.field).int32 = {gte: 100, lte: 599},
-                (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE
-            ];
-
-            string body = 2 [
-                (buf.validate.field).string = {
-                    max_len: 1000,
-                },
-                (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE
-            ];
-        }
-
-        // fallback is the fallback configuration for the response in case
-        // of an unexpected status code.
-        repeated Fallback fallback = 7;
-
-        // expected_status is the expected status code for the response.
-        // This may be repeated to allow for multiple expected status codes.
-        // If left unset, it will default to 200.
-        repeated int32 expected_status = 8 [
-            (buf.validate.field).repeated = {
-                items: {
-                    int32: {
-                        gte: 100,
-                        lte: 599,
-                    }
-                }
-            },
-            (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE
-        ];
-
-        // input_schema is the schema for the input to the REST API.
-        google.protobuf.Struct input_schema = 9;
+      // body_from_field is the field in the input to use as the body.
+      // If the value is an string, it will be used as the body, as is.
+      // If the value is an object, it will be serialized as JSON.
+      // If the value is not found in the input, the request will fail.
+      string body_from_field = 10 [(buf.validate.field).string = {
+        // We're assuming fairly short field names here.
+        max_len: 50
+      }];
     }
 
-    // defs is the list of definitions for the REST API.
-    map<string, Def> def = 1;
+    // parse is the parse configuration for the response.
+    // This allows us to serialize the response into a structured format,
+    // or not.
+    // If left unset, the response will be treated as a string.
+    // If set to "json", the response will be parsed as JSON.
+    string parse = 6 [
+      (buf.validate.field).string = {
+        in: ["json"]
+      },
+      (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE
+    ];
 
-    // provider_auth enables provider authentication for this data source.
-    // When enabled, the data source will use the provider's authentication
-    // credentials to make requests.
-    bool provider_auth = 2;
+    message Fallback {
+      int32 http_status = 1 [
+        (buf.validate.field).int32 = {
+          gte: 100
+          lte: 599
+        },
+        (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE
+      ];
+
+      string body = 2 [
+        (buf.validate.field).string = {max_len: 1000},
+        (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE
+      ];
+    }
+
+    // fallback is the fallback configuration for the response in case
+    // of an unexpected status code.
+    repeated Fallback fallback = 7;
+
+    // expected_status is the expected status code for the response.
+    // This may be repeated to allow for multiple expected status codes.
+    // If left unset, it will default to 200.
+    repeated int32 expected_status = 8 [
+      (buf.validate.field).repeated = {
+        items: {
+          int32: {
+            gte: 100
+            lte: 599
+          }
+        }
+      },
+      (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE
+    ];
+
+    // input_schema is the schema for the input to the REST API.
+    google.protobuf.Struct input_schema = 9;
+  }
+
+  // defs is the list of definitions for the REST API.
+  map<string, Def> def = 1;
+
+  // provider_auth enables provider authentication for this data source.
+  // When enabled, the data source will use the provider's authentication
+  // credentials to make requests.
+  bool provider_auth = 2;
 }
 
 // DataSourceReference is a reference to a data source.
 // Note that for a resource to refer to a data source the data source must
 // be available in the same project hierarchy.
 message DataSourceReference {
-    // name is the name of the data source within the project hierarchy.
-    string name = 1 [
-        (buf.validate.field).string = {
-            pattern: "^[a-z][-_/[:word:]]*$",
-            max_len: 200,
-        }
-    ];
-    // alias is the alias used to refer to the data source in the rule
-    // definition.
-    // If left unset, it will default to the name of the data source.
-    string alias = 2 [
-        (buf.validate.field).string = {
-            pattern: "^[a-z][-_[:word:]]*$",
-            max_len: 200,
-        },
-        (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE
-    ];
+  // name is the name of the data source within the project hierarchy.
+  string name = 1 [(buf.validate.field).string = {
+    pattern: "^[a-z][-_/[:word:]]*$"
+    max_len: 200
+  }];
+  // alias is the alias used to refer to the data source in the rule
+  // definition.
+  // If left unset, it will default to the name of the data source.
+  string alias = 2 [
+    (buf.validate.field).string = {
+      pattern: "^[a-z][-_[:word:]]*$"
+      max_len: 200
+    },
+    (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE
+  ];
 }

--- a/proto/minder/v1/minder.proto
+++ b/proto/minder/v1/minder.proto
@@ -1,95 +1,95 @@
 // SPDX-FileCopyrightText: Copyright 2023 The Minder Authors
 // SPDX-License-Identifier: Apache-2.0
 
+
 syntax = "proto3";
 package minder.v1;
-
-import "buf/validate/validate.proto";
 import "google/api/annotations.proto";
 import "google/api/field_behavior.proto";
 import "google/protobuf/descriptor.proto";
-import "google/protobuf/field_mask.proto";
-import "google/protobuf/struct.proto";
 import "google/protobuf/timestamp.proto";
+import "google/protobuf/struct.proto";
+import "google/protobuf/field_mask.proto";
+import "buf/validate/validate.proto";
 
 option go_package = "github.com/mindersec/minder/pkg/api/protobuf/go/minder/v1";
 
 enum ObjectOwner {
-  OBJECT_OWNER_UNSPECIFIED = 0;
-  OBJECT_OWNER_PROJECT = 2;
-  OBJECT_OWNER_USER = 3;
-  reserved 1; // deprecated OBJECT_OWNER_ORGANIZATION
+    OBJECT_OWNER_UNSPECIFIED = 0;
+    OBJECT_OWNER_PROJECT = 2;
+    OBJECT_OWNER_USER = 3;
+    reserved 1; // deprecated OBJECT_OWNER_ORGANIZATION
 }
 
 enum Relation {
-  RELATION_UNSPECIFIED = 0;
-  RELATION_CREATE = 1 [(name) = "create"];
-  RELATION_GET = 2 [(name) = "get"];
-  RELATION_UPDATE = 3 [(name) = "update"];
-  RELATION_DELETE = 4 [(name) = "delete"];
-  RELATION_ROLE_LIST = 5 [(name) = "role_list"];
-  RELATION_ROLE_ASSIGNMENT_LIST = 6 [(name) = "role_assignment_list"];
-  RELATION_ROLE_ASSIGNMENT_CREATE = 7 [(name) = "role_assignment_create"];
-  RELATION_ROLE_ASSIGNMENT_REMOVE = 8 [(name) = "role_assignment_remove"];
-  RELATION_REPO_GET = 9 [(name) = "repo_get"];
-  RELATION_REPO_CREATE = 10 [(name) = "repo_create"];
-  RELATION_REPO_UPDATE = 11 [(name) = "repo_update"];
-  RELATION_REPO_DELETE = 12 [(name) = "repo_delete"];
-  RELATION_ARTIFACT_GET = 13 [(name) = "artifact_get"];
-  RELATION_ARTIFACT_CREATE = 14 [(name) = "artifact_create"];
-  RELATION_ARTIFACT_UPDATE = 15 [(name) = "artifact_update"];
-  RELATION_ARTIFACT_DELETE = 16 [(name) = "artifact_delete"];
-  RELATION_PR_GET = 17 [(name) = "pr_get"];
-  RELATION_PR_CREATE = 18 [(name) = "pr_create"];
-  RELATION_PR_UPDATE = 19 [(name) = "pr_update"];
-  RELATION_PR_DELETE = 20 [(name) = "pr_delete"];
-  RELATION_PROVIDER_GET = 21 [(name) = "provider_get"];
-  RELATION_PROVIDER_CREATE = 22 [(name) = "provider_create"];
-  RELATION_PROVIDER_UPDATE = 23 [(name) = "provider_update"];
-  RELATION_PROVIDER_DELETE = 24 [(name) = "provider_delete"];
-  RELATION_RULE_TYPE_GET = 25 [(name) = "rule_type_get"];
-  RELATION_RULE_TYPE_CREATE = 26 [(name) = "rule_type_create"];
-  RELATION_RULE_TYPE_UPDATE = 27 [(name) = "rule_type_update"];
-  RELATION_RULE_TYPE_DELETE = 28 [(name) = "rule_type_delete"];
-  RELATION_PROFILE_GET = 29 [(name) = "profile_get"];
-  RELATION_PROFILE_CREATE = 30 [(name) = "profile_create"];
-  RELATION_PROFILE_UPDATE = 31 [(name) = "profile_update"];
-  RELATION_PROFILE_DELETE = 32 [(name) = "profile_delete"];
-  RELATION_PROFILE_STATUS_GET = 33 [(name) = "profile_status_get"];
-  RELATION_REMOTE_REPO_GET = 34 [(name) = "remote_repo_get"];
-  RELATION_ENTITY_RECONCILIATION_TASK_CREATE = 35 [(name) = "entity_reconciliation_task_create"];
-  RELATION_ENTITY_RECONCILE = 36 [(name) = "entity_reconcile"];
-  RELATION_ROLE_ASSIGNMENT_UPDATE = 37 [(name) = "role_assignment_update"];
-  RELATION_DATA_SOURCE_GET = 38 [(name) = "data_source_get"];
-  RELATION_DATA_SOURCE_CREATE = 39 [(name) = "data_source_create"];
-  RELATION_DATA_SOURCE_UPDATE = 40 [(name) = "data_source_update"];
-  RELATION_DATA_SOURCE_DELETE = 41 [(name) = "data_source_delete"];
-  RELATION_ENTITY_GET = 42 [(name) = "entity_get"];
-  RELATION_ENTITY_REGISTER = 43 [(name) = "entity_register"];
-  RELATION_ENTITY_UPDATE = 44 [(name) = "entity_update"];
-  RELATION_ENTITY_DELETE = 45 [(name) = "entity_delete"];
+    RELATION_UNSPECIFIED = 0;
+    RELATION_CREATE = 1 [(name) = "create"];
+    RELATION_GET = 2 [(name) = "get"];
+    RELATION_UPDATE = 3 [(name) = "update"];
+    RELATION_DELETE = 4 [(name) = "delete"];
+    RELATION_ROLE_LIST = 5 [(name) = "role_list"];
+    RELATION_ROLE_ASSIGNMENT_LIST = 6 [(name) = "role_assignment_list"];
+    RELATION_ROLE_ASSIGNMENT_CREATE = 7 [(name) = "role_assignment_create"];
+    RELATION_ROLE_ASSIGNMENT_REMOVE = 8 [(name) = "role_assignment_remove"];
+    RELATION_REPO_GET = 9 [(name) = "repo_get"];
+    RELATION_REPO_CREATE = 10 [(name) = "repo_create"];
+    RELATION_REPO_UPDATE = 11 [(name) = "repo_update"];
+    RELATION_REPO_DELETE = 12 [(name) = "repo_delete"];
+    RELATION_ARTIFACT_GET = 13 [(name) = "artifact_get"];
+    RELATION_ARTIFACT_CREATE = 14 [(name) = "artifact_create"];
+    RELATION_ARTIFACT_UPDATE = 15 [(name) = "artifact_update"];
+    RELATION_ARTIFACT_DELETE = 16 [(name) = "artifact_delete"];
+    RELATION_PR_GET = 17 [(name) = "pr_get"];
+    RELATION_PR_CREATE = 18 [(name) = "pr_create"];
+    RELATION_PR_UPDATE = 19 [(name) = "pr_update"];
+    RELATION_PR_DELETE = 20 [(name) = "pr_delete"];
+    RELATION_PROVIDER_GET = 21 [(name) = "provider_get"];
+    RELATION_PROVIDER_CREATE = 22 [(name) = "provider_create"];
+    RELATION_PROVIDER_UPDATE = 23 [(name) = "provider_update"];
+    RELATION_PROVIDER_DELETE = 24 [(name) = "provider_delete"];
+    RELATION_RULE_TYPE_GET = 25 [(name) = "rule_type_get"];
+    RELATION_RULE_TYPE_CREATE = 26 [(name) = "rule_type_create"];
+    RELATION_RULE_TYPE_UPDATE = 27 [(name) = "rule_type_update"];
+    RELATION_RULE_TYPE_DELETE = 28 [(name) = "rule_type_delete"];
+    RELATION_PROFILE_GET = 29 [(name) = "profile_get"];
+    RELATION_PROFILE_CREATE = 30 [(name) = "profile_create"];
+    RELATION_PROFILE_UPDATE = 31 [(name) = "profile_update"];
+    RELATION_PROFILE_DELETE = 32 [(name) = "profile_delete"];
+    RELATION_PROFILE_STATUS_GET = 33 [(name) = "profile_status_get"];
+    RELATION_REMOTE_REPO_GET = 34 [(name) = "remote_repo_get"];
+    RELATION_ENTITY_RECONCILIATION_TASK_CREATE = 35 [(name) = "entity_reconciliation_task_create"];
+    RELATION_ENTITY_RECONCILE = 36 [(name) = "entity_reconcile"];
+    RELATION_ROLE_ASSIGNMENT_UPDATE = 37 [(name) = "role_assignment_update"];
+    RELATION_DATA_SOURCE_GET = 38 [(name) = "data_source_get"];
+    RELATION_DATA_SOURCE_CREATE = 39 [(name) = "data_source_create"];
+    RELATION_DATA_SOURCE_UPDATE = 40 [(name) = "data_source_update"];
+    RELATION_DATA_SOURCE_DELETE = 41 [(name) = "data_source_delete"];
+    RELATION_ENTITY_GET = 42 [(name) = "entity_get"];
+    RELATION_ENTITY_REGISTER = 43 [(name) = "entity_register"];
+    RELATION_ENTITY_UPDATE = 44 [(name) = "entity_update"];
+    RELATION_ENTITY_DELETE = 45 [(name) = "entity_delete"];
 }
 
 extend google.protobuf.EnumValueOptions {
-  optional string name = 42445;
+    optional string name = 42445;
 }
 
 enum TargetResource {
-  TARGET_RESOURCE_UNSPECIFIED = 0;
-  TARGET_RESOURCE_NONE = 1;
-  TARGET_RESOURCE_USER = 2;
-  TARGET_RESOURCE_PROJECT = 3;
+    TARGET_RESOURCE_UNSPECIFIED = 0;
+    TARGET_RESOURCE_NONE = 1;
+    TARGET_RESOURCE_USER = 2;
+    TARGET_RESOURCE_PROJECT = 3;
 }
 
 message RpcOptions {
-  bool no_log = 2;
-  TargetResource target_resource = 6;
-  Relation relation = 7;
-  reserved 1, 3, 4, 5; // deprecated anonymous, owner_only, root_admin_only and auth_scope
+    bool no_log = 2;
+    TargetResource target_resource = 6;
+    Relation relation = 7;
+    reserved 1, 3, 4, 5; // deprecated anonymous, owner_only, root_admin_only and auth_scope
 }
 
 extend google.protobuf.MethodOptions {
-  RpcOptions rpc_options = 51077;
+    RpcOptions rpc_options = 51077;
 }
 
 // Cursor message to be used in request messages. Its purpose is to
@@ -97,190 +97,216 @@ extend google.protobuf.MethodOptions {
 // of index within a collection, along with the number of items to
 // retrieve.
 message Cursor {
-  // cursor is the index to start from within the collection being
-  // retrieved. It's an opaque payload specified and interpreted on
-  // an per-rpc basis. An empty string is used to indicate the first
-  // item in the collection.
-  string cursor = 1 [(buf.validate.field).string = {
-    pattern: "^[[:word:]=]*$"
-    max_len: 200
-  }];
-  // size is the number of items to retrieve from the collection.
-  // 0 uses a server-defined default.
-  uint32 size = 2 [
-    (buf.validate.field).uint32 = {
-      gte: 0
-      lte: 100
-    },
-    (google.api.field_behavior) = REQUIRED
-  ];
+    // cursor is the index to start from within the collection being
+    // retrieved. It's an opaque payload specified and interpreted on
+    // an per-rpc basis. An empty string is used to indicate the first
+    // item in the collection.
+    string cursor = 1 [
+        (buf.validate.field).string = {
+            pattern: "^[[:word:]=]*$",
+            max_len: 200,
+        }
+    ];
+    // size is the number of items to retrieve from the collection.
+    // 0 uses a server-defined default.
+    uint32 size = 2 [
+        (buf.validate.field).uint32 = { gte: 0, lte: 100 },
+        (google.api.field_behavior) = REQUIRED
+    ];
 }
 
 // CursorPage message used in response messages. Its purpose is to
 // send to clients links pointing to next and/or previous collection
 // subsets with respect to the one containing this struct.
 message CursorPage {
-  // Total number of records matching the request. This is optional.
-  uint32 total_records = 1;
-  // Cursor pointing to retrieve results logically placed after the
-  // ones shipped with the message containing this struct. This is optional.
-  Cursor next = 2;
-  // Cursor pointing to retrieve results logically placed before the
-  // ones shipped with the message containing this struct. This is optional.
-  Cursor prev = 3;
+    // Total number of records matching the request. This is optional.
+    uint32 total_records = 1;
+    // Cursor pointing to retrieve results logically placed after the
+    // ones shipped with the message containing this struct. This is optional.
+    Cursor next = 2;
+    // Cursor pointing to retrieve results logically placed before the
+    // ones shipped with the message containing this struct. This is optional.
+    Cursor prev = 3;
 }
 
 // Simple Health Check Service
 // replies with OK
 service HealthService {
-  rpc CheckHealth(CheckHealthRequest) returns (CheckHealthResponse) {
-    option (google.api.http) = {get: "/api/v1/health"};
+    rpc CheckHealth (CheckHealthRequest) returns (CheckHealthResponse) {
+        option (google.api.http) = {
+            get: "/api/v1/health"
+        };
+
+        option (rpc_options) = {
+            target_resource: TARGET_RESOURCE_NONE
+            no_log: true
+        };
+    }
+
+    rpc GetVersion(GetVersionRequest) returns (GetVersionResponse) {
+    option (google.api.http) = {
+        get: "/api/v1/version"
+    };
 
     option (rpc_options) = {
-      target_resource: TARGET_RESOURCE_NONE
-      no_log: true
+        target_resource: TARGET_RESOURCE_NONE
+        no_log: true
     };
-  }
-
-  rpc GetVersion(GetVersionRequest) returns (GetVersionResponse) {
-    option (google.api.http) = {get: "/api/v1/version"};
-
-    option (rpc_options) = {
-      target_resource: TARGET_RESOURCE_NONE
-      no_log: true
-    };
-  }
+}
 }
 
 service ArtifactService {
-  rpc ListArtifacts(ListArtifactsRequest) returns (ListArtifactsResponse) {
-    option (google.api.http) = {
-      get: "/api/v1/artifacts/{provider}"
-      additional_bindings: {get: "/api/v1/artifacts"}
-    };
+    rpc ListArtifacts (ListArtifactsRequest) returns (ListArtifactsResponse) {
+        option (google.api.http) = {
+            get: "/api/v1/artifacts/{provider}"
+            additional_bindings {
+                get: "/api/v1/artifacts"
+            }
+        };
 
-    option (rpc_options) = {
-      target_resource: TARGET_RESOURCE_PROJECT
-      relation: RELATION_ARTIFACT_GET
-    };
-  }
+        option (rpc_options) = {
+            target_resource: TARGET_RESOURCE_PROJECT
+            relation: RELATION_ARTIFACT_GET
+        };
+    }
 
-  rpc GetArtifactById(GetArtifactByIdRequest) returns (GetArtifactByIdResponse) {
-    option (google.api.http) = {get: "/api/v1/artifact/{id}"};
+    rpc GetArtifactById (GetArtifactByIdRequest) returns (GetArtifactByIdResponse) {
+        option (google.api.http) = {
+            get: "/api/v1/artifact/{id}"
+        };
 
-    option (rpc_options) = {
-      target_resource: TARGET_RESOURCE_PROJECT
-      relation: RELATION_ARTIFACT_GET
-    };
-  }
+        option (rpc_options) = {
+            target_resource: TARGET_RESOURCE_PROJECT
+            relation: RELATION_ARTIFACT_GET
+        };
+    }
 
-  rpc GetArtifactByName(GetArtifactByNameRequest) returns (GetArtifactByNameResponse) {
-    option (google.api.http) = {get: "/api/v1/artifact/name/{name=**}"};
+    rpc GetArtifactByName (GetArtifactByNameRequest) returns (GetArtifactByNameResponse) {
+        option (google.api.http) = {
+            get: "/api/v1/artifact/name/{name=**}"
+        };
 
-    option (rpc_options) = {
-      target_resource: TARGET_RESOURCE_PROJECT
-      relation: RELATION_ARTIFACT_GET
-    };
-  }
+        option (rpc_options) = {
+            target_resource: TARGET_RESOURCE_PROJECT
+            relation: RELATION_ARTIFACT_GET
+        };
+    }
+
 }
 
 message GetVersionRequest {}
 
 // GetVersionResponse returns the build and version info of the Minder server
 message GetVersionResponse {
-  string version = 1;
-  string commit = 2;
+    string version = 1;
+    string commit = 2;
 }
 
 message ListArtifactsRequest {
-  string provider = 1 [deprecated = true];
-  Context context = 3;
-  // from is the filter to apply to the list of artifacts.
-  // An example is "repository=org1/repo1,org2/repo2"
-  // to filter by repository names. This is optional.
-  string from = 4 [
-    (buf.validate.field).string = {
-      pattern: "^[[:word:]]+=[-,/[:word:]]+$"
-      max_len: 200
-    },
-    (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE
-  ];
+    string provider = 1 [deprecated=true];
+    Context context = 3;
+    // from is the filter to apply to the list of artifacts.
+    // An example is "repository=org1/repo1,org2/repo2"
+    // to filter by repository names. This is optional.
+    string from = 4 [
+        (buf.validate.field).string = {
+            pattern: "^[[:word:]]+=[-,/[:word:]]+$",
+            max_len: 200,
+        },
+        (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE
+    ];
 
-  reserved 2; // deprecated project_id
+    reserved 2; // deprecated project_id
 }
 
 message ListArtifactsResponse {
-  repeated Artifact results = 1 [(google.api.field_behavior) = REQUIRED];
+    repeated Artifact results = 1 [
+        (google.api.field_behavior) = REQUIRED
+    ];
 }
 
 message Artifact {
-  string artifact_pk = 1 [(google.api.field_behavior) = REQUIRED];
-  // owner is the artifact owner. This is optional.
-  string owner = 2;
-  string name = 3 [(google.api.field_behavior) = REQUIRED];
-  string type = 4 [(google.api.field_behavior) = REQUIRED];
-  string visibility = 5 [(google.api.field_behavior) = REQUIRED];
-  // repository is the repository the artifact originated from.
-  // This is optional.
-  string repository = 6;
-  repeated ArtifactVersion versions = 7;
-  google.protobuf.Timestamp created_at = 8 [(google.api.field_behavior) = REQUIRED];
-  Context context = 9;
+    string artifact_pk = 1 [
+        (google.api.field_behavior) = REQUIRED
+    ];
+    // owner is the artifact owner. This is optional.
+    string owner = 2;
+    string name = 3 [
+        (google.api.field_behavior) = REQUIRED
+    ];
+    string type = 4 [
+        (google.api.field_behavior) = REQUIRED
+    ];
+    string visibility = 5 [
+        (google.api.field_behavior) = REQUIRED
+    ];
+    // repository is the repository the artifact originated from.
+    // This is optional.
+    string repository = 6;
+    repeated ArtifactVersion versions = 7;
+    google.protobuf.Timestamp created_at = 8  [
+        (google.api.field_behavior) = REQUIRED
+    ];
+    Context context = 9;
 }
 
 // ArtifactVersion is a version of an artifact.
 // This is currently not populated in any requests or responses.
 message ArtifactVersion {
-  int64 version_id = 1 [
-    (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE,
-    (buf.validate.field).int64 = {gte: 1}
-  ];
-  repeated string tags = 2;
-  string sha = 3;
-  google.protobuf.Timestamp created_at = 6;
+    int64 version_id = 1 [
+        (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE,
+        (buf.validate.field).int64 = { gte: 1 }
+    ];
+    repeated string tags = 2;
+    string sha = 3;
+    google.protobuf.Timestamp created_at = 6;
 
-  reserved 4, 5;
-  reserved "github_workflow", "signature_verification";
+    reserved 4, 5;
+    reserved "github_workflow", "signature_verification";
 }
 
 message GetArtifactByIdRequest {
-  string id = 1 [
-    (buf.validate.field).string = {uuid: true},
-    (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE,
-    (google.api.field_behavior) = REQUIRED
-  ];
+    string id = 1 [
+        (buf.validate.field).string = {uuid: true},
+        (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE,
+        (google.api.field_behavior) = REQUIRED
+    ];
 
-  Context context = 7;
+    Context context = 7;
 
-  reserved 5, 6; // deprecated latest_versions, tag
-  reserved "latest_versions", "tag";
+    reserved 5, 6; // deprecated latest_versions, tag
+    reserved "latest_versions", "tag";
 }
 
 message GetArtifactByIdResponse {
-  Artifact artifact = 1 [(google.api.field_behavior) = REQUIRED];
-  // This is optional and currently always nil.
-  repeated ArtifactVersion versions = 2;
+    Artifact artifact = 1 [
+        (google.api.field_behavior) = REQUIRED
+    ];
+    // This is optional and currently always nil.
+    repeated ArtifactVersion versions = 2;
 }
 
 message GetArtifactByNameRequest {
-  string name = 1 [
-    (buf.validate.field).string = {
-      pattern: "^[-./[:word:]]*$"
-      max_len: 200
-    },
-    (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE,
-    (google.api.field_behavior) = REQUIRED
-  ];
-  Context context = 4;
+    string name = 1 [
+        (buf.validate.field).string = {
+            pattern: "^[-./[:word:]]*$",
+            max_len: 200,
+        },
+        (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE,
+        (google.api.field_behavior) = REQUIRED
+    ];
+    Context context = 4;
 
-  reserved 2, 3; // deprecated latest_versions, tag
-  reserved "latest_versions", "tag";
+    reserved 2, 3; // deprecated latest_versions, tag
+    reserved "latest_versions", "tag";
 }
 
 message GetArtifactByNameResponse {
-  Artifact artifact = 1 [(google.api.field_behavior) = REQUIRED];
-  // This is optional and currently always nil.
-  repeated ArtifactVersion versions = 2;
+    Artifact artifact = 1 [
+        (google.api.field_behavior) = REQUIRED
+    ];
+    // This is optional and currently always nil.
+    repeated ArtifactVersion versions = 2;
 }
 
 // Stubs for the SDLC entities
@@ -290,1527 +316,1768 @@ message TaskRun {}
 message Build {}
 
 service OAuthService {
-  rpc GetAuthorizationURL(GetAuthorizationURLRequest) returns (GetAuthorizationURLResponse) {
-    option (google.api.http) = {get: "/api/v1/auth/url"};
+    rpc GetAuthorizationURL (GetAuthorizationURLRequest) returns (GetAuthorizationURLResponse) {
+        option (google.api.http) = {
+            get: "/api/v1/auth/url"
+        };
 
-    option (rpc_options) = {
-      target_resource: TARGET_RESOURCE_PROJECT
-      relation: RELATION_PROVIDER_UPDATE
-    };
-  }
+        option (rpc_options) = {
+            target_resource: TARGET_RESOURCE_PROJECT
+            relation: RELATION_PROVIDER_UPDATE
+        };
+    }
 
-  rpc StoreProviderToken(StoreProviderTokenRequest) returns (StoreProviderTokenResponse) {
-    option (google.api.http) = {
-      post: "/api/v1/auth/{provider}/token"
-      additional_bindings: {
-        post: "/api/v1/auth/token"
-        body: "*"
-      }
-      body: "*"
-    };
+    rpc StoreProviderToken (StoreProviderTokenRequest) returns (StoreProviderTokenResponse) {
+        option (google.api.http) = {
+            post: "/api/v1/auth/{provider}/token"
+            additional_bindings {
+                post: "/api/v1/auth/token"
+                body: "*"
+            }
+            body: "*"
+        };
 
-    option (rpc_options) = {
-      target_resource: TARGET_RESOURCE_PROJECT
-      relation: RELATION_PROVIDER_UPDATE
-    };
-  }
+        option (rpc_options) = {
+            target_resource: TARGET_RESOURCE_PROJECT
+            relation: RELATION_PROVIDER_UPDATE
+        };
+    }
 
-  // VerifyProviderTokenFrom verifies that a token has been created for a provider since given timestamp
-  rpc VerifyProviderTokenFrom(VerifyProviderTokenFromRequest) returns (VerifyProviderTokenFromResponse) {
-    option deprecated = true;
-    option (google.api.http) = {
-      get: "/api/v1/auth/verify/{provider}/{timestamp}"
-      additional_bindings: {get: "/api/v1/auth/verify/{timestamp}"}
-    };
+    // VerifyProviderTokenFrom verifies that a token has been created for a provider since given timestamp
+    rpc VerifyProviderTokenFrom (VerifyProviderTokenFromRequest) returns (VerifyProviderTokenFromResponse) {
+        option deprecated = true;
+        option (google.api.http) = {
+            get: "/api/v1/auth/verify/{provider}/{timestamp}"
+            additional_bindings {
+                get: "/api/v1/auth/verify/{timestamp}"
+            }
+        };
 
-    option (rpc_options) = {
-      target_resource: TARGET_RESOURCE_PROJECT
-      relation: RELATION_PROVIDER_UPDATE
-    };
-  }
+        option (rpc_options) = {
+            target_resource: TARGET_RESOURCE_PROJECT
+            relation: RELATION_PROVIDER_UPDATE
+        };
+    }
 
-  // VerifyProviderCredential verifies that a credential has been created matching the enrollment nonce
-  rpc VerifyProviderCredential(VerifyProviderCredentialRequest) returns (VerifyProviderCredentialResponse) {
-    option (google.api.http) = {get: "/api/v1/auth/verify"};
+    // VerifyProviderCredential verifies that a credential has been created matching the enrollment nonce
+    rpc VerifyProviderCredential (VerifyProviderCredentialRequest) returns (VerifyProviderCredentialResponse) {
+        option (google.api.http) = {
+            get: "/api/v1/auth/verify"
+        };
 
-    option (rpc_options) = {
-      target_resource: TARGET_RESOURCE_PROJECT
-      relation: RELATION_PROVIDER_UPDATE
-    };
-  }
+        option (rpc_options) = {
+            target_resource: TARGET_RESOURCE_PROJECT
+            relation: RELATION_PROVIDER_UPDATE
+        };
+    }
+
 }
 
 service RepositoryService {
-  rpc RegisterRepository(RegisterRepositoryRequest) returns (RegisterRepositoryResponse) {
-    option (google.api.http) = {
-      post: "/api/v1/repository/provider/{provider}/register"
-      additional_bindings: {
-        post: "/api/v1/repository/register"
-        body: "*"
-      }
-      body: "*"
-    };
+    rpc RegisterRepository (RegisterRepositoryRequest) returns (RegisterRepositoryResponse) {
+        option (google.api.http) = {
+            post: "/api/v1/repository/provider/{provider}/register"
+            additional_bindings {
+                post: "/api/v1/repository/register",
+                body: "*"
+            }
+            body: "*"
+        };
 
-    option (rpc_options) = {
-      target_resource: TARGET_RESOURCE_PROJECT
-      relation: RELATION_REPO_CREATE
-    };
-  }
-  rpc ListRemoteRepositoriesFromProvider(ListRemoteRepositoriesFromProviderRequest) returns (ListRemoteRepositoriesFromProviderResponse) {
-    option (google.api.http) = {
-      get: "/api/v1/repositories/provider/{provider}/remote"
-      additional_bindings: {get: "/api/v1/repositories/remote"}
-    };
+        option (rpc_options) = {
+            target_resource: TARGET_RESOURCE_PROJECT
+            relation: RELATION_REPO_CREATE
+        };
+    }
+    rpc ListRemoteRepositoriesFromProvider(ListRemoteRepositoriesFromProviderRequest) returns (ListRemoteRepositoriesFromProviderResponse) {
+        option (google.api.http) = {
+            get: "/api/v1/repositories/provider/{provider}/remote"
+            additional_bindings {
+                get: "/api/v1/repositories/remote"
+            }
+        };
 
-    option (rpc_options) = {
-      target_resource: TARGET_RESOURCE_PROJECT
-      relation: RELATION_REMOTE_REPO_GET
-    };
-  }
-  rpc ListRepositories(ListRepositoriesRequest) returns (ListRepositoriesResponse) {
-    option (google.api.http) = {
-      get: "/api/v1/repositories/provider/{provider}"
-      additional_bindings: {get: "/api/v1/repositories"}
-    };
+        option (rpc_options) = {
+            target_resource: TARGET_RESOURCE_PROJECT
+            relation: RELATION_REMOTE_REPO_GET
+        };
+    }
+    rpc ListRepositories (ListRepositoriesRequest) returns (ListRepositoriesResponse) {
+        option (google.api.http) = {
+            get: "/api/v1/repositories/provider/{provider}"
+            additional_bindings {
+                get: "/api/v1/repositories"
+            }
+        };
 
-    option (rpc_options) = {
-      target_resource: TARGET_RESOURCE_PROJECT
-      relation: RELATION_REPO_GET
-    };
-  }
-  rpc GetRepositoryById(GetRepositoryByIdRequest) returns (GetRepositoryByIdResponse) {
-    option (google.api.http) = {get: "/api/v1/repository/id/{repository_id}"};
+        option (rpc_options) = {
+            target_resource: TARGET_RESOURCE_PROJECT
+            relation: RELATION_REPO_GET
+        };
+    }
+    rpc GetRepositoryById (GetRepositoryByIdRequest) returns (GetRepositoryByIdResponse) {
+        option (google.api.http) = {
+            get: "/api/v1/repository/id/{repository_id}"
+        };
 
-    option (rpc_options) = {
-      target_resource: TARGET_RESOURCE_PROJECT
-      relation: RELATION_REPO_GET
-    };
-  }
+        option (rpc_options) = {
+            target_resource: TARGET_RESOURCE_PROJECT
+            relation: RELATION_REPO_GET
+        };
+    }
 
-  rpc GetRepositoryByName(GetRepositoryByNameRequest) returns (GetRepositoryByNameResponse) {
-    option (google.api.http) = {
-      get: "/api/v1/repository/provider/{provider}/name/{name=**}"
-      additional_bindings: {get: "/api/v1/repository/name/{name=**}"}
-    };
+    rpc GetRepositoryByName (GetRepositoryByNameRequest) returns (GetRepositoryByNameResponse) {
+        option (google.api.http) = {
+            get: "/api/v1/repository/provider/{provider}/name/{name=**}"
+            additional_bindings {
+                get: "/api/v1/repository/name/{name=**}"
+            }
+        };
 
-    option (rpc_options) = {
-      target_resource: TARGET_RESOURCE_PROJECT
-      relation: RELATION_REPO_GET
-    };
-  }
+        option (rpc_options) = {
+            target_resource: TARGET_RESOURCE_PROJECT
+            relation: RELATION_REPO_GET
+        };
+    }
 
-  rpc DeleteRepositoryById(DeleteRepositoryByIdRequest) returns (DeleteRepositoryByIdResponse) {
-    option (google.api.http) = {delete: "/api/v1/repository/id/{repository_id}"};
+    rpc DeleteRepositoryById (DeleteRepositoryByIdRequest) returns (DeleteRepositoryByIdResponse) {
+        option (google.api.http) = {
+            delete: "/api/v1/repository/id/{repository_id}"
+        };
 
-    option (minder.v1.rpc_options) = {
-      target_resource: TARGET_RESOURCE_PROJECT
-      relation: RELATION_REPO_DELETE
-    };
-  }
+        option (minder.v1.rpc_options) = {
+            target_resource: TARGET_RESOURCE_PROJECT
+            relation: RELATION_REPO_DELETE
+        };
+    }
 
-  rpc DeleteRepositoryByName(DeleteRepositoryByNameRequest) returns (DeleteRepositoryByNameResponse) {
-    option (google.api.http) = {
-      delete: "/api/v1/repository/provider/{provider}/name/{name=**}"
-      additional_bindings: {delete: "/api/v1/repository/name/{name=**}"}
-    };
+    rpc DeleteRepositoryByName (DeleteRepositoryByNameRequest) returns (DeleteRepositoryByNameResponse) {
+        option (google.api.http) = {
+            delete: "/api/v1/repository/provider/{provider}/name/{name=**}"
+            additional_bindings {
+                delete: "/api/v1/repository/name/{name=**}"
+            }
+        };
 
-    option (minder.v1.rpc_options) = {
-      target_resource: TARGET_RESOURCE_PROJECT
-      relation: RELATION_REPO_DELETE
-    };
-  }
+        option (minder.v1.rpc_options) = {
+            target_resource: TARGET_RESOURCE_PROJECT
+            relation: RELATION_REPO_DELETE
+        };
+    }
 }
 
 // manage Users CRUD
 service UserService {
-  rpc CreateUser(CreateUserRequest) returns (CreateUserResponse) {
-    option (google.api.http) = {
-      post: "/api/v1/user"
-      body: "*"
-    };
+    rpc CreateUser (CreateUserRequest) returns (CreateUserResponse) {
+        option (google.api.http) = {
+            post: "/api/v1/user"
+            body: "*"
+        };
 
-    option (rpc_options) = {target_resource: TARGET_RESOURCE_USER};
-  }
+        option (rpc_options) = {
+            target_resource: TARGET_RESOURCE_USER
+        };
+    }
 
-  rpc DeleteUser(DeleteUserRequest) returns (DeleteUserResponse) {
-    option (google.api.http) = {delete: "/api/v1/user"};
+    rpc DeleteUser (DeleteUserRequest) returns (DeleteUserResponse) {
+        option (google.api.http) = {
+            delete: "/api/v1/user"
+        };
 
-    option (rpc_options) = {target_resource: TARGET_RESOURCE_USER};
-  }
+        option (rpc_options) = {
+            target_resource: TARGET_RESOURCE_USER
+        };
+    }
 
-  rpc GetUser(GetUserRequest) returns (GetUserResponse) {
-    option (google.api.http) = {get: "/api/v1/user"};
+    rpc GetUser (GetUserRequest) returns (GetUserResponse) {
+        option (google.api.http) = {
+            get: "/api/v1/user"
+        };
 
-    option (rpc_options) = {target_resource: TARGET_RESOURCE_USER};
-  }
+        option (rpc_options) = {
+            target_resource: TARGET_RESOURCE_USER
+        };
+    }
 
-  // ListInvitations returns a list of invitations for the user
-  // based on the user's registered email address.  Note that a
-  // user who receives an invitation code may still accept the
-  // invitation even if the code was directed to a different
-  // email address.  This is because understanding the routing of
-  // email messages is beyond the scope of Minder.
-  //
-  // This API endpoint may be called without the logged-in user
-  // previously having called `CreateUser`.
-  rpc ListInvitations(ListInvitationsRequest) returns (ListInvitationsResponse) {
-    option (google.api.http) = {get: "/api/v1/user/invitations"};
+    // ListInvitations returns a list of invitations for the user
+    // based on the user's registered email address.  Note that a
+    // user who receives an invitation code may still accept the
+    // invitation even if the code was directed to a different
+    // email address.  This is because understanding the routing of
+    // email messages is beyond the scope of Minder.
+    //
+    // This API endpoint may be called without the logged-in user
+    // previously having called `CreateUser`.
+    rpc ListInvitations (ListInvitationsRequest) returns (ListInvitationsResponse) {
+        option (google.api.http) = {
+            get: "/api/v1/user/invitations"
+        };
 
-    option (rpc_options) = {target_resource: TARGET_RESOURCE_USER};
-  }
+        option (rpc_options) = {
+            target_resource: TARGET_RESOURCE_USER
+        };
+    }
 
-  // ResolveInvitation allows a user to accept or decline an
-  // invitation to a project given the code for the invitation.
-  // A user may call ResolveInvitation to accept or decline an
-  // invitation even if they have not called CreateUser.  If a
-  // user accepts an invitation via this call before calling
-  // CreateUser, a Minder user record will be created, but no
-  // additional projects will be created (unlike CreateUser,
-  // which will also create a default project).
-  rpc ResolveInvitation(ResolveInvitationRequest) returns (ResolveInvitationResponse) {
-    option (google.api.http) = {post: "/api/v1/user/invitation/{code}"};
+    // ResolveInvitation allows a user to accept or decline an
+    // invitation to a project given the code for the invitation.
+    // A user may call ResolveInvitation to accept or decline an
+    // invitation even if they have not called CreateUser.  If a
+    // user accepts an invitation via this call before calling
+    // CreateUser, a Minder user record will be created, but no
+    // additional projects will be created (unlike CreateUser,
+    // which will also create a default project).
+    rpc ResolveInvitation (ResolveInvitationRequest) returns (ResolveInvitationResponse) {
+        option (google.api.http) = {
+            post: "/api/v1/user/invitation/{code}"
+        };
 
-    option (rpc_options) = {target_resource: TARGET_RESOURCE_USER};
-  }
+        option (rpc_options) = {
+            target_resource: TARGET_RESOURCE_USER
+        };
+    }
 }
 
 service ProfileService {
-  rpc CreateProfile(CreateProfileRequest) returns (CreateProfileResponse) {
-    option (google.api.http) = {
-      post: "/api/v1/profile"
-      body: "*"
-    };
+    rpc CreateProfile (CreateProfileRequest) returns (CreateProfileResponse) {
+        option (google.api.http) = {
+            post: "/api/v1/profile"
+            body: "*"
+        };
 
-    option (rpc_options) = {
-      target_resource: TARGET_RESOURCE_PROJECT
-      relation: RELATION_PROFILE_CREATE
-    };
-  }
+        option (rpc_options) = {
+            target_resource: TARGET_RESOURCE_PROJECT
+            relation: RELATION_PROFILE_CREATE
+        };
+    }
 
-  rpc UpdateProfile(UpdateProfileRequest) returns (UpdateProfileResponse) {
-    option (google.api.http) = {
-      put: "/api/v1/profile"
-      body: "*"
-    };
+    rpc UpdateProfile (UpdateProfileRequest) returns (UpdateProfileResponse) {
+        option (google.api.http) = {
+            put: "/api/v1/profile"
+            body: "*"
+        };
 
-    option (rpc_options) = {
-      target_resource: TARGET_RESOURCE_PROJECT
-      relation: RELATION_PROFILE_UPDATE
-    };
-  }
+        option (rpc_options) = {
+            target_resource: TARGET_RESOURCE_PROJECT
+            relation: RELATION_PROFILE_UPDATE
+        };
+    }
 
-  rpc PatchProfile(PatchProfileRequest) returns (PatchProfileResponse) {
-    option (google.api.http) = {
-      patch: "/api/v1/profile/{id}"
-      body: "patch"
-    };
+    rpc PatchProfile (PatchProfileRequest) returns (PatchProfileResponse) {
+        option (google.api.http) = {
+            patch: "/api/v1/profile/{id}"
+            body: "patch"
+        };
 
-    option (rpc_options) = {
-      target_resource: TARGET_RESOURCE_PROJECT
-      relation: RELATION_PROFILE_UPDATE
-    };
-  }
+        option (rpc_options) = {
+            target_resource: TARGET_RESOURCE_PROJECT
+            relation: RELATION_PROFILE_UPDATE
+        };
+    }
 
-  rpc DeleteProfile(DeleteProfileRequest) returns (DeleteProfileResponse) {
-    option (google.api.http) = {delete: "/api/v1/profile/{id}"};
+    rpc DeleteProfile (DeleteProfileRequest) returns (DeleteProfileResponse) {
+        option (google.api.http) = {
+            delete: "/api/v1/profile/{id}"
+        };
 
-    option (rpc_options) = {
-      target_resource: TARGET_RESOURCE_PROJECT
-      relation: RELATION_PROFILE_DELETE
-    };
-  }
+        option (rpc_options) = {
+            target_resource: TARGET_RESOURCE_PROJECT
+            relation: RELATION_PROFILE_DELETE
+        };
+    }
 
-  rpc ListProfiles(ListProfilesRequest) returns (ListProfilesResponse) {
-    option (google.api.http) = {get: "/api/v1/profiles"};
+    rpc ListProfiles (ListProfilesRequest) returns (ListProfilesResponse) {
+        option (google.api.http) = {
+            get: "/api/v1/profiles"
+        };
 
-    option (rpc_options) = {
-      target_resource: TARGET_RESOURCE_PROJECT
-      relation: RELATION_PROFILE_GET
-    };
-  }
+        option (rpc_options) = {
+            target_resource: TARGET_RESOURCE_PROJECT
+            relation: RELATION_PROFILE_GET
+        };
+    }
 
-  rpc GetProfileById(GetProfileByIdRequest) returns (GetProfileByIdResponse) {
-    option (google.api.http) = {get: "/api/v1/profile/{id}"};
+    rpc GetProfileById (GetProfileByIdRequest) returns (GetProfileByIdResponse) {
+        option (google.api.http) = {
+            get: "/api/v1/profile/{id}"
+        };
 
-    option (rpc_options) = {
-      target_resource: TARGET_RESOURCE_PROJECT
-      relation: RELATION_PROFILE_GET
-    };
-  }
+        option (rpc_options) = {
+            target_resource: TARGET_RESOURCE_PROJECT
+            relation: RELATION_PROFILE_GET
+        };
+    }
 
-  rpc GetProfileByName(GetProfileByNameRequest) returns (GetProfileByNameResponse) {
-    option (google.api.http) = {get: "/api/v1/profile/name/{name=**}"};
+    rpc GetProfileByName (GetProfileByNameRequest) returns (GetProfileByNameResponse) {
+        option (google.api.http) = {
+            get: "/api/v1/profile/name/{name=**}"
+        };
 
-    option (rpc_options) = {
-      target_resource: TARGET_RESOURCE_PROJECT
-      relation: RELATION_PROFILE_GET
-    };
-  }
+        option (rpc_options) = {
+            target_resource: TARGET_RESOURCE_PROJECT
+            relation: RELATION_PROFILE_GET
+        };
+    }
 
-  rpc GetProfileStatusByName(GetProfileStatusByNameRequest) returns (GetProfileStatusByNameResponse) {
-    option (google.api.http) = {get: "/api/v1/profile/name/{name=**}/status"};
+    rpc GetProfileStatusByName (GetProfileStatusByNameRequest) returns (GetProfileStatusByNameResponse) {
+        option (google.api.http) = {
+            get: "/api/v1/profile/name/{name=**}/status"
+        };
 
-    option (rpc_options) = {
-      target_resource: TARGET_RESOURCE_PROJECT
-      relation: RELATION_PROFILE_STATUS_GET
-    };
-  }
+        option (rpc_options) = {
+            target_resource: TARGET_RESOURCE_PROJECT
+            relation: RELATION_PROFILE_STATUS_GET
+        };
+    }
 
-  rpc GetProfileStatusById(GetProfileStatusByIdRequest) returns (GetProfileStatusByIdResponse) {
-    option (google.api.http) = {get: "/api/v1/profile/{id}/status"};
+    rpc GetProfileStatusById (GetProfileStatusByIdRequest) returns (GetProfileStatusByIdResponse) {
+        option (google.api.http) = {
+            get: "/api/v1/profile/{id}/status"
+        };
 
-    option (rpc_options) = {
-      target_resource: TARGET_RESOURCE_PROJECT
-      relation: RELATION_PROFILE_STATUS_GET
-    };
-  }
+        option (rpc_options) = {
+            target_resource: TARGET_RESOURCE_PROJECT
+            relation: RELATION_PROFILE_STATUS_GET
+        };
+    }
 
-  rpc GetProfileStatusByProject(GetProfileStatusByProjectRequest) returns (GetProfileStatusByProjectResponse) {
-    option (google.api.http) = {get: "/api/v1/profile_status"};
+    rpc GetProfileStatusByProject (GetProfileStatusByProjectRequest) returns (GetProfileStatusByProjectResponse) {
+        option (google.api.http) = {
+            get: "/api/v1/profile_status"
+        };
 
-    option (rpc_options) = {
-      target_resource: TARGET_RESOURCE_PROJECT
-      relation: RELATION_PROFILE_STATUS_GET
-    };
-  }
+        option (rpc_options) = {
+            target_resource: TARGET_RESOURCE_PROJECT
+            relation: RELATION_PROFILE_STATUS_GET
+        };
+    }
 }
 
 service DataSourceService {
-  rpc CreateDataSource(CreateDataSourceRequest) returns (CreateDataSourceResponse) {
-    option (google.api.http) = {
-      post: "/api/v1/data_source"
-      body: "*"
-    };
+    rpc CreateDataSource (CreateDataSourceRequest) returns (CreateDataSourceResponse) {
+        option (google.api.http) = {
+            post: "/api/v1/data_source"
+            body: "*"
+        };
 
-    option (rpc_options) = {
-      target_resource: TARGET_RESOURCE_PROJECT
-      relation: RELATION_DATA_SOURCE_CREATE
-    };
-  }
+        option (rpc_options) = {
+            target_resource: TARGET_RESOURCE_PROJECT
+            relation: RELATION_DATA_SOURCE_CREATE
+        };
+    }
 
-  rpc GetDataSourceById(GetDataSourceByIdRequest) returns (GetDataSourceByIdResponse) {
-    option (google.api.http) = {get: "/api/v1/data_source/{id}"};
+    rpc GetDataSourceById (GetDataSourceByIdRequest) returns (GetDataSourceByIdResponse) {
+        option (google.api.http) = {
+            get: "/api/v1/data_source/{id}"
+        };
 
-    option (rpc_options) = {
-      target_resource: TARGET_RESOURCE_PROJECT
-      relation: RELATION_DATA_SOURCE_GET
-    };
-  }
+        option (rpc_options) = {
+            target_resource: TARGET_RESOURCE_PROJECT
+            relation: RELATION_DATA_SOURCE_GET
+        };
+    }
 
-  rpc GetDataSourceByName(GetDataSourceByNameRequest) returns (GetDataSourceByNameResponse) {
-    option (google.api.http) = {get: "/api/v1/data_source/name/{name=**}"};
+    rpc GetDataSourceByName(GetDataSourceByNameRequest) returns (GetDataSourceByNameResponse) {
+        option (google.api.http) = {
+            get: "/api/v1/data_source/name/{name=**}"
+        };
 
-    option (rpc_options) = {
-      target_resource: TARGET_RESOURCE_PROJECT
-      relation: RELATION_DATA_SOURCE_GET
-    };
-  }
+        option (rpc_options) = {
+            target_resource: TARGET_RESOURCE_PROJECT
+            relation: RELATION_DATA_SOURCE_GET
+        };
+    }
 
-  rpc ListDataSources(ListDataSourcesRequest) returns (ListDataSourcesResponse) {
-    option (google.api.http) = {get: "/api/v1/data_sources"};
+    rpc ListDataSources (ListDataSourcesRequest) returns (ListDataSourcesResponse) {
+        option (google.api.http) = {
+            get: "/api/v1/data_sources"
+        };
 
-    option (rpc_options) = {
-      target_resource: TARGET_RESOURCE_PROJECT
-      relation: RELATION_DATA_SOURCE_GET
-    };
-  }
+        option (rpc_options) = {
+            target_resource: TARGET_RESOURCE_PROJECT
+            relation: RELATION_DATA_SOURCE_GET
+        };
+    }
 
-  rpc UpdateDataSource(UpdateDataSourceRequest) returns (UpdateDataSourceResponse) {
-    option (google.api.http) = {
-      put: "/api/v1/data_source"
-      body: "*"
-    };
+    rpc UpdateDataSource (UpdateDataSourceRequest) returns (UpdateDataSourceResponse) {
+        option (google.api.http) = {
+            put: "/api/v1/data_source"
+            body: "*"
+        };
 
-    option (rpc_options) = {
-      target_resource: TARGET_RESOURCE_PROJECT
-      relation: RELATION_DATA_SOURCE_UPDATE
-    };
-  }
+        option (rpc_options) = {
+            target_resource: TARGET_RESOURCE_PROJECT
+            relation: RELATION_DATA_SOURCE_UPDATE
+        };
+    }
 
-  rpc DeleteDataSourceById(DeleteDataSourceByIdRequest) returns (DeleteDataSourceByIdResponse) {
-    option (google.api.http) = {delete: "/api/v1/data_source/{id}"};
+    rpc DeleteDataSourceById(DeleteDataSourceByIdRequest) returns (DeleteDataSourceByIdResponse) {
+        option (google.api.http) = {
+            delete: "/api/v1/data_source/{id}"
+        };
 
-    option (rpc_options) = {
-      target_resource: TARGET_RESOURCE_PROJECT
-      relation: RELATION_DATA_SOURCE_DELETE
-    };
-  }
+        option (rpc_options) = {
+            target_resource: TARGET_RESOURCE_PROJECT
+            relation: RELATION_DATA_SOURCE_DELETE
+        };
+    }
 
-  rpc DeleteDataSourceByName(DeleteDataSourceByNameRequest) returns (DeleteDataSourceByNameResponse) {
-    option (google.api.http) = {delete: "/api/v1/data_source/name/{name=**}"};
+    rpc DeleteDataSourceByName(DeleteDataSourceByNameRequest) returns (DeleteDataSourceByNameResponse) {
+        option (google.api.http) = {
+            delete: "/api/v1/data_source/name/{name=**}"
+        };
 
-    option (rpc_options) = {
-      target_resource: TARGET_RESOURCE_PROJECT
-      relation: RELATION_DATA_SOURCE_DELETE
-    };
-  }
+        option (rpc_options) = {
+            target_resource: TARGET_RESOURCE_PROJECT
+            relation: RELATION_DATA_SOURCE_DELETE
+        };
+    }
 }
 
 service RuleTypeService {
-  rpc ListRuleTypes(ListRuleTypesRequest) returns (ListRuleTypesResponse) {
-    option (google.api.http) = {get: "/api/v1/rule_types"};
 
-    option (rpc_options) = {
-      target_resource: TARGET_RESOURCE_PROJECT
-      relation: RELATION_RULE_TYPE_GET
-    };
-  }
+    rpc ListRuleTypes (ListRuleTypesRequest) returns (ListRuleTypesResponse) {
+        option (google.api.http) = {
+            get: "/api/v1/rule_types"
+        };
 
-  rpc GetRuleTypeByName(GetRuleTypeByNameRequest) returns (GetRuleTypeByNameResponse) {
-    option (google.api.http) = {get: "/api/v1/rule_type/name/{name=**}"};
+        option (rpc_options) = {
+            target_resource: TARGET_RESOURCE_PROJECT
+            relation: RELATION_RULE_TYPE_GET
+        };
+    }
 
-    option (rpc_options) = {
-      target_resource: TARGET_RESOURCE_PROJECT
-      relation: RELATION_RULE_TYPE_GET
-    };
-  }
+    rpc GetRuleTypeByName (GetRuleTypeByNameRequest) returns (GetRuleTypeByNameResponse) {
+        option (google.api.http) = {
+            get: "/api/v1/rule_type/name/{name=**}"
+        };
 
-  rpc GetRuleTypeById(GetRuleTypeByIdRequest) returns (GetRuleTypeByIdResponse) {
-    option (google.api.http) = {get: "/api/v1/rule_type/{id}"};
+        option (rpc_options) = {
+            target_resource: TARGET_RESOURCE_PROJECT
+            relation: RELATION_RULE_TYPE_GET
+        };
+    }
 
-    option (rpc_options) = {
-      target_resource: TARGET_RESOURCE_PROJECT
-      relation: RELATION_RULE_TYPE_GET
-    };
-  }
+    rpc GetRuleTypeById (GetRuleTypeByIdRequest) returns (GetRuleTypeByIdResponse) {
+        option (google.api.http) = {
+            get: "/api/v1/rule_type/{id}"
+        };
 
-  rpc CreateRuleType(CreateRuleTypeRequest) returns (CreateRuleTypeResponse) {
-    option (google.api.http) = {
-      post: "/api/v1/rule_type"
-      body: "*"
-    };
+        option (rpc_options) = {
+            target_resource: TARGET_RESOURCE_PROJECT
+            relation: RELATION_RULE_TYPE_GET
+        };
+    }
 
-    option (rpc_options) = {
-      target_resource: TARGET_RESOURCE_PROJECT
-      relation: RELATION_RULE_TYPE_CREATE
-    };
-  }
+    rpc CreateRuleType (CreateRuleTypeRequest) returns (CreateRuleTypeResponse) {
+        option (google.api.http) = {
+            post: "/api/v1/rule_type"
+            body: "*"
+        };
 
-  rpc UpdateRuleType(UpdateRuleTypeRequest) returns (UpdateRuleTypeResponse) {
-    option (google.api.http) = {
-      put: "/api/v1/rule_type"
-      body: "*"
-    };
+        option (rpc_options) = {
+            target_resource: TARGET_RESOURCE_PROJECT
+            relation: RELATION_RULE_TYPE_CREATE
+        };
+    }
 
-    option (rpc_options) = {
-      target_resource: TARGET_RESOURCE_PROJECT
-      relation: RELATION_RULE_TYPE_UPDATE
-    };
-  }
+    rpc UpdateRuleType (UpdateRuleTypeRequest) returns (UpdateRuleTypeResponse) {
+        option (google.api.http) = {
+            put: "/api/v1/rule_type"
+            body: "*"
+        };
 
-  rpc DeleteRuleType(DeleteRuleTypeRequest) returns (DeleteRuleTypeResponse) {
-    option (google.api.http) = {delete: "/api/v1/rule_type/{id}"};
+        option (rpc_options) = {
+            target_resource: TARGET_RESOURCE_PROJECT
+            relation: RELATION_RULE_TYPE_UPDATE
+        };
+    }
 
-    option (rpc_options) = {
-      target_resource: TARGET_RESOURCE_PROJECT
-      relation: RELATION_RULE_TYPE_DELETE
-    };
-  }
+    rpc DeleteRuleType (DeleteRuleTypeRequest) returns (DeleteRuleTypeResponse) {
+        option (google.api.http) = {
+            delete: "/api/v1/rule_type/{id}"
+        };
+
+        option (rpc_options) = {
+            target_resource: TARGET_RESOURCE_PROJECT
+            relation: RELATION_RULE_TYPE_DELETE
+        };
+    }
 }
 
 service EvalResultsService {
-  rpc ListEvaluationResults(ListEvaluationResultsRequest) returns (ListEvaluationResultsResponse) {
-    option (google.api.http) = {
-      // TODO: use
-      // get: "/api/v1/projects/{Context.project}/results"
-      // If we can promote Context.project to not be optional
-      get: "/api/v1/results"
-    };
+    rpc ListEvaluationResults(ListEvaluationResultsRequest) returns (ListEvaluationResultsResponse) {
+        option (google.api.http) = {
+            // TODO: use
+            // get: "/api/v1/projects/{Context.project}/results"
+            // If we can promote Context.project to not be optional
+            get: "/api/v1/results"
+        };
 
-    option (rpc_options) = {
-      target_resource: TARGET_RESOURCE_PROJECT
-      relation: RELATION_PROFILE_STATUS_GET
-    };
-  }
+        option (rpc_options) = {
+            target_resource: TARGET_RESOURCE_PROJECT
+            relation: RELATION_PROFILE_STATUS_GET
+        };
+    }
 
-  rpc ListEvaluationHistory(ListEvaluationHistoryRequest) returns (ListEvaluationHistoryResponse) {
-    option (google.api.http) = {get: "/api/v1/history"};
+    rpc ListEvaluationHistory(ListEvaluationHistoryRequest) returns (ListEvaluationHistoryResponse) {
+        option (google.api.http) = {
+            get: "/api/v1/history"
+        };
 
-    option (rpc_options) = {
-      target_resource: TARGET_RESOURCE_PROJECT
-      relation: RELATION_PROFILE_STATUS_GET
-    };
-  }
+        option (rpc_options) = {
+            target_resource: TARGET_RESOURCE_PROJECT
+            relation: RELATION_PROFILE_STATUS_GET
+        };
+    }
 
-  rpc GetEvaluationHistory(GetEvaluationHistoryRequest) returns (GetEvaluationHistoryResponse) {
-    option (google.api.http) = {get: "/api/v1/history/{id}"};
+    rpc GetEvaluationHistory(GetEvaluationHistoryRequest) returns (GetEvaluationHistoryResponse) {
+        option (google.api.http) = {
+            get: "/api/v1/history/{id}"
+        };
 
-    option (rpc_options) = {
-      target_resource: TARGET_RESOURCE_PROJECT
-      relation: RELATION_PROFILE_STATUS_GET
-    };
-  }
+        option (rpc_options) = {
+            target_resource: TARGET_RESOURCE_PROJECT
+            relation: RELATION_PROFILE_STATUS_GET
+        };
+    }
 }
 
 service PermissionsService {
-  rpc ListRoles(ListRolesRequest) returns (ListRolesResponse) {
-    option (google.api.http) = {get: "/api/v1/permissions/roles"};
+    rpc ListRoles (ListRolesRequest) returns (ListRolesResponse) {
+        option (google.api.http) = {
+            get: "/api/v1/permissions/roles"
+        };
 
-    option (rpc_options) = {
-      target_resource: TARGET_RESOURCE_PROJECT
-      relation: RELATION_ROLE_LIST
-    };
-  }
+        option (rpc_options) = {
+            target_resource: TARGET_RESOURCE_PROJECT
+            relation: RELATION_ROLE_LIST
+        };
+    }
 
-  rpc ListRoleAssignments(ListRoleAssignmentsRequest) returns (ListRoleAssignmentsResponse) {
-    option (google.api.http) = {get: "/api/v1/permissions/assignments"};
+    rpc ListRoleAssignments (ListRoleAssignmentsRequest) returns (ListRoleAssignmentsResponse) {
+        option (google.api.http) = {
+            get: "/api/v1/permissions/assignments"
+        };
 
-    option (rpc_options) = {
-      target_resource: TARGET_RESOURCE_PROJECT
-      relation: RELATION_ROLE_ASSIGNMENT_LIST
-    };
-  }
+        option (rpc_options) = {
+            target_resource: TARGET_RESOURCE_PROJECT
+            relation: RELATION_ROLE_ASSIGNMENT_LIST
+        };
+    }
 
-  rpc AssignRole(AssignRoleRequest) returns (AssignRoleResponse) {
-    option (google.api.http) = {
-      post: "/api/v1/permissions/assign"
-      body: "*"
-    };
+    rpc AssignRole (AssignRoleRequest) returns (AssignRoleResponse) {
+        option (google.api.http) = {
+            post: "/api/v1/permissions/assign"
+            body: "*"
+        };
 
-    option (rpc_options) = {
-      target_resource: TARGET_RESOURCE_PROJECT
-      relation: RELATION_ROLE_ASSIGNMENT_CREATE
-    };
-  }
+        option (rpc_options) = {
+            target_resource: TARGET_RESOURCE_PROJECT
+            relation: RELATION_ROLE_ASSIGNMENT_CREATE
+        };
+    }
 
-  rpc UpdateRole(UpdateRoleRequest) returns (UpdateRoleResponse) {
-    option (google.api.http) = {
-      post: "/api/v1/permissions/update"
-      body: "*"
-    };
+    rpc UpdateRole(UpdateRoleRequest) returns (UpdateRoleResponse) {
+        option (google.api.http) = {
+            post: "/api/v1/permissions/update"
+            body: "*"
+        };
 
-    option (rpc_options) = {
-      target_resource: TARGET_RESOURCE_PROJECT
-      relation: RELATION_ROLE_ASSIGNMENT_UPDATE
-    };
-  }
+        option (rpc_options) = {
+            target_resource: TARGET_RESOURCE_PROJECT
+            relation: RELATION_ROLE_ASSIGNMENT_UPDATE
+        };
+    }
 
-  rpc RemoveRole(RemoveRoleRequest) returns (RemoveRoleResponse) {
-    // The role name comes from the name field in the role object
-    option (google.api.http) = {delete: "/api/v1/permissions/remove"};
+    rpc RemoveRole (RemoveRoleRequest) returns (RemoveRoleResponse) {
+        // The role name comes from the name field in the role object
+        option (google.api.http) = {
+            delete: "/api/v1/permissions/remove"
+        };
 
-    option (rpc_options) = {
-      target_resource: TARGET_RESOURCE_PROJECT
-      relation: RELATION_ROLE_ASSIGNMENT_REMOVE
-    };
-  }
+        option (rpc_options) = {
+            target_resource: TARGET_RESOURCE_PROJECT
+            relation: RELATION_ROLE_ASSIGNMENT_REMOVE
+        };
+    }
 }
 
 service ProjectsService {
-  rpc ListProjects(ListProjectsRequest) returns (ListProjectsResponse) {
-    option (google.api.http) = {get: "/api/v1/projects"};
 
-    option (rpc_options) = {
-      target_resource: TARGET_RESOURCE_USER
-      relation: RELATION_GET
-    };
-  }
+    rpc ListProjects(ListProjectsRequest) returns (ListProjectsResponse) {
+        option (google.api.http) = {
+            get: "/api/v1/projects"
+        };
 
-  rpc CreateProject(CreateProjectRequest) returns (CreateProjectResponse) {
-    option (google.api.http) = {
-      post: "/api/v1/projects"
-      body: "*"
-    };
+        option (rpc_options) = {
+            target_resource: TARGET_RESOURCE_USER
+            relation: RELATION_GET
+        };
+    }
 
-    option (rpc_options) = {
-      // We use TARGET_RESOURCE_USER (no specific resource is checked for authz)
-      // here when creating top-level projects, and specifically check the
-      // RELATION_CREATE permission when creating sub-projects under a parent.
-      target_resource: TARGET_RESOURCE_USER
-      relation: RELATION_CREATE
-    };
-  }
+    rpc CreateProject(CreateProjectRequest) returns (CreateProjectResponse) {
+        option (google.api.http) = {
+            post: "/api/v1/projects"
+            body: "*"
+        };
 
-  rpc ListChildProjects(ListChildProjectsRequest) returns (ListChildProjectsResponse) {
-    option (google.api.http) = {get: "/api/v1/projects/{context.project_id}/children"};
+        option (rpc_options) = {
+            // We use TARGET_RESOURCE_USER (no specific resource is checked for authz)
+            // here when creating top-level projects, and specifically check the
+            // RELATION_CREATE permission when creating sub-projects under a parent.
+            target_resource: TARGET_RESOURCE_USER
+            relation: RELATION_CREATE
+        };
+    }
 
-    option (rpc_options) = {
-      target_resource: TARGET_RESOURCE_PROJECT
-      relation: RELATION_GET
-    };
-  }
+    rpc ListChildProjects(ListChildProjectsRequest) returns (ListChildProjectsResponse) {
+        option (google.api.http) = {
+            get: "/api/v1/projects/{context.project_id}/children"
+        };
 
-  rpc DeleteProject(DeleteProjectRequest) returns (DeleteProjectResponse) {
-    option (google.api.http) = {delete: "/api/v1/projects"};
+        option (rpc_options) = {
+            target_resource: TARGET_RESOURCE_PROJECT
+            relation: RELATION_GET
+        };
+    }
 
-    option (rpc_options) = {
-      target_resource: TARGET_RESOURCE_PROJECT
-      relation: RELATION_DELETE
-    };
-  }
+    rpc DeleteProject(DeleteProjectRequest) returns (DeleteProjectResponse) {
+        option (google.api.http) = {
+            delete: "/api/v1/projects"
+        };
 
-  rpc UpdateProject(UpdateProjectRequest) returns (UpdateProjectResponse) {
-    option (google.api.http) = {
-      put: "/api/v1/projects"
-      body: "*"
-    };
+        option (rpc_options) = {
+            target_resource: TARGET_RESOURCE_PROJECT
+            relation: RELATION_DELETE
+        };
+    }
 
-    option (rpc_options) = {
-      target_resource: TARGET_RESOURCE_PROJECT
-      relation: RELATION_UPDATE
-    };
-  }
+    rpc UpdateProject(UpdateProjectRequest) returns (UpdateProjectResponse) {
+        option (google.api.http) = {
+            put: "/api/v1/projects"
+            body: "*"
+        };
 
-  rpc PatchProject(PatchProjectRequest) returns (PatchProjectResponse) {
-    option (google.api.http) = {
-      patch: "/api/v1/projects"
-      body: "patch"
-    };
+        option (rpc_options) = {
+            target_resource: TARGET_RESOURCE_PROJECT
+            relation: RELATION_UPDATE
+        };
+    }
 
-    option (rpc_options) = {
-      target_resource: TARGET_RESOURCE_PROJECT
-      relation: RELATION_UPDATE
-    };
-  }
+    rpc PatchProject(PatchProjectRequest) returns (PatchProjectResponse) {
+        option (google.api.http) = {
+            patch: "/api/v1/projects"
+            body: "patch"
+        };
 
-  rpc CreateEntityReconciliationTask(CreateEntityReconciliationTaskRequest) returns (CreateEntityReconciliationTaskResponse) {
-    option (google.api.http) = {
-      post: "/api/v1/projects/entity/reconcile"
-      body: "*"
-    };
+        option (rpc_options) = {
+            target_resource: TARGET_RESOURCE_PROJECT
+            relation: RELATION_UPDATE
+        };
+    }
 
-    option (rpc_options) = {
-      target_resource: TARGET_RESOURCE_PROJECT
-      relation: RELATION_ENTITY_RECONCILIATION_TASK_CREATE
-    };
-  }
+    rpc CreateEntityReconciliationTask(CreateEntityReconciliationTaskRequest) returns (CreateEntityReconciliationTaskResponse) {
+        option (google.api.http) = {
+            post: "/api/v1/projects/entity/reconcile"
+            body: "*"
+        };
+
+        option (rpc_options) = {
+            target_resource: TARGET_RESOURCE_PROJECT
+            relation: RELATION_ENTITY_RECONCILIATION_TASK_CREATE
+        };
+    }
 }
 
 service ProvidersService {
-  rpc PatchProvider(PatchProviderRequest) returns (PatchProviderResponse) {
-    option (google.api.http) = {
-      patch: "/api/v1/providers"
-      body: "patch"
-    };
+    rpc PatchProvider(PatchProviderRequest) returns (PatchProviderResponse) {
+        option (google.api.http) = {
+            patch: "/api/v1/providers"
+            body: "patch"
+        };
 
-    option (rpc_options) = {
-      target_resource: TARGET_RESOURCE_PROJECT
-      relation: RELATION_PROVIDER_UPDATE
-    };
-  }
+        option (rpc_options) = {
+            target_resource: TARGET_RESOURCE_PROJECT
+            relation: RELATION_PROVIDER_UPDATE
+        };
+    }
 
-  rpc GetProvider(GetProviderRequest) returns (GetProviderResponse) {
-    option (google.api.http) = {get: "/api/v1/providers/{name}"};
+    rpc GetProvider(GetProviderRequest) returns (GetProviderResponse) {
+        option (google.api.http) = {
+            get: "/api/v1/providers/{name}"
+        };
 
-    option (rpc_options) = {
-      target_resource: TARGET_RESOURCE_PROJECT
-      relation: RELATION_PROVIDER_GET
-    };
-  }
+        option (rpc_options) = {
+            target_resource: TARGET_RESOURCE_PROJECT
+            relation: RELATION_PROVIDER_GET
+        };
+    }
 
-  rpc ListProviders(ListProvidersRequest) returns (ListProvidersResponse) {
-    option (google.api.http) = {get: "/api/v1/providers"};
+    rpc ListProviders (ListProvidersRequest) returns (ListProvidersResponse) {
+        option (google.api.http) = {
+            get: "/api/v1/providers"
+        };
 
-    option (rpc_options) = {
-      target_resource: TARGET_RESOURCE_PROJECT
-      relation: RELATION_PROVIDER_GET
-    };
-  }
+        option (rpc_options) = {
+            target_resource: TARGET_RESOURCE_PROJECT
+            relation: RELATION_PROVIDER_GET
+        };
+    }
 
-  rpc CreateProvider(CreateProviderRequest) returns (CreateProviderResponse) {
-    option (google.api.http) = {
-      post: "/api/v1/providers"
-      body: "*"
-    };
+    rpc CreateProvider (CreateProviderRequest) returns (CreateProviderResponse) {
+        option (google.api.http) = {
+            post: "/api/v1/providers"
+            body: "*"
+        };
 
-    option (rpc_options) = {
-      target_resource: TARGET_RESOURCE_PROJECT
-      relation: RELATION_PROVIDER_CREATE
-    };
-  }
+        option (rpc_options) = {
+            target_resource: TARGET_RESOURCE_PROJECT
+            relation: RELATION_PROVIDER_CREATE
+        };
+    }
 
-  rpc DeleteProvider(DeleteProviderRequest) returns (DeleteProviderResponse) {
-    option (google.api.http) = {
-      // TODO: it would be nice to be able to use context.project and
-      // context.provider here, but they are optional and cannot be used
-      // in the path.  Change this for v2.
-      delete: "/api/v1/providers"
-    };
+    rpc DeleteProvider (DeleteProviderRequest) returns (DeleteProviderResponse) {
+        option (google.api.http) = {
+            // TODO: it would be nice to be able to use context.project and
+            // context.provider here, but they are optional and cannot be used
+            // in the path.  Change this for v2.
+            delete: "/api/v1/providers"
+        };
 
-    option (rpc_options) = {
-      target_resource: TARGET_RESOURCE_PROJECT
-      relation: RELATION_PROVIDER_DELETE
-    };
-  }
+        option (rpc_options) = {
+            target_resource: TARGET_RESOURCE_PROJECT
+            relation: RELATION_PROVIDER_DELETE
+        };
+    }
 
-  rpc DeleteProviderByID(DeleteProviderByIDRequest) returns (DeleteProviderByIDResponse) {
-    option (google.api.http) = {delete: "/api/v1/providers/{id}"};
+    rpc DeleteProviderByID (DeleteProviderByIDRequest) returns (DeleteProviderByIDResponse) {
+        option (google.api.http) = {
+            delete: "/api/v1/providers/{id}"
+        };
 
-    option (minder.v1.rpc_options) = {
-      target_resource: TARGET_RESOURCE_PROJECT
-      relation: RELATION_REPO_DELETE
-    };
-  }
+        option (minder.v1.rpc_options) = {
+            target_resource: TARGET_RESOURCE_PROJECT
+            relation: RELATION_REPO_DELETE
+        };
+    }
 
-  rpc ListProviderClasses(ListProviderClassesRequest) returns (ListProviderClassesResponse) {
-    option (google.api.http) = {get: "/api/v1/provider_classes"};
+    rpc ListProviderClasses (ListProviderClassesRequest) returns (ListProviderClassesResponse) {
+        option (google.api.http) = {
+            get: "/api/v1/provider_classes"
+        };
 
-    option (rpc_options) = {
-      target_resource: TARGET_RESOURCE_PROJECT
-      relation: RELATION_PROVIDER_GET
-    };
-  }
+        option (rpc_options) = {
+            target_resource: TARGET_RESOURCE_PROJECT
+            relation: RELATION_PROVIDER_GET
+        };
+    }
 
-  rpc ReconcileEntityRegistration(ReconcileEntityRegistrationRequest) returns (ReconcileEntityRegistrationResponse) {
-    option (google.api.http) = {
-      post: "/api/v1/provider/register_all"
-      body: "*"
-    };
+    rpc ReconcileEntityRegistration(ReconcileEntityRegistrationRequest) returns (ReconcileEntityRegistrationResponse) {
+        option (google.api.http) = {
+            post: "/api/v1/provider/register_all"
+            body: "*"
+        };
 
-    option (rpc_options) = {
-      target_resource: TARGET_RESOURCE_PROJECT
-      relation: RELATION_ENTITY_RECONCILE
-    };
-  }
+        option (rpc_options) = {
+            target_resource: TARGET_RESOURCE_PROJECT
+            relation: RELATION_ENTITY_RECONCILE
+        };
+    }
 }
 
 service InviteService {
-  rpc GetInviteDetails(GetInviteDetailsRequest) returns (GetInviteDetailsResponse) {
-    option (google.api.http) = {get: "/api/v1/invite/{code}"};
+    rpc GetInviteDetails(GetInviteDetailsRequest) returns (GetInviteDetailsResponse) {
+        option (google.api.http) = {
+            get: "/api/v1/invite/{code}"
+        };
 
-    option (rpc_options) = {target_resource: TARGET_RESOURCE_NONE};
-  }
+        option (rpc_options) = {
+            target_resource: TARGET_RESOURCE_NONE
+        };
+    }
 }
 
 message GetInviteDetailsRequest {
-  // Invite nonce/code to retrieve details for
-  string code = 2 [
-    (buf.validate.field).string = {
-      pattern: "^[A-Za-z0-9_-]+$"
-      len: 64
-    },
-    (google.api.field_behavior) = REQUIRED
-  ];
+    // Invite nonce/code to retrieve details for
+    string code = 2 [
+        (buf.validate.field).string = {
+            pattern: "^[A-Za-z0-9_-]+$",
+            len: 64,
+        },
+        (google.api.field_behavior) = REQUIRED
+    ];
 
-  reserved 1; // deprecated Context context = 1;
-  reserved "context";
+    reserved 1; // deprecated Context context = 1;
+    reserved "context";
 }
 
 message GetInviteDetailsResponse {
-  // Project associated with the invite
-  string project_display = 1 [(google.api.field_behavior) = REQUIRED];
-  // Sponsor of the invite
-  string sponsor_display = 2 [(google.api.field_behavior) = REQUIRED];
-  // expires_at is the time at which the invitation expires.
-  google.protobuf.Timestamp expires_at = 3 [(google.api.field_behavior) = REQUIRED];
-  // expired is true if the invitation has expired
-  bool expired = 4 [(google.api.field_behavior) = REQUIRED];
+    // Project associated with the invite
+    string project_display = 1 [
+        (google.api.field_behavior) = REQUIRED
+    ];
+    // Sponsor of the invite
+    string sponsor_display = 2 [
+        (google.api.field_behavior) = REQUIRED
+    ];
+    // expires_at is the time at which the invitation expires.
+    google.protobuf.Timestamp expires_at = 3 [
+        (google.api.field_behavior) = REQUIRED
+    ];
+    // expired is true if the invitation has expired
+    bool expired = 4 [
+        (google.api.field_behavior) = REQUIRED
+    ];
 }
 
-message CheckHealthRequest {}
+message CheckHealthRequest {
+}
 
 message CheckHealthResponse {
-  string status = 1 [(google.api.field_behavior) = REQUIRED];
+    string status = 1 [
+        (google.api.field_behavior) = REQUIRED
+    ];
 }
 
 message GetAuthorizationURLRequest {
-  // cli is true if the request is being made from a CLI.
-  bool cli = 3;
+    // cli is true if the request is being made from a CLI.
+    bool cli = 3;
 
-  // owner is the owner (e.g GitHub org) that the provider is associated with.
-  // This is optional; we allow empty string because the client may set the
-  // field unconditionally, even though the field is marked as `optional`.
-  optional string owner = 5 [(buf.validate.field).string = {
-    pattern: "^(?:[A-Za-z][-[:word:]]*)?$"
-    max_len: 200
-  }];
-  Context context = 6;
+    // owner is the owner (e.g GitHub org) that the provider is associated with.
+    // This is optional; we allow empty string because the client may set the
+    // field unconditionally, even though the field is marked as `optional`.
+    optional string owner = 5 [
+        (buf.validate.field).string = {
+            pattern: "^(?:[A-Za-z][-[:word:]]*)?$"
+            max_len: 200,
+        }
+    ];
+    Context context = 6;
 
-  // redirect_url is the URL to redirect to after the authorization is complete.
-  optional string redirect_url = 7 [(buf.validate.field).string = {
-    uri: true
-    max_len: 600
-  }];
+    // redirect_url is the URL to redirect to after the authorization is complete.
+    optional string redirect_url = 7 [
+        (buf.validate.field).string = {
+            uri: true,
+            max_len: 600,
+        }
+    ];
 
-  // config is a JSON object that can be used to pass additional configuration
-  google.protobuf.Struct config = 8;
+    // config is a JSON object that can be used to pass additional configuration
+    google.protobuf.Struct config = 8;
 
-  string provider_class = 9 [
-    (buf.validate.field).string = {
-      pattern: "^(?:[A-Za-z][-[:word:]]*)?$"
-      max_len: 200
-    },
-    (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE
-  ];
+    string provider_class = 9 [
+        (buf.validate.field).string = {
+            pattern: "^(?:[A-Za-z][-[:word:]]*)?$",
+            max_len: 200,
+        },
+        (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE
+    ];
 
-  reserved 1, 2, 4;
-  reserved "provider", "project_id", "port";
+    reserved 1, 2, 4;
+    reserved "provider", "project_id", "port";
 }
 
 message GetAuthorizationURLResponse {
-  string url = 1 [(google.api.field_behavior) = REQUIRED];
-  string state = 2 [(google.api.field_behavior) = REQUIRED];
+    string url = 1 [
+        (google.api.field_behavior) = REQUIRED
+    ];
+    string state = 2 [
+        (google.api.field_behavior) = REQUIRED
+    ];
 }
 
 message StoreProviderTokenRequest {
-  string provider = 1 [deprecated = true];
+    string provider = 1 [deprecated=true];
 
-  // access_token is the token to store.
-  string access_token = 3 [
-    (buf.validate.field).string = {
-      pattern: "^[a-zA-Z0-9-_.]+$"
-      min_len: 10
-      max_len: 200
-    },
-    (google.api.field_behavior) = REQUIRED
-  ];
+    // access_token is the token to store.
+    string access_token = 3 [
+        (buf.validate.field).string = {
+            pattern: "^[a-zA-Z0-9-_.]+$",
+            min_len: 10,
+            max_len: 200,
+        },
+        (google.api.field_behavior) = REQUIRED
+    ];
 
-  // owner is the owner (e.g GitHub org) that the provider is associated with.
-  // This is optional, but an empty string is allowed as existing clients may
-  // set the field unconditionally.
-  optional string owner = 4 [(buf.validate.field).string = {
-    pattern: "^(?:[A-Za-z][-[:word:]]*)?$"
-    max_len: 200
-  }];
-  Context context = 5;
+    // owner is the owner (e.g GitHub org) that the provider is associated with.
+    // This is optional, but an empty string is allowed as existing clients may
+    // set the field unconditionally.
+    optional string owner = 4 [
+        (buf.validate.field).string = {
+            pattern: "^(?:[A-Za-z][-[:word:]]*)?$"
+            max_len: 200,
+        }
+    ];
+    Context context = 5;
 
-  reserved 2; // deprecated project_id
+    reserved 2; // deprecated project_id
 }
 
-message StoreProviderTokenResponse {}
+message StoreProviderTokenResponse {
+}
 
 // Project API Objects. This is only used in responses.
 message Project {
-  string project_id = 1 [(google.api.field_behavior) = REQUIRED];
-  string name = 3 [(google.api.field_behavior) = REQUIRED];
+    string project_id = 1 [
+        (google.api.field_behavior) = REQUIRED
+    ];
+    string name = 3 [
+        (google.api.field_behavior) = REQUIRED
+    ];
 
-  // description is a human-readable description of the project.
-  // This is optional.
-  string description = 4;
-  google.protobuf.Timestamp created_at = 6 [(google.api.field_behavior) = REQUIRED];
-  google.protobuf.Timestamp updated_at = 7 [(google.api.field_behavior) = REQUIRED];
-  // display_name allows for a human-readable name to be used.
-  // display_names are short *non-unique* strings to provide
-  // a user-friendly name for presentation in lists, etc.
-  // This is optional.
-  string display_name = 5;
+    // description is a human-readable description of the project.
+    // This is optional.
+    string description = 4;
+    google.protobuf.Timestamp created_at = 6 [
+        (google.api.field_behavior) = REQUIRED
+    ];
+    google.protobuf.Timestamp updated_at = 7 [
+        (google.api.field_behavior) = REQUIRED
+    ];
+    // display_name allows for a human-readable name to be used.
+    // display_names are short *non-unique* strings to provide
+    // a user-friendly name for presentation in lists, etc.
+    // This is optional.
+    string display_name = 5;
 }
 
 // Repositories API objects
 
 message ListRemoteRepositoriesFromProviderRequest {
-  string provider = 1 [deprecated = true];
-  Context context = 3;
+    string provider = 1 [deprecated=true];
+    Context context = 3;
 
-  reserved 2; // deprecated project_id
+    reserved 2; // deprecated project_id
 }
 
 message ListRemoteRepositoriesFromProviderResponse {
-  repeated UpstreamRepositoryRef results = 1 [(google.api.field_behavior) = REQUIRED];
-  // entities is the same list as the repositories, but it
-  // uses the new UpstreamEntityRef message. This is what
-  // we'll migrate to eventually.
-  repeated RegistrableUpstreamEntityRef entities = 2 [(google.api.field_behavior) = REQUIRED];
+    repeated UpstreamRepositoryRef results = 1 [
+        (google.api.field_behavior) = REQUIRED
+    ];
+    // entities is the same list as the repositories, but it
+    // uses the new UpstreamEntityRef message. This is what
+    // we'll migrate to eventually.
+    repeated RegistrableUpstreamEntityRef entities = 2 [
+        (google.api.field_behavior) = REQUIRED
+    ];
 }
 
 message RegistrableUpstreamEntityRef {
-  UpstreamEntityRef entity = 1 [(google.api.field_behavior) = REQUIRED];
+    UpstreamEntityRef entity = 1 [
+        (google.api.field_behavior) = REQUIRED
+    ];
 
-  // True if the entity is already registered in Minder.
-  bool registered = 2;
+    // True if the entity is already registered in Minder.
+    bool registered = 2;
 }
 
 message UpstreamRepositoryRef {
-  // owner is the owner (e.g GitHub org) that the provider is associated with.
-  // This is optional.
-  string owner = 1 [
-    (buf.validate.field).string = {
-      pattern: "^[A-Za-z][-[:word:]]*$"
-      max_len: 200
-    },
-    (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE
-  ];
-  string name = 2 [
-    (buf.validate.field).string = {
-      pattern: "^[-.[:alnum:]_]+$"
-      max_len: 200
-    },
-    (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE,
-    (google.api.field_behavior) = REQUIRED
-  ];
-  // The upstream identity of the repository, as an integer.
-  // This is only set on output, and is ignored on input.
-  int64 repo_id = 3 [
-    (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE, // Given it's ignored on input, we can ignore empty values
-    (buf.validate.field).int64 = {gte: 1},
-    (google.api.field_behavior) = OUTPUT_ONLY
-  ];
-  Context context = 4;
-  // True if the repository is already registered in Minder.
-  // This is only set on output, and is ignored on input.
-  bool registered = 5 [(google.api.field_behavior) = OUTPUT_ONLY];
+    // owner is the owner (e.g GitHub org) that the provider is associated with.
+    // This is optional.
+    string owner = 1 [
+        (buf.validate.field).string = {
+            pattern: "^[A-Za-z][-[:word:]]*$"
+            max_len: 200,
+        },
+        (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE
+    ];
+    string name = 2 [
+        (buf.validate.field).string = {
+            pattern: "^[-.[:alnum:]_]+$",
+            max_len: 200,
+        },
+        (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE,
+        (google.api.field_behavior) = REQUIRED
+    ];
+    // The upstream identity of the repository, as an integer.
+    // This is only set on output, and is ignored on input.
+    int64 repo_id = 3 [
+        (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE, // Given it's ignored on input, we can ignore empty values
+        (buf.validate.field).int64 = { gte: 1 },
+        (google.api.field_behavior) = OUTPUT_ONLY
+    ];
+    Context context = 4;
+    // True if the repository is already registered in Minder.
+    // This is only set on output, and is ignored on input.
+    bool registered = 5 [
+        (google.api.field_behavior) = OUTPUT_ONLY
+    ];
 }
 
 // Repository API objects. This is only used in responses.
 message Repository {
-  reserved 15;
-  reserved "registered";
-  // id is the unique identifier of the repository within Minder.
-  // It is always populated, but the optional keyword is used for
-  // backwards compatibility.
-  optional string id = 1 [(google.api.field_behavior) = REQUIRED];
-  optional Context context = 2;
-  string owner = 3 [(google.api.field_behavior) = REQUIRED];
-  string name = 4 [(google.api.field_behavior) = REQUIRED];
-  int64 repo_id = 5;
-  int64 hook_id = 6;
-  string hook_url = 7;
-  string deploy_url = 8;
-  string clone_url = 9;
-  string hook_name = 10;
-  string hook_type = 11;
-  string hook_uuid = 12;
-  bool is_private = 13 [(google.api.field_behavior) = REQUIRED];
-  bool is_fork = 14 [(google.api.field_behavior) = REQUIRED];
-  google.protobuf.Timestamp created_at = 16;
-  google.protobuf.Timestamp updated_at = 17;
-  string default_branch = 18;
-  string license = 19;
-  // properties is a map of properties of the entity.
-  google.protobuf.Struct properties = 20;
+    reserved 15;
+    reserved "registered";
+    // id is the unique identifier of the repository within Minder.
+    // It is always populated, but the optional keyword is used for
+    // backwards compatibility.
+    optional string id = 1 [
+        (google.api.field_behavior) = REQUIRED
+    ];
+    optional Context context = 2;
+    string owner = 3 [
+        (google.api.field_behavior) = REQUIRED
+    ];
+    string name = 4 [
+        (google.api.field_behavior) = REQUIRED
+    ];
+    int64 repo_id = 5;
+    int64 hook_id = 6;
+    string hook_url = 7;
+    string deploy_url = 8;
+    string clone_url = 9;
+    string hook_name = 10;
+    string hook_type = 11;
+    string hook_uuid = 12;
+    bool is_private = 13 [
+        (google.api.field_behavior) = REQUIRED
+    ];
+    bool is_fork = 14 [
+        (google.api.field_behavior) = REQUIRED
+    ];
+    google.protobuf.Timestamp created_at = 16;
+    google.protobuf.Timestamp updated_at = 17;
+    string default_branch = 18;
+    string license = 19;
+    // properties is a map of properties of the entity.
+    google.protobuf.Struct properties = 20;
 }
 
 message RegisterRepositoryRequest {
-  string provider = 1 [deprecated = true];
+    string provider = 1 [deprecated=true];
 
-  // repository is the repository to register. This is optional if entity
-  // is set.
-  UpstreamRepositoryRef repository = 3;
-  Context context = 4;
-  // entity is the entity to register. This is the same as the repository
-  // field, but uses the new UpstreamEntityRef message. This is what we'll
-  // migrate to eventually. This is optional if repository is set.
-  UpstreamEntityRef entity = 5;
+    // repository is the repository to register. This is optional if entity
+    // is set.
+    UpstreamRepositoryRef repository = 3;
+    Context context = 4;
+    // entity is the entity to register. This is the same as the repository
+    // field, but uses the new UpstreamEntityRef message. This is what we'll
+    // migrate to eventually. This is optional if repository is set.
+    UpstreamEntityRef entity = 5;
 
-  reserved 2; // deprecated project_id
+    reserved 2; // deprecated project_id
 }
 
 message RegisterRepoResult {
-  message Status {
-    bool success = 1;
-    optional string error = 2;
-  }
+    message Status {
+        bool success = 1;
+        optional string error = 2;
+    }
 
-  Repository repository = 1;
-  Status status = 2 [(google.api.field_behavior) = REQUIRED];
+    Repository repository = 1;
+    Status status = 2 [
+        (google.api.field_behavior) = REQUIRED
+    ];
 }
 
 message RegisterRepositoryResponse {
-  RegisterRepoResult result = 1 [(google.api.field_behavior) = REQUIRED];
+    RegisterRepoResult result = 1 [
+        (google.api.field_behavior) = REQUIRED
+    ];
 }
 
 message GetRepositoryByIdRequest {
-  string repository_id = 1 [
-    (buf.validate.field).string = {uuid: true},
-    (google.api.field_behavior) = REQUIRED
-  ];
-  Context context = 2;
+    string repository_id = 1 [
+        (buf.validate.field).string = {uuid: true},
+        (google.api.field_behavior) = REQUIRED
+    ];
+    Context context = 2;
 }
 
 message GetRepositoryByIdResponse {
-  Repository repository = 1 [(google.api.field_behavior) = REQUIRED];
+    Repository repository = 1 [
+        (google.api.field_behavior) = REQUIRED
+    ];
 }
 
 message DeleteRepositoryByIdRequest {
-  string repository_id = 1 [
-    (buf.validate.field).string = {uuid: true},
-    (google.api.field_behavior) = REQUIRED
-  ];
-  Context context = 2;
+    string repository_id = 1 [
+        (buf.validate.field).string = {uuid: true},
+        (google.api.field_behavior) = REQUIRED
+    ];
+    Context context = 2;
 }
 
 message DeleteRepositoryByIdResponse {
-  string repository_id = 1 [(google.api.field_behavior) = REQUIRED];
+    string repository_id = 1 [
+        (google.api.field_behavior) = REQUIRED
+    ];
 }
 
 message GetRepositoryByNameRequest {
-  string provider = 1 [deprecated = true];
-  string name = 3 [
-    (buf.validate.field).string = {
-      pattern: "^[A-Za-z][-[:word:]./]*$"
-      max_len: 200
-    },
-    (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE,
-    (google.api.field_behavior) = REQUIRED
-  ];
-  Context context = 4;
+    string provider = 1 [deprecated=true];
+    string name = 3 [
+        (buf.validate.field).string = {
+            pattern: "^[A-Za-z][-[:word:]./]*$",
+            max_len: 200,
+        },
+        (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE,
+        (google.api.field_behavior) = REQUIRED
+    ];
+    Context context = 4;
 
-  reserved 2; // deprecated project_id
+    reserved 2; // deprecated project_id
 }
 
 message GetRepositoryByNameResponse {
-  Repository repository = 1 [(google.api.field_behavior) = REQUIRED];
+    Repository repository = 1 [
+        (google.api.field_behavior) = REQUIRED
+    ];
 }
 
 message DeleteRepositoryByNameRequest {
-  string provider = 1 [deprecated = true];
-  string name = 3 [
-    (buf.validate.field).string = {
-      pattern: "^[A-Za-z][-[:word:]./]*$"
-      max_len: 200
-    },
-    (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE,
-    (google.api.field_behavior) = REQUIRED
-  ];
-  Context context = 4;
+    string provider = 1 [deprecated=true];
+    string name = 3 [
+        (buf.validate.field).string = {
+            pattern: "^[A-Za-z][-[:word:]./]*$",
+            max_len: 200,
+        },
+        (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE,
+        (google.api.field_behavior) = REQUIRED
+    ];
+    Context context = 4;
 
-  reserved 2; // deprecated project_id
+    reserved 2; // deprecated project_id
 }
 
 message DeleteRepositoryByNameResponse {
-  string name = 1 [(google.api.field_behavior) = REQUIRED];
+    string name = 1 [
+        (google.api.field_behavior) = REQUIRED
+    ];
 }
 
 message ListRepositoriesRequest {
-  string provider = 1 [deprecated = true];
+    string provider = 1 [deprecated=true];
 
-  // limit is the maximum number of results to return.
-  // This is optional.
-  int64 limit = 3 [(buf.validate.field).int64 = {
-    gte: 0
-    lte: 100
-  }];
-  Context context = 5;
+    // limit is the maximum number of results to return.
+    // This is optional.
+    int64 limit = 3 [
+        (buf.validate.field).int64 = { gte: 0, lte: 100 }
+    ];
+    Context context = 5;
 
-  // cursor is the cursor to use for the next page of results.
-  // This is optional.
-  string cursor = 6 [(buf.validate.field).string = {
-    pattern: "^[[:word:]=]*$"
-    max_len: 200
-  }];
+    // cursor is the cursor to use for the next page of results.
+    // This is optional.
+    string cursor = 6 [
+        (buf.validate.field).string = {
+            pattern: "^[[:word:]=]*$",
+            max_len: 200,
+        }
+    ];
 
-  reserved 2, 4; // deprecated project_id, offset
-  reserved "project_id", "offset";
+    reserved 2,4; // deprecated project_id, offset
+    reserved "project_id", "offset";
 }
 
 message ListRepositoriesResponse {
-  repeated Repository results = 1 [(google.api.field_behavior) = REQUIRED];
+    repeated Repository results = 1 [
+        (google.api.field_behavior) = REQUIRED
+    ];
 
-  // cursor is the cursor to use for the next page of results, empty if at the end
-  string cursor = 2;
+    // cursor is the cursor to use for the next page of results, empty if at the end
+    string cursor = 2;
 }
 
 message ReconcileEntityRegistrationRequest {
-  Context context = 1;
-  // entity is the entity type
-  string entity = 2 [
-    (buf.validate.field).string = {
-      pattern: "^[a-z]+(_[a-z]+)*$"
-      min_len: 1
-      max_len: 200
-    },
-    (google.api.field_behavior) = REQUIRED
-  ];
+    Context context = 1;
+    // entity is the entity type
+    string entity = 2 [
+        (buf.validate.field).string = {
+            pattern: "^[a-z]+(_[a-z]+)*$",
+            min_len: 1,
+            max_len: 200,
+        },
+        (google.api.field_behavior) = REQUIRED
+    ];
 }
 
-message ReconcileEntityRegistrationResponse {}
+message ReconcileEntityRegistrationResponse {
+}
 
 message VerifyProviderTokenFromRequest {
-  string provider = 1 [deprecated = true];
-  google.protobuf.Timestamp timestamp = 3;
-  Context context = 4;
+    string provider = 1 [deprecated=true];
+    google.protobuf.Timestamp timestamp = 3;
+    Context context = 4;
 
-  reserved 2; // deprecated project_id
+    reserved 2; // deprecated project_id
 }
 
 message VerifyProviderTokenFromResponse {
-  string status = 1 [(google.api.field_behavior) = REQUIRED];
+    string status = 1 [
+        (google.api.field_behavior) = REQUIRED
+    ];
 }
 
 // VerifyProviderCredentialRequest contains the enrollment nonce (aka state) that was used when enrolling the provider
 message VerifyProviderCredentialRequest {
-  Context context = 1;
+    Context context = 1;
 
-  // enrollment_nonce is the state parameter returned when enrolling the provider
-  string enrollment_nonce = 2 [
-    (buf.validate.field).string = {
-      pattern: "^[A-Za-z0-9_-]+$"
-      len: 54
-    },
-    (google.api.field_behavior) = REQUIRED
-  ];
+    // enrollment_nonce is the state parameter returned when enrolling the provider
+    string enrollment_nonce = 2 [
+        (buf.validate.field).string = {
+            pattern: "^[A-Za-z0-9_-]+$",
+            len: 54,
+        },
+        (google.api.field_behavior) = REQUIRED
+    ];
 }
 
 // VerifyProviderCredentialRequest responds with a boolean indicating if the provider has been created and the provider
 // name, if it has been created
 message VerifyProviderCredentialResponse {
-  // created is true if the provider was created.
-  bool created = 1 [(google.api.field_behavior) = REQUIRED];
 
-  // provider_name is the name of the provider that was created.
-  // This is populated if creation was successful.
-  string provider_name = 2;
+    // created is true if the provider was created.
+    bool created = 1 [
+        (google.api.field_behavior) = REQUIRED
+    ];
+
+    // provider_name is the name of the provider that was created.
+    // This is populated if creation was successful.
+    string provider_name = 2;
 }
 
 // User service
-message CreateUserRequest {}
+message CreateUserRequest { }
 
 message CreateUserResponse {
-  int32 id = 1 [(google.api.field_behavior) = REQUIRED];
-  string organization_id = 2 [deprecated = true];
-  string organizatio_name = 3 [deprecated = true];
-  string project_id = 4 [(google.api.field_behavior) = REQUIRED];
-  string project_name = 5 [(google.api.field_behavior) = REQUIRED];
-  string identity_subject = 6 [(google.api.field_behavior) = REQUIRED];
-  google.protobuf.Timestamp created_at = 7 [(google.api.field_behavior) = REQUIRED];
-  Context context = 8 [deprecated = true];
+    int32 id = 1 [
+        (google.api.field_behavior) = REQUIRED
+    ];
+    string organization_id = 2 [deprecated=true];
+    string organizatio_name =3 [deprecated=true];
+    string project_id = 4 [
+        (google.api.field_behavior) = REQUIRED
+    ];
+    string project_name = 5 [
+        (google.api.field_behavior) = REQUIRED
+    ];
+    string identity_subject = 6 [
+        (google.api.field_behavior) = REQUIRED
+    ];
+    google.protobuf.Timestamp created_at = 7 [
+        (google.api.field_behavior) = REQUIRED
+    ];
+    Context context = 8 [deprecated=true];
 }
 
 message DeleteUserRequest {
-  reserved 1; // deprecated context
+    reserved 1; // deprecated context
 }
 
-message DeleteUserResponse {}
+message DeleteUserResponse {
+}
 
 // user record to be returned
 message UserRecord {
-  int32 id = 1 [(google.api.field_behavior) = REQUIRED];
-  string identity_subject = 3 [(google.api.field_behavior) = REQUIRED];
-  google.protobuf.Timestamp created_at = 4 [(google.api.field_behavior) = REQUIRED];
-  google.protobuf.Timestamp updated_at = 5 [(google.api.field_behavior) = REQUIRED];
+    int32 id = 1 [
+        (google.api.field_behavior) = REQUIRED
+    ];
+    string identity_subject = 3 [
+        (google.api.field_behavior) = REQUIRED
+    ];
+    google.protobuf.Timestamp created_at = 4 [
+        (google.api.field_behavior) = REQUIRED
+    ];
+    google.protobuf.Timestamp updated_at = 5 [
+        (google.api.field_behavior) = REQUIRED
+    ];
 
-  reserved 2; // deprecated organization_id
-  reserved "organization_id";
+    reserved 2; // deprecated organization_id
+    reserved "organization_id";
 }
 
 // ProjectRole has the project along with the role the user has in the project
 message ProjectRole {
-  Role role = 1 [(google.api.field_behavior) = REQUIRED];
-  Project project = 2 [(google.api.field_behavior) = REQUIRED];
+    Role role = 1 [
+        (google.api.field_behavior) = REQUIRED
+    ];
+    Project project = 2 [
+        (google.api.field_behavior) = REQUIRED
+    ];
 }
 
 // get user
 message GetUserRequest {
-  reserved 1; // deprecated context
+    reserved 1; // deprecated context
 }
 
 message GetUserResponse {
-  optional UserRecord user = 1 [(google.api.field_behavior) = REQUIRED];
-  // This will be deprecated in favor of the project_roles field
-  repeated Project projects = 2 [deprecated = true];
-  repeated ProjectRole project_roles = 3 [(google.api.field_behavior) = REQUIRED];
+    optional UserRecord user = 1 [
+        (google.api.field_behavior) = REQUIRED
+    ];
+    // This will be deprecated in favor of the project_roles field
+    repeated Project projects = 2 [deprecated=true];
+    repeated ProjectRole project_roles = 3 [
+        (google.api.field_behavior) = REQUIRED
+    ];
 }
 
 // DataSource service
 message CreateDataSourceRequest {
-  DataSource data_source = 1;
+    DataSource data_source = 1;
 }
 
 message CreateDataSourceResponse {
-  DataSource data_source = 1;
+    DataSource data_source = 1;
 }
 
 message GetDataSourceByIdRequest {
-  ContextV2 context = 1;
-  string id = 2 [(buf.validate.field).string = {uuid: true}];
+    ContextV2 context = 1;
+    string id = 2 [
+        (buf.validate.field).string = {uuid: true}
+    ];
 }
 
 message GetDataSourceByIdResponse {
-  DataSource data_source = 1;
+    DataSource data_source = 1;
 }
 
 // GetDataSourceByNameRequest is the request message for the GetDataSourceByName RPC.
 message GetDataSourceByNameRequest {
-  ContextV2 context = 1;
+    ContextV2 context = 1;
 
-  string name = 2 [
-    (buf.validate.field).string = {
-      pattern: "^[A-Za-z][-[:word:]]*$"
-      max_len: 200
-    },
-    (google.api.field_behavior) = REQUIRED
-  ];
+    string name = 2 [
+        (buf.validate.field).string = {
+            pattern: "^[A-Za-z][-[:word:]]*$",
+            max_len: 200,
+        },
+        (google.api.field_behavior) = REQUIRED
+    ];
 }
 
 message GetDataSourceByNameResponse {
-  DataSource data_source = 1;
+    DataSource data_source = 1;
 }
 
 message ListDataSourcesRequest {
-  ContextV2 context = 1;
+    ContextV2 context = 1;
 }
 
 message ListDataSourcesResponse {
-  repeated DataSource data_sources = 1;
+    repeated DataSource data_sources = 1;
 }
 
 message UpdateDataSourceRequest {
-  DataSource data_source = 1;
+    DataSource data_source = 1;
 }
 
 message UpdateDataSourceResponse {
-  DataSource data_source = 1;
+    DataSource data_source = 1;
 }
 
 message DeleteDataSourceByIdRequest {
-  ContextV2 context = 1;
-  string id = 2 [(buf.validate.field).string = {uuid: true}];
+    ContextV2 context = 1;
+    string id = 2 [
+        (buf.validate.field).string = {uuid: true}
+    ];
 }
 
 message DeleteDataSourceByIdResponse {
-  string id = 1;
+    string id = 1;
 }
 
 message DeleteDataSourceByNameRequest {
-  ContextV2 context = 1;
-  string name = 2 [
-    (buf.validate.field).string = {
-      pattern: "^[A-Za-z][-[:word:]]*$"
-      max_len: 200
-    },
-    (google.api.field_behavior) = REQUIRED
-  ];
+    ContextV2 context = 1;
+    string name = 2 [
+        (buf.validate.field).string = {
+            pattern: "^[A-Za-z][-[:word:]]*$",
+            max_len: 200,
+        },
+        (google.api.field_behavior) = REQUIRED
+    ];
 }
 
 message DeleteDataSourceByNameResponse {
-  string name = 1;
+    string name = 1;
 }
 
 // Profile service
 message CreateProfileRequest {
-  Profile profile = 1 [(google.api.field_behavior) = REQUIRED];
-  reserved 2; // deprecated context
+    Profile profile = 1 [
+        (google.api.field_behavior) = REQUIRED
+    ];
+    reserved 2; // deprecated context
 }
 
 message CreateProfileResponse {
-  Profile profile = 1 [(google.api.field_behavior) = REQUIRED];
+    Profile profile = 1 [
+        (google.api.field_behavior) = REQUIRED
+    ];
 }
 
 message UpdateProfileRequest {
-  Profile profile = 1 [(google.api.field_behavior) = REQUIRED];
-  reserved 2; // deprecated context
+    Profile profile = 1 [
+        (google.api.field_behavior) = REQUIRED
+    ];
+    reserved 2; // deprecated context
 }
 
 message UpdateProfileResponse {
-  Profile profile = 1 [(google.api.field_behavior) = REQUIRED];
+    Profile profile = 1 [
+        (google.api.field_behavior) = REQUIRED
+    ];
 }
 
 message PatchProfileRequest {
-  // The context in which the patch is applied. Provided explicitly
-  // so that the patch itself can be minimal and contain only
-  // the attribute to set, e.g. remediate=true
-  Context context = 1;
-  // The id or name of the profile to patch. Same explanation about explicitness
-  // as for the context
-  string id = 2 [
-    (buf.validate.field).string = {
-      pattern: "^[A-Za-z0-9][-/[:word:]]*$"
-      max_len: 200
-    },
-    (google.api.field_behavior) = REQUIRED
-  ];
-  // The patch to apply to the profile
-  Profile patch = 3;
-  // needed to enable PATCH, see https://grpc-ecosystem.github.io/grpc-gateway/docs/mapping/patch_feature/
-  // is not exposed to the API user
-  google.protobuf.FieldMask update_mask = 4;
+    // The context in which the patch is applied. Provided explicitly
+    // so that the patch itself can be minimal and contain only
+    // the attribute to set, e.g. remediate=true
+    Context context = 1;
+    // The id or name of the profile to patch. Same explanation about explicitness
+    // as for the context
+    string id = 2 [
+        (buf.validate.field).string = {
+            pattern: "^[A-Za-z0-9][-/[:word:]]*$",
+            max_len: 200,
+        },
+        (google.api.field_behavior) = REQUIRED
+    ];
+    // The patch to apply to the profile
+    Profile patch = 3;
+    // needed to enable PATCH, see https://grpc-ecosystem.github.io/grpc-gateway/docs/mapping/patch_feature/
+    // is not exposed to the API user
+    google.protobuf.FieldMask update_mask = 4;
 }
 
 message PatchProfileResponse {
-  Profile profile = 1 [(google.api.field_behavior) = REQUIRED];
+    Profile profile = 1 [
+        (google.api.field_behavior) = REQUIRED
+    ];
 }
 
 message DeleteProfileRequest {
-  // context is the context in which the rule type is evaluated.
-  Context context = 1;
-  // id is the name or id of the profile to delete
-  string id = 2 [
-    (buf.validate.field).string = {
-      pattern: "^[A-Za-z0-9][-/[:word:]]*$"
-      max_len: 200
-    },
-    (google.api.field_behavior) = REQUIRED
-  ];
+    // context is the context in which the rule type is evaluated.
+    Context context = 1;
+    // id is the name or id of the profile to delete
+    string id = 2 [
+        (buf.validate.field).string = {
+            pattern: "^[A-Za-z0-9][-/[:word:]]*$",
+            max_len: 200,
+        },
+        (google.api.field_behavior) = REQUIRED
+    ];
 }
 
-message DeleteProfileResponse {}
+message DeleteProfileResponse {
+}
 
 // list profiles
 message ListProfilesRequest {
-  // context is the context which contains the profiles
-  Context context = 1;
-  // Filter profiles to only those matching the specified labels.
-  //
-  // The default is to return all user-created profiles; the string "*" can
-  // be used to select all profiles, including system profiles.  This syntax
-  // may be expanded in the future.
-  string label_filter = 2 [
-    (buf.validate.field).string = {
-      pattern: "^(\\*|[a-z][a-z0-9_]*)$"
-      max_len: 200
-    },
-    (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE
-  ];
+    // context is the context which contains the profiles
+    Context context = 1;
+    // Filter profiles to only those matching the specified labels.
+    //
+    // The default is to return all user-created profiles; the string "*" can
+    // be used to select all profiles, including system profiles.  This syntax
+    // may be expanded in the future.
+    string label_filter = 2 [
+        (buf.validate.field).string = {
+            pattern: "^(\\*|[a-z][a-z0-9_]*)$",
+            max_len: 200,
+        },
+        (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE
+    ];
 }
 
 message ListProfilesResponse {
-  repeated Profile profiles = 1 [(google.api.field_behavior) = REQUIRED];
+    repeated Profile profiles = 1 [
+        (google.api.field_behavior) = REQUIRED
+    ];
 }
 
 // get profile by id
 message GetProfileByIdRequest {
-  // context is the context which contains the profiles
-  Context context = 1;
-  // id is the id of the profile to get
-  string id = 2 [
-    (buf.validate.field).string = {uuid: true},
-    (google.api.field_behavior) = REQUIRED
-  ];
+    // context is the context which contains the profiles
+    Context context = 1;
+    // id is the id of the profile to get
+    string id = 2 [
+        (buf.validate.field).string = {uuid: true},
+        (google.api.field_behavior) = REQUIRED
+    ];
 }
 
 message GetProfileByIdResponse {
-  Profile profile = 1 [(google.api.field_behavior) = REQUIRED];
+    Profile profile = 1 [
+        (google.api.field_behavior) = REQUIRED
+    ];
 }
 
 // get profile by name
 message GetProfileByNameRequest {
-  // context is the context in which the rule type is evaluated.
-  Context context = 1;
-  // name is the name of the profile to get
-  string name = 2 [
-    (buf.validate.field).string = {
-      pattern: "^[A-Za-z][-/[:word:]]*$"
-      max_len: 200
-    },
-    (google.api.field_behavior) = REQUIRED
-  ];
+    // context is the context in which the rule type is evaluated.
+    Context context = 1;
+    // name is the name of the profile to get
+    string name = 2 [
+        (buf.validate.field).string = {
+            pattern: "^[A-Za-z][-/[:word:]]*$",
+            max_len: 200,
+        },
+        (google.api.field_behavior) = REQUIRED
+    ];
 }
 
 message GetProfileByNameResponse {
-  Profile profile = 1 [(google.api.field_behavior) = REQUIRED];
+    Profile profile = 1 [
+        (google.api.field_behavior) = REQUIRED
+    ];
 }
 
 // get the overall profile status as output
 message ProfileStatus {
-  // profile_id is the id of the profile.  One of profile_id or profile_name must be set.
-  string profile_id = 1;
-  // profile_name is the name of the profile.  One of profile_id or profile_name must be set.
-  string profile_name = 2;
-  // profile_status is the status of the profile
-  string profile_status = 3 [(google.api.field_behavior) = REQUIRED];
-  // last_updated is the last time the profile was updated
-  google.protobuf.Timestamp last_updated = 4;
+    // profile_id is the id of the profile.  One of profile_id or profile_name must be set.
+    string profile_id = 1;
+    // profile_name is the name of the profile.  One of profile_id or profile_name must be set.
+    string profile_name = 2;
+    // profile_status is the status of the profile
+    string profile_status = 3 [
+        (google.api.field_behavior) = REQUIRED
+    ];
+    // last_updated is the last time the profile was updated
+    google.protobuf.Timestamp last_updated = 4;
 
-  // profile_display_name is the display name of the profile
-  string profile_display_name = 5;
+    // profile_display_name is the display name of the profile
+    string profile_display_name = 5;
 }
 
 // EvalResultAlert holds the alert details for a given rule evaluation
 message EvalResultAlert {
-  // status is the status of the alert
-  string status = 1;
-  // last_updated is the last time the alert was performed or attempted
-  google.protobuf.Timestamp last_updated = 2;
-  // details is the description of the alert attempt if any
-  string details = 3;
-  // url is the URL to the alert
-  string url = 4;
+    // status is the status of the alert
+    string status = 1;
+    // last_updated is the last time the alert was performed or attempted
+    google.protobuf.Timestamp last_updated = 2;
+    // details is the description of the alert attempt if any
+    string details = 3;
+    // url is the URL to the alert
+    string url = 4;
 }
 
 // get the status of the rules for a given profile
 message RuleEvaluationStatus {
-  // profile_id is the id of the profile
-  string profile_id = 1;
-  // rule_id is the id of the rule
-  string rule_id = 2 [(google.api.field_behavior) = REQUIRED];
-  // rule_name is the type of the rule. Deprecated in favor of rule_type_name
-  string rule_name = 3 [deprecated = true];
-  // entity is the entity that was evaluated
-  string entity = 4 [(google.api.field_behavior) = REQUIRED];
-  // status is the status of the evaluation
-  string status = 5 [(google.api.field_behavior) = REQUIRED];
-  // last_updated is the last time the profile was updated
-  google.protobuf.Timestamp last_updated = 6;
-  // entity_info is the information about the entity
-  map<string, string> entity_info = 7;
-  // details is the description of the evaluation if any
-  string details = 8;
-  // guidance is the guidance for the evaluation if any
-  string guidance = 9;
-  // remediation_status is the status of the remediation
-  string remediation_status = 10;
-  // remediation_last_updated is the last time the remediation was performed or attempted
-  optional google.protobuf.Timestamp remediation_last_updated = 11;
-  // remediation_details is the description of the remediation attempt if any
-  string remediation_details = 12;
-  // rule_type_name is the name of the rule
-  string rule_type_name = 13 [(google.api.field_behavior) = REQUIRED];
-  // rule_description_name is the name to describe the rule
-  string rule_description_name = 14;
-  // alert holds the alert details if the rule generated an alert in an external system
-  EvalResultAlert alert = 15;
-  // severity is the severity of the rule. This may be empty.
-  Severity severity = 16;
-  // rule_evaluation_id is the id of the rule evaluation
-  string rule_evaluation_id = 17;
-  // remediation_url is a url to get more data about a remediation, for PRs is the link to the PR
-  string remediation_url = 18;
-  // rule_display_name captures the display name of the rule
-  string rule_display_name = 19;
-  // release_phase is the phase of the release
-  RuleTypeReleasePhase release_phase = 20 [(google.api.field_behavior) = REQUIRED];
-  // output optionally contains the structured rule evaluation output.
-  // Because output may be multiple KB, it is only returned
-  // if include_outputs is set. Historical evaluations may
-  // discard structured output sooner than status results.
-  google.protobuf.Value output = 21;
+    // profile_id is the id of the profile
+    string profile_id = 1;
+    // rule_id is the id of the rule
+    string rule_id = 2 [
+        (google.api.field_behavior) = REQUIRED
+    ];
+    // rule_name is the type of the rule. Deprecated in favor of rule_type_name
+    string rule_name = 3 [deprecated=true];
+    // entity is the entity that was evaluated
+    string entity = 4 [
+        (google.api.field_behavior) = REQUIRED
+    ];
+    // status is the status of the evaluation
+    string status = 5 [
+        (google.api.field_behavior) = REQUIRED
+    ];
+    // last_updated is the last time the profile was updated
+    google.protobuf.Timestamp last_updated = 6;
+    // entity_info is the information about the entity
+    map<string, string> entity_info = 7;
+    // details is the description of the evaluation if any
+    string details = 8;
+    // guidance is the guidance for the evaluation if any
+    string guidance = 9;
+    // remediation_status is the status of the remediation
+    string remediation_status = 10;
+    // remediation_last_updated is the last time the remediation was performed or attempted
+    optional google.protobuf.Timestamp remediation_last_updated = 11;
+    // remediation_details is the description of the remediation attempt if any
+    string remediation_details = 12;
+    // rule_type_name is the name of the rule
+    string rule_type_name = 13 [
+        (google.api.field_behavior) = REQUIRED
+    ];
+    // rule_description_name is the name to describe the rule
+    string rule_description_name = 14;
+    // alert holds the alert details if the rule generated an alert in an external system
+    EvalResultAlert alert = 15;
+    // severity is the severity of the rule. This may be empty.
+    Severity severity = 16;
+    // rule_evaluation_id is the id of the rule evaluation
+    string rule_evaluation_id = 17;
+    // remediation_url is a url to get more data about a remediation, for PRs is the link to the PR
+    string remediation_url = 18;
+    // rule_display_name captures the display name of the rule
+    string rule_display_name = 19;
+    // release_phase is the phase of the release
+    RuleTypeReleasePhase release_phase = 20 [
+        (google.api.field_behavior) = REQUIRED
+    ];
+    // output optionally contains the structured rule evaluation output.
+    // Because output may be multiple KB, it is only returned
+    // if include_outputs is set. Historical evaluations may
+    // discard structured output sooner than status results.
+    google.protobuf.Value output = 21;
 }
 
 // EntityTypedId is a message that carries an ID together with a type to uniquely identify an entity
 // such as (repo, 1), (artifact, 2), ...
 message EntityTypedId {
-  // entity is the entity to get status for. Incompatible with `all`
-  Entity type = 1 [(google.api.field_behavior) = REQUIRED];
-  // On input, at least one of id and name must be set.  If both are set, they must both match.
-  // On output, both id and name will be set.
+    // entity is the entity to get status for. Incompatible with `all`
+    Entity type = 1 [
+        (google.api.field_behavior) = REQUIRED
+    ];
+    // On input, at least one of id and name must be set.  If both are set, they must both match.
+    // On output, both id and name will be set.
 
-  // id is the ID of the entity to get status for. Incompatible with `all`
-  string id = 2 [
-    (buf.validate.field).string = {uuid: true},
-    (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE,
-    (google.api.field_behavior) = OPTIONAL
-  ];
-  // name is the name of the entity.  This name is unique within a given project, type, and provider, but may not be globally unique.
-  string name = 3 [
-    (buf.validate.field).string = {
-      max_bytes: 200
-      pattern: "^[[:alnum:]][-/[:word:]]*"
-    },
-    (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE,
-    (google.api.field_behavior) = OPTIONAL
-  ];
+    // id is the ID of the entity to get status for. Incompatible with `all`
+    string id = 2 [
+        (buf.validate.field).string = {uuid: true},
+        (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE,
+        (google.api.field_behavior) = OPTIONAL
+    ];
+    // name is the name of the entity.  This name is unique within a given project, type, and provider, but may not be globally unique.
+    string name = 3 [
+        (buf.validate.field).string = {
+            max_bytes: 200
+            pattern: "^[[:alnum:]][-/[:word:]]*"
+        },
+        (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE,
+        (google.api.field_behavior) = OPTIONAL
+    ];
 }
 
 message GetProfileStatusByNameRequest {
-  // context is the context in which the rule type is evaluated.
-  Context context = 1;
-  // name is the name of the profile to get
-  string name = 2 [
-    (buf.validate.field).string = {
-      pattern: "^[A-Za-z][-/[:word:]]*$"
-      max_len: 200
-    },
-    (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE
-  ];
+    // context is the context in which the rule type is evaluated.
+    Context context = 1;
+    // name is the name of the profile to get
+    string name = 2 [
+        (buf.validate.field).string = {
+            pattern: "^[A-Za-z][-/[:word:]]*$",
+            max_len: 200,
+        },
+        (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE
+    ];
 
-  // entity is the entity to get status for. Incompatible with `all`.
-  // This is optional.
-  EntityTypedId entity = 3;
+    // entity is the entity to get status for. Incompatible with `all`.
+    // This is optional.
+    EntityTypedId entity = 3;
 
-  // all is true if the status of all entities should be returned.
-  // Incompatible with `entity`. This is optional.
-  bool all = 4;
+    // all is true if the status of all entities should be returned.
+    // Incompatible with `entity`. This is optional.
+    bool all = 4;
 
-  // rule is the type of the rule. Deprecated in favor of rule_type
-  string rule = 5 [deprecated = true];
+    // rule is the type of the rule. Deprecated in favor of rule_type
+    string rule = 5 [deprecated=true];
 
-  // rule_type is the type of the rule to filter on.
-  // This is optional.
-  string rule_type = 6 [
-    (buf.validate.field).string = {
-      pattern: "^[A-Za-z][-/[:word:]]*$"
-      max_len: 200
-    },
-    (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE
-  ];
+    // rule_type is the type of the rule to filter on.
+    // This is optional.
+    string rule_type = 6 [
+        (buf.validate.field).string = {
+            pattern: "^[A-Za-z][-/[:word:]]*$"
+            max_len: 200,
+        },
+        (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE
+    ];
 
-  // rule_name is the name of the rule to filter on.
-  // This is optional.
-  string rule_name = 7 [
-    (buf.validate.field).string = {
-      pattern: "^[A-Za-z][-/'()[:word:] :]*$"
-      max_len: 200
-    },
-    (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE
-  ];
+    // rule_name is the name of the rule to filter on.
+    // This is optional.
+    string rule_name = 7 [
+        (buf.validate.field).string = {
+            pattern: "^[A-Za-z][-/'()[:word:] :]*$",
+            max_len: 200,
+        },
+        (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE
+    ];
 }
 
 message GetProfileStatusByNameResponse {
-  // profile_status is the status of the profile
-  ProfileStatus profile_status = 1 [(google.api.field_behavior) = REQUIRED];
+    // profile_status is the status of the profile
+    ProfileStatus profile_status = 1[
+        (google.api.field_behavior) = REQUIRED
+    ];
 
-  // rule_evaluation_status is the status of the rules
-  repeated RuleEvaluationStatus rule_evaluation_status = 2;
+    // rule_evaluation_status is the status of the rules
+    repeated RuleEvaluationStatus rule_evaluation_status = 2;
 }
 
 message GetProfileStatusByIdRequest {
-  // context is the context in which the rule type is evaluated.
-  Context context = 1;
-  // id is the id of the profile to get
-  string id = 2 [(buf.validate.field).string = {uuid: true}];
+    // context is the context in which the rule type is evaluated.
+    Context context = 1;
+    // id is the id of the profile to get
+    string id = 2 [
+        (buf.validate.field).string = {uuid: true}
+    ];
 
-  EntityTypedId entity = 3;
-  bool all = 4;
+    EntityTypedId entity = 3;
+    bool all = 4;
 
-  string rule_type = 5 [
-    (buf.validate.field).string = {
-      pattern: "^[A-Za-z][-/[:word:]]*$"
-      max_len: 200
-    },
-    (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE
-  ];
-  string rule_name = 6 [
-    (buf.validate.field).string = {
-      pattern: "^[A-Za-z][-/'()[:word:] :]*$"
-      max_len: 200
-    },
-    (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE
-  ];
+    string rule_type = 5 [
+        (buf.validate.field).string = {
+            pattern: "^[A-Za-z][-/[:word:]]*$"
+            max_len: 200,
+        },
+        (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE
+    ];
+    string rule_name = 6 [
+        (buf.validate.field).string = {
+            pattern: "^[A-Za-z][-/'()[:word:] :]*$",
+            max_len: 200,
+        },
+        (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE
+    ];
 }
 
 message GetProfileStatusByIdResponse {
-  // profile_status is the status of the profile
-  ProfileStatus profile_status = 1 [(google.api.field_behavior) = REQUIRED];
+    // profile_status is the status of the profile
+    ProfileStatus profile_status = 1[
+        (google.api.field_behavior) = REQUIRED
+    ];
 
-  // rule_evaluation_status is the status of the rules
-  repeated RuleEvaluationStatus rule_evaluation_status = 2;
+    // rule_evaluation_status is the status of the rules
+    repeated RuleEvaluationStatus rule_evaluation_status = 2;
 }
 
+
 message GetProfileStatusByProjectRequest {
-  // context is the context in which the rule type is evaluated.
-  Context context = 1;
+    // context is the context in which the rule type is evaluated.
+    Context context = 1;
 }
 
 message GetProfileStatusByProjectResponse {
-  // profile_status is the status of the profile
-  repeated ProfileStatus profile_status = 1 [(google.api.field_behavior) = REQUIRED];
+    // profile_status is the status of the profile
+    repeated ProfileStatus profile_status = 1 [
+        (google.api.field_behavior) = REQUIRED
+    ];
 }
 
 // Entity defines the entity that is supported by the provider.
 enum Entity {
-  ENTITY_UNSPECIFIED = 0;
-  ENTITY_REPOSITORIES = 1;
-  ENTITY_BUILD_ENVIRONMENTS = 2;
-  ENTITY_ARTIFACTS = 3;
-  ENTITY_PULL_REQUESTS = 4;
-  ENTITY_RELEASE = 5;
-  ENTITY_PIPELINE_RUN = 6;
-  ENTITY_TASK_RUN = 7;
-  ENTITY_BUILD = 8;
+    ENTITY_UNSPECIFIED = 0;
+    ENTITY_REPOSITORIES = 1;
+    ENTITY_BUILD_ENVIRONMENTS = 2;
+    ENTITY_ARTIFACTS = 3;
+    ENTITY_PULL_REQUESTS = 4;
+    ENTITY_RELEASE = 5;
+    ENTITY_PIPELINE_RUN = 6;
+    ENTITY_TASK_RUN = 7;
+    ENTITY_BUILD = 8;
 }
 
 message EntityAutoRegistrationConfig {
-  optional bool enabled = 1;
+   optional bool enabled = 1;
 }
 
 // AutoRegistration is the configuration for auto-registering entities.
 // When nothing is set, it means that auto-registration is disabled. There is no difference between disabled
 // and undefined so for the "let's not auto-register anything" case we'd just let the repeated string empty
 message AutoRegistration {
-  // enabled is the list of entities that are enabled for auto-registration.
-  map<string, EntityAutoRegistrationConfig> entities = 1 [(google.api.field_behavior) = REQUIRED];
+    // enabled is the list of entities that are enabled for auto-registration.
+    map<string, EntityAutoRegistrationConfig> entities = 1 [
+        (google.api.field_behavior) = REQUIRED
+    ];
 }
 
 // ProviderConfig contains the generic configuration for a provider.
 message ProviderConfig {
-  // auto_registration is the configuration for auto-registering entities.
-  optional AutoRegistration auto_registration = 1;
+    // auto_registration is the configuration for auto-registering entities.
+    optional AutoRegistration auto_registration = 1;
 }
 
 // RESTProviderConfig contains the configuration for the REST provider.
 message RESTProviderConfig {
-  // base_url is the base URL for the REST provider.
-  optional string base_url = 1;
+    // base_url is the base URL for the REST provider.
+	optional string base_url = 1;
 }
 
 // GitHubProviderConfig contains the configuration for the GitHub client
@@ -1821,8 +2088,8 @@ message RESTProviderConfig {
 // disable revive linting for this struct as there is nothing wrong with the
 // naming convention
 message GitHubProviderConfig {
-  // Endpoint is the GitHub API endpoint. If using the public GitHub API, Endpoint can be left blank.
-  optional string endpoint = 1;
+    // Endpoint is the GitHub API endpoint. If using the public GitHub API, Endpoint can be left blank.
+	optional string endpoint = 1;
 }
 
 // GitHubAppProviderConfig contains the configuration for the GitHub App provider
@@ -1839,11 +2106,11 @@ message GitHubAppProviderConfig {
 //
 // If using the public GitLab API, Endpoint can be left blank
 message GitLabProviderConfig {
-  // Endpoint is the GitLab API endpoint. If using the public GitLab API, Endpoint can be left blank.
-  string endpoint = 1;
+    // Endpoint is the GitLab API endpoint. If using the public GitLab API, Endpoint can be left blank.
+    string endpoint = 1;
 
-  // group is the GitLab group to use for the provider
-  string group = 2;
+    // group is the GitLab group to use for the provider
+    string group = 2;
 }
 
 // DockerHubProviderConfig contains the configuration for the DockerHub provider.
@@ -1851,8 +2118,8 @@ message GitLabProviderConfig {
 // Namespace: is the namespace for the DockerHub provider.
 //
 message DockerHubProviderConfig {
-  // namespace is the namespace for the DockerHub provider.
-  optional string namespace = 1;
+    // namespace is the namespace for the DockerHub provider.
+    optional string namespace = 1;
 }
 
 // GHCRProviderConfig contains the configuration for the GHCR provider.
@@ -1860,1651 +2127,1791 @@ message DockerHubProviderConfig {
 // Namespace: is the namespace for the GHCR provider.
 //
 message GHCRProviderConfig {
-  // namespace is the namespace for the GHCR provider.
-  optional string namespace = 1;
+    // namespace is the namespace for the GHCR provider.
+    optional string namespace = 1;
 }
 
 // Context defines the context in which a rule is evaluated.
 // this normally refers to a combination of the provider, organization and project.
 message Context {
-  // Removing the 'optional' keyword from the following two fields below will break
-  // buf compatibility checks.
+    // Removing the 'optional' keyword from the following two fields below will break
+    // buf compatibility checks.
 
-  // name of the provider
-  // This is optional, but some existing clients may set the field unconditionally,
-  // so an empty string is also an allowed value.
-  optional string provider = 1 [(buf.validate.field).string = {
-    pattern: "^(?:[A-Za-z][-[:word:]]*)?$"
-    max_len: 200
-  }];
-  // ID or name of the project.  If empty or unset, will select the user's default
-  // project if they only have one project.  Existing clients may unconditionally set
-  // this to the empty string rather than leaving this unset, so we allow "" as an
-  // alias for unset.
-  optional string project = 3 [(buf.validate.field).string = {
-    pattern: "^[-a-zA-Z0-9.]{0,63}$"
-    max_len: 63
-  }];
+    // name of the provider
+    // This is optional, but some existing clients may set the field unconditionally,
+    // so an empty string is also an allowed value.
+    optional string provider = 1 [
+        (buf.validate.field).string = {
+            pattern: "^(?:[A-Za-z][-[:word:]]*)?$",
+            max_len: 200,
+        }
+    ];
+    // ID or name of the project.  If empty or unset, will select the user's default
+    // project if they only have one project.  Existing clients may unconditionally set
+    // this to the empty string rather than leaving this unset, so we allow "" as an
+    // alias for unset.
+    optional string project = 3 [
+        (buf.validate.field).string = {
+            pattern: "^[-a-zA-Z0-9.]{0,63}$"
+            max_len: 63
+        }
+    ];
 
-  optional string retired_organization = 2;
+    optional string retired_organization = 2;
 }
 
 // ContextV2 defines the context in which a rule is evaluated.
 message ContextV2 {
-  // project is the project ID or name.  If empty or unset, will select the user's
-  // default project if they only have one project.
-  string project_id = 1 [
-    (buf.validate.field).string = {
-      pattern: "^[-a-zA-Z0-9.]{1,63}$"
-      max_len: 63
-    },
-    (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE
-  ];
+    // project is the project ID or name.  If empty or unset, will select the user's
+    // default project if they only have one project.
+    string project_id = 1 [
+        (buf.validate.field).string = {
+            pattern: "^[-a-zA-Z0-9.]{1,63}$"
+            max_len: 63
+        },
+        (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE
+    ];
 
-  // name of the provider. Set to empty string when not applicable.
-  string provider = 2 [
-    (buf.validate.field).string = {
-      pattern: "^[A-Za-z][-[:word:]]*$"
-      max_len: 200
-    },
-    (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE
-  ];
+    // name of the provider. Set to empty string when not applicable.
+    string provider = 2 [
+        (buf.validate.field).string = {
+            pattern: "^[A-Za-z][-[:word:]]*$",
+            max_len: 200,
+        },
+        (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE
+    ];
 }
 
 // --- START RuleType CRUD definitions
 
 // ListRuleTypesRequest is the request to list rule types.
 message ListRuleTypesRequest {
-  // context is the context in which the rule types are evaluated.
-  Context context = 1;
+    // context is the context in which the rule types are evaluated.
+    Context context = 1;
 }
 
 // ListRuleTypesResponse is the response to list rule types.
 message ListRuleTypesResponse {
-  // rule_types is the list of rule types.
-  repeated RuleType rule_types = 1 [(google.api.field_behavior) = REQUIRED];
+    // rule_types is the list of rule types.
+    repeated RuleType rule_types = 1 [
+        (google.api.field_behavior) = REQUIRED
+    ];
 }
 
 // GetRuleTypeByNameRequest is the request to get a rule type by name.
 message GetRuleTypeByNameRequest {
-  // context is the context in which the rule type is evaluated.
-  Context context = 1;
-  // name is the name of the rule type.
-  string name = 2 [
-    (buf.validate.field).string = {
-      pattern: "^[A-Za-z][-/[:word:]]*$"
-      max_len: 200
-    },
-    (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE
-  ];
+    // context is the context in which the rule type is evaluated.
+    Context context = 1;
+    // name is the name of the rule type.
+    string name = 2 [
+        (buf.validate.field).string = {
+            pattern: "^[A-Za-z][-/[:word:]]*$",
+            max_len: 200,
+        },
+        (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE
+    ];
 }
 
 // GetRuleTypeByNameResponse is the response to get a rule type by name.
 message GetRuleTypeByNameResponse {
-  // rule_type is the rule type.
-  RuleType rule_type = 1 [(google.api.field_behavior) = REQUIRED];
+    // rule_type is the rule type.
+    RuleType rule_type = 1 [
+        (google.api.field_behavior) = REQUIRED
+    ];
 }
 
 // GetRuleTypeByIdRequest is the request to get a rule type by id.
 message GetRuleTypeByIdRequest {
-  // context is the context in which the rule type is evaluated.
-  Context context = 1;
-  // id is the id of the rule type.
-  string id = 2 [
-    (buf.validate.field).string = {uuid: true},
-    (google.api.field_behavior) = REQUIRED
-  ];
+    // context is the context in which the rule type is evaluated.
+    Context context = 1;
+    // id is the id of the rule type.
+    string id = 2 [
+        (buf.validate.field).string = {uuid: true},
+        (google.api.field_behavior) = REQUIRED
+    ];
 }
 
 // GetRuleTypeByIdResponse is the response to get a rule type by id.
 message GetRuleTypeByIdResponse {
-  // rule_type is the rule type.
-  RuleType rule_type = 1 [(google.api.field_behavior) = REQUIRED];
+    // rule_type is the rule type.
+    RuleType rule_type = 1 [
+        (google.api.field_behavior) = REQUIRED
+    ];
 }
 
 // CreateRuleTypeRequest is the request to create a rule type.
 message CreateRuleTypeRequest {
-  // rule_type is the rule type to be created.
-  RuleType rule_type = 1 [(google.api.field_behavior) = REQUIRED];
-  reserved 2; // deprecated context
+    // rule_type is the rule type to be created.
+    RuleType rule_type = 1 [
+        (google.api.field_behavior) = REQUIRED
+    ];
+    reserved 2; // deprecated context
 }
 
 // CreateRuleTypeResponse is the response to create a rule type.
 message CreateRuleTypeResponse {
-  // rule_type is the rule type that was created.
-  RuleType rule_type = 1 [(google.api.field_behavior) = REQUIRED];
+    // rule_type is the rule type that was created.
+    RuleType rule_type = 1 [
+        (google.api.field_behavior) = REQUIRED
+    ];
 }
 
 // UpdateRuleTypeRequest is the request to update a rule type.
 message UpdateRuleTypeRequest {
-  // rule_type is the rule type to be updated.
-  RuleType rule_type = 2 [(google.api.field_behavior) = REQUIRED];
-  reserved 3; // deprecated context
+    // rule_type is the rule type to be updated.
+    RuleType rule_type = 2 [
+        (google.api.field_behavior) = REQUIRED
+    ];
+    reserved 3; // deprecated context
 }
 
 // UpdateRuleTypeResponse is the response to update a rule type.
 message UpdateRuleTypeResponse {
-  // rule_type is the rule type that was updated.
-  RuleType rule_type = 1 [(google.api.field_behavior) = REQUIRED];
+    // rule_type is the rule type that was updated.
+    RuleType rule_type = 1 [
+        (google.api.field_behavior) = REQUIRED
+    ];
 }
 
 // DeleteRuleTypeRequest is the request to delete a rule type.
 message DeleteRuleTypeRequest {
-  // context is the context in which the rule type is evaluated.
-  Context context = 1;
-  // id is the name or id of the rule type to be deleted.
-  string id = 2 [
-    (buf.validate.field).string = {
-      pattern: "^[A-Za-z0-9][-/[:word:]]*$"
-      max_len: 200
-    },
-    (google.api.field_behavior) = REQUIRED
-  ];
+    // context is the context in which the rule type is evaluated.
+    Context context = 1;
+    // id is the name or id of the rule type to be deleted.
+    string id = 2 [
+        (buf.validate.field).string = {
+            pattern: "^[A-Za-z0-9][-/[:word:]]*$",
+            max_len: 200,
+        },
+        (google.api.field_behavior) = REQUIRED
+    ];
 }
 
 // DeleteRuleTypeResponse is the response to delete a rule type.
-message DeleteRuleTypeResponse {}
+message DeleteRuleTypeResponse {
+}
 
 // --- END RuleType CRUD definitions
 
 // --- START EvaluationResults definitions
 
 message ListEvaluationResultsRequest {
-  // context is the context in which the evaluation results are evaluated.
-  Context context = 1;
+    // context is the context in which the evaluation results are evaluated.
+    Context context = 1;
 
-  // profile is the profile name or ID to retrieve results for.
-  // If empty, return evaluation results for profiles selected by
-  // an empty label_filter.
-  oneof profile_selector {
-    // ID can contain either a profile name or an ID.
-    string profile = 2 [(buf.validate.field).string = {
-      pattern: "^([[:alnum:]][-[:word:]]*)?$"
-      max_len: 200
-    }];
-    // Filter profiles to only those matching the specified labels.
-    //
-    // The default is to return all user-created profiles; the string "*" can
-    // be used to select all profiles, including system profiles.  This syntax
-    // may be expanded in the future.
-    string label_filter = 3 [(buf.validate.field).string = {
-      pattern: "^(\\*|[a-zA-Z][a-zA-Z0-9_]*)$"
-      max_len: 200
-    }];
-  }
-
-  // If set, only return evaluation results for the named entities.
-  // If empty, return evaluation results for all entities
-  repeated EntityTypedId entity = 4;
-
-  // If set, only return evaluation results for the named rules.
-  // If empty, return evaluation results for all rules
-  repeated string rule_name = 5 [(buf.validate.field).repeated = {
-    items: {
-      string: {
-        pattern: "^[A-Za-z][-/[:word:]]*$"
-        max_len: 200
-      }
+    // profile is the profile name or ID to retrieve results for.
+    // If empty, return evaluation results for profiles selected by
+    // an empty label_filter.
+    oneof profile_selector {
+        // ID can contain either a profile name or an ID.
+        string profile = 2 [
+            (buf.validate.field).string = {
+                pattern: "^([[:alnum:]][-[:word:]]*)?$"
+                max_len: 200,
+            }
+        ];
+        // Filter profiles to only those matching the specified labels.
+        //
+        // The default is to return all user-created profiles; the string "*" can
+        // be used to select all profiles, including system profiles.  This syntax
+        // may be expanded in the future.
+        string label_filter = 3 [
+            (buf.validate.field).string = {
+                pattern: "^(\\*|[a-zA-Z][a-zA-Z0-9_]*)$",
+                max_len: 200,
+            }
+        ];
     }
-  }];
 
-  // If true, include structured rule output for the matched evaluations.
-  // Not all ruletypes may generate structured outputs.
-  // Because the evaluation output may be large, it is only returned
-  // when explicitly requested.
-  bool include_outputs = 6;
+    // If set, only return evaluation results for the named entities.
+    // If empty, return evaluation results for all entities
+    repeated EntityTypedId entity = 4;
+
+    // If set, only return evaluation results for the named rules.
+    // If empty, return evaluation results for all rules
+    repeated string rule_name = 5 [
+        (buf.validate.field).repeated = {
+            items: {
+                string: {
+                    pattern: "^[A-Za-z][-/[:word:]]*$",
+                        max_len: 200,
+                    }
+            }
+        }
+    ];
+
+    // If true, include structured rule output for the matched evaluations.
+    // Not all ruletypes may generate structured outputs.
+    // Because the evaluation output may be large, it is only returned
+    // when explicitly requested.
+    bool include_outputs = 6;
 }
 
 message ListEvaluationResultsResponse {
-  reserved 1; // deprecated status
-  reserved "status";
+    reserved 1; // deprecated status
+    reserved "status";
 
-  message EntityProfileEvaluationResults {
-    // profile_status is the status of the profile - id, name, status, last_updated
-    ProfileStatus profile_status = 1;
+    message EntityProfileEvaluationResults {
+        // profile_status is the status of the profile - id, name, status, last_updated
+        ProfileStatus profile_status = 1;
 
-    // Note that some fields like profile_id and entity might be empty
-    // Eventually we might replace this type with another one that fits the API better
-    repeated RuleEvaluationStatus results = 2;
-  }
+        // Note that some fields like profile_id and entity might be empty
+        // Eventually we might replace this type with another one that fits the API better
+        repeated RuleEvaluationStatus results = 2;
+    }
 
-  message EntityEvaluationResults {
-    EntityTypedId entity = 1;
-    repeated EntityProfileEvaluationResults profiles = 2;
-  }
+    message EntityEvaluationResults {
+        EntityTypedId entity = 1;
+        repeated EntityProfileEvaluationResults profiles = 2;
+    }
 
-  // Each entity selected by the list request will have _single_ entry in entities which contains results of all evaluations for each profile.
-  repeated EntityEvaluationResults entities = 2 [(google.api.field_behavior) = REQUIRED];
+    // Each entity selected by the list request will have _single_ entry in entities which contains results of all evaluations for each profile.
+    repeated EntityEvaluationResults entities = 2 [
+        (google.api.field_behavior) = REQUIRED
+    ];
 }
 
 // --- END EvaluationResults definitions
 
+
+
 // RestType defines the rest data evaluation.
 // This is used to fetch data from a REST endpoint.
 message RestType {
-  message Fallback {
-    int32 http_code = 1 [(buf.validate.field).int32 = {
-      gte: 100
-      lte: 599
-    }];
-    // This is expected to be a valid JSON string.
-    string body = 2 [
-      (buf.validate.field).string = {max_len: 1000},
-      (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE
-    ];
-  }
-
-  // endpoint is the endpoint to fetch data from.
-  // This can be a URL or path on the API.
-  // This is a required field and must be set.
-  // This is also evaluated via a template which allows
-  // us dynamically fill in the values.
-  string endpoint = 1 [
-    (buf.validate.field).string = {max_len: 400},
-    (google.api.field_behavior) = REQUIRED
-  ];
-
-  // method is the method to use to fetch data.
-  // Go templates may be used to vary the method using the same parameters
-  // as the endpoint.
-  string method = 2 [
-    (buf.validate.field).string = {max_len: 50},
-    (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE
-  ];
-
-  // headers are the headers to be sent to the endpoint.
-  repeated string headers = 3 [(buf.validate.field).repeated = {
-    items: {
-      string: {
-        pattern: "^[a-zA-Z0-9-]+:[[:graph:][:blank:]]+$"
-        max_len: 400
-      }
+    message Fallback {
+        int32 http_code = 1 [(buf.validate.field).int32 = { gte: 100, lte: 599 }];
+        // This is expected to be a valid JSON string.
+        string body = 2 [
+            (buf.validate.field).string = {
+                max_len: 1000,
+            },
+            (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE
+        ];
     }
-  }];
 
-  // body is the body to be sent to the endpoint, which must be valid JSON
-  // Go templates may be used to vary the method using the same parameters
-  // as the endpoint.
-  optional string body = 4 [(buf.validate.field).string = {max_len: 1000}];
+    // endpoint is the endpoint to fetch data from.
+    // This can be a URL or path on the API.
+    // This is a required field and must be set.
+    // This is also evaluated via a template which allows
+    // us dynamically fill in the values.
+    string endpoint = 1 [
+        (buf.validate.field).string = {
+            max_len: 400,
+        },
+        (google.api.field_behavior) = REQUIRED
+    ];
 
-  // parse is the parsing mechanism to be used to parse the data.
-  string parse = 5 [
-    (buf.validate.field).string = {
-      pattern: "^[a-z_]+$"
-      max_len: 50
-    },
-    (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE
-  ];
+    // method is the method to use to fetch data.
+    // Go templates may be used to vary the method using the same parameters
+    // as the endpoint.
+    string method = 2 [
+        (buf.validate.field).string = {
+            max_len: 50
+        },
+        (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE
+    ];
 
-  // fallback provides a body that the ingester would return in case
-  // the REST call returns a non-200 status code.
-  repeated Fallback fallback = 6;
+    // headers are the headers to be sent to the endpoint.
+    repeated string headers = 3 [
+        (buf.validate.field).repeated = {
+            items: {
+                string: {
+                    pattern: "^[a-zA-Z0-9-]+:[[:graph:][:blank:]]+$",
+                    max_len: 400,
+                }
+            }
+        }
+    ];
+
+    // body is the body to be sent to the endpoint, which must be valid JSON
+    // Go templates may be used to vary the method using the same parameters
+    // as the endpoint.
+    optional string body = 4 [
+        (buf.validate.field).string = {
+            max_len: 1000,
+        }
+    ];
+
+    // parse is the parsing mechanism to be used to parse the data.
+    string parse = 5 [
+        (buf.validate.field).string = {
+            pattern: "^[a-z_]+$",
+            max_len: 50,
+        },
+        (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE
+    ];
+
+    // fallback provides a body that the ingester would return in case
+    // the REST call returns a non-200 status code.
+    repeated Fallback fallback = 6;
 }
 
 // BuiltinType defines the builtin data evaluation.
 message BuiltinType {
-  string method = 1;
+    string method = 1;
 }
 
 // ArtifactType defines the artifact data evaluation.
-message ArtifactType {}
+message ArtifactType {
+}
 
 // GitType defines the git data ingester.
 message GitType {
-  // clone_url is the url of the git repository.
-  string clone_url = 1 [
-    (buf.validate.field).string = {
-      uri: true
-      max_len: 200
-    },
-    (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE
-  ];
+    // clone_url is the url of the git repository.
+    string clone_url = 1 [
+        (buf.validate.field).string = {
+            uri: true,
+            max_len: 200,
+        },
+        (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE
+    ];
 
-  // branch is the branch of the git repository.
-  string branch = 2 [
-    (buf.validate.field).string = {
-      pattern: "^[[:word:]./-]+$"
-      max_len: 200
-    },
-    (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE
-  ];
+    // branch is the branch of the git repository.
+    string branch = 2 [
+        (buf.validate.field).string = {
+            pattern: "^[[:word:]./-]+$",
+            max_len: 200,
+        },
+        (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE
+    ];
 }
 
 // DiffType defines the diff data ingester.
 message DiffType {
-  message Ecosystem {
-    // name is the name of the ecosystem.
-    string name = 1 [(buf.validate.field).string = {
-      pattern: "^[a-z]+(_[a-z]+)*$"
-      min_len: 1
-      max_len: 200
-    }];
-    // depfile is the file that contains the dependencies for this ecosystem
-    string depfile = 2 [(buf.validate.field).string = {
-      pattern: "^(\\./)?([a-zA-Z0-9_\\-]+/)*[a-zA-Z0-9_\\-]+(\\.[a-zA-Z0-9]+)?$"
-      min_len: 1
-      max_len: 200
-    }];
-  }
+    message Ecosystem {
+        // name is the name of the ecosystem.
+        string name = 1 [
+            (buf.validate.field).string = {
+                pattern: "^[a-z]+(_[a-z]+)*$",
+                min_len: 1,
+                max_len: 200,
+            }
+        ];
+        // depfile is the file that contains the dependencies for this ecosystem
+        string depfile = 2 [
+            (buf.validate.field).string = {
+                pattern: "^(\\./)?([a-zA-Z0-9_\\-]+/)*[a-zA-Z0-9_\\-]+(\\.[a-zA-Z0-9]+)?$",
+                min_len: 1,
+                max_len: 200,
+            }
+        ];
+    }
 
-  // ecosystems is the list of ecosystems to be used
-  // for the "dep" diff type.
-  repeated Ecosystem ecosystems = 1;
+    // ecosystems is the list of ecosystems to be used
+    // for the "dep" diff type.
+    repeated Ecosystem ecosystems = 1;
 
-  // type is the type of diff ingestor to use.
-  // The default is "dep" which will leverage
-  // the ecosystems array.
-  string type = 2 [
-    (buf.validate.field).string = {
-      pattern: "^[a-z]+(_[a-z]+)*$"
-      max_len: 200
-    },
-    (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE
-  ];
+    // type is the type of diff ingestor to use.
+    // The default is "dep" which will leverage
+    // the ecosystems array.
+    string type = 2 [
+        (buf.validate.field).string = {
+            pattern: "^[a-z]+(_[a-z]+)*$",
+            max_len: 200,
+        },
+        (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE
+    ];
 }
 
 // DepsType defines the "deps" ingester which can extract depndencies in protobom
 // format for rule evaluation.
 message DepsType {
-  // branch is the branch of the git repository, when applied to repository entities.
-  // Has no meaning or effect on other entity types.
-  message RepoConfigs {
-    string branch = 1 [
-      (buf.validate.field).string = {
-        pattern: "^[[:word:]./-]+$"
-        max_len: 200
-      },
-      (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE
-    ];
-  }
+    // branch is the branch of the git repository, when applied to repository entities.
+    // Has no meaning or effect on other entity types.
+    message RepoConfigs {
+        string branch = 1 [
+            (buf.validate.field).string = {
+                pattern: "^[[:word:]./-]+$",
+                max_len: 200,
+            },
+            (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE
+        ];
+    }
 
-  message PullRequestConfigs {
-    // filter is the filter to apply to the PRs.  The default value is "NEW_AND_UPDATED".
-    string filter = 1 [
-      (buf.validate.field).string = {
-        in: [
-          "NEW_AND_UPDATED",
-          "NEW_ONLY"
-        ]
-      },
-      (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE
-    ];
-  }
+    message PullRequestConfigs {
+        // filter is the filter to apply to the PRs.  The default value is "NEW_AND_UPDATED".
+        string filter = 1 [
+            (buf.validate.field).string = {
+                in: ["NEW_AND_UPDATED", "NEW_ONLY"],
+            },
+            (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE
+        ];
+    }
 
-  oneof entity_type {
-    RepoConfigs repo = 1;
-    PullRequestConfigs pr = 2;
-  }
+    oneof entity_type {
+        RepoConfigs repo = 1;
+        PullRequestConfigs pr = 2;
+    }
 }
 
 // Severity defines the severity of the rule.
 message Severity {
-  // Value enumerates the severity values.
-  enum Value {
-    VALUE_UNSPECIFIED = 0;
-    // unknown severity means that the severity is unknown or hasn't
-    // been set.
-    VALUE_UNKNOWN = 1 [(name) = "unknown"];
-    // info severity means that the severity is informational and
-    // does not incur risk.
-    VALUE_INFO = 2 [(name) = "info"];
-    // low severity means that the severity is low and does not
-    // incur significant risk.
-    VALUE_LOW = 3 [(name) = "low"];
-    // medium severity means that the severity is medium and may
-    // incur some risk.
-    VALUE_MEDIUM = 4 [(name) = "medium"];
-    // high severity means that the severity is high and may incur
-    // significant risk.
-    VALUE_HIGH = 5 [(name) = "high"];
-    // critical severity means that the severity is critical and
-    // requires immediate attention.
-    VALUE_CRITICAL = 6 [(name) = "critical"];
-  }
+    // Value enumerates the severity values.
+    enum Value {
+        VALUE_UNSPECIFIED = 0;
+        // unknown severity means that the severity is unknown or hasn't
+        // been set.
+        VALUE_UNKNOWN = 1 [(name) = "unknown"];
+        // info severity means that the severity is informational and
+        // does not incur risk.
+        VALUE_INFO = 2 [(name) = "info"];
+        // low severity means that the severity is low and does not
+        // incur significant risk.
+        VALUE_LOW = 3 [(name) = "low"];
+        // medium severity means that the severity is medium and may
+        // incur some risk.
+        VALUE_MEDIUM = 4 [(name) = "medium"];
+        // high severity means that the severity is high and may incur
+        // significant risk.
+        VALUE_HIGH = 5 [(name) = "high"];
+        // critical severity means that the severity is critical and
+        // requires immediate attention.
+        VALUE_CRITICAL = 6 [(name) = "critical"];
+    }
 
-  // value is the severity value.
-  Value value = 1;
+    // value is the severity value.
+    Value value = 1;
 }
 
 // RuleTypeReleasePhase defines the release phase of the rule type.
 enum RuleTypeReleasePhase {
-  RULE_TYPE_RELEASE_PHASE_UNSPECIFIED = 0;
-  RULE_TYPE_RELEASE_PHASE_ALPHA = 1 [(name) = "alpha"];
-  RULE_TYPE_RELEASE_PHASE_BETA = 2 [(name) = "beta"];
-  RULE_TYPE_RELEASE_PHASE_GA = 3 [(name) = "ga"];
-  RULE_TYPE_RELEASE_PHASE_DEPRECATED = 4 [(name) = "deprecated"];
+    RULE_TYPE_RELEASE_PHASE_UNSPECIFIED = 0;
+    RULE_TYPE_RELEASE_PHASE_ALPHA = 1 [(name) = "alpha"];
+    RULE_TYPE_RELEASE_PHASE_BETA = 2 [(name) = "beta"];
+    RULE_TYPE_RELEASE_PHASE_GA = 3 [(name) = "ga"];
+    RULE_TYPE_RELEASE_PHASE_DEPRECATED = 4 [(name) = "deprecated"];
 }
 
 // RuleType defines rules that may or may not be user defined.
 // The version is assumed from the folder's version.
 message RuleType {
-  // version is the version of the rule type API.
-  string version = 11 [(buf.validate.field).string = {pattern: "^v\\d$"}];
-
-  // type is the type of the rule.
-  string type = 12 [(buf.validate.field).string = {pattern: "rule-type"}];
-
-  // id is the id of the rule type.
-  // This is mostly optional and is set by the server.
-  optional string id = 1 [
-    (buf.validate.field).string = {uuid: true},
-    (google.api.field_behavior) = OUTPUT_ONLY
-  ];
-
-  // name is the name of the rule type.
-  string name = 2 [
-    (buf.validate.field).string = {
-      pattern: "^[A-Za-z][-/[:word:]]*$"
-      max_len: 200
-    },
-    (google.api.field_behavior) = REQUIRED
-  ];
-
-  // display_name is the display name of the rule type.
-  string display_name = 8 [
-    (buf.validate.field).string = {
-      pattern: "^[A-Za-z][-/'()[:word:] :]*$"
-      max_len: 200
-    },
-    (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE
-  ];
-
-  // short_failure_message is the message to display when the evaluation fails.
-  string short_failure_message = 10 [
-    (buf.validate.field).string = {max_len: 400},
-    (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE
-  ];
-
-  // context is the context in which the rule is evaluated.
-  Context context = 3;
-
-  // Definition defines the rule type. It encompases the schema and the data evaluation.
-  message Definition {
-    // in_entity is the entity in which the rule is evaluated.
-    // This can be repository, build_environment or artifact.
-    string in_entity = 1 [(buf.validate.field).string = {
-      pattern: "^[a-z]+(_[a-z]+)*$"
-      min_len: 1
-      max_len: 200
-    }];
-
-    // rule_schema is the schema of the rule. This is expressed in JSON Schema.
-    google.protobuf.Struct rule_schema = 2;
-
-    // param_schema is the schema of the parameters that are passed to the rule.
-    // This is expressed in JSON Schema.
-    optional google.protobuf.Struct param_schema = 3;
-
-    // Ingest defines how the data is ingested.
-    message Ingest {
-      // type is the type of the data ingestion.
-      // we currently support rest, artifact and builtin.
-      string type = 1 [
+    // version is the version of the rule type API.
+    string version = 11 [
         (buf.validate.field).string = {
-          in: [
-            "rest",
-            "artifact",
-            "builtin",
-            "git",
-            "diff",
-            "deps"
-          ]
+            pattern: "^v\\d$",
+        }
+    ];
+
+    // type is the type of the rule.
+    string type = 12 [
+        (buf.validate.field).string = {
+            pattern: "rule-type",
+        }
+    ];
+
+    // id is the id of the rule type.
+    // This is mostly optional and is set by the server.
+    optional string id = 1 [
+        (buf.validate.field).string = {uuid: true},
+        (google.api.field_behavior) = OUTPUT_ONLY
+    ];
+
+    // name is the name of the rule type.
+    string name = 2 [
+        (buf.validate.field).string = {
+            pattern: "^[A-Za-z][-/[:word:]]*$",
+            max_len: 200,
         },
         (google.api.field_behavior) = REQUIRED
-      ];
+    ];
 
-      // NOTE: we should have used the "oneof" feature here rather than
-      // having both a string "type" and a series of optional messages.
-      // We can consider fixing this in a V2 API, but it's probably too
-      // to do in V1.
-
-      // rest is the rest data ingestion.
-      // this is only used if the type is rest.
-      optional RestType rest = 3;
-
-      // builtin is the builtin data ingestion.
-      optional BuiltinType builtin = 4;
-
-      // artifact is the artifact data ingestion.
-      // artifact currently only applies to artifacts.
-      optional ArtifactType artifact = 5;
-
-      // git is the git data ingestion.
-      // git currently only applies to repositories.
-      optional GitType git = 6;
-
-      // diff is the diff data ingestion.
-      // diff currently only applies to pull_requests.
-      optional DiffType diff = 7;
-
-      // deps is the deps data ingestion.
-      // deps currently only applies to repositories.
-      optional DepsType deps = 8;
-    }
-    Ingest ingest = 4 [(google.api.field_behavior) = REQUIRED];
-
-    // Eval defines the data evaluation definition.
-    // This pertains to the way we traverse data from the upstream
-    // endpoint and how we compare it to the rule.
-    message Eval {
-      // type is the type of the data evaluation.
-      string type = 1 [
+    // display_name is the display name of the rule type.
+    string display_name = 8 [
         (buf.validate.field).string = {
-          in: [
-            "jq",
-            "rego",
-            "vulncheck",
-            "trusty",
-            "homoglyphs"
-          ]
+            pattern: "^[A-Za-z][-/'()[:word:] :]*$",
+            max_len: 200,
         },
-        (google.api.field_behavior) = REQUIRED
-      ];
+        (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE
+    ];
 
-      message JQComparison {
-        message Operator {
-          string def = 1 [
+    // short_failure_message is the message to display when the evaluation fails.
+    string short_failure_message = 10 [
+        (buf.validate.field).string = {
+            max_len: 400,
+        },
+        (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE
+    ];
+
+    // context is the context in which the rule is evaluated.
+    Context context = 3;
+
+    // Definition defines the rule type. It encompases the schema and the data evaluation.
+    message Definition {
+        // in_entity is the entity in which the rule is evaluated.
+        // This can be repository, build_environment or artifact.
+        string in_entity = 1 [
             (buf.validate.field).string = {
-              pattern: "^\\.[a-zA-Z_]+(\\.[a-zA-Z_]+|\\[\\d+]|\\[\"[a-zA-Z_]+\"\\])*$"
-              min_len: 1
-              max_len: 200
-            },
-            (google.api.field_behavior) = REQUIRED
-          ];
-        }
-
-        // Ingested points to the data retrieved in the `ingest` section
-        Operator ingested = 1 [(google.api.field_behavior) = REQUIRED];
-
-        // Profile points to the profile itself.
-        // This is mutually exclusive with the `constant` field.
-        Operator profile = 2;
-
-        // Constant points to a constant value.
-        // This is mutually exclusive with the `profile` field.
-        google.protobuf.Value constant = 3;
-      }
-
-      message Rego {
-        // type is the type of evaluation engine to use
-        // for rego. We currently have two modes of operation:
-        // - deny-by-default: this is the default mode of operation
-        //   where we deny access by default and allow access only
-        //   if the profile explicitly allows it. It expects the
-        //   profile to set an `allow` variable to true or false.
-        // - constraints: this is the mode of operation where we
-        //   allow access by default and deny access only if a
-        //   violation is found. It expects the profile to set a
-        //   `violations` variable with a "msg" field.
-        string type = 1 [
-          (buf.validate.field).string = {
-            pattern: "^[a-z]+([_-][a-z]+)*$"
-            min_len: 1
-            max_len: 200
-          },
-          (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE
-        ];
-        // def is the definition of the rego profile.
-        string def = 2 [(google.api.field_behavior) = REQUIRED];
-        // how are violations reported. This is only used if the
-        // `constraints` type is selected. The default is `text`
-        // which returns human-readable text. The other option is
-        // `json` which returns a JSON array containing the violations.
-        optional string violation_format = 3 [(buf.validate.field).string = {
-          in: [
-            "text",
-            "json"
-          ]
-        }];
-      }
-
-      message Vulncheck {
-        // no configuration for now
-      }
-
-      message Trusty {
-        // This is no longer used, but is still here for backwards
-        // compatibility with existing stored rules
-        string endpoint = 1 [
-          (buf.validate.field).string = {uri: true},
-          (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE
-        ];
-      }
-
-      message Homoglyphs {
-        string type = 1 [(buf.validate.field).string = {
-          in: [
-            "invisible_characters",
-            "mixed_scripts"
-          ]
-        }];
-      }
-
-      // jq is only used if the `jq` type is selected.
-      // It defines the comparisons that are made between
-      // the ingested data and the profile rule.
-      repeated JQComparison jq = 2;
-
-      // rego is only used if the `rego` type is selected.
-      optional Rego rego = 3;
-
-      // vulncheck is only used if the `vulncheck` type is selected.
-      optional Vulncheck vulncheck = 4;
-
-      // The trusty type is no longer used, but is still here for backwards
-      // compatibility with existing stored rules
-      optional Trusty trusty = 5;
-
-      // homoglyphs is only used if the `homoglyphs` type is selected.
-      optional Homoglyphs homoglyphs = 6;
-
-      // Data sources that the rule refers to. These are used to
-      // instantiate the relevant data sources for the rule and keep
-      // track of them as dependencies.
-      //
-      // Note that the data source must exist in the project hierarchy
-      // in order to be used in the rule.
-      repeated DataSourceReference data_sources = 7;
-    }
-    Eval eval = 5 [(google.api.field_behavior) = REQUIRED];
-
-    message Remediate {
-      // type is the type of the remediation.
-      // * 'rest' can be used with any entity type.
-      // * 'gh_branch_protection' and 'pull_request' can only be used with the 'repository' entity type.
-      // * 'pull_request_comment' can only be used with the 'pull_request' entity type.
-      string type = 1 [
-        (buf.validate.field).string = {
-          in: [
-            "rest",
-            "gh_branch_protection",
-            "pull_request",
-            "pull_request_comment"
-          ]
-        },
-        (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE
-      ];
-
-      message GhBranchProtectionType {
-        string patch = 1 [
-          (buf.validate.field).string = {max_len: 1000},
-          (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE
-        ];
-      }
-
-      // the name stutters a bit but we already use a PullRequest message for handling PR entities
-      message PullRequestRemediation {
-        message Content {
-          // the file to patch
-          string path = 1 [(buf.validate.field).string = {
-            min_len: 1
-            max_len: 200
-          }];
-          // how to patch the file. For now, only replace is supported
-          string action = 2 [(buf.validate.field).string = {
-            in: ["replace"]
-            min_len: 1
-            max_len: 50
-          }];
-          // the content of the file
-          string content = 4;
-          // the GIT mode of the file. Not UNIX mode! String because the GH API also uses strings
-          // the usual modes are: 100644 for regular files, 100755 for executable files and
-          // 040000 for submodules (which we don't use but now you know the meaning of the 1 in 100644)
-          // see e.g. https://github.com/go-git/go-git/blob/32e0172851c35ae2fac495069c923330040903d2/plumbing/filemode/filemode.go#L16
-          optional string mode = 3 [(buf.validate.field).string = {
-            pattern: "^\\d+$"
-            max_len: 6
-          }];
-        }
-
-        message ActionsReplaceTagsWithSha {
-          // List of actions to exclude from the replacement
-          repeated string exclude = 1 [(buf.validate.field).repeated = {
-            items: {
-              string: {
-                pattern: "^\\.?([[:word:].-]+\\/)*[[:word:].-]+(?:\\.[[:alnum:]]+)?$"
-                max_len: 200
-              }
+                pattern: "^[a-z]+(_[a-z]+)*$",
+                min_len: 1,
+                max_len: 200,
             }
-          }];
+        ];
+
+        // rule_schema is the schema of the rule. This is expressed in JSON Schema.
+        google.protobuf.Struct rule_schema = 2;
+
+        // param_schema is the schema of the parameters that are passed to the rule.
+        // This is expressed in JSON Schema.
+        optional google.protobuf.Struct param_schema = 3;
+
+        // Ingest defines how the data is ingested.
+        message Ingest {
+            // type is the type of the data ingestion.
+            // we currently support rest, artifact and builtin.
+            string type = 1 [
+                (buf.validate.field).string = {
+                    in: ["rest", "artifact", "builtin", "git", "diff", "deps"],
+                },
+                (google.api.field_behavior) = REQUIRED
+            ];
+
+            // NOTE: we should have used the "oneof" feature here rather than
+            // having both a string "type" and a series of optional messages.
+            // We can consider fixing this in a V2 API, but it's probably too
+            // to do in V1.
+
+            // rest is the rest data ingestion.
+            // this is only used if the type is rest.
+            optional RestType rest = 3;
+
+            // builtin is the builtin data ingestion.
+            optional BuiltinType builtin = 4;
+
+            // artifact is the artifact data ingestion.
+            // artifact currently only applies to artifacts.
+            optional ArtifactType artifact = 5;
+
+            // git is the git data ingestion.
+            // git currently only applies to repositories.
+            optional GitType git = 6;
+
+            // diff is the diff data ingestion.
+            // diff currently only applies to pull_requests.
+            optional DiffType diff = 7;
+
+            // deps is the deps data ingestion.
+            // deps currently only applies to repositories.
+            optional DepsType deps = 8;
         }
-
-        // the title of the PR
-        // This is not validated here as it will be validated by the repository provider, i.e. GitHub upon
-        // creation of the PR.
-        string title = 1 [(buf.validate.field).string = {
-          min_len: 1
-          max_len: 75
-        }];
-        // the body of the PR
-        // This is not validated here as it will be validated by the repository provider, i.e. GitHub upon
-        // creation of the PR.
-        string body = 2 [(buf.validate.field).string = {
-          min_len: 1
-          max_len: 65536
-        }];
-        repeated Content contents = 3;
-        // the method to use to create the PR. For now, these are supported:
-        // -- minder.content - ensures that the content of the file is exactly as specified
-        //                     refer to the Content message for more details
-        // -- minder.actions.replace_tags_with_sha - finds any github actions within a workflow
-        //                                           file and replaces the tag with the SHA
-        // -- minder.yq.evaluate - evaluates a yq expression on a file
-        string method = 4 [
-          (buf.validate.field).string = {
-            in: [
-              "minder.content",
-              "minder.actions.replace_tags_with_sha",
-              "minder.yq.evaluate"
-            ]
-          },
-          (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE
+        Ingest ingest = 4 [
+            (google.api.field_behavior) = REQUIRED
         ];
-        // params are unstructured parameters passed to the method. These are optional
-        // and evaluated by the method.
-        google.protobuf.Struct params = 6;
 
-        // If the method is minder.actions.replace_tags_with_sha, this is the configuration
-        // for that method
-        optional ActionsReplaceTagsWithSha actions_replace_tags_with_sha = 5;
-      }
+        // Eval defines the data evaluation definition.
+        // This pertains to the way we traverse data from the upstream
+        // endpoint and how we compare it to the rule.
+        message Eval {
+            // type is the type of the data evaluation.
+            string type = 1 [
+                (buf.validate.field).string = {
+                    in: ["jq", "rego", "vulncheck", "trusty", "homoglyphs"],
+                },
+                (google.api.field_behavior) = REQUIRED
+            ];
 
-      // NOTE: Issue remediation is not yet implemented.
-      // This configuration is reserved for future support.
-      // "issue" is intentionally not a supported remediation type yet.
-      message IssueRemediation {
-        // the title of the issue
-        // Supports Minder's template interpolation syntax.
-        // This is not validated here as it will be validated by the repository provider, i.e. GitHub upon
-        // creation of the issue
-        string title = 1 [(buf.validate.field).string = {
-          min_len: 1
-          max_len: 75
-        }];
-        // the body of the issue
-        // Supports Minder's template interpolation syntax
-        // The rendered body is interpreted as Markdown by repository providers that
-        // support Markdown (e.g. Github)
-        // This is not validated here as it will be validated by the repository provider, i.e. GitHub upon
-        // creation of the issue
-        string body = 2 [(buf.validate.field).string = {
-          min_len: 1
-          max_len: 65536
-        }];
-      }
+            message JQComparison {
+                message Operator {
+                    string def = 1 [
+                        (buf.validate.field).string = {
+                            pattern: "^\\.[a-zA-Z_]+(\\.[a-zA-Z_]+|\\[\\d+]|\\[\"[a-zA-Z_]+\"\\])*$",
+                            min_len: 1,
+                            max_len: 200,
+                        },
+                        (google.api.field_behavior) = REQUIRED
+                    ];
+                }
 
-      optional RestType rest = 2;
-      optional GhBranchProtectionType gh_branch_protection = 3;
-      optional PullRequestRemediation pull_request = 4;
-      optional Alert.AlertTypePRComment pull_request_comment = 5;
-      optional IssueRemediation issue = 6;
+                // Ingested points to the data retrieved in the `ingest` section
+                Operator ingested = 1 [
+                    (google.api.field_behavior) = REQUIRED
+                ];
+
+                // Profile points to the profile itself.
+                // This is mutually exclusive with the `constant` field.
+                Operator profile = 2;
+
+                // Constant points to a constant value.
+                // This is mutually exclusive with the `profile` field.
+                google.protobuf.Value constant = 3;
+            }
+
+            message Rego {
+                // type is the type of evaluation engine to use
+                // for rego. We currently have two modes of operation:
+                // - deny-by-default: this is the default mode of operation
+                //   where we deny access by default and allow access only
+                //   if the profile explicitly allows it. It expects the
+                //   profile to set an `allow` variable to true or false.
+                // - constraints: this is the mode of operation where we
+                //   allow access by default and deny access only if a
+                //   violation is found. It expects the profile to set a
+                //   `violations` variable with a "msg" field.
+                string type = 1 [
+                    (buf.validate.field).string = {
+                        pattern: "^[a-z]+([_-][a-z]+)*$",
+                        min_len: 1,
+                        max_len: 200,
+                    },
+                    (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE
+                ];
+                // def is the definition of the rego profile.
+                string def = 2 [
+                    (google.api.field_behavior) = REQUIRED
+                ];
+                // how are violations reported. This is only used if the
+                // `constraints` type is selected. The default is `text`
+                // which returns human-readable text. The other option is
+                // `json` which returns a JSON array containing the violations.
+                optional string violation_format = 3 [
+                    (buf.validate.field).string = {
+                        in: ["text", "json"],
+                    }
+                ];
+            }
+
+            message Vulncheck {
+                // no configuration for now
+            }
+
+            message Trusty {
+                // This is no longer used, but is still here for backwards
+                // compatibility with existing stored rules
+                string endpoint = 1 [
+                    (buf.validate.field).string = {
+                        uri: true,
+                    },
+                    (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE
+                ];
+            }
+
+            message Homoglyphs {
+                string type = 1 [
+                    (buf.validate.field).string = {
+                        in: ["invisible_characters", "mixed_scripts"]
+                    }
+                ];
+            }
+
+            // jq is only used if the `jq` type is selected.
+            // It defines the comparisons that are made between
+            // the ingested data and the profile rule.
+            repeated JQComparison jq = 2;
+
+            // rego is only used if the `rego` type is selected.
+            optional Rego rego = 3;
+
+            // vulncheck is only used if the `vulncheck` type is selected.
+            optional Vulncheck vulncheck = 4;
+
+            // The trusty type is no longer used, but is still here for backwards
+            // compatibility with existing stored rules
+            optional Trusty trusty = 5;
+
+            // homoglyphs is only used if the `homoglyphs` type is selected.
+            optional Homoglyphs homoglyphs = 6;
+
+            // Data sources that the rule refers to. These are used to
+            // instantiate the relevant data sources for the rule and keep
+            // track of them as dependencies.
+            //
+            // Note that the data source must exist in the project hierarchy
+            // in order to be used in the rule.
+            repeated DataSourceReference data_sources = 7;
+        }
+        Eval eval = 5 [
+            (google.api.field_behavior) = REQUIRED
+        ];
+
+        message Remediate {
+            // type is the type of the remediation.
+            // * 'rest' can be used with any entity type.
+            // * 'gh_branch_protection' and 'pull_request' can only be used with the 'repository' entity type.
+            // * 'pull_request_comment' can only be used with the 'pull_request' entity type.
+            string type = 1 [
+                (buf.validate.field).string = {
+                    in: ["rest", "gh_branch_protection", "pull_request", "pull_request_comment"],
+                },
+                (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE
+            ];
+
+            message GhBranchProtectionType {
+                string patch = 1 [
+                    (buf.validate.field).string = {
+                        max_len: 1000,
+                    },
+                    (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE
+                ];
+            }
+
+            // the name stutters a bit but we already use a PullRequest message for handling PR entities
+            message PullRequestRemediation {
+                message Content {
+                    // the file to patch
+                    string path = 1 [
+                        (buf.validate.field).string = {
+                            min_len: 1,
+                            max_len: 200,
+                        }
+                    ];
+                    // how to patch the file. For now, only replace is supported
+                    string action = 2 [
+                        (buf.validate.field).string = {
+                            in: ["replace"],
+                            min_len: 1,
+                            max_len: 50,
+                        }
+                    ];
+                    // the content of the file
+                    string content = 4;
+                    // the GIT mode of the file. Not UNIX mode! String because the GH API also uses strings
+                    // the usual modes are: 100644 for regular files, 100755 for executable files and
+                    // 040000 for submodules (which we don't use but now you know the meaning of the 1 in 100644)
+                    // see e.g. https://github.com/go-git/go-git/blob/32e0172851c35ae2fac495069c923330040903d2/plumbing/filemode/filemode.go#L16
+                    optional string mode = 3 [
+                        (buf.validate.field).string = {
+                            pattern: "^\\d+$",
+                            max_len: 6,
+                        }
+                    ];
+                }
+
+                message ActionsReplaceTagsWithSha {
+                    // List of actions to exclude from the replacement
+                    repeated string exclude = 1 [
+                        (buf.validate.field).repeated = {
+                            items: {
+                                string: {
+                                    pattern: "^\\.?([[:word:].-]+\\/)*[[:word:].-]+(?:\\.[[:alnum:]]+)?$",
+                                    max_len: 200,
+                                }
+                            }
+                        }
+                    ];
+                }
+
+                // the title of the PR
+                // This is not validated here as it will be validated by the repository provider, i.e. GitHub upon
+                // creation of the PR.
+                string title = 1 [
+                    (buf.validate.field).string = {
+                        min_len: 1,
+                        max_len: 75,
+                    }
+                ];
+                // the body of the PR
+                // This is not validated here as it will be validated by the repository provider, i.e. GitHub upon
+                // creation of the PR.
+                string body = 2 [
+                    (buf.validate.field).string = {
+                        min_len: 1,
+                        max_len: 65536,
+                    }
+                ];
+                repeated Content contents = 3;
+                // the method to use to create the PR. For now, these are supported:
+                // -- minder.content - ensures that the content of the file is exactly as specified
+                //                     refer to the Content message for more details
+                // -- minder.actions.replace_tags_with_sha - finds any github actions within a workflow
+                //                                           file and replaces the tag with the SHA
+                // -- minder.yq.evaluate - evaluates a yq expression on a file
+                string method = 4 [
+                    (buf.validate.field).string = {
+                        in: ["minder.content", "minder.actions.replace_tags_with_sha", "minder.yq.evaluate"],
+                    },
+                    (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE
+                ];
+                // params are unstructured parameters passed to the method. These are optional
+                // and evaluated by the method.
+                google.protobuf.Struct params = 6;
+
+                // If the method is minder.actions.replace_tags_with_sha, this is the configuration
+                // for that method
+                optional ActionsReplaceTagsWithSha actions_replace_tags_with_sha = 5;
+            }
+
+            // NOTE: Issue remediation is not yet implemented.
+            // This configuration is reserved for future support.
+            // "issue" is intentionally not a supported remediation type yet.
+            message IssueRemediation {
+                // the title of the issue
+                // Supports Minder's template interpolation syntax.
+                // This is not validated here as it will be validated by the repository provider, i.e. GitHub upon
+                // creation of the issue
+                string title = 1 [(buf.validate.field).string = {
+                    min_len: 1
+                    max_len: 75
+                }];
+                // the body of the issue
+                // Supports Minder's template interpolation syntax
+                // The rendered body is interpreted as Markdown by repository providers that
+                // support Markdown (e.g. Github)
+                // This is not validated here as it will be validated by the repository provider, i.e. GitHub upon
+                // creation of the issue
+                string body = 2 [(buf.validate.field).string = {
+                    min_len: 1
+                    max_len: 65536
+                }];
+            }
+
+            optional RestType rest = 2;
+            optional GhBranchProtectionType gh_branch_protection = 3;
+            optional PullRequestRemediation pull_request = 4;
+            optional Alert.AlertTypePRComment pull_request_comment = 5;
+            optional IssueRemediation issue = 6;
+        }
+        Remediate remediate = 6;
+
+        message Alert {
+            // type is the type of the alert.
+            // * 'security_advisory' can only be used with the 'repository' entity type.
+            // * 'pull_request_comment' can only be used with the 'pull_request' entity type.
+            string type = 1 [
+                (buf.validate.field).string = {
+                    in: ["security_advisory", "pull_request_comment"],
+                },
+                (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE
+            ];
+
+            message AlertTypeSA {
+                string severity = 1 [
+                    (buf.validate.field).string = {
+                        in: ["unknown", "info", "low", "medium", "high", "critical"],
+                    },
+                    (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE
+                ];
+            }
+            optional AlertTypeSA security_advisory = 2;
+
+            message AlertTypePRComment {
+                // review_message is the message to post in the PR review.
+                string review_message = 1 [
+                    (buf.validate.field).string = {
+                        max_len: 65536,
+                    },
+                    (google.api.field_behavior) = REQUIRED
+                ];
+                // action is the action to use for the PR review (comment or request_changes).
+                // Default is comment.
+                optional string action = 2 [
+                    (buf.validate.field).string = {
+                        in: ["comment", "request_changes"],
+                    }
+                ];
+            }
+            optional AlertTypePRComment pull_request_comment = 3;
+        }
+        Alert alert = 7;
     }
-    Remediate remediate = 6;
 
-    message Alert {
-      // type is the type of the alert.
-      // * 'security_advisory' can only be used with the 'repository' entity type.
-      // * 'pull_request_comment' can only be used with the 'pull_request' entity type.
-      string type = 1 [
+    // def is the definition of the rule type.
+    Definition def = 4 [
+        (google.api.field_behavior) = REQUIRED
+    ];
+
+    // description is the description of the rule type.
+    // This is expected to be a valid markdown formatted string.
+    string description = 5 [
         (buf.validate.field).string = {
-          in: [
-            "security_advisory",
-            "pull_request_comment"
-          ]
+            min_len: 1,
+            max_len: 1500,
         },
-        (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE
-      ];
+        (google.api.field_behavior) = REQUIRED
+    ];
 
-      message AlertTypeSA {
-        string severity = 1 [
-          (buf.validate.field).string = {
-            in: [
-              "unknown",
-              "info",
-              "low",
-              "medium",
-              "high",
-              "critical"
-            ]
-          },
-          (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE
-        ];
-      }
-      optional AlertTypeSA security_advisory = 2;
+    // guidance are instructions we give the user in case a rule fails.
+    // This is expected to be a valid markdown formatted string.
+    string guidance = 6 [
+        (buf.validate.field).string = {
+            min_len: 1,
+            max_len: 1000,
+        },
+        (google.api.field_behavior) = REQUIRED
+    ];
 
-      message AlertTypePRComment {
-        // review_message is the message to post in the PR review.
-        string review_message = 1 [
-          (buf.validate.field).string = {max_len: 65536},
-          (google.api.field_behavior) = REQUIRED
-        ];
-        // action is the action to use for the PR review (comment or request_changes).
-        // Default is comment.
-        optional string action = 2 [(buf.validate.field).string = {
-          in: [
-            "comment",
-            "request_changes"
-          ]
-        }];
-      }
-      optional AlertTypePRComment pull_request_comment = 3;
-    }
-    Alert alert = 7;
-  }
+    // severity is the severity of the rule type.
+    Severity severity = 7;
 
-  // def is the definition of the rule type.
-  Definition def = 4 [(google.api.field_behavior) = REQUIRED];
-
-  // description is the description of the rule type.
-  // This is expected to be a valid markdown formatted string.
-  string description = 5 [
-    (buf.validate.field).string = {
-      min_len: 1
-      max_len: 1500
-    },
-    (google.api.field_behavior) = REQUIRED
-  ];
-
-  // guidance are instructions we give the user in case a rule fails.
-  // This is expected to be a valid markdown formatted string.
-  string guidance = 6 [
-    (buf.validate.field).string = {
-      min_len: 1
-      max_len: 1000
-    },
-    (google.api.field_behavior) = REQUIRED
-  ];
-
-  // severity is the severity of the rule type.
-  Severity severity = 7;
-
-  // release_phase is the release phase of the rule type, i.e. alpha, beta, ga, deprecated.
-  RuleTypeReleasePhase release_phase = 9;
+    // release_phase is the release phase of the rule type, i.e. alpha, beta, ga, deprecated.
+    RuleTypeReleasePhase release_phase = 9;
 }
 
 // Profile defines a profile that is user defined.
 // All fields are optional because we want to allow partial updates.
 message Profile {
-  // context is the context in which the profile is evaluated.
-  Context context = 1;
+    // context is the context in which the profile is evaluated.
+    Context context = 1;
 
-  // id is the id of the profile.
-  // This is optional and is set by the system.
-  optional string id = 2 [
-    (buf.validate.field).string = {uuid: true},
-    (google.api.field_behavior) = OUTPUT_ONLY
-  ];
+    // id is the id of the profile.
+    // This is optional and is set by the system.
+    optional string id = 2 [
+        (buf.validate.field).string = {uuid: true},
+        (google.api.field_behavior) = OUTPUT_ONLY
+    ];
 
-  // name is the name of the profile instance.
-  string name = 3 [
-    (buf.validate.field).string = {
-      pattern: "^[A-Za-z][-/[:word:]]*$"
-      max_len: 200
-    },
-    (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE
-  ];
+    // name is the name of the profile instance.
+    string name = 3 [
+        (buf.validate.field).string = {
+            pattern: "^[A-Za-z][-/[:word:]]*$",
+            max_len: 200,
+        },
+        (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE
+    ];
 
-  // labels are a set of system-provided attributes which can be used to
-  // filter profiles and status results.  Labels cannot be set by the user,
-  // but are returned in ListProfiles.
-  //
-  // Labels use DNS label constraints, with a possible namespace prefix
-  // separated by a colon (:).  They are intended to allow filtering, but
-  // not to store arbitrary metadata.
-  // DNS labels are 1-63 character alphanumeric strings with internal hyphens.
-  // An RE2-style validation regex would be:
-  //
-  // DNS_STR = "[a-zA-Z0-9](?[-a-zA-Z0-9]{0,61}[a-zA-Z0-9])?"
-  // ($DNS_STR:)?$DNS_STR
-  repeated string labels = 12 [(buf.validate.field) = {
-    repeated: {
-      items: {
-        string: {
-          // DNS label constraints extended to allow for underscores
-          pattern: "^([a-zA-Z0-9_]([-a-zA-Z0-9_]{0,61}[a-zA-Z0-9_])?:)?[a-zA-Z0-9_]([-a-zA-Z0-9_]{0,61}[a-zA-Z0-9_])?$"
+    // labels are a set of system-provided attributes which can be used to
+    // filter profiles and status results.  Labels cannot be set by the user,
+    // but are returned in ListProfiles.
+    //
+    // Labels use DNS label constraints, with a possible namespace prefix
+    // separated by a colon (:).  They are intended to allow filtering, but
+    // not to store arbitrary metadata.
+    // DNS labels are 1-63 character alphanumeric strings with internal hyphens.
+    // An RE2-style validation regex would be:
+    //
+    // DNS_STR = "[a-zA-Z0-9](?[-a-zA-Z0-9]{0,61}[a-zA-Z0-9])?"
+    // ($DNS_STR:)?$DNS_STR
+    repeated string labels = 12 [
+        (buf.validate.field) = {
+            repeated: {
+                items: {
+                    string: {
+                        // DNS label constraints extended to allow for underscores
+                        pattern: "^([a-zA-Z0-9_]([-a-zA-Z0-9_]{0,61}[a-zA-Z0-9_])?:)?[a-zA-Z0-9_]([-a-zA-Z0-9_]{0,61}[a-zA-Z0-9_])?$"
+                    }
+                },
+                unique: true
+            }
         }
-      }
-      unique: true
+    ];
+
+    // Rule defines the individual call of a certain rule type.
+    message Rule {
+        // type is the type of the rule to be instantiated.
+        string type = 1 [
+            (buf.validate.field).string = {
+                pattern: "^[A-Za-z][-/[:word:]]*$",
+                max_len: 200,
+            },
+            (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE
+        ];
+        // params are the parameters that are passed to the rule.
+        // This is optional and depends on the rule type.
+        google.protobuf.Struct params = 2;
+        // def is the definition of the rule.
+        // This depends on the rule type.
+        google.protobuf.Struct def = 3;
+
+        // name is the descriptive name of the rule, not to be confused with type
+        string name = 4 [
+            (buf.validate.field).string = {
+                pattern: "^[A-Za-z][-/'()[:word:] :]*$",
+                max_len: 200,
+            },
+            (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE
+        ];
     }
-  }];
 
-  // Rule defines the individual call of a certain rule type.
-  message Rule {
-    // type is the type of the rule to be instantiated.
-    string type = 1 [
-      (buf.validate.field).string = {
-        pattern: "^[A-Za-z][-/[:word:]]*$"
-        max_len: 200
-      },
-      (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE
+    // These are the entities that one could set in the profile.
+    repeated Rule repository = 4;
+    repeated Rule build_environment = 5;
+    repeated Rule artifact = 6;
+    repeated Rule pull_request = 7;
+    repeated Rule release = 15;
+    repeated Rule pipeline_run = 16;
+    repeated Rule task_run = 17;
+    repeated Rule build = 18;
+
+    message Selector {
+        // id is optional and use for updates to match upserts as well as read operations. It is ignored for creates.
+        string id = 1;
+        // entity is the entity to select.
+        string entity = 2 [
+            (buf.validate.field).string = {
+                pattern: "^[a-z]+(_[a-z]+)*$",
+                min_len: 1,
+                max_len: 200,
+            },
+            (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE
+        ];
+        // expr is the expression to select the entity.
+        string selector = 4 [
+            (buf.validate.field).string = {
+                max_len: 200,
+            },
+            (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE
+        ];
+        reserved 5;
+        reserved "comment";
+        // description is the human-readable description of the selector.
+        string description = 6 [
+            (buf.validate.field).string = {
+                pattern: "^[A-Za-z][-/.!?,:;'[:word:] ]*$",
+                max_len: 1000,
+            },
+            (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE
+        ];
+    }
+
+    repeated Selector selection = 14;
+
+    // whether and how to remediate (on,off,dry_run)
+    // this is optional and defaults to "off"
+    optional string remediate = 8 [
+        (buf.validate.field).string = {
+            in: ["on", "off", "dry_run"]
+        }
     ];
-    // params are the parameters that are passed to the rule.
-    // This is optional and depends on the rule type.
-    google.protobuf.Struct params = 2;
-    // def is the definition of the rule.
-    // This depends on the rule type.
-    google.protobuf.Struct def = 3;
 
-    // name is the descriptive name of the rule, not to be confused with type
-    string name = 4 [
-      (buf.validate.field).string = {
-        pattern: "^[A-Za-z][-/'()[:word:] :]*$"
-        max_len: 200
-      },
-      (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE
+    // whether and how to alert (on,off,dry_run)
+    // this is optional and defaults to "on"
+    optional string alert = 9 [
+        (buf.validate.field).string = {
+            in: ["on", "off", "dry_run"]
+        }
     ];
-  }
 
-  // These are the entities that one could set in the profile.
-  repeated Rule repository = 4;
-  repeated Rule build_environment = 5;
-  repeated Rule artifact = 6;
-  repeated Rule pull_request = 7;
-  repeated Rule release = 15;
-  repeated Rule pipeline_run = 16;
-  repeated Rule task_run = 17;
-  repeated Rule build = 18;
-
-  message Selector {
-    // id is optional and use for updates to match upserts as well as read operations. It is ignored for creates.
-    string id = 1;
-    // entity is the entity to select.
-    string entity = 2 [
-      (buf.validate.field).string = {
-        pattern: "^[a-z]+(_[a-z]+)*$"
-        min_len: 1
-        max_len: 200
-      },
-      (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE
+    // type is a placeholder for the object type. It should always be set to "profile".
+    string type = 10 [
+        (buf.validate.field).string = {
+            pattern: "profile",
+        }
     ];
-    // expr is the expression to select the entity.
-    string selector = 4 [
-      (buf.validate.field).string = {max_len: 200},
-      (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE
+
+    // version is the version of the profile type. In this case, it is "v1"
+    string version = 11 [
+        (buf.validate.field).string = {
+            pattern: "^v\\d$",
+        }
     ];
-    reserved 5;
-    reserved "comment";
-    // description is the human-readable description of the selector.
-    string description = 6 [
-      (buf.validate.field).string = {
-        pattern: "^[A-Za-z][-/.!?,:;'[:word:] ]*$"
-        max_len: 1000
-      },
-      (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE
+
+    // display_name is the display name of the profile.
+    string display_name = 13 [
+        (buf.validate.field).string = {
+            pattern: "^[A-Za-z][-/'()[:word:] :]*$",
+            max_len: 1000,
+        },
+        (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE
     ];
-  }
-
-  repeated Selector selection = 14;
-
-  // whether and how to remediate (on,off,dry_run)
-  // this is optional and defaults to "off"
-  optional string remediate = 8 [(buf.validate.field).string = {
-    in: [
-      "on",
-      "off",
-      "dry_run"
-    ]
-  }];
-
-  // whether and how to alert (on,off,dry_run)
-  // this is optional and defaults to "on"
-  optional string alert = 9 [(buf.validate.field).string = {
-    in: [
-      "on",
-      "off",
-      "dry_run"
-    ]
-  }];
-
-  // type is a placeholder for the object type. It should always be set to "profile".
-  string type = 10 [(buf.validate.field).string = {pattern: "profile"}];
-
-  // version is the version of the profile type. In this case, it is "v1"
-  string version = 11 [(buf.validate.field).string = {pattern: "^v\\d$"}];
-
-  // display_name is the display name of the profile.
-  string display_name = 13 [
-    (buf.validate.field).string = {
-      pattern: "^[A-Za-z][-/'()[:word:] :]*$"
-      max_len: 1000
-    },
-    (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE
-  ];
 }
 
-message ListProjectsRequest {}
+message ListProjectsRequest {
+
+}
 
 message ListProjectsResponse {
-  repeated Project projects = 1 [(google.api.field_behavior) = REQUIRED];
+    repeated Project projects = 1 [
+        (google.api.field_behavior) = REQUIRED
+    ];
 }
 
 message CreateProjectRequest {
-  // context is the context in which the project is created.
-  Context context = 1;
+    // context is the context in which the project is created.
+    Context context = 1;
 
-  // name is the name of the project to create.
-  string name = 2 [
-    (buf.validate.field).string = {
-      pattern: "^[A-Za-z][-/[:word:]]*$"
-      max_len: 200
-    },
-    (google.api.field_behavior) = REQUIRED
-  ];
+    // name is the name of the project to create.
+    string name = 2 [
+        (buf.validate.field).string = {
+            pattern: "^[A-Za-z][-/[:word:]]*$",
+            max_len: 200,
+        },
+        (google.api.field_behavior) = REQUIRED
+    ];
 }
 
 message CreateProjectResponse {
-  // project is the project that was created.
-  Project project = 1 [(google.api.field_behavior) = REQUIRED];
+    // project is the project that was created.
+    Project project = 1 [
+        (google.api.field_behavior) = REQUIRED
+    ];
 }
 
 message DeleteProjectRequest {
-  // context is the context in which the project is deleted.
-  Context context = 1;
+    // context is the context in which the project is deleted.
+    Context context = 1;
 }
 
 message DeleteProjectResponse {
-  // project_id is the id of the project that was deleted.
-  string project_id = 1 [(google.api.field_behavior) = REQUIRED];
+    // project_id is the id of the project that was deleted.
+    string project_id = 1 [
+        (google.api.field_behavior) = REQUIRED
+    ];
 }
 
 message UpdateProjectRequest {
-  // context is the context in which the project is updated.
-  Context context = 1;
+    // context is the context in which the project is updated.
+    Context context = 1;
 
-  // display_name is the display name of the project to update.
-  // This is optional.
-  string display_name = 2 [
-    (buf.validate.field).string = {
-      pattern: "^[A-Za-z][-/'()[:word:] :]*$"
-      max_len: 200
-    },
-    (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE
-  ];
+    // display_name is the display name of the project to update.
+    // This is optional.
+    string display_name = 2 [
+        (buf.validate.field).string = {
+            pattern: "^[A-Za-z][-/'()[:word:] :]*$",
+            max_len: 200,
+        },
+        (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE
+    ];
 
-  // description is the description of the project to update.
-  // This is optional.
-  string description = 3 [
-    (buf.validate.field).string = {
-      pattern: "^[A-Za-z][-/.!?,:;'[:word:] ]*$"
-      min_len: 0
-      max_len: 1000
-    },
-    (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE
-  ];
+    // description is the description of the project to update.
+    // This is optional.
+    string description = 3 [
+        (buf.validate.field).string = {
+            pattern: "^[A-Za-z][-/.!?,:;'[:word:] ]*$",
+            min_len: 0,
+            max_len: 1000,
+        },
+        (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE
+    ];
 }
 
 message UpdateProjectResponse {
-  // project is the project that was updated.
-  Project project = 1 [(google.api.field_behavior) = REQUIRED];
+    // project is the project that was updated.
+    Project project = 1 [
+        (google.api.field_behavior) = REQUIRED
+    ];
 }
 
 message ProjectPatch {
-  // display_name is the display name of the project to update.
-  optional string display_name = 1 [(buf.validate.field).string = {
-    pattern: "^[A-Za-z][-/'()[:word:] :]*$"
-    max_len: 200
-  }];
+    // display_name is the display name of the project to update.
+    optional string display_name = 1 [
+        (buf.validate.field).string = {
+            pattern: "^[A-Za-z][-/'()[:word:] :]*$",
+            max_len: 200,
+        }
+    ];
 
-  // description is the description of the project to update.
-  optional string description = 2 [(buf.validate.field).string = {
-    pattern: "^[A-Za-z][-/.!?,:;'[:word:] ]*$"
-    min_len: 0
-    max_len: 1000
-  }];
+    // description is the description of the project to update.
+    optional string description = 2 [
+        (buf.validate.field).string = {
+            pattern: "^[A-Za-z][-/.!?,:;'[:word:] ]*$",
+            min_len: 0,
+            max_len: 1000,
+        }
+    ];
 }
 
 message PatchProjectRequest {
-  // context is the context in which the project is updated.
-  Context context = 1;
+    // context is the context in which the project is updated.
+    Context context = 1;
 
-  // patch is the patch to apply to the project
-  ProjectPatch patch = 3;
+    // patch is the patch to apply to the project
+    ProjectPatch patch = 3;
 
-  // needed to enable PATCH, see https://grpc-ecosystem.github.io/grpc-gateway/docs/mapping/patch_feature/
-  // is not exposed to the API user
-  google.protobuf.FieldMask update_mask = 4;
+    // needed to enable PATCH, see https://grpc-ecosystem.github.io/grpc-gateway/docs/mapping/patch_feature/
+    // is not exposed to the API user
+    google.protobuf.FieldMask update_mask = 4;
 }
 
 message PatchProjectResponse {
-  // project is the project that was updated.
-  Project project = 1 [(google.api.field_behavior) = REQUIRED];
+    // project is the project that was updated.
+    Project project = 1 [
+        (google.api.field_behavior) = REQUIRED
+    ];
 }
 
 message ListChildProjectsRequest {
-  // context is the context in which the child projects are listed.
-  ContextV2 context = 1;
+    // context is the context in which the child projects are listed.
+    ContextV2 context = 1;
 
-  // recursive is true if child projects should be listed recursively.
-  bool recursive = 2;
+    // recursive is true if child projects should be listed recursively.
+    bool recursive = 2;
 }
 
 message ListChildProjectsResponse {
-  repeated Project projects = 1 [(google.api.field_behavior) = REQUIRED];
+    repeated Project projects = 1 [
+        (google.api.field_behavior) = REQUIRED
+    ];
 }
 
 message CreateEntityReconciliationTaskRequest {
-  // entity is the entity to be reconciled.
-  EntityTypedId entity = 1 [(google.api.field_behavior) = REQUIRED];
+    // entity is the entity to be reconciled.
+    EntityTypedId entity = 1 [
+        (google.api.field_behavior) = REQUIRED
+    ];
 
-  // context is the context in which the entity reconciliation task is created.
-  Context context = 2;
+    // context is the context in which the entity reconciliation task is created.
+    Context context = 2;
 }
 
-message CreateEntityReconciliationTaskResponse {}
+message CreateEntityReconciliationTaskResponse {
+}
 
 message ListRolesRequest {
-  // context is the context in which the roles are evaluated.
-  Context context = 1;
+    // context is the context in which the roles are evaluated.
+    Context context = 1;
 }
 
 message ListRolesResponse {
-  repeated Role roles = 1 [(google.api.field_behavior) = REQUIRED];
+    repeated Role roles = 1 [
+        (google.api.field_behavior) = REQUIRED
+    ];
 }
 
 message ListRoleAssignmentsRequest {
-  // context is the context in which the role assignments are evaluated.
-  Context context = 1;
+    // context is the context in which the role assignments are evaluated.
+    Context context = 1;
 }
 
 message ListRoleAssignmentsResponse {
-  // role_assignments contains permission grants which have been accepted
-  // by a user.
-  repeated RoleAssignment role_assignments = 1 [(google.api.field_behavior) = REQUIRED];
+    // role_assignments contains permission grants which have been accepted
+    // by a user.
+    repeated RoleAssignment role_assignments = 1 [
+        (google.api.field_behavior) = REQUIRED
+    ];
 
-  // invitations contains outstanding role invitations which have not yet
-  // been accepted by a user.
-  repeated Invitation invitations = 2 [(google.api.field_behavior) = REQUIRED];
+    // invitations contains outstanding role invitations which have not yet
+    // been accepted by a user.
+    repeated Invitation invitations = 2 [
+        (google.api.field_behavior) = REQUIRED
+    ];
 }
 
 message AssignRoleRequest {
-  // context is the context in which the role assignment is evaluated.
-  Context context = 1;
-  // role_assignment is the role assignment to be created.
-  RoleAssignment role_assignment = 2 [(google.api.field_behavior) = REQUIRED];
+    // context is the context in which the role assignment is evaluated.
+    Context context = 1;
+    // role_assignment is the role assignment to be created.
+    RoleAssignment role_assignment = 2 [
+        (google.api.field_behavior) = REQUIRED
+    ];
 }
 
 message AssignRoleResponse {
-  // role_assignment is the role assignment that was created.
-  // This is optional.
-  RoleAssignment role_assignment = 1;
+    // role_assignment is the role assignment that was created.
+    // This is optional.
+    RoleAssignment role_assignment = 1;
 
-  // invitation contains the details of the invitation for the
-  // assigned user to join the project if the user is not already
-  // a member. This is optional.
-  Invitation invitation = 2;
+    // invitation contains the details of the invitation for the
+    // assigned user to join the project if the user is not already
+    // a member. This is optional.
+    Invitation invitation = 2;
 }
 
 message UpdateRoleRequest {
-  // context is the context in which the role assignment is evaluated.
-  Context context = 1;
-  // subject is the account to change permissions for.
-  // The account must already have permissions on the project
-  string subject = 2 [
-    (buf.validate.field).string = {uuid: true},
-    (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE
-  ];
-  // All subject roles are _replaced_ with the following role assignments.  Must be non-empty,
-  // use RemoveRole to remove permissions entirely from the project.
-  repeated string roles = 4 [
-    (buf.validate.field).repeated = {
-      items: {
-        string: {
-          pattern: "^[a-z]+(_[a-z]+)*$"
-          min_len: 1
-          max_len: 200
-        }
-      }
-    },
-    (google.api.field_behavior) = REQUIRED
-  ];
-  // email is the email address of the subject used for updating invitations
-  string email = 5 [
-    (buf.validate.field) = {
-      string: {email: true}
-    },
-    (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE
-  ];
+    // context is the context in which the role assignment is evaluated.
+    Context context = 1;
+    // subject is the account to change permissions for.
+    // The account must already have permissions on the project
+    string subject = 2 [
+        (buf.validate.field).string = {uuid: true},
+        (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE
+    ];
+    // All subject roles are _replaced_ with the following role assignments.  Must be non-empty,
+    // use RemoveRole to remove permissions entirely from the project.
+    repeated string roles = 4 [
+        (buf.validate.field).repeated = {
+            items: {
+                string: {
+                    pattern: "^[a-z]+(_[a-z]+)*$",
+                    min_len: 1,
+                    max_len: 200,
+                }
+            }
+        },
+        (google.api.field_behavior) = REQUIRED
+    ];
+    // email is the email address of the subject used for updating invitations
+    string email = 5 [
+      (buf.validate.field) = {string: {email: true}},
+      (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE
+    ];
 
-  reserved 3; // deprecated repeated string role = 3;
-  reserved "role";
+    reserved 3; // deprecated repeated string role = 3;
+    reserved "role";
 }
 
 message UpdateRoleResponse {
-  // role_assignments are the role assignments that were updated.
-  repeated RoleAssignment role_assignments = 1;
-  // invitations contains the details of the invitations that were updated.
-  repeated Invitation invitations = 2;
+    // role_assignments are the role assignments that were updated.
+    repeated RoleAssignment role_assignments = 1;
+    // invitations contains the details of the invitations that were updated.
+    repeated Invitation invitations = 2;
 }
 
+
 message RemoveRoleRequest {
-  // context is the context in which the role assignment is evaluated.
-  Context context = 1;
-  // role_assignment is the role assignment to be removed.
-  RoleAssignment role_assignment = 2 [(google.api.field_behavior) = REQUIRED];
+    // context is the context in which the role assignment is evaluated.
+    Context context = 1;
+    // role_assignment is the role assignment to be removed.
+    RoleAssignment role_assignment = 2 [
+        (google.api.field_behavior) = REQUIRED
+    ];
 }
 
 message RemoveRoleResponse {
-  // role_assignment is the role assignment that was removed.
-  RoleAssignment role_assignment = 1;
-  // invitation contains the details of the invitation that was removed.
-  Invitation invitation = 2;
+    // role_assignment is the role assignment that was removed.
+    RoleAssignment role_assignment = 1;
+    // invitation contains the details of the invitation that was removed.
+    Invitation invitation = 2;
 }
 
 message Role {
-  // name is the name of the role.
-  string name = 1 [(google.api.field_behavior) = REQUIRED];
-  // display name of the role
-  string display_name = 3 [(google.api.field_behavior) = REQUIRED];
-  // description is the description of the role.
-  string description = 2 [(google.api.field_behavior) = REQUIRED];
+    // name is the name of the role.
+    string name = 1 [
+        (google.api.field_behavior) = REQUIRED
+    ];
+    // display name of the role
+    string display_name = 3 [
+        (google.api.field_behavior) = REQUIRED
+    ];
+    // description is the description of the role.
+    string description = 2 [
+        (google.api.field_behavior) = REQUIRED
+    ];
 }
 
 message RoleAssignment {
-  // role is the role that is assigned.
-  string role = 1 [
-    (buf.validate.field).string = {
-      pattern: "^[a-z]+(_[a-z]+)*$"
-      min_len: 1
-      max_len: 200
-    },
-    (google.api.field_behavior) = REQUIRED
-  ];
-  // subject is the subject to which the role is assigned.
-  // Can be either a UUID or a providername/subject string.
-  string subject = 2 [
-    (buf.validate.field).string.pattern = /* Can be either a UUID or a providername/<subject> string */ "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12})|([a-z]+/[-/[:word:]:]+)$",
-    (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE
-  ];
-  // display_name is the display name of the subject.
-  string display_name = 5 [
-    (buf.validate.field).string = {
-      pattern: "^[A-Za-z][-/'()[:word:] :]*$"
-      max_len: 200
-    },
-    (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE
-  ];
-  // project is the project in which the role is assigned.
-  optional string project = 4 [(buf.validate.field).string = {uuid: true}];
-  // email is the email address of the subject used for invitations.
-  string email = 6 [
-    (buf.validate.field) = {
-      string: {email: true}
-    },
-    (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE
-  ];
-  // first_name is the first name of the subject.
-  string first_name = 7 [
-    (buf.validate.field).string = {
-      pattern: "^[A-Za-z][- [:word:]\\[\\]\\(\\)]*$"
-      max_len: 200
-    },
-    (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE
-  ];
-  // last_name is the last name of the subject.
-  string last_name = 8 [
-    (buf.validate.field).string = {
-      pattern: "^[A-Za-z][- [:word:]\\[\\]\\(\\)]*$"
-      max_len: 200
-    },
-    (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE
-  ];
+    // role is the role that is assigned.
+    string role = 1 [
+        (buf.validate.field).string = {
+            pattern: "^[a-z]+(_[a-z]+)*$",
+            min_len: 1,
+            max_len: 200,
+        },
+        (google.api.field_behavior) = REQUIRED
+    ];
+    // subject is the subject to which the role is assigned.
+    // Can be either a UUID or a providername/subject string.
+    string subject = 2 [
+        (buf.validate.field).string.pattern =
+            // Can be either a UUID or a providername/<subject> string
+            "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12})|([a-z]+/[-/[:word:]:]+)$",
+        (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE
+    ];
+    // display_name is the display name of the subject.
+    string display_name = 5 [
+        (buf.validate.field).string = {
+            pattern: "^[A-Za-z][-/'()[:word:] :]*$",
+            max_len: 200,
+        },
+        (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE
+    ];
+    // project is the project in which the role is assigned.
+    optional string project = 4 [
+        (buf.validate.field).string = {uuid: true}
+    ];
+    // email is the email address of the subject used for invitations.
+    string email = 6 [
+        (buf.validate.field) = {string: {email: true}},
+        (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE
+    ];
+    // first_name is the first name of the subject.
+    string first_name = 7 [
+        (buf.validate.field).string = {
+            pattern: "^[A-Za-z][- [:word:]\\[\\]\\(\\)]*$",
+            max_len: 200,
+        },
+        (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE
+    ];
+    // last_name is the last name of the subject.
+    string last_name = 8 [
+        (buf.validate.field).string = {
+            pattern: "^[A-Za-z][- [:word:]\\[\\]\\(\\)]*$",
+            max_len: 200,
+        },
+        (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE
+    ];
 
-  reserved 3; // deprecated context
+    reserved 3; // deprecated context
 }
 
-message ListInvitationsRequest {}
+message ListInvitationsRequest {
+}
 
 message ListInvitationsResponse {
-  repeated Invitation invitations = 1 [(google.api.field_behavior) = REQUIRED];
+    repeated Invitation invitations = 1 [
+        (google.api.field_behavior) = REQUIRED
+    ];
 }
 
 message ResolveInvitationRequest {
-  // code is the code of the invitation to resolve.
-  string code = 1 [
-    (buf.validate.field).string = {
-      pattern: "^[A-Za-z0-9_-]+$"
-      len: 64
-    },
-    (google.api.field_behavior) = REQUIRED
-  ];
-  // accept is true if the invitation is accepted, false if it is rejected.
-  bool accept = 2;
+    // code is the code of the invitation to resolve.
+    string code = 1 [
+        (buf.validate.field).string = {
+            pattern: "^[A-Za-z0-9_-]+$",
+            len: 64,
+        },
+        (google.api.field_behavior) = REQUIRED
+    ];
+    // accept is true if the invitation is accepted, false if it is rejected.
+    bool accept = 2;
 }
 
 message ResolveInvitationResponse {
-  // role is the role that would be assigned if the user
-  // accepts the invitation.
-  string role = 1 [(google.api.field_behavior) = REQUIRED];
-  // email is the email address of the invited user.
-  string email = 2;
-  // project is the project to which the user is invited.
-  string project = 3 [(google.api.field_behavior) = REQUIRED];
-  // is_accepted is the status of the invitation.
-  bool is_accepted = 4 [(google.api.field_behavior) = REQUIRED];
-  // project_display is the display name of the project to which the user
-  // is invited.
-  string project_display = 5;
+    // role is the role that would be assigned if the user
+    // accepts the invitation.
+    string role = 1 [
+        (google.api.field_behavior) = REQUIRED
+    ];
+    // email is the email address of the invited user.
+    string email = 2;
+    // project is the project to which the user is invited.
+    string project = 3 [
+        (google.api.field_behavior) = REQUIRED
+    ];
+    // is_accepted is the status of the invitation.
+    bool is_accepted = 4 [
+        (google.api.field_behavior) = REQUIRED
+    ];
+    // project_display is the display name of the project to which the user
+    // is invited.
+    string project_display = 5;
 }
 
 // Invitation is an invitation to join a project. This is only used in responses.
 message Invitation {
-  // role is the role that would be assigned if the user
-  // accepts the invitation.
-  string role = 1 [(google.api.field_behavior) = REQUIRED];
-  // email is the email address of the invited user.  This is
-  // presented as a convenience for display purposes, and does
-  // not affect who can accept the invitation using the code.
-  string email = 2;
-  // project is the project to which the user is invited.
-  string project = 3 [(google.api.field_behavior) = REQUIRED];
+    // role is the role that would be assigned if the user
+    // accepts the invitation.
+    string role = 1 [
+        (google.api.field_behavior) = REQUIRED
+    ];
+    // email is the email address of the invited user.  This is
+    // presented as a convenience for display purposes, and does
+    // not affect who can accept the invitation using the code.
+    string email = 2;
+    // project is the project to which the user is invited.
+    string project = 3 [
+        (google.api.field_behavior) = REQUIRED
+    ];
 
-  // code is a unique identifier for the invitation, which can
-  // be used by the recipient to accept or reject the invitation.
-  // The code is only transmitted in response to AssignRole or
-  // ListInvitations RPCs, and not transmitted in
-  // ListRoleAssignments or other calls.
-  string code = 4;
+    // code is a unique identifier for the invitation, which can
+    // be used by the recipient to accept or reject the invitation.
+    // The code is only transmitted in response to AssignRole or
+    // ListInvitations RPCs, and not transmitted in
+    // ListRoleAssignments or other calls.
+    string code = 4;
 
-  // created_at is the time at which the invitation was created.
-  google.protobuf.Timestamp created_at = 5;
-  // expires_at is the time at which the invitation expires.
-  google.protobuf.Timestamp expires_at = 6;
-  // expired is true if the invitation has expired.
-  bool expired = 9;
+    // created_at is the time at which the invitation was created.
+    google.protobuf.Timestamp created_at = 5;
+    // expires_at is the time at which the invitation expires.
+    google.protobuf.Timestamp expires_at = 6;
+    // expired is true if the invitation has expired.
+    bool expired = 9;
 
-  // sponsor is the account (ID) of the user who created the invitation.
-  string sponsor = 7;
-  // sponsor_display is the display name of the user who created the
-  // invitation.
-  string sponsor_display = 8;
-  // project_display is the display name of the project to which the user
-  // is invited.
-  string project_display = 10;
-  // inviteURL is the URL that can be used to accept the invitation.
-  string invite_url = 11;
-  // emailSkipped is true if the email was not sent to the invitee.
-  bool email_skipped = 12;
+    // sponsor is the account (ID) of the user who created the invitation.
+    string sponsor = 7;
+    // sponsor_display is the display name of the user who created the
+    // invitation.
+    string sponsor_display = 8;
+    // project_display is the display name of the project to which the user
+    // is invited.
+    string project_display = 10;
+    // inviteURL is the URL that can be used to accept the invitation.
+    string invite_url = 11;
+    // emailSkipped is true if the email was not sent to the invitee.
+    bool email_skipped = 12;
 }
 
 message GetProviderRequest {
-  // context is the context in which the provider is evaluated.
-  Context context = 1;
-  // name is the name of the provider to get.
-  string name = 2 [
-    (buf.validate.field).string = {
-      pattern: "^[-[:word:]]*$"
-      max_len: 200
-    },
-    (google.api.field_behavior) = REQUIRED
-  ];
+    // context is the context in which the provider is evaluated.
+    Context context = 1;
+    // name is the name of the provider to get.
+    string name = 2 [
+        (buf.validate.field).string = {
+            pattern: "^[-[:word:]]*$",
+            max_len: 200,
+        },
+        (google.api.field_behavior) = REQUIRED
+    ];
 }
 
 message GetProviderResponse {
-  // provider is the provider that was retrieved.
-  Provider provider = 1 [(google.api.field_behavior) = REQUIRED];
+    // provider is the provider that was retrieved.
+    Provider provider = 1 [
+        (google.api.field_behavior) = REQUIRED
+    ];
 }
 
 message ListProvidersRequest {
-  // context is the context in which the providers are evaluated.
-  Context context = 1;
+    // context is the context in which the providers are evaluated.
+    Context context = 1;
 
-  // limit is the maximum number of providers to return.
-  // 0 uses a server-defined default.
-  int32 limit = 2 [
-    (buf.validate.field).int32 = {
-      gte: 0
-      lte: 100
-    },
-    (google.api.field_behavior) = REQUIRED
-  ];
+    // limit is the maximum number of providers to return.
+    // 0 uses a server-defined default.
+    int32 limit = 2 [
+        (buf.validate.field).int32 = {gte: 0, lte: 100},
+        (google.api.field_behavior) = REQUIRED
+    ];
 
-  // cursor is the cursor to use for the page of results, empty if at the beginning
-  string cursor = 3 [(buf.validate.field).string = {
-    pattern: "^[[:word:]=]*$"
-    max_len: 200
-  }];
+    // cursor is the cursor to use for the page of results, empty if at the beginning
+    string cursor = 3 [
+        (buf.validate.field).string = {
+            pattern: "^[[:word:]=]*$",
+            max_len: 200,
+        }
+    ];
 }
 
 message ListProvidersResponse {
-  repeated Provider providers = 1 [(google.api.field_behavior) = REQUIRED];
+    repeated Provider providers = 1 [
+        (google.api.field_behavior) = REQUIRED
+    ];
 
-  // cursor is the cursor to use for the next page of results, empty if at the end
-  string cursor = 2;
+    // cursor is the cursor to use for the next page of results, empty if at the end
+    string cursor = 2;
 }
 
 message CreateProviderRequest {
-  // context is the context in which the provider is created.
-  Context context = 1;
-  // provider is the provider to be created.
-  Provider provider = 2 [(google.api.field_behavior) = REQUIRED];
+    // context is the context in which the provider is created.
+    Context context = 1;
+    // provider is the provider to be created.
+    Provider provider = 2 [
+        (google.api.field_behavior) = REQUIRED
+    ];
 }
 
 message CreateProviderResponse {
-  // provider is the provider that was created.
-  Provider provider = 1 [(google.api.field_behavior) = REQUIRED];
+    // provider is the provider that was created.
+    Provider provider = 1 [
+        (google.api.field_behavior) = REQUIRED
+    ];
 
-  // authorization provides additional authorization information needed
-  // to complete the initialization of the provider.
-  AuthorizationParams authorization = 2;
+    // authorization provides additional authorization information needed
+    // to complete the initialization of the provider.
+    AuthorizationParams authorization = 2;
 }
 
 message DeleteProviderRequest {
-  // context is the context in which the provider is deleted.  Both
-  // project and provider are required in this context.
-  Context context = 1 [(google.api.field_behavior) = REQUIRED];
+    // context is the context in which the provider is deleted.  Both
+    // project and provider are required in this context.
+    Context context = 1 [
+        (google.api.field_behavior) = REQUIRED
+    ];
 }
 
 message DeleteProviderResponse {
-  // name is the name of the provider that was deleted
-  string name = 1 [(google.api.field_behavior) = REQUIRED];
+    // name is the name of the provider that was deleted
+    string name = 1 [
+        (google.api.field_behavior) = REQUIRED
+    ];
 }
 
 message DeleteProviderByIDRequest {
-  // context is the context in which the provider is deleted. Only the project is required in this context.
-  Context context = 1;
-  // id is the id of the provider to delete
-  string id = 2 [
-    (buf.validate.field).string = {uuid: true},
-    (google.api.field_behavior) = REQUIRED
-  ];
+    // context is the context in which the provider is deleted. Only the project is required in this context.
+    Context context = 1;
+    // id is the id of the provider to delete
+    string id = 2 [
+        (buf.validate.field).string = {uuid: true},
+        (google.api.field_behavior) = REQUIRED
+    ];
 }
 
 message DeleteProviderByIDResponse {
-  // id is the id of the provider that was deleted
-  string id = 1 [(google.api.field_behavior) = REQUIRED];
+    // id is the id of the provider that was deleted
+    string id = 1 [
+        (google.api.field_behavior) = REQUIRED
+    ];
 }
 
 message ListProviderClassesRequest {
-  // context is the context in which the provider classes are evaluated.
-  Context context = 1;
+    // context is the context in which the provider classes are evaluated.
+    Context context = 1;
 }
 
 message ProviderClassInfo {
-  // class is the provider class identifier.
-  string class = 1 [(google.api.field_behavior) = REQUIRED];
+    // class is the provider class identifier.
+    string class = 1 [
+        (google.api.field_behavior) = REQUIRED
+    ];
 
-  // display_name is a human-friendly provider class name.
-  string display_name = 2 [(google.api.field_behavior) = REQUIRED];
+    // display_name is a human-friendly provider class name.
+    string display_name = 2 [
+        (google.api.field_behavior) = REQUIRED
+    ];
 
-  // description is a short plaintext summary of the provider class.
-  string description = 3;
+    // description is a short plaintext summary of the provider class.
+    string description = 3;
 
-  // supported_provider_types is the list of provider traits/interfaces supported by this class.
-  repeated ProviderType supported_provider_types = 4 [(google.api.field_behavior) = REQUIRED];
+    // supported_provider_types is the list of provider traits/interfaces supported by this class.
+    repeated ProviderType supported_provider_types = 4 [
+        (google.api.field_behavior) = REQUIRED
+    ];
 
-  // supported_auth_flows is the list of supported authorization flows.
-  repeated AuthorizationFlow supported_auth_flows = 5 [(google.api.field_behavior) = REQUIRED];
+    // supported_auth_flows is the list of supported authorization flows.
+    repeated AuthorizationFlow supported_auth_flows = 5 [
+        (google.api.field_behavior) = REQUIRED
+    ];
 
-  // supported_entities is the list of entity types supported by this provider class.
-  repeated Entity supported_entities = 6;
+    // supported_entities is the list of entity types supported by this provider class.
+    repeated Entity supported_entities = 6;
 
-  // documentation_url points to provider-specific or generic documentation.
-  string documentation_url = 7;
+    // documentation_url points to provider-specific or generic documentation.
+    string documentation_url = 7;
 
-  reserved 8;
-  reserved "creation_help";
+    reserved 8;
+    reserved "creation_help";
 }
 
 message ListProviderClassesResponse {
-  // provider_classes is the legacy list of provider class names.
-  // Deprecated: use provider_class_infos for rich metadata.
-  repeated string provider_classes = 1 [
-    (google.api.field_behavior) = REQUIRED,
-    deprecated = true
-  ];
+    // provider_classes is the legacy list of provider class names.
+    // Deprecated: use provider_class_infos for rich metadata.
+    repeated string provider_classes = 1 [
+        (google.api.field_behavior) = REQUIRED,
+        deprecated = true
+    ];
 
-  // provider_class_infos is the rich metadata for each provider class.
-  repeated ProviderClassInfo provider_class_infos = 2 [(google.api.field_behavior) = REQUIRED];
+    // provider_class_infos is the rich metadata for each provider class.
+    repeated ProviderClassInfo provider_class_infos = 2 [
+        (google.api.field_behavior) = REQUIRED
+    ];
 }
 
 message PatchProviderRequest {
-  // context is the context in which the provider is updated.
-  // The provider name is required in this context.
-  Context context = 1 [(google.api.field_behavior) = REQUIRED];
-  Provider patch = 2;
+    // context is the context in which the provider is updated.
+    // The provider name is required in this context.
+    Context context = 1 [
+        (google.api.field_behavior) = REQUIRED
+    ];
+    Provider patch = 2;
 
-  google.protobuf.FieldMask update_mask = 3;
+    google.protobuf.FieldMask update_mask = 3;
 }
 
 message PatchProviderResponse {
-  Provider provider = 1 [(google.api.field_behavior) = REQUIRED];
+    Provider provider = 1 [
+        (google.api.field_behavior) = REQUIRED
+    ];
 }
 
 message AuthorizationParams {
-  // authorization_url is an external URL to use to authorize the provider.
-  string authorization_url = 1;
+    // authorization_url is an external URL to use to authorize the provider.
+    string authorization_url = 1;
+
 }
 
 message ProviderParameter {
-  oneof parameters {
-    GitHubAppParams github_app = 1;
-  }
+    oneof parameters {
+        GitHubAppParams github_app = 1;
+    }
 }
 
 // GitHubAppParams is the parameters for a GitHub App provider.
 message GitHubAppParams {
-  // The GitHub installation ID for the app.  On create, this is the only
-  // parameter used; the organization parameters are ignored.
-  int64 installation_id = 1 [
-    (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE,
-    (buf.validate.field).int64 = {gt: 0}
-  ];
+    // The GitHub installation ID for the app.  On create, this is the only
+    // parameter used; the organization parameters are ignored.
+    int64 installation_id = 1 [
+        (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE,
+        (buf.validate.field).int64 = {gt: 0}
+    ];
 
-  // The GitHub organization slug where the app is installed.  This is an
-  // output-only parameter, and is validated on input if set (i.e. the value
-  // must be either empty or match the org of the installation_id).
-  string organization = 2 [(google.api.field_behavior) = OUTPUT_ONLY];
-  // The GitHub organization ID where the app is installed.  This is an
-  // output-only parameter, and is validated on input if set (i.e. the value
-  // must be either empty or match the org of the installation_id).
-  int64 organization_id = 3 [
-    (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE,
-    (buf.validate.field).int64 = {gt: 0},
-    (google.api.field_behavior) = OUTPUT_ONLY
-  ];
+    // The GitHub organization slug where the app is installed.  This is an
+    // output-only parameter, and is validated on input if set (i.e. the value
+    // must be either empty or match the org of the installation_id).
+    string organization = 2 [
+        (google.api.field_behavior) = OUTPUT_ONLY
+    ];
+    // The GitHub organization ID where the app is installed.  This is an
+    // output-only parameter, and is validated on input if set (i.e. the value
+    // must be either empty or match the org of the installation_id).
+    int64 organization_id = 3 [
+        (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE,
+        (buf.validate.field).int64 = {gt: 0},
+        (google.api.field_behavior) = OUTPUT_ONLY
+    ];
 }
 
 // ProviderTrait is the type of the provider.
 enum ProviderType {
-  PROVIDER_TYPE_UNSPECIFIED = 0;
-  PROVIDER_TYPE_GITHUB = 1 [(name) = "github"];
-  PROVIDER_TYPE_REST = 2 [(name) = "rest"];
-  PROVIDER_TYPE_GIT = 3 [(name) = "git"];
-  PROVIDER_TYPE_OCI = 4 [(name) = "oci"];
-  PROVIDER_TYPE_REPO_LISTER = 5 [(name) = "repo-lister"];
-  PROVIDER_TYPE_IMAGE_LISTER = 6 [(name) = "image-lister"];
+    PROVIDER_TYPE_UNSPECIFIED = 0;
+    PROVIDER_TYPE_GITHUB = 1 [(name) = "github"];
+    PROVIDER_TYPE_REST = 2 [(name) = "rest"];
+    PROVIDER_TYPE_GIT = 3 [(name) = "git"];
+    PROVIDER_TYPE_OCI = 4 [(name) = "oci"];
+    PROVIDER_TYPE_REPO_LISTER = 5 [(name) = "repo-lister"];
+    PROVIDER_TYPE_IMAGE_LISTER = 6 [(name) = "image-lister"];
 }
 
 enum ProviderClass {
-  PROVIDER_CLASS_UNSPECIFIED = 0;
-  PROVIDER_CLASS_GITHUB = 1 [(name) = "github"];
-  PROVIDER_CLASS_GITHUB_APP = 2 [(name) = "github-app"];
-  PROVIDER_CLASS_GHCR = 3 [(name) = "ghcr"];
-  PROVIDER_CLASS_DOCKERHUB = 4 [(name) = "dockerhub"];
+    PROVIDER_CLASS_UNSPECIFIED = 0;
+    PROVIDER_CLASS_GITHUB = 1 [(name) = "github"];
+    PROVIDER_CLASS_GITHUB_APP = 2 [(name) = "github-app"];
+    PROVIDER_CLASS_GHCR = 3 [(name) = "ghcr"];
+    PROVIDER_CLASS_DOCKERHUB = 4 [(name) = "dockerhub"];
 }
 
 enum AuthorizationFlow {
-  AUTHORIZATION_FLOW_UNSPECIFIED = 0;
-  AUTHORIZATION_FLOW_NONE = 1 [(name) = "none"];
-  AUTHORIZATION_FLOW_USER_INPUT = 2 [(name) = "user_input"];
-  AUTHORIZATION_FLOW_OAUTH2_AUTHORIZATION_CODE_FLOW = 3 [(name) = "oauth2_authorization_code_flow"];
-  AUTHORIZATION_FLOW_GITHUB_APP_FLOW = 4 [(name) = "github_app_flow"];
+    AUTHORIZATION_FLOW_UNSPECIFIED = 0;
+    AUTHORIZATION_FLOW_NONE = 1 [(name) = "none"];
+    AUTHORIZATION_FLOW_USER_INPUT = 2 [(name) = "user_input"];
+    AUTHORIZATION_FLOW_OAUTH2_AUTHORIZATION_CODE_FLOW = 3 [(name) = "oauth2_authorization_code_flow"];
+    AUTHORIZATION_FLOW_GITHUB_APP_FLOW = 4 [(name) = "github_app_flow"];
 }
 
 enum CredentialsState {
-  CREDENTIALS_STATE_UNSPECIFIED = 0;
-  CREDENTIALS_STATE_SET = 1 [(name) = "set"];
-  CREDENTIALS_STATE_UNSET = 2 [(name) = "unset"];
-  CREDENTIALS_STATE_NOT_APPLICABLE = 3 [(name) = "not_applicable"];
+    CREDENTIALS_STATE_UNSPECIFIED = 0;
+    CREDENTIALS_STATE_SET = 1 [(name) = "set"];
+    CREDENTIALS_STATE_UNSET = 2 [(name) = "unset"];
+    CREDENTIALS_STATE_NOT_APPLICABLE = 3 [(name) = "not_applicable"];
 }
 
 // Provider represents a provider that is used to interact with external systems.
 // All fields are optional because we want to allow partial updates.
 message Provider {
-  // name is the name of the provider.
-  string name = 1 [
-    (buf.validate.field).string = {
-      pattern: "^[A-Za-z][-[:word:]]*$"
-      max_len: 200
-    },
-    (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE
-  ];
-  // class is the name of the provider implementation, eg. 'github' or 'gh-app'.
-  string class = 7 [
-    (buf.validate.field).string = {
-      pattern: "^[a-z][a-z0-9_-]*$"
-      max_len: 200
-    },
-    (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE
-  ];
-  // project is the project where the provider is.  This is ignored on input
-  // in favor of the context field in CreateProviderRequest.
-  string project = 2 [(google.api.field_behavior) = OUTPUT_ONLY];
-  // version is the version of the provider.
-  // if unset, "v1" is assumed.
-  string version = 3 [
-    (buf.validate.field).string = {pattern: "v1"},
-    (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE
-  ];
+    // name is the name of the provider.
+    string name = 1 [
+        (buf.validate.field).string = {
+            pattern: "^[A-Za-z][-[:word:]]*$",
+            max_len: 200,
+        },
+        (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE
+    ];
+    // class is the name of the provider implementation, eg. 'github' or 'gh-app'.
+    string class = 7 [
+        (buf.validate.field).string = {
+            pattern: "^[a-z][a-z0-9_-]*$",
+            max_len: 200,
+        },
+        (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE
+    ];
+    // project is the project where the provider is.  This is ignored on input
+    // in favor of the context field in CreateProviderRequest.
+    string project = 2 [
+        (google.api.field_behavior) = OUTPUT_ONLY
+    ];
+    // version is the version of the provider.
+    // if unset, "v1" is assumed.
+    string version = 3 [
+        (buf.validate.field).string = {
+            pattern: "v1",
+        },
+        (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE
+    ];
 
-  // implements is the list of interfaces that the provider implements.
-  repeated ProviderType implements = 4;
+    // implements is the list of interfaces that the provider implements.
+    repeated ProviderType implements = 4;
 
-  // config is the configuration of the provider.
-  google.protobuf.Struct config = 5;
+    // config is the configuration of the provider.
+    google.protobuf.Struct config = 5;
 
-  // auth_flows is the list of authorization flows that the provider supports.
-  repeated AuthorizationFlow auth_flows = 6;
+    // auth_flows is the list of authorization flows that the provider supports.
+    repeated AuthorizationFlow auth_flows = 6;
 
-  // parameters is the list of parameters that the provider requires.
-  ProviderParameter parameters = 8;
+    // parameters is the list of parameters that the provider requires.
+    ProviderParameter parameters = 8;
 
-  // credentials_state is the state of the credentials for the provider.
-  // This is an output-only field. It may be: "set", "unset", "not_applicable".
-  string credentials_state = 9 [(google.api.field_behavior) = OUTPUT_ONLY];
+    // credentials_state is the state of the credentials for the provider.
+    // This is an output-only field. It may be: "set", "unset", "not_applicable".
+    string credentials_state = 9 [
+        (google.api.field_behavior) = OUTPUT_ONLY
+    ];
 
-  // id is the unique identifier of the provider.
-  string id = 10 [
-    (buf.validate.field).string = {uuid: true},
-    (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE
-  ];
+    // id is the unique identifier of the provider.
+    string id = 10 [
+        (buf.validate.field).string = {uuid: true},
+        (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE
+    ];
 }
 
 // GetEvaluationHistoryRequest represents a request for the GetEvaluationHistory endpoint
 message GetEvaluationHistoryRequest {
-  string id = 1 [
-    (buf.validate.field).string = {uuid: true},
-    (google.api.field_behavior) = REQUIRED
-  ];
+    string id = 1 [
+        (buf.validate.field).string = {uuid: true},
+        (google.api.field_behavior) = REQUIRED
+    ];
 
-  Context context = 2;
+    Context context = 2;
 
-  // If true, include structured rule output for the matched evaluations.
-  // Not all ruletypes may generate structured outputs.
-  // Because the evaluation output may be large, it is only returned
-  // when explicitly requested.
-  bool include_outputs = 3;
+    // If true, include structured rule output for the matched evaluations.
+    // Not all ruletypes may generate structured outputs.
+    // Because the evaluation output may be large, it is only returned
+    // when explicitly requested.
+    bool include_outputs = 3;
 }
 
 // ListEvaluationHistoryRequest represents a request message for the
@@ -3513,96 +3920,112 @@ message GetEvaluationHistoryRequest {
 // Most of its fields are used for filtering, except for `cursor`
 // which is used for pagination.
 message ListEvaluationHistoryRequest {
-  Context context = 1;
+    Context context = 1;
 
-  // List of entity types to retrieve.
-  repeated string entity_type = 2 [(buf.validate.field).repeated = {
-    items: {
-      string: {
-        pattern: "^[,[:word:]]*$"
-        max_len: 200
-      }
-    }
-  }];
-  // List of entity names to retrieve.
-  repeated string entity_name = 3 [(buf.validate.field).repeated = {
-    items: {
-      string: {
-        pattern: "^[,-./[:word:]]*$"
-        max_len: 200
-      }
-    }
-  }];
-  // List of profile names to retrieve.
-  repeated string profile_name = 4 [(buf.validate.field).repeated = {
-    items: {
-      string: {
-        pattern: "^[A-Za-z][-/[:word:]]*$"
-        max_len: 200
-      }
-    }
-  }];
-  // List of evaluation statuses to retrieve.
-  repeated string status = 5 [(buf.validate.field).repeated = {
-    items: {
-      string: {
-        pattern: "^[,[:word:]]*$"
-        max_len: 200
-      }
-    }
-  }];
-  // List of remediation statuses to retrieve.
-  repeated string remediation = 6 [(buf.validate.field).repeated = {
-    items: {
-      string: {
-        pattern: "^[,[:word:]]*$"
-        max_len: 200
-      }
-    }
-  }];
-  // List of alert statuses to retrieve.
-  repeated string alert = 7 [(buf.validate.field).repeated = {
-    items: {
-      string: {
-        pattern: "^[,[:word:]]*$"
-        max_len: 200
-      }
-    }
-  }];
-  // Timestamp representing the start time of the selection window.
-  google.protobuf.Timestamp from = 8;
-  // Timestamp representing the end time of the selection window.
-  google.protobuf.Timestamp to = 9;
+    // List of entity types to retrieve.
+    repeated string entity_type = 2 [
+        (buf.validate.field).repeated = {
+            items: {
+                string: {
+                    pattern: "^[,[:word:]]*$",
+                    max_len: 200,
+                }
+            }
+        }
+    ];
+    // List of entity names to retrieve.
+    repeated string entity_name = 3 [
+        (buf.validate.field).repeated = {
+            items: {
+                string: {
+                    pattern: "^[,-./[:word:]]*$",
+                    max_len: 200,
+                }
+            }
+        }
+    ];
+    // List of profile names to retrieve.
+    repeated string profile_name = 4 [
+        (buf.validate.field).repeated = {
+            items: {
+                string: {
+                    pattern: "^[A-Za-z][-/[:word:]]*$",
+                    max_len: 200,
+                }
+            }
+        }
+    ];
+    // List of evaluation statuses to retrieve.
+    repeated string status = 5 [
+        (buf.validate.field).repeated = {
+            items: {
+                string: {
+                    pattern: "^[,[:word:]]*$",
+                    max_len: 200,
+                }
+            }
+        }
+    ];
+    // List of remediation statuses to retrieve.
+    repeated string remediation = 6 [
+        (buf.validate.field).repeated = {
+            items: {
+                string: {
+                    pattern: "^[,[:word:]]*$",
+                    max_len: 200,
+                }
+            }
+        }
+    ];
+    // List of alert statuses to retrieve.
+    repeated string alert = 7 [
+        (buf.validate.field).repeated = {
+            items: {
+                string: {
+                    pattern: "^[,[:word:]]*$",
+                    max_len: 200,
+                }
+            }
+        }
+    ];
+    // Timestamp representing the start time of the selection window.
+    google.protobuf.Timestamp from = 8;
+    // Timestamp representing the end time of the selection window.
+    google.protobuf.Timestamp to = 9;
 
-  // Filter evaluation history to only those matching the specified labels.
-  //
-  // The default is to return all user-created profiles; the string "*" can
-  // be used to select all profiles, including system profiles.  This syntax
-  // may be expanded in the future.
-  repeated string label_filter = 11 [(buf.validate.field).repeated = {
-    items: {
-      string: {
-        pattern: "^(\\*|[a-z][a-z0-9_]*)$"
-        max_len: 200
-      }
-    }
-  }];
+    // Filter evaluation history to only those matching the specified labels.
+    //
+    // The default is to return all user-created profiles; the string "*" can
+    // be used to select all profiles, including system profiles.  This syntax
+    // may be expanded in the future.
+    repeated string label_filter = 11 [
+        (buf.validate.field).repeated = {
+            items: {
+                string: {
+                    pattern: "^(\\*|[a-z][a-z0-9_]*)$",
+                    max_len: 200,
+                },
+            },
+        }
+    ];
 
-  // Cursor object to select the "page" of data to retrieve. This is optional.
-  Cursor cursor = 10;
+    // Cursor object to select the "page" of data to retrieve. This is optional.
+    Cursor cursor = 10;
 
-  // If true, include structured rule output for the matched evaluations.
-  // Not all ruletypes may generate structured outputs.
-  // Because the evaluation output may be large, it is only returned
-  // when explicitly requested.
-  bool include_outputs = 12;
+    // If true, include structured rule output for the matched evaluations.
+    // Not all ruletypes may generate structured outputs.
+    // Because the evaluation output may be large, it is only returned
+    // when explicitly requested.
+    bool include_outputs = 12;
 }
 
 // GetEvaluationHistoryResponse represents a response message for the
 // GetEvaluationHistory RPC.
 message GetEvaluationHistoryResponse {
-  // The requested record
-  EvaluationHistory evaluation = 1 [(google.api.field_behavior) = REQUIRED];
+    // The requested record
+    EvaluationHistory evaluation = 1 [
+        (google.api.field_behavior) = REQUIRED
+    ];
 }
 
 // ListEvaluationHistoryResponse represents a response message for the
@@ -3611,296 +4034,356 @@ message GetEvaluationHistoryResponse {
 // It ships a collection of records retrieved and pointers to get to
 // the next and/or previous pages of data.
 message ListEvaluationHistoryResponse {
-  // List of records retrieved.
-  repeated EvaluationHistory data = 1 [(google.api.field_behavior) = REQUIRED];
-  // Metadata of the current page and pointers to next and/or
-  // previous pages.
-  CursorPage page = 2;
+    // List of records retrieved.
+    repeated EvaluationHistory data = 1 [
+        (google.api.field_behavior) = REQUIRED
+    ];
+    // Metadata of the current page and pointers to next and/or
+    // previous pages.
+    CursorPage page = 2;
 }
 
 // EvaluationHistory represents the history of an entity evaluation.
 // This is only used in responses.
 message EvaluationHistory {
-  // entity contains details of the entity which was evaluated.
-  EvaluationHistoryEntity entity = 1 [(google.api.field_behavior) = REQUIRED];
+    // entity contains details of the entity which was evaluated.
+    EvaluationHistoryEntity entity = 1 [
+        (google.api.field_behavior) = REQUIRED
+    ];
 
-  // rule contains details of the rule which the entity was evaluated against.
-  EvaluationHistoryRule rule = 2 [(google.api.field_behavior) = REQUIRED];
+    // rule contains details of the rule which the entity was evaluated against.
+    EvaluationHistoryRule rule = 2 [
+        (google.api.field_behavior) = REQUIRED
+    ];
 
-  // status contains the evaluation status.
-  EvaluationHistoryStatus status = 3 [(google.api.field_behavior) = REQUIRED];
+    // status contains the evaluation status.
+    EvaluationHistoryStatus status = 3 [
+        (google.api.field_behavior) = REQUIRED
+    ];
 
-  // alert contains details of the alerts for this evaluation.
-  // This is optional.
-  EvaluationHistoryAlert alert = 4;
+    // alert contains details of the alerts for this evaluation.
+    // This is optional.
+    EvaluationHistoryAlert alert = 4;
 
-  // remediation contains details of the remediation for this evaluation.
-  // This is optional.
-  EvaluationHistoryRemediation remediation = 5;
+    // remediation contains details of the remediation for this evaluation.
+    // This is optional.
+    EvaluationHistoryRemediation remediation = 5;
 
-  // created_at is the timestamp of creation of this evaluation
-  google.protobuf.Timestamp evaluated_at = 6 [(google.api.field_behavior) = REQUIRED];
+    // created_at is the timestamp of creation of this evaluation
+    google.protobuf.Timestamp evaluated_at = 6 [
+        (google.api.field_behavior) = REQUIRED
+    ];
 
-  // id is the unique identifier of the evaluation.
-  string id = 7 [(google.api.field_behavior) = REQUIRED];
+    // id is the unique identifier of the evaluation.
+    string id = 7 [
+        (google.api.field_behavior) = REQUIRED
+    ];
 }
 
 message EvaluationHistoryEntity {
-  // id is the unique identifier of the entity.
-  string id = 1 [(google.api.field_behavior) = REQUIRED];
+    // id is the unique identifier of the entity.
+    string id = 1 [
+        (google.api.field_behavior) = REQUIRED
+    ];
 
-  // type is the entity type.
-  Entity type = 2 [(google.api.field_behavior) = REQUIRED];
+    // type is the entity type.
+    Entity type = 2 [
+        (google.api.field_behavior) = REQUIRED
+    ];
 
-  // name is the entity name.
-  string name = 3 [(google.api.field_behavior) = REQUIRED];
+    // name is the entity name.
+    string name = 3 [
+        (google.api.field_behavior) = REQUIRED
+    ];
 }
 
 message EvaluationHistoryRule {
-  // name is the name of the rule instance.
-  string name = 1 [(google.api.field_behavior) = REQUIRED];
+    // name is the name of the rule instance.
+    string name = 1 [
+        (google.api.field_behavior) = REQUIRED
+    ];
 
-  // type is the name of the rule type.
-  string rule_type = 2 [(google.api.field_behavior) = REQUIRED];
+    // type is the name of the rule type.
+    string rule_type = 2 [
+        (google.api.field_behavior) = REQUIRED
+    ];
 
-  // profile is the name of the profile which contains the rule.
-  string profile = 3 [(google.api.field_behavior) = REQUIRED];
+    // profile is the name of the profile which contains the rule.
+    string profile = 3 [
+        (google.api.field_behavior) = REQUIRED
+    ];
 
-  // severity is the severity of the rule type.
-  Severity severity = 4 [(google.api.field_behavior) = REQUIRED];
+    // severity is the severity of the rule type.
+    Severity severity = 4 [
+        (google.api.field_behavior) = REQUIRED
+    ];
 }
 
 message EvaluationHistoryStatus {
-  // status is one of (success, error, failure, skipped)
-  // not using enums to mirror the behaviour of the existing API contracts.
-  string status = 1 [(google.api.field_behavior) = REQUIRED];
+    // status is one of (success, error, failure, skipped)
+    // not using enums to mirror the behaviour of the existing API contracts.
+    string status = 1 [
+        (google.api.field_behavior) = REQUIRED
+    ];
 
-  // details contains optional details about the evaluation.
-  // the structure and contents are rule type specific, and are subject to change.
-  string details = 2 [(google.api.field_behavior) = REQUIRED];
+    // details contains optional details about the evaluation.
+    // the structure and contents are rule type specific, and are subject to change.
+    string details = 2 [
+        (google.api.field_behavior) = REQUIRED
+    ];
 
-  // output optionally contains the structured rule evaluation output.
-  // Because output may be multiple KB, it is only returned
-  // if include_outputs is set. Historical evaluations may
-  // discard structured output sooner than status results.
-  google.protobuf.Value output = 3;
+    // output optionally contains the structured rule evaluation output.
+    // Because output may be multiple KB, it is only returned
+    // if include_outputs is set. Historical evaluations may
+    // discard structured output sooner than status results.
+    google.protobuf.Value output = 3;
 }
 
 message EvaluationHistoryRemediation {
-  // status is one of (success, error, failure, skipped, not available)
-  // not using enums to mirror the behaviour of the existing API contracts.
-  string status = 1 [(google.api.field_behavior) = REQUIRED];
+    // status is one of (success, error, failure, skipped, not available)
+    // not using enums to mirror the behaviour of the existing API contracts.
+    string status = 1 [
+        (google.api.field_behavior) = REQUIRED
+    ];
 
-  // details contains optional details about the remediation.
-  // the structure and contents are remediation specific, and are subject to change.
-  string details = 2;
+    // details contains optional details about the remediation.
+    // the structure and contents are remediation specific, and are subject to change.
+    string details = 2;
 }
 
 message EvaluationHistoryAlert {
-  // status is one of (on, off, error, skipped, not available)
-  // not using enums to mirror the behaviour of the existing API contracts.
-  string status = 1 [(google.api.field_behavior) = REQUIRED];
+    // status is one of (on, off, error, skipped, not available)
+    // not using enums to mirror the behaviour of the existing API contracts.
+    string status = 1 [
+        (google.api.field_behavior) = REQUIRED
+    ];
 
-  // details contains optional details about the alert.
-  // the structure and contents are alert specific, and are subject to change.
-  string details = 2;
+    // details contains optional details about the alert.
+    // the structure and contents are alert specific, and are subject to change.
+    string details = 2;
 }
 
 // used for parsing resources in ruletypes
 message EntityInstance {
-  // id is the unique identifier of the entity.
-  string id = 1;
+    // id is the unique identifier of the entity.
+    string id = 1;
 
-  // context is the context in which the entity is evaluated.
-  ContextV2 context = 2;
+    // context is the context in which the entity is evaluated.
+    ContextV2 context = 2;
 
-  // name is the name of the entity.
-  string name = 3;
+    // name is the name of the entity.
+    string name = 3;
 
-  // type is the type of the entity.
-  // DISCUSSION: If we're aiming for a BYO entity type, we should probably
-  // have this be a string, and have the user provide the type.
-  Entity type = 4;
+    // type is the type of the entity.
+    // DISCUSSION: If we're aiming for a BYO entity type, we should probably
+    // have this be a string, and have the user provide the type.
+    Entity type = 4;
 
-  // properties is a map of properties of the entity.
-  google.protobuf.Struct properties = 5;
+    // properties is a map of properties of the entity.
+    google.protobuf.Struct properties = 5;
 }
 
 // EntityInstanceService provides API endpoints for managing entity instances
 service EntityInstanceService {
-  // ListEntities returns a list of entity instances for a given project and provider
-  rpc ListEntities(ListEntitiesRequest) returns (ListEntitiesResponse) {
-    option (google.api.http) = {get: "/api/v1/entities"};
+    // ListEntities returns a list of entity instances for a given project and provider
+    rpc ListEntities (ListEntitiesRequest) returns (ListEntitiesResponse) {
+        option (google.api.http) = {
+            get: "/api/v1/entities"
+        };
 
-    option (rpc_options) = {
-      target_resource: TARGET_RESOURCE_PROJECT
-      relation: RELATION_ENTITY_GET
-    };
-  }
+        option (rpc_options) = {
+            target_resource: TARGET_RESOURCE_PROJECT
+            relation: RELATION_ENTITY_GET
+        };
+    }
 
-  // GetEntityById returns an entity instance for a given entity ID
-  rpc GetEntityById(GetEntityByIdRequest) returns (GetEntityByIdResponse) {
-    option (google.api.http) = {get: "/api/v1/entity/id/{id}"};
+    // GetEntityById returns an entity instance for a given entity ID
+    rpc GetEntityById (GetEntityByIdRequest) returns (GetEntityByIdResponse) {
+        option (google.api.http) = {
+            get: "/api/v1/entity/id/{id}"
+        };
 
-    option (rpc_options) = {
-      target_resource: TARGET_RESOURCE_PROJECT
-      relation: RELATION_ENTITY_GET
-    };
-  }
+        option (rpc_options) = {
+            target_resource: TARGET_RESOURCE_PROJECT
+            relation: RELATION_ENTITY_GET
+        };
+    }
 
-  // GetEntityByName returns an entity instance for a given entity name
-  rpc GetEntityByName(GetEntityByNameRequest) returns (GetEntityByNameResponse) {
-    option (google.api.http) = {get: "/api/v1/entity/{entity_type}/{name=**}"};
+    // GetEntityByName returns an entity instance for a given entity name
+    rpc GetEntityByName (GetEntityByNameRequest) returns (GetEntityByNameResponse) {
+        option (google.api.http) = {
+            get: "/api/v1/entity/{entity_type}/{name=**}"
+        };
 
-    option (rpc_options) = {
-      target_resource: TARGET_RESOURCE_PROJECT
-      relation: RELATION_ENTITY_GET
-    };
-  }
+        option (rpc_options) = {
+            target_resource: TARGET_RESOURCE_PROJECT
+            relation: RELATION_ENTITY_GET
+        };
+    }
 
-  // DeleteEntityById deletes an entity instance for a given entity ID
-  rpc DeleteEntityById(DeleteEntityByIdRequest) returns (DeleteEntityByIdResponse) {
-    option (google.api.http) = {delete: "/api/v1/entity/id/{id}"};
+    // DeleteEntityById deletes an entity instance for a given entity ID
+    rpc DeleteEntityById (DeleteEntityByIdRequest) returns (DeleteEntityByIdResponse) {
+        option (google.api.http) = {
+            delete: "/api/v1/entity/id/{id}"
+        };
 
-    option (minder.v1.rpc_options) = {
-      target_resource: TARGET_RESOURCE_PROJECT
-      relation: RELATION_ENTITY_DELETE
-    };
-  }
+        option (minder.v1.rpc_options) = {
+            target_resource: TARGET_RESOURCE_PROJECT
+            relation: RELATION_ENTITY_DELETE
+        };
+    }
 
-  // RegisterEntity creates a new entity instance
-  rpc RegisterEntity(RegisterEntityRequest) returns (RegisterEntityResponse) {
-    option (google.api.http) = {
-      post: "/api/v1/entity"
-      body: "*"
-    };
+    // RegisterEntity creates a new entity instance
+    rpc RegisterEntity (RegisterEntityRequest) returns (RegisterEntityResponse) {
+        option (google.api.http) = {
+            post: "/api/v1/entity"
+            body: "*"
+        };
 
-    option (rpc_options) = {
-      target_resource: TARGET_RESOURCE_PROJECT
-      relation: RELATION_ENTITY_REGISTER
-    };
-  }
+        option (rpc_options) = {
+            target_resource: TARGET_RESOURCE_PROJECT
+            relation: RELATION_ENTITY_REGISTER
+        };
+    }
 }
 
 // ListEntitiesRequest is the request message for the ListEntities method
 message ListEntitiesRequest {
-  // context is the context in which the entities are listed
-  ContextV2 context = 1;
+    // context is the context in which the entities are listed
+    ContextV2 context = 1;
 
-  // entity_type is the type of entity to list
-  Entity entity_type = 2 [(google.api.field_behavior) = REQUIRED];
+    // entity_type is the type of entity to list
+    Entity entity_type = 2 [
+        (google.api.field_behavior) = REQUIRED
+    ];
 
-  // cursor is the pagination cursor
-  Cursor cursor = 3;
+    // cursor is the pagination cursor
+    Cursor cursor = 3;
 }
 
 // ListEntitiesResponse is the response message for the ListEntities method
 message ListEntitiesResponse {
-  // results is the list of entities
-  repeated EntityInstance results = 1 [(google.api.field_behavior) = REQUIRED];
+    // results is the list of entities
+    repeated EntityInstance results = 1 [
+        (google.api.field_behavior) = REQUIRED
+    ];
 
-  // page is the pagination information
-  CursorPage page = 2;
+    // page is the pagination information
+    CursorPage page = 2;
 }
 
 // GetEntityByIdRequest is the request message for the GetEntityById method
 message GetEntityByIdRequest {
-  // context is the context in which the entity is evaluated
-  ContextV2 context = 1;
+    // context is the context in which the entity is evaluated
+    ContextV2 context = 1;
 
-  // id is the ID of the entity to get
-  string id = 2 [
-    (buf.validate.field).string = {uuid: true},
-    (google.api.field_behavior) = REQUIRED
-  ];
+    // id is the ID of the entity to get
+    string id = 2 [
+        (buf.validate.field).string = {uuid: true},
+        (google.api.field_behavior) = REQUIRED
+    ];
 }
 
 // GetEntityByIdResponse is the response message for the GetEntityById method
 message GetEntityByIdResponse {
-  // entity is the entity that was retrieved
-  EntityInstance entity = 1 [(google.api.field_behavior) = REQUIRED];
+    // entity is the entity that was retrieved
+    EntityInstance entity = 1 [
+        (google.api.field_behavior) = REQUIRED
+    ];
 }
 
 // GetEntityByNameRequest is the request message for the GetEntityByName method
 message GetEntityByNameRequest {
-  // context is the context in which the entity is evaluated
-  ContextV2 context = 1;
+    // context is the context in which the entity is evaluated
+    ContextV2 context = 1;
 
-  // name is the name of the entity to get
-  string name = 2 [
-    (buf.validate.field).string = {
-      pattern: "^[A-Za-z][-/[:word:]]*$"
-      max_len: 200
-    },
-    (google.api.field_behavior) = REQUIRED
-  ];
+    // name is the name of the entity to get
+    string name = 2 [
+        (buf.validate.field).string = {
+            pattern: "^[A-Za-z][-/[:word:]]*$",
+            max_len: 200,
+        },
+        (google.api.field_behavior) = REQUIRED
+    ];
 
-  // entity_type is the type of entity to get
-  Entity entity_type = 3 [(google.api.field_behavior) = REQUIRED];
+    // entity_type is the type of entity to get
+    Entity entity_type = 3 [
+        (google.api.field_behavior) = REQUIRED
+    ];
 }
 
 // GetEntityByNameResponse is the response message for the GetEntityByName method
 message GetEntityByNameResponse {
-  // entity is the entity that was retrieved
-  EntityInstance entity = 1 [(google.api.field_behavior) = REQUIRED];
+    // entity is the entity that was retrieved
+    EntityInstance entity = 1 [
+        (google.api.field_behavior) = REQUIRED
+    ];
 }
 
 // DeleteEntityByIdRequest is the request message for the DeleteEntityById method
 message DeleteEntityByIdRequest {
-  // context is the context in which the entity is evaluated
-  ContextV2 context = 1;
+    // context is the context in which the entity is evaluated
+    ContextV2 context = 1;
 
-  // id is the ID of the entity to delete
-  string id = 2 [
-    (buf.validate.field).string = {uuid: true},
-    (google.api.field_behavior) = REQUIRED
-  ];
+    // id is the ID of the entity to delete
+    string id = 2 [
+        (buf.validate.field).string = {uuid: true},
+        (google.api.field_behavior) = REQUIRED
+    ];
 }
 
 // DeleteEntityByIdResponse is the response message for the DeleteEntityById method
 message DeleteEntityByIdResponse {
-  // id is the ID of the entity that was deleted
-  string id = 1 [(google.api.field_behavior) = REQUIRED];
+    // id is the ID of the entity that was deleted
+    string id = 1 [
+        (google.api.field_behavior) = REQUIRED
+    ];
 }
 
 // RegisterEntityRequest is the request message for the RegisterEntity method
 message RegisterEntityRequest {
-  // context is the context in which the entity is created
-  ContextV2 context = 1;
+    // context is the context in which the entity is created
+    ContextV2 context = 1;
 
-  // entity_type is the type of entity to create
-  Entity entity_type = 2 [(google.api.field_behavior) = REQUIRED];
+    // entity_type is the type of entity to create
+    Entity entity_type = 2 [
+        (google.api.field_behavior) = REQUIRED
+    ];
 
-  // identifying_properties uniquely identifies the entity in the provider.
-  // For example, for a GitHub repository use github/repo_owner and github/repo_name,
-  // or use upstream_id to identify by provider's internal ID.
-  // Each key maps to a value that can be a string, number, boolean, or nested structure.
-  map<string, google.protobuf.Value> identifying_properties = 3 [(google.api.field_behavior) = REQUIRED];
+    // identifying_properties uniquely identifies the entity in the provider.
+    // For example, for a GitHub repository use github/repo_owner and github/repo_name,
+    // or use upstream_id to identify by provider's internal ID.
+    // Each key maps to a value that can be a string, number, boolean, or nested structure.
+    map<string, google.protobuf.Value> identifying_properties = 3 [
+        (google.api.field_behavior) = REQUIRED
+    ];
 }
 
 // RegisterEntityResponse is the response message for the RegisterEntity method
 message RegisterEntityResponse {
-  // entity is the entity that was created
-  EntityInstance entity = 1 [(google.api.field_behavior) = REQUIRED];
+    // entity is the entity that was created
+    EntityInstance entity = 1 [
+        (google.api.field_behavior) = REQUIRED
+    ];
 }
 
 // UpstreamEntityRef providers enough information for the
 // provider to identify the entity in the upstream system.
 message UpstreamEntityRef {
-  // context is the context in which the entity is evaluated.
-  // Note that the context is included here since users of
-  // this message may return upstream references from
-  // multiple providers
-  ContextV2 context = 1;
+    // context is the context in which the entity is evaluated.
+    // Note that the context is included here since users of
+    // this message may return upstream references from
+    // multiple providers
+    ContextV2 context = 1;
 
-  // type is the type of the entity.
-  Entity type = 2;
+    // type is the type of the entity.
+    Entity type = 2;
 
-  // properties is a map of properties of the entity.
-  // This will be used to identify the entity in the upstream system
-  // and will be a subset of the properties of the entity that will
-  // be stored in Minder.
-  google.protobuf.Struct properties = 3;
+    // properties is a map of properties of the entity.
+    // This will be used to identify the entity in the upstream system
+    // and will be a subset of the properties of the entity that will
+    // be stored in Minder.
+    google.protobuf.Struct properties = 3;
 }
 
 // DataSource is a Data source instance. Data sources represent
@@ -3908,190 +4391,197 @@ message UpstreamEntityRef {
 // have explicit lifecycle objects (entities).  Integrations which
 // create entities are called Providers.
 message DataSource {
-  // version is the version of the data source API.
-  string version = 1 [
-    (buf.validate.field).string = {pattern: "^v\\d$"},
-    (google.api.field_behavior) = REQUIRED
-  ];
+    // version is the version of the data source API.
+    string version = 1 [
+        (buf.validate.field).string = {
+            pattern: "^v\\d$",
+        },
+        (google.api.field_behavior) = REQUIRED
+    ];
 
-  // type is the data source type
-  string type = 2 [(buf.validate.field).string = {
-    in: ["data-source"]
-    max_len: 12
-  }];
+    // type is the data source type
+    string type = 2 [
+        (buf.validate.field).string = {
+            in: ["data-source"],
+            max_len: 12,
+        }
+    ];
 
-  // context is the context in which the data source is evaluated.
-  // Note that in this case we only need the project in the
-  // context, since data sources are not provider-specific.
-  ContextV2 context = 3;
+    // context is the context in which the data source is evaluated.
+    // Note that in this case we only need the project in the
+    // context, since data sources are not provider-specific.
+    ContextV2 context = 3;
 
-  // name is the name of the data source.
-  // Note that this is unique within a project hierarchy.
-  // Names must be lowercase and can only contain letters, numbers,
-  // hyphens, and underscores.
-  string name = 4 [
-    (buf.validate.field).string = {
-      pattern: "^[a-z][-_[:word:]]*$"
-      max_len: 200
-    },
-    (google.api.field_behavior) = REQUIRED
-  ];
+    // name is the name of the data source.
+    // Note that this is unique within a project hierarchy.
+    // Names must be lowercase and can only contain letters, numbers,
+    // hyphens, and underscores.
+    string name = 4 [
+        (buf.validate.field).string = {
+            pattern: "^[a-z][-_[:word:]]*$",
+            max_len: 200,
+        },
+        (google.api.field_behavior) = REQUIRED
+    ];
 
-  // id is the unique identifier of the data source.
-  string id = 5 [
-    (buf.validate.field).string = {uuid: true},
-    (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE,
-    (google.api.field_behavior) = OUTPUT_ONLY
-  ];
+    // id is the unique identifier of the data source.
+    string id = 5 [
+        (buf.validate.field).string = {uuid: true},
+        (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE,
+        (google.api.field_behavior) = OUTPUT_ONLY
+    ];
 
-  oneof driver {
-    // structured is the structired data - data source.
-    StructDataSource structured = 8;
-    // rest is the REST data source driver.
-    RestDataSource rest = 6;
-  }
+    oneof driver {
+        // structured is the structired data - data source.
+        StructDataSource structured = 8;
+        // rest is the REST data source driver.
+        RestDataSource rest = 6;
+    }
 }
 
 // StructDataSource is the structured data source driver.
 message StructDataSource {
-  message Def {
-    // Path is the path specification for the structured data source.
-    Path path = 1 [(google.api.field_behavior) = REQUIRED];
+    message Def {
+        // Path is the path specification for the structured data source.
+        Path path = 1 [
+              (google.api.field_behavior) = REQUIRED
+        ];
 
-    message Path {
-      string file_name = 1;
-      repeated string alternatives = 2;
+        message Path {
+            string file_name = 1;
+            repeated string alternatives = 2;
+        }
     }
-  }
 
-  // defs is the list of definitions for the structured data API.
-  map<string, Def> def = 1;
+    // defs is the list of definitions for the structured data API.
+    map<string, Def> def = 1;
 }
 
 // RestDataSource is the REST data source driver.
 message RestDataSource {
-  message Def {
-    // endpoint is the URL of the REST API. Note that endpoints are
-    // templates that can be parameterized with variables. Parametrization
-    // is done using RFC 6570.
-    string endpoint = 1 [
-      (buf.validate.field).string = {
-        pattern: "^https?://.*$"
-        max_len: 800
-      },
-      (google.api.field_behavior) = REQUIRED
-    ];
+    message Def {
+        // endpoint is the URL of the REST API. Note that endpoints are
+        // templates that can be parameterized with variables. Parametrization
+        // is done using RFC 6570.
+        string endpoint = 1 [
+            (buf.validate.field).string = {
+                pattern: "^https?://.*$",
+                max_len: 800,
+            },
+            (google.api.field_behavior) = REQUIRED
+        ];
 
-    // method is the HTTP method to use for the request.
-    // If left unset, it will default to "GET".
-    string method = 2 [
-      (buf.validate.field).string = {
-        in: [
-          "GET",
-          "POST",
-          "PUT",
-          "PATCH",
-          "DELETE"
-        ]
-      },
-      (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE
-    ];
+        // method is the HTTP method to use for the request.
+        // If left unset, it will default to "GET".
+        string method = 2 [
+            (buf.validate.field).string = {
+                in: ["GET", "POST", "PUT", "PATCH", "DELETE"]
+            },
+            (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE
+        ];
 
-    // headers is a map of headers to send with the request.
-    map<string, string> headers = 3;
+        // headers is a map of headers to send with the request.
+        map<string, string> headers = 3;
 
-    oneof body {
-      // body is the body of the request.
-      google.protobuf.Struct bodyobj = 4;
-      // bodystr is the body of the request as a string.
-      string bodystr = 5 [(buf.validate.field).string = {max_len: 1000}];
+        oneof body {
+            // body is the body of the request.
+            google.protobuf.Struct bodyobj = 4;
+            // bodystr is the body of the request as a string.
+            string bodystr = 5 [
+                (buf.validate.field).string = {
+                    max_len: 1000,
+                }
+            ];
 
-      // body_from_field is the field in the input to use as the body.
-      // If the value is an string, it will be used as the body, as is.
-      // If the value is an object, it will be serialized as JSON.
-      // If the value is not found in the input, the request will fail.
-      string body_from_field = 10 [(buf.validate.field).string = {
-        // We're assuming fairly short field names here.
-        max_len: 50
-      }];
-    }
-
-    // parse is the parse configuration for the response.
-    // This allows us to serialize the response into a structured format,
-    // or not.
-    // If left unset, the response will be treated as a string.
-    // If set to "json", the response will be parsed as JSON.
-    string parse = 6 [
-      (buf.validate.field).string = {
-        in: ["json"]
-      },
-      (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE
-    ];
-
-    message Fallback {
-      int32 http_status = 1 [
-        (buf.validate.field).int32 = {
-          gte: 100
-          lte: 599
-        },
-        (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE
-      ];
-
-      string body = 2 [
-        (buf.validate.field).string = {max_len: 1000},
-        (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE
-      ];
-    }
-
-    // fallback is the fallback configuration for the response in case
-    // of an unexpected status code.
-    repeated Fallback fallback = 7;
-
-    // expected_status is the expected status code for the response.
-    // This may be repeated to allow for multiple expected status codes.
-    // If left unset, it will default to 200.
-    repeated int32 expected_status = 8 [
-      (buf.validate.field).repeated = {
-        items: {
-          int32: {
-            gte: 100
-            lte: 599
-          }
+            // body_from_field is the field in the input to use as the body.
+            // If the value is an string, it will be used as the body, as is.
+            // If the value is an object, it will be serialized as JSON.
+            // If the value is not found in the input, the request will fail.
+            string body_from_field = 10 [
+                (buf.validate.field).string = {
+                    // We're assuming fairly short field names here.
+                    max_len: 50,
+                }
+            ];
         }
-      },
-      (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE
-    ];
 
-    // input_schema is the schema for the input to the REST API.
-    google.protobuf.Struct input_schema = 9;
-  }
+        // parse is the parse configuration for the response.
+        // This allows us to serialize the response into a structured format,
+        // or not.
+        // If left unset, the response will be treated as a string.
+        // If set to "json", the response will be parsed as JSON.
+        string parse = 6 [
+            (buf.validate.field).string = {
+                in: ["json"]
+            },
+            (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE
+        ];
 
-  // defs is the list of definitions for the REST API.
-  map<string, Def> def = 1;
+        message Fallback {
+            int32 http_status = 1 [
+                (buf.validate.field).int32 = {gte: 100, lte: 599},
+                (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE
+            ];
 
-  // provider_auth enables provider authentication for this data source.
-  // When enabled, the data source will use the provider's authentication
-  // credentials to make requests.
-  bool provider_auth = 2;
+            string body = 2 [
+                (buf.validate.field).string = {
+                    max_len: 1000,
+                },
+                (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE
+            ];
+        }
+
+        // fallback is the fallback configuration for the response in case
+        // of an unexpected status code.
+        repeated Fallback fallback = 7;
+
+        // expected_status is the expected status code for the response.
+        // This may be repeated to allow for multiple expected status codes.
+        // If left unset, it will default to 200.
+        repeated int32 expected_status = 8 [
+            (buf.validate.field).repeated = {
+                items: {
+                    int32: {
+                        gte: 100,
+                        lte: 599,
+                    }
+                }
+            },
+            (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE
+        ];
+
+        // input_schema is the schema for the input to the REST API.
+        google.protobuf.Struct input_schema = 9;
+    }
+
+    // defs is the list of definitions for the REST API.
+    map<string, Def> def = 1;
+
+    // provider_auth enables provider authentication for this data source.
+    // When enabled, the data source will use the provider's authentication
+    // credentials to make requests.
+    bool provider_auth = 2;
 }
 
 // DataSourceReference is a reference to a data source.
 // Note that for a resource to refer to a data source the data source must
 // be available in the same project hierarchy.
 message DataSourceReference {
-  // name is the name of the data source within the project hierarchy.
-  string name = 1 [(buf.validate.field).string = {
-    pattern: "^[a-z][-_/[:word:]]*$"
-    max_len: 200
-  }];
-  // alias is the alias used to refer to the data source in the rule
-  // definition.
-  // If left unset, it will default to the name of the data source.
-  string alias = 2 [
-    (buf.validate.field).string = {
-      pattern: "^[a-z][-_[:word:]]*$"
-      max_len: 200
-    },
-    (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE
-  ];
+    // name is the name of the data source within the project hierarchy.
+    string name = 1 [
+        (buf.validate.field).string = {
+            pattern: "^[a-z][-_/[:word:]]*$",
+            max_len: 200,
+        }
+    ];
+    // alias is the alias used to refer to the data source in the rule
+    // definition.
+    // If left unset, it will default to the name of the data source.
+    string alias = 2 [
+        (buf.validate.field).string = {
+            pattern: "^[a-z][-_[:word:]]*$",
+            max_len: 200,
+        },
+        (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE
+    ];
 }


### PR DESCRIPTION
# Summary

This PR introduces the initial infrastructure for issue based remediation support.

### Changes

* Introduce the `IssuePublisher` provider facet for issue operations.
* Implement the `IssuePublisher` interface for the GitHub provider with support for:

  * `CreateIssue`
  * `GetIssue`
  * `CloseIssue`
  * `ReopenIssue`
  * `AssignIssue`
* Add the `IssueRemediation` configuration message to the remediation protobuf schema.
* Regenerate protobuf, OpenAPI, and documentation artifacts.

This PR intentionally focuses on provider capabilities and configuration. Runtime integration (remediation implementation, lifecycle management, metadata handling, template interpolation, and engine integration) will follow in subsequent PRs.

Fixes: #6532

# Testing

* Verified the project builds successfully using:

  ```bash
  go build ./...
  ```

* Regenerated protobuf artifacts using:

  ```bash
  make buf
  ```

* Verified the generated protobuf, OpenAPI, and documentation files were updated successfully.

* Verified the GitHub provider compiles and satisfies the new `IssuePublisher` interface through compile time interface assertions.
