### PR TITLE
Implement runtime support for issue remediation

### DIFF
--- a/docs/docs/ref/proto.mdx
+++ b/docs/docs/ref/proto.mdx
@@ -2929,7 +2929,7 @@ Ingest defines how the data is ingested.
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
-| type | <TypeLink type="string">string</TypeLink> |  | type is the type of the remediation. * 'rest' can be used with any entity type. * 'gh_branch_protection' and 'pull_request' can only be used with the 'repository' entity type. * 'pull_request_comment' can only be used with the 'pull_request' entity type. |
+| type | <TypeLink type="string">string</TypeLink> |  | type is the type of the remediation. * 'rest' can be used with any entity type. * 'gh_branch_protection' 'pull_request', and 'issue' can only be used with the 'repository' entity type. * 'pull_request_comment' can only be used with the 'pull_request' entity type. |
 | rest | <TypeLink type="minder-v1-RestType">RestType</TypeLink> | optional |  |
 | gh_branch_protection | <TypeLink type="minder-v1-RuleType-Definition-Remediate-GhBranchProtectionType">RuleType.Definition.Remediate.GhBranchProtectionType</TypeLink> | optional |  |
 | pull_request | <TypeLink type="minder-v1-RuleType-Definition-Remediate-PullRequestRemediation">RuleType.Definition.Remediate.PullRequestRemediation</TypeLink> | optional |  |
@@ -2951,9 +2951,7 @@ Ingest defines how the data is ingested.
 
 <Message id="minder-v1-RuleType-Definition-Remediate-IssueRemediation">RuleType.Definition.Remediate.IssueRemediation</Message>
 
-NOTE: Issue remediation is not yet implemented.
-This configuration is reserved for future support.
-"issue" is intentionally not a supported remediation type yet.
+
 
 
 | Field | Type | Label | Description |

--- a/internal/engine/actions/remediate/issue/issue.go
+++ b/internal/engine/actions/remediate/issue/issue.go
@@ -42,6 +42,7 @@ type issueMetadata struct {
 	Number int `json:"issue_number,omitempty"`
 }
 
+// Remediator implements the issue remediation engine.
 type Remediator struct {
 	issueCli   provifv1.IssuePublisher
 	actionType interfaces.ActionType
@@ -97,8 +98,8 @@ func NewIssueRemediate(
 	}, nil
 }
 
