### PR TITLE
test Rego v1 dual-parse pipeline

### DIFF
--- a/internal/engine/eval/eval_test.go
+++ b/internal/engine/eval/eval_test.go
@@ -9,7 +9,9 @@ import (
 	"context"
 	"testing"
 
+	"github.com/open-policy-agent/opa/v1/ast"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/mindersec/minder/internal/engine/eval"
 	"github.com/mindersec/minder/internal/engine/eval/rego"
@@ -110,6 +112,143 @@ func TestNewRuleEvaluatorWorks(t *testing.T) {
 			assert.Equal(t, tt.out, result)
 		})
 	}
+}
+
+func TestNewRuleEvaluatorWithRegoVersion(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		evalType    string
+		def         string
+		version     ast.RegoVersion
+		wantOutput  any
+		wantEvalErr bool
+	}{
+		{
+			name:     "V1 deny-by-default",
+			evalType: rego.DenyByDefaultEvaluationType.String(),
+			def: `package minder
+
+default allow := false
+
+allow if {
+	input.ingested.data == "bar"
+}`,
+			version:     ast.RegoV1,
+			wantOutput:  "denied",
+			wantEvalErr: true,
+		},
+		{
+			name:     "V1 constraints",
+			evalType: rego.ConstraintsEvaluationType.String(),
+			def: `package minder
+
+violations contains result if {
+	input.ingested.data == "foo"
+	result := {"msg": "foo is not allowed"}
+}`,
+			version:     ast.RegoV1,
+			wantOutput:  []any{"foo is not allowed"},
+			wantEvalErr: true,
+		},
+		{
+			name:     "V0 regression",
+			evalType: rego.DenyByDefaultEvaluationType.String(),
+			def: `package minder
+
+default allow = false
+
+allow {
+	input.ingested.data == "bar"
+}`,
+			version:     ast.RegoV0,
+			wantOutput:  "denied",
+			wantEvalErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			rt := &pb.RuleType{
+				Def: &pb.RuleType_Definition{
+					Eval: &pb.RuleType_Definition_Eval{
+						Type: "rego",
+						Rego: &pb.RuleType_Definition_Eval_Rego{
+							Type: tt.evalType,
+							Def:  tt.def,
+						},
+					},
+				},
+			}
+
+			evaluator, err := eval.NewRuleEvaluator(
+				context.Background(),
+				rt,
+				nil,
+				rego.WithRegoVersion(tt.version),
+			)
+			require.NoError(t, err)
+			require.NotNil(t, evaluator)
+
+			result, err := evaluator.Eval(
+				context.Background(),
+				nil,
+				nil,
+				&interfaces.Ingested{Object: map[string]any{"data": "foo"}},
+			)
+			if tt.wantEvalErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+			require.NotNil(t, result)
+			assert.Equal(t, tt.wantOutput, result.Output)
+		})
+	}
+}
+
+func TestV1RuleEvaluatorAllowsMatchingInput(t *testing.T) {
+	t.Parallel()
+
+	rt := &pb.RuleType{
+		Def: &pb.RuleType_Definition{
+			Eval: &pb.RuleType_Definition_Eval{
+				Type: "rego",
+				Rego: &pb.RuleType_Definition_Eval_Rego{
+					Type: rego.DenyByDefaultEvaluationType.String(),
+					Def: `package minder
+
+default allow := false
+
+allow if {
+	input.ingested.data == "bar"
+}`,
+				},
+			},
+		},
+	}
+
+	evaluator, err := eval.NewRuleEvaluator(
+		context.Background(),
+		rt,
+		nil,
+		rego.WithRegoVersion(ast.RegoV1),
+	)
+	require.NoError(t, err)
+	require.NotNil(t, evaluator)
+
+	result, err := evaluator.Eval(
+		context.Background(),
+		nil,
+		nil,
+		&interfaces.Ingested{Object: map[string]any{"data": "bar"}},
+	)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.Nil(t, result.Output)
 }
 
 func TestNewRuleEvaluatorFails(t *testing.T) {

--- a/internal/engine/eval/rego/version_test.go
+++ b/internal/engine/eval/rego/version_test.go
@@ -121,6 +121,62 @@ default allow := false`,
 			want:    ast.RegoV1,
 			wantStr: "v1",
 		},
+		{
+			name: "v0 function syntax",
+			def: `
+package minder
+
+format_message(name) = msg {
+	msg := sprintf("hello, %s", [name])
+}`,
+			want:    ast.RegoV0,
+			wantStr: "v0",
+		},
+		{
+			name: "v1 function syntax",
+			def: `
+package minder
+
+format_message(name) := msg if {
+	msg := sprintf("hello, %s", [name])
+}`,
+			want:    ast.RegoV1,
+			wantStr: "v1",
+		},
+		{
+			name: "v0 partial set with comprehension",
+			def: `
+package minder
+
+violations[msg] {
+	names := [item.name | item := input.items[_]]
+	msg = sprintf("items: %v", [names])
+}`,
+			want:    ast.RegoV0,
+			wantStr: "v0",
+		},
+		{
+			name: "v1 every keyword",
+			def: `
+package minder
+
+allow if {
+	every item in input.items {
+		item.allowed
+	}
+}`,
+			want:    ast.RegoV1,
+			wantStr: "v1",
+		},
+		{
+			name: "syntax error falls back to v0",
+			def: `
+package minder
+
+allow {`,
+			want:    ast.RegoV0,
+			wantStr: "v0",
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/ruletypes/service_test.go
+++ b/pkg/ruletypes/service_test.go
@@ -327,6 +327,41 @@ func TestRuleTypeService(t *testing.T) {
 			FeatureFlags: map[string]any{string(flags.RegoV1DualParse): true},
 		},
 		{
+			Name:         "CreateRuleType stores detected V0 rego version",
+			RuleType:     newRuleType(withBasicStructure, withRegoEval("package minder\n\ndefault allow = false\n\nallow {\n    input.allowed\n}\n")),
+			DBSetup:      dbf.NewDBMock(withHierarchyGet, withNotFoundGet, withSuccessfulCreateForRegoVersion("v0"), withSuccessfulDeleteRuleTypeDataSource),
+			TestMethod:   create,
+			FeatureFlags: map[string]any{string(flags.RegoV1DualParse): true},
+		},
+		{
+			Name:         "CreateRuleType stores detected V1 rego version",
+			RuleType:     newRuleType(withBasicStructure, withRegoEval("package minder\n\ndefault allow := false\n\nallow if {\n    input.allowed\n}\n")),
+			DBSetup:      dbf.NewDBMock(withHierarchyGet, withNotFoundGet, withSuccessfulCreateForRegoVersion("v1"), withSuccessfulDeleteRuleTypeDataSource),
+			TestMethod:   create,
+			FeatureFlags: map[string]any{string(flags.RegoV1DualParse): true},
+		},
+		{
+			Name:         "CreateRuleType without rego stores V0 rego version",
+			RuleType:     newRuleType(withBasicStructure),
+			DBSetup:      dbf.NewDBMock(withHierarchyGet, withNotFoundGet, withSuccessfulCreateForRegoVersion("v0"), withSuccessfulDeleteRuleTypeDataSource),
+			TestMethod:   create,
+			FeatureFlags: map[string]any{string(flags.RegoV1DualParse): true},
+		},
+		{
+			Name:         "UpdateRuleType stores detected V0 rego version",
+			RuleType:     newRuleType(withBasicStructure, withRegoEval("package minder\n\ndefault allow = false\n\nallow {\n    input.allowed\n}\n")),
+			DBSetup:      dbf.NewDBMock(withHierarchyGet, withSuccessfulGet, withSuccessfulUpdateForRegoVersion("v0"), withSuccessfulDeleteRuleTypeDataSource),
+			TestMethod:   update,
+			FeatureFlags: map[string]any{string(flags.RegoV1DualParse): true},
+		},
+		{
+			Name:         "UpdateRuleType stores detected V1 rego version",
+			RuleType:     newRuleType(withBasicStructure, withRegoEval("package minder\n\ndefault allow := false\n\nallow if {\n    input.allowed\n}\n")),
+			DBSetup:      dbf.NewDBMock(withHierarchyGet, withSuccessfulGet, withSuccessfulUpdateForRegoVersion("v1"), withSuccessfulDeleteRuleTypeDataSource),
+			TestMethod:   update,
+			FeatureFlags: map[string]any{string(flags.RegoV1DualParse): true},
+		},
+		{
 			Name:          "CreateRuleType rejects invalid rego syntax",
 			RuleType:      newRuleType(withBasicStructure, withInvalidRego),
 			ExpectedError: "rego definition is invalid",
@@ -506,6 +541,18 @@ func withV1OnlyRego(ruleType *pb.RuleType) {
 	}
 }
 
+func withRegoEval(def string) func(*pb.RuleType) {
+	return func(ruleType *pb.RuleType) {
+		ruleType.Def.Eval = &pb.RuleType_Definition_Eval{
+			Type: "rego",
+			Rego: &pb.RuleType_Definition_Eval_Rego{
+				Type: "deny-by-default",
+				Def:  def,
+			},
+		}
+	}
+}
+
 // withInvalidRego sets a Rego definition with a syntax error that is
 // invalid in both V0 and V1.
 func withInvalidRego(ruleType *pb.RuleType) {
@@ -567,6 +614,14 @@ func withSuccessfulCreate(mock dbf.DBMock) {
 		Return(expectation, nil)
 }
 
+func withSuccessfulCreateForRegoVersion(version string) func(dbf.DBMock) {
+	return func(mock dbf.DBMock) {
+		mock.EXPECT().
+			CreateRuleType(gomock.Any(), regoVersionMatcher{version: version}).
+			Return(expectation, nil)
+	}
+}
+
 func withSuccessfulNamespaceCreate(mock dbf.DBMock) {
 	mock.EXPECT().
 		CreateRuleType(gomock.Any(), gomock.Any()).
@@ -583,6 +638,14 @@ func withSuccessfulUpdate(mock dbf.DBMock) {
 	mock.EXPECT().
 		UpdateRuleType(gomock.Any(), gomock.Any()).
 		Return(expectation, nil)
+}
+
+func withSuccessfulUpdateForRegoVersion(version string) func(dbf.DBMock) {
+	return func(mock dbf.DBMock) {
+		mock.EXPECT().
+			UpdateRuleType(gomock.Any(), regoVersionMatcher{version: version}).
+			Return(expectation, nil)
+	}
 }
 
 func withFailedUpdate(mock dbf.DBMock) {
@@ -635,6 +698,25 @@ func withFailedAddRuleTypeDataSourceReference(mock dbf.DBMock) {
 	mock.EXPECT().
 		AddRuleTypeDataSourceReference(gomock.Any(), gomock.Any()).
 		Return(db.RuleTypeDataSource{}, errDefault)
+}
+
+type regoVersionMatcher struct {
+	version string
+}
+
+func (m regoVersionMatcher) Matches(value any) bool {
+	switch params := value.(type) {
+	case db.CreateRuleTypeParams:
+		return params.RegoVersion == m.version
+	case db.UpdateRuleTypeParams:
+		return params.RegoVersion == m.version
+	default:
+		return false
+	}
+}
+
+func (m regoVersionMatcher) String() string {
+	return fmt.Sprintf("has RegoVersion %q", m.version)
 }
 
 func newDBRuleType(severity db.Severity, subscriptionID uuid.UUID, failureMessage string) db.RuleType {


### PR DESCRIPTION
Resolves #6318

## Summary

Adds the missing test coverage for the Rego v1 dual-parse pipeline, ensuring detected versions are stored correctly and used during evaluation.

## What changed

- Verify CreateRuleType and UpdateRuleType persist the detected `rego_version`.
- Cover V0, V1, and rule types without Rego evaluation.
- Test V1 deny-by-default and constraints policies with `WithRegoVersion(ast.RegoV1)`.
- Preserve explicit V0 evaluation as regression coverage.
- Add detection cases for function syntax, comprehensions, `every`, and invalid policies.

## Testing

```sh
go test ./pkg/ruletypes ./internal/engine/eval ./internal/engine/eval/rego