### PR TITLE
feat: warn when accepting Rego V0 policies

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -28,6 +28,7 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@82606bf257cbaff209d206a39f5134f0cfbfd2ee # v9.2.1
         with:
+          version: v2.11.4
           only-new-issues: true
 
   check-go-mod-tidy-and-make-gen:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -42,8 +42,6 @@ linters:
     goconst:
       min-len: 6
       min-occurrences: 5
-      # Tests can be clearer with string literals
-      ignore-tests: true
     gocyclo:
       min-complexity: 15
     gosec:
@@ -85,6 +83,7 @@ linters:
     generated: lax
     rules:
       - linters:
+          - goconst
           - lll
           - gosec
         path: (.+)_test\.go

--- a/cmd/cli/app/ruletype/common.go
+++ b/cmd/cli/app/ruletype/common.go
@@ -13,6 +13,8 @@ import (
 	"slices"
 	"strings"
 
+	"github.com/spf13/cobra"
+
 	"github.com/mindersec/minder/internal/util"
 	"github.com/mindersec/minder/internal/util/cli"
 	"github.com/mindersec/minder/internal/util/cli/table"
@@ -80,6 +82,12 @@ func validateFilesArg(files []string) error {
 	}
 
 	return nil
+}
+
+func printWarnings(cmd *cobra.Command, warnings []string) {
+	for _, warning := range warnings {
+		cmd.PrintErrf("Warning: %s\n", warning)
+	}
 }
 
 func shouldSkipFile(f string) bool {

--- a/cmd/cli/app/ruletype/ruletype_apply.go
+++ b/cmd/cli/app/ruletype/ruletype_apply.go
@@ -80,6 +80,7 @@ func applyCommand(cmd *cobra.Command, args []string) error {
 		})
 
 		if err == nil {
+			printWarnings(cmd, createResp.GetWarnings())
 			return createResp.RuleType, nil
 		}
 
@@ -100,6 +101,7 @@ func applyCommand(cmd *cobra.Command, args []string) error {
 			return nil, fmt.Errorf("error updating rule type from %s: %w", fileName, err)
 		}
 
+		printWarnings(cmd, updateResp.GetWarnings())
 		return updateResp.RuleType, nil
 	}
 

--- a/cmd/cli/app/ruletype/ruletype_apply_test.go
+++ b/cmd/cli/app/ruletype/ruletype_apply_test.go
@@ -59,6 +59,29 @@ func TestApplyCommand(t *testing.T) {
 			GoldenFileName: "apply_update.table",
 		},
 		{
+			Name: "apply displays update warnings",
+			Args: []string{"ruletype", "apply", applyFixture},
+			MockSetup: func(t *testing.T, ctrl *gomock.Controller) context.Context {
+				t.Helper()
+				client := mockv1.NewMockRuleTypeServiceClient(ctrl)
+				mockResp := &minderv1.ListRuleTypesResponse{}
+				cli.LoadFixture(t, "mock_ruletypes_response.json", mockResp)
+
+				client.EXPECT().
+					CreateRuleType(gomock.Any(), gomock.Any()).
+					Return(nil, status.Error(codes.AlreadyExists, "already exists"))
+
+				client.EXPECT().
+					UpdateRuleType(gomock.Any(), gomock.Any()).
+					Return(&minderv1.UpdateRuleTypeResponse{
+						RuleType: mockResp.RuleTypes[0],
+						Warnings: []string{"Rego V0 is deprecated"},
+					}, nil)
+				return cli.WithRPCClient[minderv1.RuleTypeServiceClient](context.Background(), client)
+			},
+			GoldenFileName: "apply_warning.table",
+		},
+		{
 			Name:          "no files specified",
 			Args:          []string{"ruletype", "apply"},
 			ExpectedError: "no files specified",

--- a/cmd/cli/app/ruletype/ruletype_create.go
+++ b/cmd/cli/app/ruletype/ruletype_create.go
@@ -70,6 +70,7 @@ func createCommand(cmd *cobra.Command, _ []string) error {
 			return nil, err
 		}
 
+		printWarnings(cmd, resprt.GetWarnings())
 		return resprt.RuleType, nil
 	}
 