-// IssueTemplateParams is the parameters for the Issue templates
-type IssueTemplateParams struct {
+// TemplateParams is the parameters for the Issue templates
+type TemplateParams struct {
 	// Entity is the entity being evaluated.
 	Entity any
 	// Profile contains the profile definition.
@@ -183,7 +184,7 @@ func (r *Remediator) getParamsForIssueRemediation(
 		return nil, fmt.Errorf("expected repository, got %T", ent)
 	}
 
-	tmplParams := &IssueTemplateParams{
+	tmplParams := &TemplateParams{
 		Entity:  ent,
 		Profile: params.GetRule().Def,
 		Params:  params.GetRule().Params,
@@ -363,7 +364,7 @@ func (r *Remediator) runOff(
 
 func (r *Remediator) getIssueBodyText(
 	ctx context.Context,
-	tmplParams *IssueTemplateParams,
+	tmplParams *TemplateParams,
 ) (string, error) {
 
 	body := new(bytes.Buffer)

--- a/internal/engine/actions/remediate/issue/issue.go
+++ b/internal/engine/actions/remediate/issue/issue.go
@@ -1,0 +1,401 @@
+// SPDX-FileCopyrightText: Copyright 2023 The Minder Authors
+// SPDX-License-Identifier: Apache-2.0
+
+// Package issue provides the issue remediation engine.
+package issue
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	"github.com/rs/zerolog"
+	"google.golang.org/protobuf/proto"
+
+	dbadapter "github.com/mindersec/minder/internal/adapters/db"
+	"github.com/mindersec/minder/internal/db"
+	"github.com/mindersec/minder/internal/engine/interfaces"
+	"github.com/mindersec/minder/internal/util"
+	pb "github.com/mindersec/minder/pkg/api/protobuf/go/minder/v1"
+	enginerr "github.com/mindersec/minder/pkg/engine/errors"
+	"github.com/mindersec/minder/pkg/profiles/models"
+	provifv1 "github.com/mindersec/minder/pkg/providers/v1"
+)
+
+const (
+	// RemediateType is the type of the Issue remediation engine.
+	RemediateType = "issue"
+)
+
+// Keep these limits in sync with the proto validation constraints.
+const (
+	// TitleMaxLength is the maximum number of bytes for the title.
+	TitleMaxLength = 75
+
+	// BodyMaxLength is the maximum number of bytes for the body.
+	BodyMaxLength = 65536
+)
+
+type issueMetadata struct {
+	Number int `json:"issue_number,omitempty"`
+}
+
+type Remediator struct {
+	issueCli   provifv1.IssuePublisher
+	actionType interfaces.ActionType
+	setting    models.ActionOpt
+
+	issueCfg *pb.RuleType_Definition_Remediate_IssueRemediation
+
+	titleTemplate *util.SafeTemplate
+	bodyTemplate  *util.SafeTemplate
+}
+
+type paramsIssue struct {
+	repo       *pb.Repository
+	title      string
+	body       string
+	labels     []string
+	assignees  []string
+	metadata   *issueMetadata
+	prevStatus *db.ListRuleEvaluationsByProfileIdRow
+}
+
+// NewIssueRemediate creates a new Issue remediation engine.
+func NewIssueRemediate(
+	actionType interfaces.ActionType,
+	issueCfg *pb.RuleType_Definition_Remediate_IssueRemediation,
+	issueCli provifv1.IssuePublisher,
+	setting models.ActionOpt,
+) (*Remediator, error) {
+	err := issueCfg.Validate()
+	if err != nil {
+		return nil, fmt.Errorf("issue remediation config is invalid: %w", err)
+	}
+
+	titleTmpl, err := util.NewSafeHTMLTemplate(&issueCfg.Title, "title")
+	if err != nil {
+		return nil, fmt.Errorf("cannot parse title template: %w", err)
+	}
+
+	bodyTmpl, err := util.NewSafeHTMLTemplate(&issueCfg.Body, "body")
+	if err != nil {
+		return nil, fmt.Errorf("cannot parse body template: %w", err)
+	}
+
+	return &Remediator{
+		issueCli: issueCli,
+		issueCfg: issueCfg,
+
+		actionType: actionType,
+		setting:    setting,
+
+		titleTemplate: titleTmpl,
+		bodyTemplate:  bodyTmpl,
+	}, nil
+}
+
+// IssueTemplateParams is the parameters for the Issue templates
+type IssueTemplateParams struct {
+	// Entity is the entity being evaluated.
+	Entity any
+	// Profile contains the profile definition.
+	Profile map[string]any
+	// Params contains the rule instance parameters.
+	Params map[string]any
+	// EvalResultOutput contains the evaluation output.
+	EvalResultOutput any
+}
+
+// Class returns the action type of the remediation engine.
+func (r *Remediator) Class() interfaces.ActionType {
+	return r.actionType
+}
+
+// Type returns the action subtype of the remediation engine.
+func (*Remediator) Type() string {
+	return RemediateType
+}
+
+// GetOnOffState returns the remediation action state read from the profile.
+func (r *Remediator) GetOnOffState() models.ActionOpt {
+	return models.ActionOptOrDefault(r.setting, models.ActionOptOff)
+}
+
+func (r *Remediator) run(
+	ctx context.Context,
+	cmd interfaces.ActionCmd,
+	p *paramsIssue,
+) (json.RawMessage, error) {
+	switch cmd {
+	case interfaces.ActionCmdOn:
+		return r.runOn(ctx, p)
+
+	case interfaces.ActionCmdOff:
+		return r.runOff(ctx, p)
+
+	case interfaces.ActionCmdDoNothing:
+		return r.runDoNothing(ctx, p)
+	}
+
+	return nil, enginerr.ErrActionSkipped
+}
+
+// Do perform the remediation
+func (r *Remediator) Do(
+	ctx context.Context,
+	cmd interfaces.ActionCmd,
+	ent proto.Message,
+	params interfaces.ActionsParams,
+	metadata *json.RawMessage,
+) (json.RawMessage, error) {
+	p, err := r.getParamsForIssueRemediation(ctx, ent, params, metadata)
+	if err != nil {
+		return nil, fmt.Errorf("cannot get issue remediation params: %w", err)
+	}
+
+	var remErr error
+	switch r.setting {
+	case models.ActionOptOn:
+		return r.run(ctx, cmd, p)
+
+	case models.ActionOptDryRun:
+		return r.dryRun(ctx, cmd, p)
+
+	case models.ActionOptOff, models.ActionOptUnknown:
+		remErr = errors.New("unexpected action")
+	}
+
+	return nil, remErr
+}
+
+func (r *Remediator) getParamsForIssueRemediation(
+	ctx context.Context,
+	ent proto.Message,
+	params interfaces.ActionsParams,
+	metadata *json.RawMessage,
+) (*paramsIssue, error) {
+
+	repo, ok := ent.(*pb.Repository)
+	if !ok {
+		return nil, fmt.Errorf("expected repository, got %T", ent)
+	}
+
+	tmplParams := &IssueTemplateParams{
+		Entity:  ent,
+		Profile: params.GetRule().Def,
+		Params:  params.GetRule().Params,
+	}
+
+	if params.GetEvalResult() != nil {
+		tmplParams.EvalResultOutput = params.GetEvalResult().Output
+	}
+
+	title, err := r.titleTemplate.Render(ctx, tmplParams, TitleMaxLength)
+	if err != nil {
+		return nil, fmt.Errorf("cannot execute title template: %w", err)
+	}
+
+	body, err := r.getIssueBodyText(ctx, tmplParams)
+	if err != nil {
+		return nil, fmt.Errorf("cannot create issue body: %w", err)
+	}
+
+	// Unmarshal existing remediation metadata, if any.
+	meta := &issueMetadata{}
+	if metadata != nil {
+		if err := json.Unmarshal(*metadata, meta); err != nil {
+			// Metadata may not exist yet; log and continue.
+			return nil, fmt.Errorf("cannot unmarshal remediation metadata: %w", err)
+		}
+	}
+
+	// Labels and assignees are intentionally left empty for now.
+	// Runtime support already exists in the provider API and will be
+	// wired to configuration in a followup PR.
+	labels := []string{}
+	assignees := []string{}
+
+	return &paramsIssue{
+		repo:       repo,
+		title:      title,
+		body:       body,
+		labels:     labels,
+		assignees:  assignees,
+		metadata:   meta,
+		prevStatus: params.GetEvalStatusFromDb(),
+	}, nil
+}
+
+func (r *Remediator) dryRun(
+	ctx context.Context,
+	cmd interfaces.ActionCmd,
+	p *paramsIssue,
+) (json.RawMessage, error) {
+	logger := zerolog.Ctx(ctx).Info().Str("repo", p.repo.String())
+
+	// Process the command
+	switch cmd {
+	case interfaces.ActionCmdOn:
+		logger.Msgf("title:\n%s\n", p.title)
+		logger.Msgf("body:\n%s\n", p.body)
+		logger.Msgf("labels:\n%v\n", p.labels)
+		logger.Msgf("assignees:\n%v\n", p.assignees)
+
+		return nil, nil
+
+	case interfaces.ActionCmdOff:
+		if p.metadata == nil || p.metadata.Number == 0 {
+			// We cannot do anything without an issue number, so we assume that closing this is a success.
+			return nil, fmt.Errorf("no issue number provided: %w", enginerr.ErrActionSkipped)
+		}
+
+		logger.Msgf(
+			"would close issue #%d in %s/%s",
+			p.metadata.Number,
+			p.repo.GetOwner(),
+			p.repo.GetName(),
+		)
+
+		return nil, nil
+
+	case interfaces.ActionCmdDoNothing:
+		return r.runDoNothing(ctx, p)
+	}
+
+	return nil, nil
+}
+
+func (r *Remediator) runOn(
+	ctx context.Context,
+	p *paramsIssue,
+) (json.RawMessage, error) {
+	logger := zerolog.Ctx(ctx).With().
+		Str("repo", p.repo.String()).
+		Logger()
+
+	// If we already have an issue recorded in the remediation metadata,
+	// don't create another one.
+	if p.metadata != nil && p.metadata.Number != 0 {
+		logger.Info().
+			Int("issue_number", p.metadata.Number).
+			Msg("issue already exists")
+
+		newMeta, err := json.Marshal(*p.metadata)
+		if err != nil {
+			return nil, fmt.Errorf("error marshalling issue remediation metadata json: %w", err)
+		}
+
+		return newMeta, enginerr.ErrActionPending
+	}
+
+	issue, err := r.issueCli.CreateIssue(
+		ctx,
+		p.repo.GetOwner(),
+		p.repo.GetName(),
+		p.title,
+		p.body,
+		p.labels,
+		p.assignees,
+	)
+	if err != nil {
+		return nil, fmt.Errorf(
+			"cannot create issue: %w, %w",
+			err,
+			enginerr.ErrActionFailed,
+		)
+	}
+
+	newMeta, err := json.Marshal(issueMetadata{
+		Number: issue.GetNumber(),
+	})
+	if err != nil {
+		return nil, fmt.Errorf(
+			"error marshalling issue remediation metadata json: %w",
+			err,
+		)
+	}
+
+	logger.Info().
+		Int("issue_number", issue.GetNumber()).
+		Msg("issue remediation completed")
+
+	return newMeta, enginerr.ErrActionPending
+}
+
+func (r *Remediator) runOff(
+	ctx context.Context,
+	p *paramsIssue,
+) (json.RawMessage, error) {
+	logger := zerolog.Ctx(ctx).With().
+		Str("repo", p.repo.String()).
+		Logger()
+
+	if p.metadata == nil || p.metadata.Number == 0 {
+		// We cannot do anything without an issue number, so we assume that closing this is a success.
+		return nil, fmt.Errorf("no issue number provided: %w", enginerr.ErrActionSkipped)
+	}
+
+	issue, err := r.issueCli.CloseIssue(
+		ctx,
+		p.repo.GetOwner(),
+		p.repo.GetName(),
+		p.metadata.Number,
+		"",
+	)
+	if err != nil {
+		return nil, fmt.Errorf(
+			"error closing issue %d: %w, %w",
+			p.metadata.Number,
+			err,
+			enginerr.ErrActionFailed,
+		)
+	}
+
+	logger.Info().
+		Int("issue_number", issue.GetNumber()).
+		Msg("issue closed")
+
+	return nil, enginerr.ErrActionSkipped
+}
+
+func (r *Remediator) getIssueBodyText(
+	ctx context.Context,
+	tmplParams *IssueTemplateParams,
+) (string, error) {
+
+	body := new(bytes.Buffer)
+
+	if err := r.bodyTemplate.Execute(
+		ctx,
+		body,
+		tmplParams,
+		BodyMaxLength,
+	); err != nil {
+		return "", fmt.Errorf("cannot execute body template: %w", err)
+	}
+
+	return body.String(), nil
+}
+
+// runDoNothing returns the previous remediation status.
+func (*Remediator) runDoNothing(
+	ctx context.Context,
+	p *paramsIssue,
+) (json.RawMessage, error) {
+	logger := zerolog.Ctx(ctx).With().
+		Str("repo", p.repo.String()).
+		Logger()
+
+	logger.Debug().Msg("Running do nothing")
+
+	err := dbadapter.RemediationStatusAsError(p.prevStatus)
+
+	if p.prevStatus != nil {
+		return p.prevStatus.RemMetadata, err
+	}
+
+	return nil, err
+}

--- a/internal/engine/actions/remediate/issue/issue.go
+++ b/internal/engine/actions/remediate/issue/issue.go
@@ -28,7 +28,7 @@ const (
 	RemediateType = "issue"
 )
 
-// Keep these limits in sync with the proto validation constraints.
+// Limits on the rendered output sent to the repository provider.
 const (
 	// TitleMaxLength is the maximum number of bytes for the title.
 	TitleMaxLength = 75
@@ -156,7 +156,6 @@ func (r *Remediator) Do(
 		return nil, fmt.Errorf("cannot get issue remediation params: %w", err)
 	}
 
-	var remErr error
 	switch r.setting {
 	case models.ActionOptOn:
 		return r.run(ctx, cmd, p)
@@ -165,10 +164,11 @@ func (r *Remediator) Do(
 		return r.dryRun(ctx, cmd, p)
 
 	case models.ActionOptOff, models.ActionOptUnknown:
-		remErr = errors.New("unexpected action")
-	}
+		return nil, errors.New("unexpected remediation action setting")
 
-	return nil, remErr
+	default:
+		return nil, fmt.Errorf("unexpected remediation action setting: %v", r.setting)
+	}
 }
 
 func (r *Remediator) getParamsForIssueRemediation(

--- a/internal/engine/actions/remediate/issue/issue.go
+++ b/internal/engine/actions/remediate/issue/issue.go
@@ -5,7 +5,6 @@
 package issue
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -141,7 +140,7 @@ func (r *Remediator) run(
 		return r.runDoNothing(ctx, p)
 	}
 
-	return nil, enginerr.ErrActionSkipped
+	return nil, fmt.Errorf("unimplemented action command: %v", cmd)
 }
 
 // Do perform the remediation
@@ -196,12 +195,12 @@ func (r *Remediator) getParamsForIssueRemediation(
 
 	title, err := r.titleTemplate.Render(ctx, tmplParams, TitleMaxLength)
 	if err != nil {
-		return nil, fmt.Errorf("cannot execute title template: %w", err)
+		return nil, fmt.Errorf("cannot render title template: %w", err)
 	}
 
-	body, err := r.getIssueBodyText(ctx, tmplParams)
+	body, err := r.bodyTemplate.Render(ctx, tmplParams, BodyMaxLength)
 	if err != nil {
-		return nil, fmt.Errorf("cannot create issue body: %w", err)
+		return nil, fmt.Errorf("cannot render body template: %w", err)
 	}
 
 	// Unmarshal existing remediation metadata, if any.
@@ -235,15 +234,19 @@ func (r *Remediator) dryRun(
 	cmd interfaces.ActionCmd,
 	p *paramsIssue,
 ) (json.RawMessage, error) {
-	logger := zerolog.Ctx(ctx).Info().Str("repo", p.repo.String())
+	logger := zerolog.Ctx(ctx).With().
+		Str("repo", p.repo.String()).
+		Logger()
 
 	// Process the command
 	switch cmd {
 	case interfaces.ActionCmdOn:
-		logger.Msgf("title:\n%s\n", p.title)
-		logger.Msgf("body:\n%s\n", p.body)
-		logger.Msgf("labels:\n%v\n", p.labels)
-		logger.Msgf("assignees:\n%v\n", p.assignees)
+		logger.Info().
+			Str("title", p.title).
+			Str("body", p.body).
+			Strs("labels", p.labels).
+			Strs("assignees", p.assignees).
+			Msg("issue remediation dry run")
 
 		return nil, nil
 
@@ -253,12 +256,11 @@ func (r *Remediator) dryRun(
 			return nil, fmt.Errorf("no issue number provided: %w", enginerr.ErrActionSkipped)
 		}
 
-		logger.Msgf(
-			"would close issue #%d in %s/%s",
-			p.metadata.Number,
-			p.repo.GetOwner(),
-			p.repo.GetName(),
-		)
+		logger.Info().
+			Int("issue_number", p.metadata.Number).
+			Str("owner", p.repo.GetOwner()).
+			Str("repo", p.repo.GetName()).
+			Msg("would close issue")
 
 		return nil, nil
 
@@ -280,7 +282,7 @@ func (r *Remediator) runOn(
 	// If we already have an issue recorded in the remediation metadata,
 	// don't create another one.
 	if p.metadata != nil && p.metadata.Number != 0 {
-		logger.Info().
+		logger.Debug().
 			Int("issue_number", p.metadata.Number).
 			Msg("issue already exists")
 
@@ -321,7 +323,7 @@ func (r *Remediator) runOn(
 
 	logger.Info().
 		Int("issue_number", issue.GetNumber()).
-		Msg("issue remediation completed")
+		Msg("issue created")
 
 	return newMeta, enginerr.ErrActionPending
 }
@@ -360,25 +362,6 @@ func (r *Remediator) runOff(
 		Msg("issue closed")
 
 	return nil, enginerr.ErrActionSkipped
-}
-
-func (r *Remediator) getIssueBodyText(
-	ctx context.Context,
-	tmplParams *TemplateParams,
-) (string, error) {
-
-	body := new(bytes.Buffer)
-
-	if err := r.bodyTemplate.Execute(
-		ctx,
-		body,
-		tmplParams,
-		BodyMaxLength,
-	); err != nil {
-		return "", fmt.Errorf("cannot execute body template: %w", err)
-	}
-
-	return body.String(), nil
 }
 
 // runDoNothing returns the previous remediation status.

--- a/internal/engine/actions/remediate/issue/issue_test.go
+++ b/internal/engine/actions/remediate/issue/issue_test.go
@@ -1,0 +1,279 @@
+// SPDX-FileCopyrightText: Copyright 2023 The Minder Authors
+// SPDX-License-Identifier: Apache-2.0
+
+// Package issue provides the issue remediation engine.
+package issue
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	"github.com/google/go-github/v63/github"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/reflect/protoreflect"
+
+	"github.com/mindersec/minder/internal/engine/interfaces"
+	"github.com/mindersec/minder/internal/providers/credentials"
+	"github.com/mindersec/minder/internal/providers/github/clients"
+	mockghclient "github.com/mindersec/minder/internal/providers/github/mock"
+	"github.com/mindersec/minder/internal/providers/github/properties"
+	"github.com/mindersec/minder/internal/providers/ratecache"
+	"github.com/mindersec/minder/internal/providers/telemetry"
+
+	pb "github.com/mindersec/minder/pkg/api/protobuf/go/minder/v1"
+	"github.com/mindersec/minder/pkg/engine/errors"
+	interfaces2 "github.com/mindersec/minder/pkg/engine/v1/interfaces"
+	"github.com/mindersec/minder/pkg/profiles/models"
+	provifv1 "github.com/mindersec/minder/pkg/providers/v1"
+)
+
+const (
+	ghAPIURL = "https://api.github.com"
+
+	repoOwner = "stacklok"
+	repoName  = "minder"
+
+	issueTitle = "Dependency vulnerability detected"
+
+	issueBody = "A dependency vulnerability has been detected."
+)
+
+var TestActionTypeValid interfaces.ActionType = "remediate-test"
+
+func testGithubProvider() (provifv1.GitHub, error) {
+	return clients.NewRestClient(
+		&pb.GitHubProviderConfig{
+			Endpoint: proto.String(ghAPIURL + "/"),
+		},
+		nil,
+		nil,
+		&ratecache.NoopRestClientCache{},
+		credentials.NewGitHubTokenCredential("token"),
+		clients.NewGitHubClientFactory(telemetry.NewNoopMetrics()),
+		properties.NewPropertyFetcherFactory(),
+		"",
+	)
+}
+
+func defaultIssueRem() *pb.RuleType_Definition_Remediate_IssueRemediation {
+	return &pb.RuleType_Definition_Remediate_IssueRemediation{
+		Title: issueTitle,
+		Body:  issueBody,
+	}
+}
+
+type remediateArgs struct {
+	remAction models.ActionOpt
+	ent       protoreflect.ProtoMessage
+	pol       map[string]any
+	params    map[string]any
+	ruleName  string
+}
+
+func createTestRemArgs() *remediateArgs {
+	return &remediateArgs{
+		remAction: models.ActionOptOn,
+		ent: &pb.Repository{
+			Owner: repoOwner,
+			Name:  repoName,
+		},
+		pol:    map[string]any{},
+		params: map[string]any{},
+	}
+}
+
+func TestIssueRemediate(t *testing.T) {
+	t.Parallel()
+
+	type newIssueRemediateArgs struct {
+		issueRem   *pb.RuleType_Definition_Remediate_IssueRemediation
+		actionType interfaces.ActionType
+	}
+
+	tests := []struct {
+		name             string
+		newRemArgs       *newIssueRemediateArgs
+		remArgs          *remediateArgs
+		mockSetup        func(*testing.T, *mockghclient.MockGitHub)
+		expectedErr      error
+		wantInitErr      bool
+		expectedMetadata json.RawMessage
+	}{
+		{
+			name: "create an issue",
+			newRemArgs: &newIssueRemediateArgs{
+				issueRem:   defaultIssueRem(),
+				actionType: TestActionTypeValid,
+			},
+			remArgs: createTestRemArgs(),
+			mockSetup: func(_ *testing.T, mockGitHub *mockghclient.MockGitHub) {
+				mockGitHub.EXPECT().
+					CreateIssue(
+						gomock.Any(),
+						repoOwner,
+						repoName,
+						issueTitle,
+						issueBody,
+						[]string{},
+						[]string{},
+					).
+					Return(
+						&github.Issue{
+							Number: github.Int(42),
+						},
+						nil,
+					)
+			},
+			expectedErr:      errors.ErrActionPending,
+			expectedMetadata: json.RawMessage(`{"issue_number":42}`),
+		},
+		{
+			name: "fail to create issue",
+			newRemArgs: &newIssueRemediateArgs{
+				issueRem:   defaultIssueRem(),
+				actionType: TestActionTypeValid,
+			},
+			remArgs: createTestRemArgs(),
+			mockSetup: func(_ *testing.T, mockGitHub *mockghclient.MockGitHub) {
+				mockGitHub.EXPECT().
+					CreateIssue(
+						gomock.Any(),
+						repoOwner,
+						repoName,
+						issueTitle,
+						issueBody,
+						[]string{},
+						[]string{},
+					).
+					Return(nil, fmt.Errorf("failed to create issue"))
+			},
+			expectedErr:      errors.ErrActionFailed,
+			expectedMetadata: nil,
+		},
+		{
+			name: "issue already exists",
+			newRemArgs: &newIssueRemediateArgs{
+				issueRem:   defaultIssueRem(),
+				actionType: TestActionTypeValid,
+			},
+			remArgs: createTestRemArgs(),
+			mockSetup: func(_ *testing.T, mockGitHub *mockghclient.MockGitHub) {
+				// Intentionally empty.
+				// If CreateIssue() is called, gomock will fail the test.
+			},
+			expectedErr:      errors.ErrActionPending,
+			expectedMetadata: json.RawMessage(`{"issue_number":42}`),
+		},
+		{
+			name: "close an issue",
+			newRemArgs: &newIssueRemediateArgs{
+				issueRem:   defaultIssueRem(),
+				actionType: TestActionTypeValid,
+			},
+			remArgs: createTestRemArgs(),
+			mockSetup: func(_ *testing.T, mockGitHub *mockghclient.MockGitHub) {
+				mockGitHub.EXPECT().
+					CloseIssue(
+						gomock.Any(),
+						repoOwner,
+						repoName,
+						42,
+						"",
+					).
+					Return(
+						&github.Issue{
+							Number: github.Int(42),
+						},
+						nil,
+					)
+			},
+			expectedErr:      errors.ErrActionSkipped,
+			expectedMetadata: nil,
+		},
+		{
+			name: "close issue without metadata",
+			newRemArgs: &newIssueRemediateArgs{
+				issueRem:   defaultIssueRem(),
+				actionType: TestActionTypeValid,
+			},
+			remArgs: createTestRemArgs(),
+			mockSetup: func(_ *testing.T, mockGitHub *mockghclient.MockGitHub) {
+				// No expectations.
+				// CloseIssue must NOT be called.
+			},
+			expectedErr:      errors.ErrActionSkipped,
+			expectedMetadata: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			mockClient := mockghclient.NewMockGitHub(ctrl)
+
+			provider, err := testGithubProvider()
+			require.NoError(t, err)
+
+			engine, err := NewIssueRemediate(
+				tt.newRemArgs.actionType,
+				tt.newRemArgs.issueRem,
+				provider,
+				tt.remArgs.remAction,
+			)
+
+			if tt.wantInitErr {
+				require.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+			require.NotNil(t, engine)
+
+			engine.issueCli = mockClient
+
+			tt.mockSetup(t, mockClient)
+
+			evalParams := &interfaces.EvalStatusParams{
+				Rule: &models.RuleInstance{
+					Def:    tt.remArgs.pol,
+					Params: tt.remArgs.params,
+					Name:   tt.remArgs.ruleName,
+				},
+			}
+
+			evalParams.SetEvalResult(&interfaces2.EvaluationResult{})
+
+			cmd := interfaces.ActionCmdOn
+			switch tt.name {
+			case "close an issue", "close issue without metadata":
+				cmd = interfaces.ActionCmdOff
+			}
+
+			var metadata *json.RawMessage
+			switch tt.name {
+			case "issue already exists", "close an issue":
+				m := json.RawMessage(`{"issue_number":42}`)
+				metadata = &m
+			}
+
+			retMeta, err := engine.Do(
+				context.Background(),
+				cmd,
+				tt.remArgs.ent,
+				evalParams,
+				metadata,
+			)
+
+			require.ErrorIs(t, err, tt.expectedErr)
+			require.Equal(t, tt.expectedMetadata, retMeta)
+		})
+	}
+}

--- a/internal/engine/actions/remediate/issue/issue_test.go
+++ b/internal/engine/actions/remediate/issue/issue_test.go
@@ -74,6 +74,8 @@ func TestIssueRemediate(t *testing.T) {
 		newRemArgs       *newIssueRemediateArgs
 		remArgs          *remediateArgs
 		mockSetup        func(*testing.T, *mockghclient.MockGitHub)
+		cmd              interfaces.ActionCmd
+		metadata         *json.RawMessage
 		expectedErr      error
 		wantInitErr      bool
 		expectedMetadata json.RawMessage
@@ -103,6 +105,8 @@ func TestIssueRemediate(t *testing.T) {
 						nil,
 					)
 			},
+			cmd:              interfaces.ActionCmdOn,
+			metadata:         nil,
 			expectedErr:      errors.ErrActionPending,
 			expectedMetadata: json.RawMessage(`{"issue_number":42}`),
 		},
@@ -126,6 +130,8 @@ func TestIssueRemediate(t *testing.T) {
 					).
 					Return(nil, fmt.Errorf("failed to create issue"))
 			},
+			cmd:              interfaces.ActionCmdOn,
+			metadata:         nil,
 			expectedErr:      errors.ErrActionFailed,
 			expectedMetadata: nil,
 		},
@@ -140,6 +146,11 @@ func TestIssueRemediate(t *testing.T) {
 				// Intentionally empty.
 				// If CreateIssue() is called, gomock will fail the test.
 			},
+			cmd: interfaces.ActionCmdOn,
+			metadata: func() *json.RawMessage {
+				m := json.RawMessage(`{"issue_number":42}`)
+				return &m
+			}(),
 			expectedErr:      errors.ErrActionPending,
 			expectedMetadata: json.RawMessage(`{"issue_number":42}`),
 		},
@@ -166,6 +177,11 @@ func TestIssueRemediate(t *testing.T) {
 						nil,
 					)
 			},
+			cmd: interfaces.ActionCmdOff,
+			metadata: func() *json.RawMessage {
+				m := json.RawMessage(`{"issue_number":42}`)
+				return &m
+			}(),
 			expectedErr:      errors.ErrActionSkipped,
 			expectedMetadata: nil,
 		},
@@ -194,6 +210,11 @@ func TestIssueRemediate(t *testing.T) {
 						nil,
 					)
 			},
+			cmd: interfaces.ActionCmdOff,
+			metadata: func() *json.RawMessage {
+				m := json.RawMessage(`{"issue_number":42}`)
+				return &m
+			}(),
 			expectedErr:      errors.ErrActionSkipped,
 			expectedMetadata: nil,
 		},
@@ -208,6 +229,8 @@ func TestIssueRemediate(t *testing.T) {
 				// No expectations.
 				// CloseIssue must NOT be called.
 			},
+			cmd:              interfaces.ActionCmdOff,
+			metadata:         nil,
 			expectedErr:      errors.ErrActionSkipped,
 			expectedMetadata: nil,
 		},
