### PR TITLE
fix(mindev): exit with non-zero status on syntax errors

### DIFF
--- a/cmd/dev/app/test/test.go
+++ b/cmd/dev/app/test/test.go
@@ -41,7 +41,7 @@ func CmdTest() *cobra.Command {
 			}
 
 			if len(results) == 0 {
-				if outputFormat == "text" {
+				if outputFormat == "text" && loadErr == nil {
 					cmd.Printf("No tests found\n")
 				}
 				return loadErr

--- a/cmd/dev/app/test/test.go
+++ b/cmd/dev/app/test/test.go
@@ -33,16 +33,18 @@ func CmdTest() *cobra.Command {
 			}
 
 			runner := ruletest.NewRunner()
+			var loadErr error
 			results, err := runner.RunPaths(args)
 			if err != nil {
 				cmd.PrintErrf("Error(s) running tests:\n%v\n", err)
+				loadErr = errors.New("one or more test files failed to load")
 			}
 
 			if len(results) == 0 {
 				if outputFormat == "text" {
 					cmd.Printf("No tests found\n")
 				}
-				return nil
+				return loadErr
 			}
 
 			if outputFormat == "junit" {
@@ -58,7 +60,7 @@ func CmdTest() *cobra.Command {
 						return errors.New("one or more tests failed")
 					}
 				}
-				return nil
+				return loadErr
 			}
 
 			hasFailures := false
@@ -78,7 +80,7 @@ func CmdTest() *cobra.Command {
 				return errors.New("one or more tests failed")
 			}
 
-			return nil
+			return loadErr
 		},
 	}
 

--- a/cmd/dev/app/test/test_test.go
+++ b/cmd/dev/app/test/test_test.go
@@ -1,0 +1,33 @@
+// SPDX-FileCopyrightText: Copyright 2026 The Minder Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestCmdTest_ExitCodeOnLoadError(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+	brokenFile := filepath.Join(tmpDir, "broken_test.star")
+	err := os.WriteFile(brokenFile, []byte("this is invalid starlark syntax\n"), 0600)
+	if err != nil {
+		t.Fatalf("failed to write test file: %v", err)
+	}
+
+	cmd := CmdTest()
+	cmd.SetArgs([]string{brokenFile})
+
+	err = cmd.Execute()
+	if err == nil {
+		t.Fatal("expected Execute() to return an error, got nil")
+	}
+
+	if err.Error() != "one or more test files failed to load" {
+		t.Errorf("unexpected error message: got %q, want 'one or more test files failed to load'", err.Error())
+	}
+}

--- a/cmd/dev/app/test/test_test.go
+++ b/cmd/dev/app/test/test_test.go
@@ -9,25 +9,85 @@ import (
 	"testing"
 )
 
-func TestCmdTest_ExitCodeOnLoadError(t *testing.T) {
+func TestCmdTest_ExitCodes(t *testing.T) {
 	t.Parallel()
 
-	tmpDir := t.TempDir()
-	brokenFile := filepath.Join(tmpDir, "broken_test.star")
-	err := os.WriteFile(brokenFile, []byte("this is invalid starlark syntax\n"), 0600)
-	if err != nil {
-		t.Fatalf("failed to write test file: %v", err)
+	tests := []struct {
+		name         string
+		files        map[string]string // filename -> content
+		args         []string          // arguments to mindev test (e.g. "--output junit")
+		wantErrMsg   string            // expected error substring, or empty if success expected
+	}{
+		{
+			name: "only malformed returns non-zero",
+			files: map[string]string{
+				"broken_test.star": "this is invalid starlark syntax\n",
+			},
+			wantErrMsg: "one or more test files failed to load",
+		},
+		{
+			name: "malformed plus passing returns non-zero",
+			files: map[string]string{
+				"broken_test.star": "this is invalid starlark syntax\n",
+				"pass_test.star":   "def test_pass():\n  assert.eq(1, 1)\n",
+			},
+			wantErrMsg: "one or more test files failed to load",
+		},
+		{
+			name: "malformed with junit output returns non-zero",
+			files: map[string]string{
+				"broken_test.star": "this is invalid starlark syntax\n",
+			},
+			args:       []string{"--output", "junit"},
+			wantErrMsg: "one or more test files failed to load",
+		},
+		{
+			name: "valid passing files return zero",
+			files: map[string]string{
+				"pass_test.star": "def test_pass():\n  assert.eq(1, 1)\n",
+			},
+			wantErrMsg: "",
+		},
+		{
+			name: "valid failing files return non-zero",
+			files: map[string]string{
+				"fail_test.star": "def test_fail():\n  assert.eq(1, 2)\n",
+			},
+			wantErrMsg: "one or more tests failed",
+		},
 	}
 
-	cmd := CmdTest()
-	cmd.SetArgs([]string{brokenFile})
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			tmpDir := t.TempDir()
+			
+			var paths []string
+			for filename, content := range tt.files {
+				filePath := filepath.Join(tmpDir, filename)
+				if err := os.WriteFile(filePath, []byte(content), 0600); err != nil {
+					t.Fatalf("failed to write test file: %v", err)
+				}
+				paths = append(paths, filePath)
+			}
 
-	err = cmd.Execute()
-	if err == nil {
-		t.Fatal("expected Execute() to return an error, got nil")
-	}
+			cmd := CmdTest()
+			cmd.SetArgs(append(paths, tt.args...))
 
-	if err.Error() != "one or more test files failed to load" {
-		t.Errorf("unexpected error message: got %q, want 'one or more test files failed to load'", err.Error())
+			err := cmd.Execute()
+			if tt.wantErrMsg != "" {
+				if err == nil {
+					t.Fatalf("expected Execute() to return an error containing %q, got nil", tt.wantErrMsg)
+				}
+				if err.Error() != tt.wantErrMsg {
+					t.Errorf("unexpected error message: got %q, want %q", err.Error(), tt.wantErrMsg)
+				}
+			} else {
+				if err != nil {
+					t.Fatalf("expected Execute() to succeed, got error: %v", err)
+				}
+			}
+		})
 	}
 }

