### PR TITLE
feat(ruletest): Expose rule evaluation output to Starlark tests

### DIFF
--- a/pkg/ruletest/eval.go
+++ b/pkg/ruletest/eval.go
@@ -103,16 +103,15 @@ func (tr *testCaseRunner) builtinEval(
 	}
 
 	res, err := rte.Eval(ctx, entityProto, profileMap, paramsMap, &stubResultSink{})
-	_ = res
 
-	return formatEvalResult(err), nil
+	return formatEvalResult(res, err), nil
 }
 
 type stubResultSink struct{}
 
 func (*stubResultSink) SetIngestResult(*interfaces.Ingested) {}
 
-func formatEvalResult(evalErr error) *starlark.Dict {
+func formatEvalResult(res *interfaces.EvaluationResult, evalErr error) *starlark.Dict {
 	result := starlark.NewDict(2)
 	status, msg := "", ""
 
@@ -136,7 +135,56 @@ func formatEvalResult(evalErr error) *starlark.Dict {
 
 	_ = result.SetKey(starlark.String("status"), starlark.String(status))
 	_ = result.SetKey(starlark.String("message"), starlark.String(msg))
+
+	if res != nil && res.Output != nil {
+		if slVal, err := goToStarlarkValue(res.Output); err == nil {
+			_ = result.SetKey(starlark.String("output"), slVal)
+		}
+	}
+
 	return result
+}
+
+func goToStarlarkValue(v any) (starlark.Value, error) {
+	if v == nil {
+		return starlark.None, nil
+	}
+	switch x := v.(type) {
+	case string:
+		return starlark.String(x), nil
+	case bool:
+		return starlark.Bool(x), nil
+	case int:
+		return starlark.MakeInt(x), nil
+	case int64:
+		return starlark.MakeInt64(x), nil
+	case float64:
+		return starlark.Float(x), nil
+	case map[string]any:
+		dict := starlark.NewDict(len(x))
+		for k, val := range x {
+			slVal, err := goToStarlarkValue(val)
+			if err != nil {
+				return nil, err
+			}
+			if err := dict.SetKey(starlark.String(k), slVal); err != nil {
+				return nil, err
+			}
+		}
+		return dict, nil
+	case []any:
+		var list []starlark.Value
+		for _, val := range x {
+			slVal, err := goToStarlarkValue(val)
+			if err != nil {
+				return nil, err
+			}
+			list = append(list, slVal)
+		}
+		return starlark.NewList(list), nil
+	default:
+		return starlark.String(fmt.Sprintf("%v", x)), nil
+	}
 }
 
 func parseMockFSDict(mockFSDict *starlark.Dict) (map[string]string, error) {

--- a/pkg/ruletest/eval.go
+++ b/pkg/ruletest/eval.go
@@ -145,48 +145,6 @@ func formatEvalResult(res *interfaces.EvaluationResult, evalErr error) *starlark
 	return result
 }
 
-func goToStarlarkValue(v any) (starlark.Value, error) {
-	if v == nil {
-		return starlark.None, nil
-	}
-	switch x := v.(type) {
-	case string:
-		return starlark.String(x), nil
-	case bool:
-		return starlark.Bool(x), nil
-	case int:
-		return starlark.MakeInt(x), nil
-	case int64:
-		return starlark.MakeInt64(x), nil
-	case float64:
-		return starlark.Float(x), nil
-	case map[string]any:
-		dict := starlark.NewDict(len(x))
-		for k, val := range x {
-			slVal, err := goToStarlarkValue(val)
-			if err != nil {
-				return nil, err
-			}
-			if err := dict.SetKey(starlark.String(k), slVal); err != nil {
-				return nil, err
-			}
-		}
-		return dict, nil
-	case []any:
-		var list []starlark.Value
-		for _, val := range x {
-			slVal, err := goToStarlarkValue(val)
-			if err != nil {
-				return nil, err
-			}
-			list = append(list, slVal)
-		}
-		return starlark.NewList(list), nil
-	default:
-		return starlark.String(fmt.Sprintf("%v", x)), nil
-	}
-}
-
 func parseMockFSDict(mockFSDict *starlark.Dict) (map[string]string, error) {
 	mockFSMap := make(map[string]string)
 	if mockFSDict != nil {

--- a/pkg/ruletest/eval_test.go
+++ b/pkg/ruletest/eval_test.go
@@ -19,12 +19,23 @@ func TestFormatEvalResult(t *testing.T) {
 
 	tests := []struct {
 		name    string
+		res     *interfaces.EvaluationResult
 		err     error
 		wantSt  string
 		wantMsg string
+		wantOut any
 	}{
 		{
+			name:    "pass on nil error with output",
+			res:     &interfaces.EvaluationResult{Output: map[string]any{"foo": "bar"}},
+			err:     nil,
+			wantSt:  "pass",
+			wantMsg: "",
+			wantOut: map[string]any{"foo": "bar"},
+		},
+		{
 			name:    "pass on nil error",
+			res:     nil,
 			err:     nil,
 			wantSt:  "pass",
 			wantMsg: "",
@@ -52,14 +63,19 @@ func TestFormatEvalResult(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			dict := formatEvalResult(tt.err)
+			dict := formatEvalResult(tt.res, tt.err)
 
 			result, err := dictToGoMap(dict)
 			if err != nil {
 				t.Fatalf("dictToGoMap failed: %v", err)
 			}
 
-			diff := cmp.Diff(result, map[string]any{"status": tt.wantSt, "message": tt.wantMsg})
+			want := map[string]any{"status": tt.wantSt, "message": tt.wantMsg}
+			if tt.wantOut != nil {
+				want["output"] = tt.wantOut
+			}
+
+			diff := cmp.Diff(result, want)
 			if diff != "" {
 				t.Errorf("unexpected result: %s", diff)
 			}

--- a/pkg/ruletest/starlark_util.go
+++ b/pkg/ruletest/starlark_util.go
@@ -55,6 +55,50 @@ func starlarkValueToGo(val starlark.Value) (any, error) {
 	}
 }
 
+// goToStarlarkValue converts a Go value into its starlark.Value equivalent.
+// Unknown types are stringified as a fallback.
+func goToStarlarkValue(v any) (starlark.Value, error) {
+	if v == nil {
+		return starlark.None, nil
+	}
+	switch x := v.(type) {
+	case string:
+		return starlark.String(x), nil
+	case bool:
+		return starlark.Bool(x), nil
+	case int:
+		return starlark.MakeInt(x), nil
+	case int64:
+		return starlark.MakeInt64(x), nil
+	case float64:
+		return starlark.Float(x), nil
+	case map[string]any:
+		dict := starlark.NewDict(len(x))
+		for k, val := range x {
+			slVal, err := goToStarlarkValue(val)
+			if err != nil {
+				return nil, err
+			}
+			if err := dict.SetKey(starlark.String(k), slVal); err != nil {
+				return nil, err
+			}
+		}
+		return dict, nil
+	case []any:
+		var list []starlark.Value
+		for _, val := range x {
+			slVal, err := goToStarlarkValue(val)
+			if err != nil {
+				return nil, err
+			}
+			list = append(list, slVal)
+		}
+		return starlark.NewList(list), nil
+	default:
+		return starlark.String(fmt.Sprintf("%v", x)), nil
+	}
+}
+
 // dictToGoMap converts a starlark.Dict to map[string]any, defaulting to
 // an empty map when d is nil.
 func dictToGoMap(d *starlark.Dict) (map[string]any, error) {

--- a/pkg/ruletest/starlark_util_test.go
+++ b/pkg/ruletest/starlark_util_test.go
@@ -120,3 +120,52 @@ func TestStarlarkValueToGo(t *testing.T) {
 		})
 	}
 }
+
+func TestGoToStarlarkValue(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name     string
+		input    any
+		expected any // round-tripped back via starlarkValueToGo for comparison
+		wantErr  bool
+	}{
+		{name: "nil", input: nil, expected: nil},
+		{name: "string", input: "hello", expected: "hello"},
+		{name: "bool true", input: true, expected: true},
+		{name: "bool false", input: false, expected: false},
+		// int comes back as int64 after the Starlark round-trip
+		{name: "int", input: int(42), expected: int64(42)},
+		{name: "int64", input: int64(99), expected: int64(99)},
+		{name: "float64", input: float64(3.14), expected: float64(3.14)},
+		{
+			name:     "map",
+			input:    map[string]any{"key": "val", "num": int64(1)},
+			expected: map[string]any{"key": "val", "num": int64(1)},
+		},
+		{
+			name:     "slice",
+			input:    []any{"a", int64(2)},
+			expected: []any{"a", int64(2)},
+		},
+		{
+			name:  "unknown type falls back to string",
+			input: struct{ X int }{X: 7},
+			// default case: fmt.Sprintf("%v", ...) → "{7}"
+			expected: "{7}",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			slVal, err := goToStarlarkValue(tc.input)
+			require.NoError(t, err)
+
+			got, err := starlarkValueToGo(slVal)
+			require.NoError(t, err)
+			assert.Equal(t, tc.expected, got)
+		})
+	}
+}

--- a/pkg/ruletest/testdata/output.star
+++ b/pkg/ruletest/testdata/output.star
@@ -1,0 +1,31 @@
+# SPDX-FileCopyrightText: Copyright 2026 The Minder Authors
+# SPDX-License-Identifier: Apache-2.0
+
+# These tests demonstrate that res["output"] is populated from the rule's rego
+# `output` expression, allowing test authors to assert on structured evaluation
+# data rather than just status/message.
+
+def test_output_present_on_fail():
+    res = eval(
+        rule="check_required_setting",
+        entity={"owner": "test", "name": "repo"},
+        profile={"required_value": "enabled"},
+        mock_http={
+            "/repos/test/repo/settings": body('{"value": "disabled"}')
+        }
+    )
+    assert.eq(res["status"], "fail")
+    assert.eq(res["output"]["actual"], "disabled")
+    assert.eq(res["output"]["expected"], "enabled")
+
+def test_output_absent_on_pass():
+    res = eval(
+        rule="check_required_setting",
+        entity={"owner": "test", "name": "repo"},
+        profile={"required_value": "enabled"},
+        mock_http={
+            "/repos/test/repo/settings": body('{"value": "enabled"}')
+        }
+    )
+    assert.eq(res["status"], "pass")
+    assert.true("output" not in res)

--- a/pkg/ruletest/testdata/output_rule.yaml
+++ b/pkg/ruletest/testdata/output_rule.yaml
@@ -1,0 +1,39 @@
+# SPDX-FileCopyrightText: Copyright 2026 The Minder Authors
+# SPDX-License-Identifier: Apache-2.0
+
+version: v1
+type: rule-type
+name: check_required_setting
+context:
+  project: 00000000-0000-0000-0000-000000000000
+description: Checks whether a required setting matches the expected value.
+def:
+  in_entity: repository
+  rule_schema:
+    properties:
+      required_value:
+        type: string
+  ingest:
+    type: rest
+    rest:
+      endpoint: '/repos/{{.Entity.Owner}}/{{.Entity.Name}}/settings'
+      parse: 'json'
+  eval:
+    type: rego
+    rego:
+      type: 'deny-by-default'
+      def: |
+        package minder
+
+        import rego.v1
+
+        default allow := false
+
+        allow if {
+          input.ingested.value == input.profile.required_value
+        }
+
+        output := {
+          "actual": input.ingested.value,
+          "expected": input.profile.required_value,
+        }


### PR DESCRIPTION
Currently, the rule testing framework evaluates rules and ignores the `EvaluationResult` output returned by the engine. This means developers writing tests only have access to a pass/fail/skip status and a string error message, making it difficult to debug why a rule failed, especially when dealing with complex JSON payloads (like those from jq or rego).\n\nThis PR exposes the `res.Output` data directly to the Starlark testing context under the key `'output'` so users can assert against it and view it.\n\nThis PR addresses feedback from Evan in PR #6637 and supports the testing infrastructure epic #6434.