@@ -249,25 +272,12 @@ func TestIssueRemediate(t *testing.T) {
 
 			evalParams.SetEvalResult(&interfaces2.EvaluationResult{})
 
-			cmd := interfaces.ActionCmdOn
-			switch tt.name {
-			case "close an issue", "close already closed issue", "close issue without metadata":
-				cmd = interfaces.ActionCmdOff
-			}
-
-			var metadata *json.RawMessage
-			switch tt.name {
-			case "issue already exists", "close an issue", "close already closed issue":
-				m := json.RawMessage(`{"issue_number":42}`)
-				metadata = &m
-			}
-
 			retMeta, err := engine.Do(
 				context.Background(),
-				cmd,
+				tt.cmd,
 				tt.remArgs.ent,
 				evalParams,
-				metadata,
+				tt.metadata,
 			)
 
 			require.ErrorIs(t, err, tt.expectedErr)

--- a/internal/engine/actions/remediate/issue/issue_test.go
+++ b/internal/engine/actions/remediate/issue/issue_test.go
@@ -11,6 +11,11 @@ import (
 	"testing"
 
 	"github.com/google/go-github/v63/github"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/reflect/protoreflect"
+
 	"github.com/mindersec/minder/internal/engine/interfaces"
 	"github.com/mindersec/minder/internal/providers/credentials"
 	"github.com/mindersec/minder/internal/providers/github/clients"
@@ -23,10 +28,6 @@ import (
 	interfaces2 "github.com/mindersec/minder/pkg/engine/v1/interfaces"
 	"github.com/mindersec/minder/pkg/profiles/models"
 	provifv1 "github.com/mindersec/minder/pkg/providers/v1"
-	"github.com/stretchr/testify/require"
-	"go.uber.org/mock/gomock"
-	"google.golang.org/protobuf/proto"
-	"google.golang.org/protobuf/reflect/protoreflect"
 )
 
 const (

--- a/internal/engine/actions/remediate/issue/issue_test.go
+++ b/internal/engine/actions/remediate/issue/issue_test.go
@@ -13,26 +13,17 @@ import (
 	"github.com/google/go-github/v63/github"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
-	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/reflect/protoreflect"
 
 	"github.com/mindersec/minder/internal/engine/interfaces"
-	"github.com/mindersec/minder/internal/providers/credentials"
-	"github.com/mindersec/minder/internal/providers/github/clients"
 	mockghclient "github.com/mindersec/minder/internal/providers/github/mock"
-	"github.com/mindersec/minder/internal/providers/github/properties"
-	"github.com/mindersec/minder/internal/providers/ratecache"
-	"github.com/mindersec/minder/internal/providers/telemetry"
 	pb "github.com/mindersec/minder/pkg/api/protobuf/go/minder/v1"
 	"github.com/mindersec/minder/pkg/engine/errors"
 	interfaces2 "github.com/mindersec/minder/pkg/engine/v1/interfaces"
 	"github.com/mindersec/minder/pkg/profiles/models"
-	provifv1 "github.com/mindersec/minder/pkg/providers/v1"
 )
 
 const (
-	ghAPIURL = "https://api.github.com"
-
 	repoOwner = "stacklok"
 	repoName  = "minder"
 
@@ -42,21 +33,6 @@ const (
 )
 
 var TestActionTypeValid interfaces.ActionType = "remediate-test"
-
-func testGithubProvider() (provifv1.GitHub, error) {
-	return clients.NewRestClient(
-		&pb.GitHubProviderConfig{
-			Endpoint: proto.String(ghAPIURL + "/"),
-		},
-		nil,
-		nil,
-		&ratecache.NoopRestClientCache{},
-		credentials.NewGitHubTokenCredential("token"),
-		clients.NewGitHubClientFactory(telemetry.NewNoopMetrics()),
-		properties.NewPropertyFetcherFactory(),
-		"",
-	)
-}
 
 func defaultIssueRem() *pb.RuleType_Definition_Remediate_IssueRemediation {
 	return &pb.RuleType_Definition_Remediate_IssueRemediation{
@@ -194,6 +170,34 @@ func TestIssueRemediate(t *testing.T) {
 			expectedMetadata: nil,
 		},
 		{
+			name: "close already closed issue",
+			newRemArgs: &newIssueRemediateArgs{
+				issueRem:   defaultIssueRem(),
+				actionType: TestActionTypeValid,
+			},
+			remArgs: createTestRemArgs(),
+			mockSetup: func(_ *testing.T, mockGitHub *mockghclient.MockGitHub) {
+				// GitHub returns 200 OK when closing an already closed issue.
+				// This documents provider behavior; other code forges may differ.
+				mockGitHub.EXPECT().
+					CloseIssue(
+						gomock.Any(),
+						repoOwner,
+						repoName,
+						42,
+						"",
+					).
+					Return(
+						&github.Issue{
+							Number: github.Int(42),
+						},
+						nil,
+					)
+			},
+			expectedErr:      errors.ErrActionSkipped,
+			expectedMetadata: nil,
+		},
+		{
 			name: "close issue without metadata",
 			newRemArgs: &newIssueRemediateArgs{
 				issueRem:   defaultIssueRem(),
@@ -218,13 +222,10 @@ func TestIssueRemediate(t *testing.T) {
 
 			mockClient := mockghclient.NewMockGitHub(ctrl)
 
-			provider, err := testGithubProvider()
-			require.NoError(t, err)
-
 			engine, err := NewIssueRemediate(
 				tt.newRemArgs.actionType,
 				tt.newRemArgs.issueRem,
-				provider,
+				mockClient,
 				tt.remArgs.remAction,
 			)
 
@@ -235,8 +236,6 @@ func TestIssueRemediate(t *testing.T) {
 
 			require.NoError(t, err)
 			require.NotNil(t, engine)
-
-			engine.issueCli = mockClient
 
 			tt.mockSetup(t, mockClient)
 
@@ -252,13 +251,13 @@ func TestIssueRemediate(t *testing.T) {
 
 			cmd := interfaces.ActionCmdOn
 			switch tt.name {
-			case "close an issue", "close issue without metadata":
+			case "close an issue", "close already closed issue", "close issue without metadata":
 				cmd = interfaces.ActionCmdOff
 			}
 
 			var metadata *json.RawMessage
 			switch tt.name {
-			case "issue already exists", "close an issue":
+			case "issue already exists", "close an issue", "close already closed issue":
 				m := json.RawMessage(`{"issue_number":42}`)
 				metadata = &m
 			}

--- a/internal/engine/actions/remediate/issue/issue_test.go
+++ b/internal/engine/actions/remediate/issue/issue_test.go
@@ -11,11 +11,6 @@ import (
 	"testing"
 
 	"github.com/google/go-github/v63/github"
-	"github.com/stretchr/testify/require"
-	"go.uber.org/mock/gomock"
-	"google.golang.org/protobuf/proto"
-	"google.golang.org/protobuf/reflect/protoreflect"
-
 	"github.com/mindersec/minder/internal/engine/interfaces"
 	"github.com/mindersec/minder/internal/providers/credentials"
 	"github.com/mindersec/minder/internal/providers/github/clients"
@@ -23,12 +18,15 @@ import (
 	"github.com/mindersec/minder/internal/providers/github/properties"
 	"github.com/mindersec/minder/internal/providers/ratecache"
 	"github.com/mindersec/minder/internal/providers/telemetry"
-
 	pb "github.com/mindersec/minder/pkg/api/protobuf/go/minder/v1"
 	"github.com/mindersec/minder/pkg/engine/errors"
 	interfaces2 "github.com/mindersec/minder/pkg/engine/v1/interfaces"
 	"github.com/mindersec/minder/pkg/profiles/models"
 	provifv1 "github.com/mindersec/minder/pkg/providers/v1"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/reflect/protoreflect"
 )
 
 const (
@@ -161,7 +159,7 @@ func TestIssueRemediate(t *testing.T) {
 				actionType: TestActionTypeValid,
 			},
 			remArgs: createTestRemArgs(),
-			mockSetup: func(_ *testing.T, mockGitHub *mockghclient.MockGitHub) {
+			mockSetup: func(_ *testing.T, _ *mockghclient.MockGitHub) {
 				// Intentionally empty.
 				// If CreateIssue() is called, gomock will fail the test.
 			},
@@ -201,7 +199,7 @@ func TestIssueRemediate(t *testing.T) {
 				actionType: TestActionTypeValid,
 			},
 			remArgs: createTestRemArgs(),
-			mockSetup: func(_ *testing.T, mockGitHub *mockghclient.MockGitHub) {
+			mockSetup: func(_ *testing.T, _ *mockghclient.MockGitHub) {
 				// No expectations.
 				// CloseIssue must NOT be called.
 			},

--- a/internal/engine/actions/remediate/remediate.go
+++ b/internal/engine/actions/remediate/remediate.go
@@ -11,10 +11,10 @@ import (
 
 	"github.com/mindersec/minder/internal/engine/actions/alert/pull_request_comment"
 	"github.com/mindersec/minder/internal/engine/actions/remediate/gh_branch_protect"
+	"github.com/mindersec/minder/internal/engine/actions/remediate/issue"
 	"github.com/mindersec/minder/internal/engine/actions/remediate/noop"
 	"github.com/mindersec/minder/internal/engine/actions/remediate/pull_request"
 	"github.com/mindersec/minder/internal/engine/actions/remediate/rest"
-	"github.com/mindersec/minder/internal/engine/actions/remediate/issue"
 	engif "github.com/mindersec/minder/internal/engine/interfaces"
 	pb "github.com/mindersec/minder/pkg/api/protobuf/go/minder/v1"
 	"github.com/mindersec/minder/pkg/profiles/models"
@@ -71,17 +71,17 @@ func NewRuleRemediator(
 			ActionType, remediate.GetPullRequest(), client, setting)
 
 	case issue.RemediateType:
-	    client, err := provinfv1.As[provinfv1.IssuePublisher](provider)
-	    if err != nil {
-		    return nil, errors.New("provider does not implement issue trait")
-	    }
-	    if remediate.GetIssue() == nil {
-		return nil, fmt.Errorf("remediations engine missing issue configuration")
-	    }
+		client, err := provinfv1.As[provinfv1.IssuePublisher](provider)
+		if err != nil {
+			return nil, errors.New("provider does not implement issue trait")
+		}
+		if remediate.GetIssue() == nil {
+			return nil, fmt.Errorf("remediations engine missing issue configuration")
+		}
 
-	    return issue.NewIssueRemediate(
-		    ActionType,remediate.GetIssue(),client,setting)
-			
+		return issue.NewIssueRemediate(
+			ActionType, remediate.GetIssue(), client, setting)
+
 	case pull_request_comment.AlertType:
 		client, err := provinfv1.As[provinfv1.ReviewPublisher](provider)
 		if err != nil {

--- a/internal/engine/actions/remediate/remediate.go
+++ b/internal/engine/actions/remediate/remediate.go
@@ -14,6 +14,7 @@ import (
 	"github.com/mindersec/minder/internal/engine/actions/remediate/noop"
 	"github.com/mindersec/minder/internal/engine/actions/remediate/pull_request"
 	"github.com/mindersec/minder/internal/engine/actions/remediate/rest"
+	"github.com/mindersec/minder/internal/engine/actions/remediate/issue"
 	engif "github.com/mindersec/minder/internal/engine/interfaces"
 	pb "github.com/mindersec/minder/pkg/api/protobuf/go/minder/v1"
 	"github.com/mindersec/minder/pkg/profiles/models"
@@ -68,6 +69,19 @@ func NewRuleRemediator(
 
 		return pull_request.NewPullRequestRemediate(
 			ActionType, remediate.GetPullRequest(), client, setting)
+
+	case issue.RemediateType:
+	    client, err := provinfv1.As[provinfv1.IssuePublisher](provider)
+	    if err != nil {
+		    return nil, errors.New("provider does not implement issue trait")
+	    }
+	    if remediate.GetIssue() == nil {
+		return nil, fmt.Errorf("remediations engine missing issue configuration")
+	    }
+
+	    return issue.NewIssueRemediate(
+		    ActionType,remediate.GetIssue(),client,setting)
+			
 	case pull_request_comment.AlertType:
 		client, err := provinfv1.As[provinfv1.ReviewPublisher](provider)
 		if err != nil {

--- a/pkg/api/openapi/minder/v1/minder.swagger.json
+++ b/pkg/api/openapi/minder/v1/minder.swagger.json
@@ -3599,7 +3599,7 @@
       "properties": {
         "type": {
           "type": "string",
-          "description": "type is the type of the remediation.\n* 'rest' can be used with any entity type.\n* 'gh_branch_protection' and 'pull_request' can only be used with the 'repository' entity type.\n* 'pull_request_comment' can only be used with the 'pull_request' entity type."
+          "description": "type is the type of the remediation.\n* 'rest' can be used with any entity type.\n* 'gh_branch_protection' 'pull_request', and 'issue' can only be used with the 'repository' entity type.\n* 'pull_request_comment' can only be used with the 'pull_request' entity type."
         },
         "rest": {
           "$ref": "#/definitions/v1RestType"
@@ -3866,8 +3866,7 @@
           "type": "string",
           "title": "the body of the issue\nSupports Minder's template interpolation syntax\nThe rendered body is interpreted as Markdown by repository providers that\nsupport Markdown (e.g. Github)\nThis is not validated here as it will be validated by the repository provider, i.e. GitHub upon\ncreation of the issue"
         }
-      },
-      "description": "NOTE: Issue remediation is not yet implemented.\nThis configuration is reserved for future support.\n\"issue\" is intentionally not a supported remediation type yet."
+      }
     },
     "RemediatePullRequestRemediation": {
       "type": "object",

--- a/pkg/api/protobuf/go/minder/v1/minder.pb.go
+++ b/pkg/api/protobuf/go/minder/v1/minder.pb.go
@@ -13721,7 +13721,7 @@ type RuleType_Definition_Remediate struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// type is the type of the remediation.
 	// * 'rest' can be used with any entity type.
-	// * 'gh_branch_protection' and 'pull_request' can only be used with the 'repository' entity type.
+	// * 'gh_branch_protection' 'pull_request', and 'issue' can only be used with the 'repository' entity type.
 	// * 'pull_request_comment' can only be used with the 'pull_request' entity type.
 	Type               string                                                `protobuf:"bytes,1,opt,name=type,proto3" json:"type,omitempty"`
 	Rest               *RestType                                             `protobuf:"bytes,2,opt,name=rest,proto3,oneof" json:"rest,omitempty"`
@@ -14327,9 +14327,6 @@ func (x *RuleType_Definition_Remediate_PullRequestRemediation) GetActionsReplace
 	return nil
 }
 
-// NOTE: Issue remediation is not yet implemented.
-// This configuration is reserved for future support.
-// "issue" is intentionally not a supported remediation type yet.
 type RuleType_Definition_Remediate_IssueRemediation struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// the title of the issue
@@ -15656,7 +15653,7 @@ const file_minder_v1_minder_proto_rawDesc = "" +
 	"\xea\xdc\x14\x06medium\x12\x18\n" +
 	"\n" +
 	"VALUE_HIGH\x10\x05\x1a\b\xea\xdc\x14\x04high\x12 \n" +
-	"\x0eVALUE_CRITICAL\x10\x06\x1a\f\xea\xdc\x14\bcritical\"\xa3'\n" +
+	"\x0eVALUE_CRITICAL\x10\x06\x1a\f\xea\xdc\x14\bcritical\"\xaa'\n" +
 	"\bRuleType\x12&\n" +
 	"\aversion\x18\v \x01(\tB\f\xbaH\tr\a2\x05^v\\d$R\aversion\x12$\n" +
 	"\x04type\x18\f \x01(\tB\x10\xbaH\rr\v2\trule-typeR\x04type\x12 \n" +
@@ -15670,7 +15667,7 @@ const file_minder_v1_minder_proto_rawDesc = "" +
 	"\vdescription\x18\x05 \x01(\tB\r\xe0A\x02\xbaH\ar\x05\x10\x01\x18\xdc\vR\vdescription\x12)\n" +
 	"\bguidance\x18\x06 \x01(\tB\r\xe0A\x02\xbaH\ar\x05\x10\x01\x18\xe8\aR\bguidance\x12/\n" +
 	"\bseverity\x18\a \x01(\v2\x13.minder.v1.SeverityR\bseverity\x12D\n" +
-	"\rrelease_phase\x18\t \x01(\x0e2\x1f.minder.v1.RuleTypeReleasePhaseR\freleasePhase\x1a\x9e\"\n" +
+	"\rrelease_phase\x18\t \x01(\x0e2\x1f.minder.v1.RuleTypeReleasePhaseR\freleasePhase\x1a\xa5\"\n" +
 	"\n" +
 	"Definition\x12;\n" +
 	"\tin_entity\x18\x01 \x01(\tB\x1e\xbaH\x1br\x19\x10\x01\x18\xc8\x012\x12^[a-z]+(_[a-z]+)*$R\binEntity\x128\n" +
@@ -15728,9 +15725,9 @@ const file_minder_v1_minder_proto_rawDesc = "" +
 	"\n" +
 	"_vulncheckB\t\n" +
 	"\a_trustyB\r\n" +
-	"\v_homoglyphs\x1a\xee\f\n" +
-	"\tRemediate\x12\\\n" +
-	"\x04type\x18\x01 \x01(\tBH\xbaHE\xd8\x01\x01r@R\x04restR\x14gh_branch_protectionR\fpull_requestR\x14pull_request_commentR\x04type\x12,\n" +
+	"\v_homoglyphs\x1a\xf5\f\n" +
+	"\tRemediate\x12c\n" +
+	"\x04type\x18\x01 \x01(\tBO\xbaHL\xd8\x01\x01rGR\x04restR\x14gh_branch_protectionR\fpull_requestR\x14pull_request_commentR\x05issueR\x04type\x12,\n" +
 	"\x04rest\x18\x02 \x01(\v2\x13.minder.v1.RestTypeH\x00R\x04rest\x88\x01\x01\x12v\n" +
 	"\x14gh_branch_protection\x18\x03 \x01(\v2?.minder.v1.RuleType.Definition.Remediate.GhBranchProtectionTypeH\x01R\x12ghBranchProtection\x88\x01\x01\x12g\n" +
 	"\fpull_request\x18\x04 \x01(\v2?.minder.v1.RuleType.Definition.Remediate.PullRequestRemediationH\x02R\vpullRequest\x88\x01\x01\x12n\n" +

--- a/pkg/api/protobuf/go/minder/v1/validators.go
+++ b/pkg/api/protobuf/go/minder/v1/validators.go
@@ -510,6 +510,33 @@ func (prRem *RuleType_Definition_Remediate_PullRequestRemediation) Validate() er
 	return nil
 }
 
+// Validate validates an issue remediation definition.
+func (issueRem *RuleType_Definition_Remediate_IssueRemediation) Validate() error {
+	if issueRem == nil {
+		return fmt.Errorf("%w: issue remediation is nil", ErrInvalidRuleTypeDefinition)
+	}
+
+	if issueRem.Title == "" {
+		return fmt.Errorf("%w: issue title cannot be empty", ErrInvalidRuleTypeDefinition)
+	}
+
+	if issueRem.Body == "" {
+		return fmt.Errorf("%w: issue body cannot be empty", ErrInvalidRuleTypeDefinition)
+	}
+
+	_, err := util.NewSafeHTMLTemplate(&issueRem.Title, "title")
+	if err != nil {
+		return fmt.Errorf("%w: issue title is not parsable: %w", ErrInvalidRuleTypeDefinition, err)
+	}
+
+	_, err = util.NewSafeHTMLTemplate(&issueRem.Body, "body")
+	if err != nil {
+		return fmt.Errorf("%w: issue body is not parsable: %w", ErrInvalidRuleTypeDefinition, err)
+	}
+
+	return nil
+}
+
 // Validate validates a rule type definition ingest diff
 func (diffing *DiffType) Validate() error {
 	if diffing == nil {

--- a/pkg/api/protobuf/go/minder/v1/validators.go
+++ b/pkg/api/protobuf/go/minder/v1/validators.go
@@ -421,6 +421,10 @@ func (rem *RuleType_Definition_Remediate) Validate() error {
 		if err := rem.GetGhBranchProtection().Validate(); err != nil {
 			return err
 		}
+	case "issue":
+		if err := rem.GetIssue().Validate(); err != nil {
+			return err
+		}
 	default:
 		return fmt.Errorf("%w: remediate type cannot be empty", ErrInvalidRuleTypeDefinition)
 	}

--- a/proto/minder/v1/minder.proto
+++ b/proto/minder/v1/minder.proto
@@ -2829,11 +2829,11 @@ message RuleType {
         message Remediate {
             // type is the type of the remediation.
             // * 'rest' can be used with any entity type.
-            // * 'gh_branch_protection' and 'pull_request' can only be used with the 'repository' entity type.
+            // * 'gh_branch_protection' 'pull_request', and 'issue' can only be used with the 'repository' entity type.
             // * 'pull_request_comment' can only be used with the 'pull_request' entity type.
             string type = 1 [
                 (buf.validate.field).string = {
-                    in: ["rest", "gh_branch_protection", "pull_request", "pull_request_comment"],
+                    in: ["rest", "gh_branch_protection", "pull_request", "pull_request_comment", "issue"],
                 },
                 (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE
             ];
@@ -2933,9 +2933,6 @@ message RuleType {
                 optional ActionsReplaceTagsWithSha actions_replace_tags_with_sha = 5;
             }
 
-            // NOTE: Issue remediation is not yet implemented.
-            // This configuration is reserved for future support.
-            // "issue" is intentionally not a supported remediation type yet.
             message IssueRemediation {
                 // the title of the issue
                 // Supports Minder's template interpolation syntax.


### PR DESCRIPTION
# Summary

This PR completes the runtime implementation for Issue Remediation, building on the previously introduced provider interface and remediation configuration.

## Changes

- Add the Issue remediation engine.

- Implement runtime support for:

     - creating GitHub issues when remediation is enabled
     - closing previously created issues when remediation is disabled

- Persist issue metadata to avoid creating duplicate issues while a remediation remains active.

- Wire the issue remediation type into the remediation engine.

- Enable type: issue in remediation validation.

- Add validation for IssueRemediation configuration.

- Add unit tests covering:

     - issue creation
     - issue creation failures
     - existing issue reuse
     - issue closure
     - issue closure without stored metadata

- Regenerate protobuf, OpenAPI, and documentation after enabling the new remediation type.

This makes issue a functional remediation type end-to-end.

Related to #6533 

## Testing

Verified with:

go test ./internal/engine/actions/remediate/issue
go test ./internal/engine/actions/remediate/...
go build ./...