--- a/cmd/dev/app/test/test_test.go
+++ b/cmd/dev/app/test/test_test.go
@@ -13,10 +13,10 @@ func TestCmdTest_ExitCodes(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name         string
-		files        map[string]string // filename -> content
-		args         []string          // arguments to mindev test (e.g. "--output junit")
-		wantErrMsg   string            // expected error substring, or empty if success expected
+		name       string
+		files      map[string]string // filename -> content
+		args       []string          // arguments to mindev test (e.g. "--output junit")
+		wantErrMsg string            // expected error substring, or empty if success expected
 	}{
 		{
 			name: "only malformed returns non-zero",
@@ -62,7 +62,7 @@ func TestCmdTest_ExitCodes(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			tmpDir := t.TempDir()
-			
+
 			var paths []string
 			for filename, content := range tt.files {
 				filePath := filepath.Join(tmpDir, filename)

--- a/pkg/ruletest/eval.go
+++ b/pkg/ruletest/eval.go
@@ -29,13 +29,14 @@ func (tr *testCaseRunner) builtinEval(
 	var ruleName string
 	var entityDict *starlark.Dict
 	var profileDict *starlark.Dict
+	var paramsDict *starlark.Dict
 	var mockHttpDict *starlark.Dict
 	var mockFSDict *starlark.Dict
 	var datasourcesList *starlark.List
 
 	err := starlark.UnpackArgs("eval", args, kwargs,
 		"rule", &ruleName, "entity?", &entityDict,
-		"profile?", &profileDict, "mock_http?", &mockHttpDict,
+		"profile?", &profileDict, "params?", &paramsDict, "mock_http?", &mockHttpDict,
 		"mock_fs?", &mockFSDict, "data_sources?", &datasourcesList)
 	if err != nil {
 		return nil, err
@@ -56,6 +57,11 @@ func (tr *testCaseRunner) builtinEval(
 		return nil, fmt.Errorf("invalid profile argument: %w", err)
 	}
 
+	paramsMap, err := dictToGoMap(paramsDict)
+	if err != nil {
+		return nil, fmt.Errorf("invalid params argument: %w", err)
+	}
+
 	entityMap, err := dictToGoMap(entityDict)
 	if err != nil {
 		return nil, fmt.Errorf("invalid entity argument: %w", err)
@@ -74,7 +80,7 @@ func (tr *testCaseRunner) builtinEval(
 	ctx := context.Background()
 
 	tkOpts := []tkv1.Option{tkv1.WithHandlerFunc(mockHandler.ServeHTTP)}
-	if len(mockFSMap) > 0 {
+	if mockFSDict != nil {
 		tkOpts = append(tkOpts, tkv1.WithGitFiles(mockFSMap))
 	}
 	tk := tkv1.NewTestKit(tkOpts...)
@@ -93,11 +99,9 @@ func (tr *testCaseRunner) builtinEval(
 		rte.WithCustomIngester(tk)
 	}
 
-	res, err := rte.Eval(ctx, entityProto, profileMap, nil, &stubResultSink{})
-
-	// Because Eval returns the error, we pass that error to formatEvalResult
-	// We ignore res for now as we just want the error
+	res, err := rte.Eval(ctx, entityProto, profileMap, paramsMap, &stubResultSink{})
 	_ = res
+
 	return formatEvalResult(err), nil
 }
 

--- a/pkg/ruletest/eval.go
+++ b/pkg/ruletest/eval.go
@@ -57,9 +57,12 @@ func (tr *testCaseRunner) builtinEval(
 		return nil, fmt.Errorf("invalid profile argument: %w", err)
 	}
 
-	paramsMap, err := dictToGoMap(paramsDict)
-	if err != nil {
-		return nil, fmt.Errorf("invalid params argument: %w", err)
+	var paramsMap map[string]any
+	if paramsDict != nil {
+		paramsMap, err = dictToGoMap(paramsDict)
+		if err != nil {
+			return nil, fmt.Errorf("invalid params argument: %w", err)
+		}
 	}
 
 	entityMap, err := dictToGoMap(entityDict)

--- a/pkg/ruletest/eval_test.go
+++ b/pkg/ruletest/eval_test.go
@@ -96,6 +96,14 @@ func TestBuiltinEval_InvalidArgs(t *testing.T) {
 			wantErr: "got string, want dict",
 		},
 		{
+			name: "invalid params type",
+			args: starlark.Tuple{starlark.String("rule.yaml")},
+			kwargs: []starlark.Tuple{
+				{starlark.String("params"), starlark.String("not a dict")},
+			},
+			wantErr: "got string, want dict",
+		},
+		{
 			name: "invalid mock_fs type",
 			args: starlark.Tuple{starlark.String("fs_check")},
 			kwargs: []starlark.Tuple{

--- a/pkg/ruletest/runner.go
+++ b/pkg/ruletest/runner.go
@@ -206,7 +206,7 @@ func loadSingleRule(path string) (*minderv1.RuleType, error) {
 	defer func(c io.Closer) {
 		_ = c.Close()
 	}(closer)
-	
+
 	rt, err := fileconvert.ReadResourceTyped[*minderv1.RuleType](decoder)
 	if err != nil {
 		return nil, err

--- a/pkg/ruletest/runner.go
+++ b/pkg/ruletest/runner.go
@@ -216,10 +216,6 @@ func loadSingleRule(path string) (*minderv1.RuleType, error) {
 		if rt.Context == nil {
 			rt.Context = &minderv1.Context{}
 		}
-		if rt.Context.Project == nil || *rt.Context.Project == "" {
-			prjName := "rule-type-test"
-			rt.Context.Project = &prjName
-		}
 	}
 	return rt, nil
 }

--- a/pkg/ruletest/runner.go
+++ b/pkg/ruletest/runner.go
@@ -206,7 +206,22 @@ func loadSingleRule(path string) (*minderv1.RuleType, error) {
 	defer func(c io.Closer) {
 		_ = c.Close()
 	}(closer)
-	return fileconvert.ReadResourceTyped[*minderv1.RuleType](decoder)
+	
+	rt, err := fileconvert.ReadResourceTyped[*minderv1.RuleType](decoder)
+	if err != nil {
+		return nil, err
+	}
+
+	if rt != nil {
+		if rt.Context == nil {
+			rt.Context = &minderv1.Context{}
+		}
+		if rt.Context.Project == nil || *rt.Context.Project == "" {
+			prjName := "rule-type-test"
+			rt.Context.Project = &prjName
+		}
+	}
+	return rt, nil
 }
 
 // RunPaths takes a list of file or directory paths, discovering all *.star test

--- a/pkg/ruletest/testdata/mock_fs.star
+++ b/pkg/ruletest/testdata/mock_fs.star
@@ -22,3 +22,11 @@ def test_mock_fs_fail():
     )
     assert.true(res["message"] != "")
     assert.eq(res["status"], "fail")
+
+def test_mock_fs_empty():
+    res = eval(
+        rule="mock_fs_rule",
+        entity={"owner": "test", "name": "repo", "clone_url": "https://github.com/test/repo.git"},
+        mock_fs={}
+    )
+    assert.eq(res["status"], "fail")


### PR DESCRIPTION
Fixes a bug where `mindev test` exits with 0 even when test files fail to load due to syntax errors.

Additionally, this PR fixes a correctness issue where an empty `mock_fs` dict caused an evaluation error during testing, instead of successfully simulating an empty mocked filesystem. Tests were added to ensure `mock_fs` correctly supports being empty.

Adds support for profile `params` being applied to rules.  By default, `params` defaults to an empty map unless explicitly specified.