### PR TITLE
Fix cosign invocation from goreleaser

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -62,11 +62,11 @@ builds:
     main: ./cmd/dev
 # This section defines the release format.
 archives:
-  - format: tar.gz # we can use binary, but it seems there's an issue where goreleaser skips the sboms
+  - formats: tar.gz # we can use binary, but it seems there's an issue where goreleaser skips the sboms
     name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}" # "{{ .Binary }}-{{ .Os }}-{{ .Arch }}"
     format_overrides:
       - goos: windows
-        format: zip
+        formats: zip
 # This section defines how to release to winget.
 winget:
   - name: minder
@@ -125,11 +125,11 @@ release:
     name: minder
 # This section defines how and which artifacts we want to sign for the release.
 signs:
-  - cmd: cosign
+  - id: cosign
+    cmd: cosign
     args:
       - "sign-blob"
-      - "--output-signature=${signature}"
-      - "--output-certificate=${certificate}"
+      - "--bundle=${signature}"
       - "${artifact}"
       - "--yes" # needed on cosign 2.0.0+
     artifacts: archive


### PR DESCRIPTION
# Summary

The `--output-signature` and `--output-certificate` flags have been deprecated.

# Testing

Manual testing with `goreleaser release --snapshot --clean`
