### PR TITLE
Update dependabot for codeql-action

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -34,6 +34,10 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    groups:
+      codeql:
+        patterns:
+          - "github/codeql-action/*"
     # GitHub Actions doesn't support cooldown
   - package-ecosystem: "npm"
     directory: "docs"


### PR DESCRIPTION
# Summary

The various codeql actions share common formats; see e.g. #6613 and #6618 for updates that would be fine together, but fail separately.

Fixes #6613
Fixes #6618
