### PR TITLE
feat(dev): add JUnit XML output to mindev test and ruletest cleanups

### DIFF
--- a/cmd/dev/app/test/test.go
+++ b/cmd/dev/app/test/test.go
@@ -5,7 +5,9 @@
 package test
 
 import (
+	"encoding/xml"
 	"errors"
+	"fmt"
 
 	"github.com/spf13/cobra"
 
@@ -14,12 +16,18 @@ import (
 
 // CmdTest returns the test cobra command
 func CmdTest() *cobra.Command {
+	var outputFormat string
+
 	cmd := &cobra.Command{
 		Use:   "test [paths...]",
 		Short: "Run Minder rule tests",
 		Long: "Run Starlark-based tests for Minder rules. Each path may be a file or directory. " +
 			"If no paths are provided, tests the current directory.",
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if outputFormat != "text" && outputFormat != "junit" {
+				return fmt.Errorf("unsupported output format %q: must be \"text\" or \"junit\"", outputFormat)
+			}
+
 			if len(args) == 0 {
 				args = []string{"."}
 			}
@@ -31,7 +39,25 @@ func CmdTest() *cobra.Command {
 			}
 
 			if len(results) == 0 {
-				cmd.Printf("No tests found\n")
+				if outputFormat == "text" {
+					cmd.Printf("No tests found\n")
+				}
+				return nil
+			}
+
+			if outputFormat == "junit" {
+				suites := ruletest.AsJUnit(results)
+				bytes, fmtErr := xml.MarshalIndent(suites, "", "  ")
+				if fmtErr != nil {
+					return fmtErr
+				}
+				cmd.Println(xml.Header + string(bytes))
+
+				for _, res := range results {
+					if len(res.Failures) > 0 {
+						return errors.New("one or more tests failed")
+					}
+				}
 				return nil
 			}
 
@@ -55,6 +81,8 @@ func CmdTest() *cobra.Command {
 			return nil
 		},
 	}
+
+	cmd.Flags().StringVarP(&outputFormat, "output", "o", "text", "Output format (text, junit)")
 
 	return cmd
 }

--- a/pkg/ruletest/eval.go
+++ b/pkg/ruletest/eval.go
@@ -154,10 +154,7 @@ func buildDataSourceRegistry(datasourcesList *starlark.List, tk *tkv1.TestKit) (
 		return registry, nil
 	}
 
-	iter := datasourcesList.Iterate()
-	defer iter.Done()
-	var val starlark.Value
-	for iter.Next(&val) {
+	for val := range datasourcesList.Elements() {
 		pathStr, ok := val.(starlark.String)
 		if !ok {
 			return nil, fmt.Errorf("data_sources must be a list of strings")

--- a/pkg/ruletest/junit.go
+++ b/pkg/ruletest/junit.go
@@ -1,0 +1,80 @@
+// SPDX-FileCopyrightText: Copyright 2026 The Minder Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package ruletest
+
+import (
+	"encoding/xml"
+	"maps"
+	"slices"
+	"strings"
+)
+
+// JUnitTestSuites is the root element of a JUnit XML report.
+type JUnitTestSuites struct {
+	XMLName    xml.Name         `xml:"testsuites"`
+	TestSuites []JUnitTestSuite `xml:"testsuite"`
+}
+
+// JUnitTestSuite represents a single test suite in a JUnit XML report.
+type JUnitTestSuite struct {
+	Name      string          `xml:"name,attr"`
+	Tests     int             `xml:"tests,attr"`
+	Failures  int             `xml:"failures,attr"`
+	TestCases []JUnitTestCase `xml:"testcase"`
+}
+
+// JUnitTestCase represents a single test case in a JUnit XML report.
+type JUnitTestCase struct {
+	Name      string        `xml:"name,attr"`
+	ClassName string        `xml:"classname,attr"`
+	Failure   *JUnitFailure `xml:"failure,omitempty"`
+}
+
+// JUnitFailure represents a failure within a test case.
+type JUnitFailure struct {
+	Message string `xml:"message,attr"`
+	Type    string `xml:"type,attr,omitempty"`
+	Body    string `xml:",chardata"`
+}
+
+// AsJUnit converts test results into a JUnitTestSuites structure.
+func AsJUnit(results []TestResult) JUnitTestSuites {
+	suitesMap := make(map[string]*JUnitTestSuite)
+
+	for _, res := range results {
+		suiteName := res.Filename
+		if _, ok := suitesMap[suiteName]; !ok {
+			suitesMap[suiteName] = &JUnitTestSuite{
+				Name: suiteName,
+			}
+		}
+
+		suite := suitesMap[suiteName]
+		suite.Tests++
+
+		tc := JUnitTestCase{
+			Name:      res.Name,
+			ClassName: suiteName,
+		}
+
+		if len(res.Failures) > 0 {
+			suite.Failures++
+			tc.Failure = &JUnitFailure{
+				Message: "Test failed",
+				Body:    strings.Join(res.Failures, "\n"),
+			}
+		}
+
+		suite.TestCases = append(suite.TestCases, tc)
+	}
+
+	var suitesList []JUnitTestSuite
+	for _, suite := range slices.Collect(maps.Values(suitesMap)) {
+		suitesList = append(suitesList, *suite)
+	}
+
+	return JUnitTestSuites{
+		TestSuites: suitesList,
+	}
+}

--- a/pkg/ruletest/junit_test.go
+++ b/pkg/ruletest/junit_test.go
@@ -1,0 +1,94 @@
+// SPDX-FileCopyrightText: Copyright 2026 The Minder Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package ruletest
+
+import (
+	"testing"
+)
+
+func TestAsJUnit_PassingResultsMultipleSuites(t *testing.T) {
+	t.Parallel()
+	results := []TestResult{
+		{Filename: "file_a.star", Name: "test_one"},
+		{Filename: "file_a.star", Name: "test_two"},
+		{Filename: "file_b.star", Name: "test_three"},
+	}
+
+	suites := AsJUnit(results)
+
+	if len(suites.TestSuites) != 2 {
+		t.Fatalf("expected 2 suites, got %d", len(suites.TestSuites))
+	}
+
+	suiteMap := make(map[string]JUnitTestSuite)
+	for _, s := range suites.TestSuites {
+		suiteMap[s.Name] = s
+	}
+
+	a := suiteMap["file_a.star"]
+	if a.Tests != 2 {
+		t.Errorf("file_a.star: expected 2 tests, got %d", a.Tests)
+	}
+	if a.Failures != 0 {
+		t.Errorf("file_a.star: expected 0 failures, got %d", a.Failures)
+	}
+
+	b := suiteMap["file_b.star"]
+	if b.Tests != 1 {
+		t.Errorf("file_b.star: expected 1 test, got %d", b.Tests)
+	}
+	if b.Failures != 0 {
+		t.Errorf("file_b.star: expected 0 failures, got %d", b.Failures)
+	}
+}
+
+func TestAsJUnit_FailuresAggregated(t *testing.T) {
+	t.Parallel()
+	results := []TestResult{
+		{Filename: "suite.star", Name: "test_fail_one", Failures: []string{"err1", "err2"}},
+		{Filename: "suite.star", Name: "test_fail_two", Failures: []string{"err3"}},
+		{Filename: "suite.star", Name: "test_pass"},
+	}
+
+	suites := AsJUnit(results)
+
+	if len(suites.TestSuites) != 1 {
+		t.Fatalf("expected 1 suite, got %d", len(suites.TestSuites))
+	}
+
+	suite := suites.TestSuites[0]
+	if suite.Tests != 3 {
+		t.Errorf("expected 3 tests, got %d", suite.Tests)
+	}
+	if suite.Failures != 2 {
+		t.Errorf("expected 2 failures, got %d", suite.Failures)
+	}
+
+	tcMap := make(map[string]JUnitTestCase)
+	for _, tc := range suite.TestCases {
+		tcMap[tc.Name] = tc
+	}
+
+	failOne := tcMap["test_fail_one"]
+	if failOne.Failure == nil {
+		t.Fatal("test_fail_one: expected a failure")
+	}
+	if failOne.Failure.Body != "err1\nerr2" {
+		t.Errorf("test_fail_one: expected joined failures, got %q", failOne.Failure.Body)
+	}
+
+	pass := tcMap["test_pass"]
+	if pass.Failure != nil {
+		t.Error("test_pass: expected no failure")
+	}
+}
+
+func TestAsJUnit_EmptyInput(t *testing.T) {
+	t.Parallel()
+	suites := AsJUnit(nil)
+
+	if len(suites.TestSuites) != 0 {
+		t.Errorf("expected 0 suites, got %d", len(suites.TestSuites))
+	}
+}

--- a/pkg/ruletest/mock_http.go
+++ b/pkg/ruletest/mock_http.go
@@ -131,6 +131,9 @@ func buildMockHTTPHandler(mockDict *starlark.Dict) (http.Handler, error) {
 			return nil, fmt.Errorf("mock endpoints must have string keys, got %s", key.Type())
 		}
 
+		// Normalize the URL to just the host and path to avoid mismatches from scheme,
+		// query parameters, etc. If url.Parse fails (e.g. it's just a raw path like
+		// "/api/v1/repos"), we safely fall back to using the raw key string.
 		parsedURL, err := url.Parse(keyStr)
 		if err == nil && parsedURL.Host != "" {
 			keyStr = parsedURL.Host + parsedURL.Path


### PR DESCRIPTION
# Summary

This PR introduces a new CLI capability for `mindev test` to produce parsable JUnit XML output for CI integration. This allows standard CI tools (like GitHub Actions) to natively parse and display `mindev test` results. Additionally, it addresses follow-up cleanups from #6575.

**Changes:**
* `cmd/dev/app/test/`: Added an `--output` (`-o`) flag to `mindev test`. By passing `--output=junit`, the tool natively outputs standard JUnit XML to `stdout` instead of the traditional plain-text format.
* `pkg/ruletest/eval.go`: Refactored to use Go 1.23 iterator `range` loops with `datasourcesList.Elements()` instead of manual iteration logic.
* `pkg/ruletest/mock_http.go`: Added comments to clarify why URL normalization is done for mock endpoints and why we safely fall back to the raw string if parsing fails.

Fixes #6576 

# Testing

* Built the updated `mindev` CLI locally:
  ```bash
  go build ./cmd/dev/...
  ```
* Ran rule tests with the new JUnit output flag:
  ```bash
  ./dev test -o junit
  ```
* Verified that the standard output produces valid, well-formatted XML conforming to the JUnit schema, with test suites, test cases, and nested failure details correctly serialized.
* Verified that error logs and general info continue to output to `stderr` so they do not corrupt the XML payload when redirecting stdout to a file (e.g. `./dev test -o junit > results.xml`).
* Ran `make test` to ensure no existing tests were broken by the `ruletest` cleanups.