### PR TITLE
Migrate goconst test setting

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -42,8 +42,6 @@ linters:
     goconst:
       min-len: 6
       min-occurrences: 5
-      # Tests can be clearer with string literals
-      ignore-tests: true
     gocyclo:
       min-complexity: 15
     gosec:
@@ -87,6 +85,7 @@ linters:
       - linters:
           - lll
           - gosec
+          - goconst  # Tests can be clearer with string literals
         path: (.+)_test\.go
     paths:
       - third_party$


### PR DESCRIPTION
# Summary

See https://golangci-lint.run/docs/product/migration-guide/#linters-settingsgoconstignore-tests

This cropped up today in e.g. https://github.com/mindersec/minder/actions/runs/28392549560/job/84125073065?pr=6554