--- a/cmd/cli/app/ruletype/ruletype_create_test.go
+++ b/cmd/cli/app/ruletype/ruletype_create_test.go
@@ -39,6 +39,25 @@ func TestCreateCommand(t *testing.T) {
 			GoldenFileName: "create_success.table",
 		},
 		{
+			Name: "display server warnings",
+			Args: []string{"ruletype", "create", "-f", sampleFile},
+			MockSetup: func(t *testing.T, ctrl *gomock.Controller) context.Context {
+				t.Helper()
+				client := mockv1.NewMockRuleTypeServiceClient(ctrl)
+				mockResp := &minderv1.ListRuleTypesResponse{}
+				cli.LoadFixture(t, "mock_ruletypes_response.json", mockResp)
+
+				client.EXPECT().
+					CreateRuleType(gomock.Any(), gomock.Any()).
+					Return(&minderv1.CreateRuleTypeResponse{
+						RuleType: mockResp.RuleTypes[0],
+						Warnings: []string{"Rego V0 is deprecated"},
+					}, nil)
+				return cli.WithRPCClient[minderv1.RuleTypeServiceClient](context.Background(), client)
+			},
+			GoldenFileName: "create_warning.table",
+		},
+		{
 			Name:          "missing required file flag",
 			Args:          []string{"ruletype", "create"},
 			ExpectedError: "required flag(s) \"file\" not set",

--- a/cmd/cli/app/ruletype/testdata/apply_warning.table.golden
+++ b/cmd/cli/app/ruletype/testdata/apply_warning.table.golden
@@ -1,0 +1,9 @@
+Warning: Rego V0 is deprecated
+ NAME                   │ ENTITY TYPE │ DESCRIPTION                                                 
+────────────────────────┼─────────────┼─────────────────────────────────────────────────────────────
+ secret_push_protection │ repository  │ Verifies that secret push protection is enabled for a given 
+ (release_phase: beta)  │             │ repository. Note that this will will not work as expected   
+                        │             │ for private repositories unless you have GitHub Advanced    
+                        │             │ Security enabled. If you still want to use this rule        
+                        │             │ because you have a mixture of private and public            
+                        │             │ repositories, enable the `skip_private_repos` flag.         

--- a/cmd/cli/app/ruletype/testdata/create_warning.table.golden
+++ b/cmd/cli/app/ruletype/testdata/create_warning.table.golden
@@ -1,0 +1,9 @@
+Warning: Rego V0 is deprecated
+ NAME                   │ ENTITY TYPE │ DESCRIPTION                                                 
+────────────────────────┼─────────────┼─────────────────────────────────────────────────────────────
+ secret_push_protection │ repository  │ Verifies that secret push protection is enabled for a given 
+ (release_phase: beta)  │             │ repository. Note that this will will not work as expected   
+                        │             │ for private repositories unless you have GitHub Advanced    
+                        │             │ Security enabled. If you still want to use this rule        
+                        │             │ because you have a mixture of private and public            
+                        │             │ repositories, enable the `skip_private_repos` flag.         

--- a/docs/docs/ref/proto.mdx
+++ b/docs/docs/ref/proto.mdx
@@ -543,6 +543,7 @@ CreateRuleTypeResponse is the response to create a rule type.
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
 | rule_type | <TypeLink type="minder-v1-RuleType">RuleType</TypeLink> |  | rule_type is the rule type that was created. |
+| warnings | <TypeLink type="string">string</TypeLink> | repeated | warnings contains non-fatal notices about the created rule type. |
 
 
 
@@ -3184,6 +3185,7 @@ UpdateRuleTypeResponse is the response to update a rule type.
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
 | rule_type | <TypeLink type="minder-v1-RuleType">RuleType</TypeLink> |  | rule_type is the rule type that was updated. |
+| warnings | <TypeLink type="string">string</TypeLink> | repeated | warnings contains non-fatal notices about the updated rule type. |
 
 
 

--- a/internal/controlplane/handlers_ruletype.go
+++ b/internal/controlplane/handlers_ruletype.go
@@ -32,7 +32,9 @@ import (
 	"github.com/mindersec/minder/pkg/ruletypes"
 )
 
-const regoV0DeprecationWarning = "This rule type uses Rego V0 syntax. Please migrate to V1 using `opa fmt --v0-v1`. V0 support will be removed in a future release."
+const regoV0DeprecationWarning = "This rule type uses Rego V0 syntax. " +
+	"Please migrate to V1 using `opa fmt --v0-v1`. " +
+	"V0 support will be removed in a future release."
 
 var (
 	maxReadableStringSize = 3 * 1 << 10 // 3kB

--- a/internal/controlplane/handlers_ruletype.go
+++ b/internal/controlplane/handlers_ruletype.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/microcosm-cc/bluemonday"
+	"github.com/open-policy-agent/opa/v1/ast"
 	"github.com/yuin/goldmark"
 	"github.com/yuin/goldmark/extension"
 	"github.com/yuin/goldmark/parser"
@@ -23,11 +24,15 @@ import (
 
 	"github.com/mindersec/minder/internal/db"
 	"github.com/mindersec/minder/internal/engine/engcontext"
+	regoeval "github.com/mindersec/minder/internal/engine/eval/rego"
 	"github.com/mindersec/minder/internal/logger"
 	"github.com/mindersec/minder/internal/util"
 	minderv1 "github.com/mindersec/minder/pkg/api/protobuf/go/minder/v1"
+	"github.com/mindersec/minder/pkg/flags"
 	"github.com/mindersec/minder/pkg/ruletypes"
 )
+
+const regoV0DeprecationWarning = "This rule type uses Rego V0 syntax. Please migrate to V1 using 'opa fmt --v0-v1'. V0 support will be removed in a future release."
 
 var (
 	maxReadableStringSize = 3 * 1 << 10 // 3kB
@@ -190,6 +195,7 @@ func (s *Server) CreateRuleType(
 
 	return &minderv1.CreateRuleTypeResponse{
 		RuleType: newRuleType,
+		Warnings: s.regoVersionWarnings(ctx, crt.GetRuleType()),
 	}, nil
 }
 
@@ -230,7 +236,29 @@ func (s *Server) UpdateRuleType(
 
 	return &minderv1.UpdateRuleTypeResponse{
 		RuleType: updatedRuleType,
+		Warnings: s.regoVersionWarnings(ctx, urt.GetRuleType()),
 	}, nil
+}
+
+func (s *Server) regoVersionWarnings(ctx context.Context, ruleType *minderv1.RuleType) []string {
+	if !flags.Bool(ctx, s.featureFlags, flags.RegoV1WarnV0) {
+		return nil
+	}
+
+	eval := ruleType.GetDef().GetEval()
+	if eval.GetType() != regoeval.RegoEvalType || eval.GetRego().GetDef() == "" {
+		return nil
+	}
+
+	version := ast.RegoV0
+	if flags.Bool(ctx, s.featureFlags, flags.RegoV1DualParse) {
+		version = regoeval.DetectRegoVersion(eval.GetRego().GetDef())
+	}
+	if version != ast.RegoV0 {
+		return nil
+	}
+
+	return []string{regoV0DeprecationWarning}
 }
 
 // DeleteRuleType is a method to delete a rule type

--- a/internal/controlplane/handlers_ruletype.go
+++ b/internal/controlplane/handlers_ruletype.go
@@ -32,7 +32,7 @@ import (
 	"github.com/mindersec/minder/pkg/ruletypes"
 )
 
-const regoV0DeprecationWarning = "This rule type uses Rego V0 syntax. Please migrate to V1 using 'opa fmt --v0-v1'. V0 support will be removed in a future release."
+const regoV0DeprecationWarning = "This rule type uses Rego V0 syntax. Please migrate to V1 using `opa fmt --v0-v1`. V0 support will be removed in a future release."
 
 var (
 	maxReadableStringSize = 3 * 1 << 10 // 3kB

--- a/internal/controlplane/handlers_ruletype_test.go
+++ b/internal/controlplane/handlers_ruletype_test.go
@@ -105,6 +105,23 @@ func TestCreateRuleType(t *testing.T) {
 			expectedWarnings: []string{regoV0DeprecationWarning},
 		},
 		{
+			name: "warns when creating a V0 rule type without dual-parse",
+			mockStoreFunc: df.NewMockStore(
+				df.WithTransaction(),
+				WithSuccessfulGetProjectByID(projectID),
+			),
+			ruleTypeServiceFunc: sf.NewRuleTypeServiceMock(
+				sf.WithSuccessfulCreateRuleType,
+			),
+			features: map[string]any{
+				string(flags.RegoV1WarnV0): true,
+			},
+			request: &minderv1.CreateRuleTypeRequest{
+				RuleType: ruleTypeWithRego(regoV0Definition),
+			},
+			expectedWarnings: []string{regoV0DeprecationWarning},
+		},
+		{
 			name: "does not warn when creating a V1 rule type",
 			mockStoreFunc: df.NewMockStore(
 				df.WithTransaction(),
@@ -254,6 +271,23 @@ func TestUpdateRuleType(t *testing.T) {
 			features: map[string]any{
 				string(flags.RegoV1DualParse): true,
 				string(flags.RegoV1WarnV0):    true,
+			},
+			request: &minderv1.UpdateRuleTypeRequest{
+				RuleType: ruleTypeWithRego(regoV0Definition),
+			},
+			expectedWarnings: []string{regoV0DeprecationWarning},
+		},
+		{
+			name: "warns when updating a V0 rule type without dual-parse",
+			mockStoreFunc: df.NewMockStore(
+				df.WithTransaction(),
+				WithSuccessfulGetProjectByID(projectID),
+			),
+			ruleTypeServiceFunc: sf.NewRuleTypeServiceMock(
+				sf.WithSuccessfulUpdateRuleType,
+			),
+			features: map[string]any{
+				string(flags.RegoV1WarnV0): true,
 			},
 			request: &minderv1.UpdateRuleTypeRequest{
 				RuleType: ruleTypeWithRego(regoV0Definition),

--- a/internal/controlplane/handlers_ruletype_test.go
+++ b/internal/controlplane/handlers_ruletype_test.go
@@ -40,6 +40,25 @@ const ruleDefJSON = `
 }
 `
 
+const (
+	regoV0Definition = "package minder\n\ndefault allow = false\n\nallow {\n\tinput.allowed\n}\n"
+	regoV1Definition = "package minder\n\ndefault allow := false\n\nallow if {\n\tinput.allowed\n}\n"
+)
+
+func ruleTypeWithRego(def string) *minderv1.RuleType {
+	return &minderv1.RuleType{
+		Def: &minderv1.RuleType_Definition{
+			Eval: &minderv1.RuleType_Definition_Eval{
+				Type: "rego",
+				Rego: &minderv1.RuleType_Definition_Eval_Rego{
+					Type: "deny-by-default",
+					Def:  def,
+				},
+			},
+		},
+	}
+}
+
 func TestCreateRuleType(t *testing.T) {
 	t.Parallel()
 
@@ -51,6 +70,7 @@ func TestCreateRuleType(t *testing.T) {
 		dataSourcesServiceFunc dsf.DataSourcesSvcMockBuilder
 		features               map[string]any
 		request                *minderv1.CreateRuleTypeRequest
+		expectedWarnings       []string
 		error                  bool
 	}{
 		{
@@ -64,6 +84,41 @@ func TestCreateRuleType(t *testing.T) {
 			),
 			request: &minderv1.CreateRuleTypeRequest{
 				RuleType: &minderv1.RuleType{},
+			},
+		},
+		{
+			name: "warns when creating a V0 rule type",
+			mockStoreFunc: df.NewMockStore(
+				df.WithTransaction(),
+				WithSuccessfulGetProjectByID(projectID),
+			),
+			ruleTypeServiceFunc: sf.NewRuleTypeServiceMock(
+				sf.WithSuccessfulCreateRuleType,
+			),
+			features: map[string]any{
+				string(flags.RegoV1DualParse): true,
+				string(flags.RegoV1WarnV0):    true,
+			},
+			request: &minderv1.CreateRuleTypeRequest{
+				RuleType: ruleTypeWithRego(regoV0Definition),
+			},
+			expectedWarnings: []string{regoV0DeprecationWarning},
+		},
+		{
+			name: "does not warn when creating a V1 rule type",
+			mockStoreFunc: df.NewMockStore(
+				df.WithTransaction(),
+				WithSuccessfulGetProjectByID(projectID),
+			),
+			ruleTypeServiceFunc: sf.NewRuleTypeServiceMock(
+				sf.WithSuccessfulCreateRuleType,
+			),
+			features: map[string]any{
+				string(flags.RegoV1DualParse): true,
+				string(flags.RegoV1WarnV0):    true,
+			},
+			request: &minderv1.CreateRuleTypeRequest{
+				RuleType: ruleTypeWithRego(regoV1Definition),
 			},
 		},
 		{
@@ -155,6 +210,7 @@ func TestCreateRuleType(t *testing.T) {
 
 			require.NoError(t, err)
 			require.NotNil(t, resp)
+			require.Equal(t, tt.expectedWarnings, resp.GetWarnings())
 		})
 	}
 }
@@ -170,6 +226,7 @@ func TestUpdateRuleType(t *testing.T) {
 		dataSourcesServiceFunc dsf.DataSourcesSvcMockBuilder
 		features               map[string]any
 		request                *minderv1.UpdateRuleTypeRequest
+		expectedWarnings       []string
 		error                  bool
 	}{
 		{
@@ -184,6 +241,24 @@ func TestUpdateRuleType(t *testing.T) {
 			request: &minderv1.UpdateRuleTypeRequest{
 				RuleType: &minderv1.RuleType{},
 			},
+		},
+		{
+			name: "warns when updating a V0 rule type",
+			mockStoreFunc: df.NewMockStore(
+				df.WithTransaction(),
+				WithSuccessfulGetProjectByID(projectID),
+			),
+			ruleTypeServiceFunc: sf.NewRuleTypeServiceMock(
+				sf.WithSuccessfulUpdateRuleType,
+			),
+			features: map[string]any{
+				string(flags.RegoV1DualParse): true,
+				string(flags.RegoV1WarnV0):    true,
+			},
+			request: &minderv1.UpdateRuleTypeRequest{
+				RuleType: ruleTypeWithRego(regoV0Definition),
+			},
+			expectedWarnings: []string{regoV0DeprecationWarning},
 		},
 		{
 			name: "guidance sanitize error",
@@ -274,6 +349,7 @@ func TestUpdateRuleType(t *testing.T) {
 
 			require.NoError(t, err)
 			require.NotNil(t, resp)
+			require.Equal(t, tt.expectedWarnings, resp.GetWarnings())
 		})
 	}
 }

--- a/pkg/api/openapi/minder/v1/minder.swagger.json
+++ b/pkg/api/openapi/minder/v1/minder.swagger.json
@@ -4266,6 +4266,13 @@
         "ruleType": {
           "$ref": "#/definitions/v1RuleType",
           "description": "rule_type is the rule type that was created."
+        },
+        "warnings": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "warnings contains non-fatal notices about the created rule type."
         }
       },
       "description": "CreateRuleTypeResponse is the response to create a rule type.",
@@ -6632,6 +6639,13 @@
         "ruleType": {
           "$ref": "#/definitions/v1RuleType",
           "description": "rule_type is the rule type that was updated."
+        },
+        "warnings": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "warnings contains non-fatal notices about the updated rule type."
         }
       },
       "description": "UpdateRuleTypeResponse is the response to update a rule type.",

--- a/pkg/api/protobuf/go/minder/v1/minder.pb.go
+++ b/pkg/api/protobuf/go/minder/v1/minder.pb.go
@@ -7164,7 +7164,9 @@ func (x *CreateRuleTypeRequest) GetRuleType() *RuleType {
 type CreateRuleTypeResponse struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// rule_type is the rule type that was created.
-	RuleType      *RuleType `protobuf:"bytes,1,opt,name=rule_type,json=ruleType,proto3" json:"rule_type,omitempty"`
+	RuleType *RuleType `protobuf:"bytes,1,opt,name=rule_type,json=ruleType,proto3" json:"rule_type,omitempty"`
+	// warnings contains non-fatal notices about the created rule type.
+	Warnings      []string `protobuf:"bytes,2,rep,name=warnings,proto3" json:"warnings,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -7202,6 +7204,13 @@ func (*CreateRuleTypeResponse) Descriptor() ([]byte, []int) {
 func (x *CreateRuleTypeResponse) GetRuleType() *RuleType {
 	if x != nil {
 		return x.RuleType
+	}
+	return nil
+}
+
+func (x *CreateRuleTypeResponse) GetWarnings() []string {
+	if x != nil {
+		return x.Warnings
 	}
 	return nil
 }
@@ -7256,7 +7265,9 @@ func (x *UpdateRuleTypeRequest) GetRuleType() *RuleType {
 type UpdateRuleTypeResponse struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// rule_type is the rule type that was updated.
-	RuleType      *RuleType `protobuf:"bytes,1,opt,name=rule_type,json=ruleType,proto3" json:"rule_type,omitempty"`
+	RuleType *RuleType `protobuf:"bytes,1,opt,name=rule_type,json=ruleType,proto3" json:"rule_type,omitempty"`
+	// warnings contains non-fatal notices about the updated rule type.
+	Warnings      []string `protobuf:"bytes,2,rep,name=warnings,proto3" json:"warnings,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -7294,6 +7305,13 @@ func (*UpdateRuleTypeResponse) Descriptor() ([]byte, []int) {
 func (x *UpdateRuleTypeResponse) GetRuleType() *RuleType {
 	if x != nil {
 		return x.RuleType
+	}
+	return nil
+}
+
+func (x *UpdateRuleTypeResponse) GetWarnings() []string {
+	if x != nil {
+		return x.Warnings
 	}
 	return nil
 }
@@ -15489,13 +15507,15 @@ const file_minder_v1_minder_proto_rawDesc = "" +
 	"\x17GetRuleTypeByIdResponse\x125\n" +
 	"\trule_type\x18\x01 \x01(\v2\x13.minder.v1.RuleTypeB\x03\xe0A\x02R\bruleType\"T\n" +
 	"\x15CreateRuleTypeRequest\x125\n" +
-	"\trule_type\x18\x01 \x01(\v2\x13.minder.v1.RuleTypeB\x03\xe0A\x02R\bruleTypeJ\x04\b\x02\x10\x03\"O\n" +
+	"\trule_type\x18\x01 \x01(\v2\x13.minder.v1.RuleTypeB\x03\xe0A\x02R\bruleTypeJ\x04\b\x02\x10\x03\"k\n" +
 	"\x16CreateRuleTypeResponse\x125\n" +
-	"\trule_type\x18\x01 \x01(\v2\x13.minder.v1.RuleTypeB\x03\xe0A\x02R\bruleType\"T\n" +
+	"\trule_type\x18\x01 \x01(\v2\x13.minder.v1.RuleTypeB\x03\xe0A\x02R\bruleType\x12\x1a\n" +
+	"\bwarnings\x18\x02 \x03(\tR\bwarnings\"T\n" +
 	"\x15UpdateRuleTypeRequest\x125\n" +
-	"\trule_type\x18\x02 \x01(\v2\x13.minder.v1.RuleTypeB\x03\xe0A\x02R\bruleTypeJ\x04\b\x03\x10\x04\"O\n" +
+	"\trule_type\x18\x02 \x01(\v2\x13.minder.v1.RuleTypeB\x03\xe0A\x02R\bruleTypeJ\x04\b\x03\x10\x04\"k\n" +
 	"\x16UpdateRuleTypeResponse\x125\n" +
-	"\trule_type\x18\x01 \x01(\v2\x13.minder.v1.RuleTypeB\x03\xe0A\x02R\bruleType\"~\n" +
+	"\trule_type\x18\x01 \x01(\v2\x13.minder.v1.RuleTypeB\x03\xe0A\x02R\bruleType\x12\x1a\n" +
+	"\bwarnings\x18\x02 \x03(\tR\bwarnings\"~\n" +
 	"\x15DeleteRuleTypeRequest\x12,\n" +
 	"\acontext\x18\x01 \x01(\v2\x12.minder.v1.ContextR\acontext\x127\n" +
 	"\x02id\x18\x02 \x01(\tB'\xe0A\x02\xbaH!r\x1f\x18\xc8\x012\x1a^[A-Za-z0-9][-/[:word:]]*$R\x02id\"\x18\n" +

--- a/pkg/flags/constants.go
+++ b/pkg/flags/constants.go
@@ -18,4 +18,7 @@ const (
 	// to V0) when creating or updating rule types. When disabled, all rule
 	// types are treated as Rego V0.
 	RegoV1DualParse Experiment = "rego_v1_dual_parse"
+	// RegoV1WarnV0 adds a non-fatal warning to rule type create and update
+	// responses when the accepted policy is evaluated as Rego V0.
+	RegoV1WarnV0 Experiment = "rego_v1_warn_v0"
 )

--- a/proto/minder/v1/minder.proto
+++ b/proto/minder/v1/minder.proto
@@ -2254,6 +2254,8 @@ message CreateRuleTypeResponse {
     RuleType rule_type = 1 [
         (google.api.field_behavior) = REQUIRED
     ];
+    // warnings contains non-fatal notices about the created rule type.
+    repeated string warnings = 2;
 }
 
 // UpdateRuleTypeRequest is the request to update a rule type.
@@ -2271,6 +2273,8 @@ message UpdateRuleTypeResponse {
     RuleType rule_type = 1 [
         (google.api.field_behavior) = REQUIRED
     ];
+    // warnings contains non-fatal notices about the updated rule type.
+    repeated string warnings = 2;
 }
 
 // DeleteRuleTypeRequest is the request to delete a rule type.


### PR DESCRIPTION
Part of #5262
Resolves #6555 
## Summary

Introduces the warn-but-accept stage of the Rego v1 migration. Rego V0 rule types continue to work, but clients can now receive a clear migration warning when the new feature flag is enabled.

## What changed

- Added non-fatal `warnings` fields to CreateRuleType and UpdateRuleType responses.
- Added the `rego_v1_warn_v0` feature flag.
- Return an actionable warning when an accepted rule type uses Rego V0.
- Display server warnings in `minder ruletype create` and `minder ruletype apply`.
- Added control-plane and CLI coverage for V0 warnings and V1 policies without warnings.
- Regenerated protobuf, OpenAPI, and reference documentation.

The warning recommends migrating with:

```sh
opa fmt --v0-v1
```

No policies are rejected by this change.

## Testing

```sh
go test ./cmd/cli/app/ruletype ./internal/controlplane ./pkg/api/protobuf/go/minder/v1 ./pkg/flags
go run github.com/bufbuild/buf/cmd/buf@v1.70.0 lint
```
