### PR TITLE
Fix lint errors which crept into the codebase

### DIFF
--- a/cmd/cli/app/profile/edit.go
+++ b/cmd/cli/app/profile/edit.go
@@ -95,7 +95,7 @@ func editCommand(cmd *cobra.Command, _ []string) error {
 		return err
 	}
 
-	updatedBytes, err := os.ReadFile(tmpFile.Name())
+	updatedBytes, err := os.ReadFile(tmpFile.Name()) //nolint:gosec  // Confused on path traversal
 	if err != nil {
 		return cli.MessageAndError("Error reading updated temporary file", err)
 	}

--- a/cmd/dev/app/root.go
+++ b/cmd/dev/app/root.go
@@ -19,8 +19,8 @@ import (
 // CmdRoot represents the base command when called without any subcommands
 func CmdRoot() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "mindev",
-		Short: "mindev provides developer tooling for minder",
+		Use:           "mindev",
+		Short:         "mindev provides developer tooling for minder",
 		SilenceErrors: true,
 		Long: `For more information about minder, please visit:
 https://mindersec.github.io/`,

--- a/cmd/dev/app/test/test.go
+++ b/cmd/dev/app/test/test.go
@@ -23,68 +23,70 @@ func CmdTest() *cobra.Command {
 		Short: "Run Minder rule tests",
 		Long: "Run Starlark-based tests for Minder rules. Each path may be a file or directory. " +
 			"If no paths are provided, tests the current directory.",
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(cmd *cobra.Command, args []string) (finalErr error) {
 			if outputFormat != "text" && outputFormat != "junit" {
 				return fmt.Errorf("unsupported output format %q: must be \"text\" or \"junit\"", outputFormat)
 			}
+
+			cmd.SilenceUsage = true
 
 			if len(args) == 0 {
 				args = []string{"."}
 			}
 
 			runner := ruletest.NewRunner()
-			var loadErr error
 			results, err := runner.RunPaths(args)
 			if err != nil {
 				cmd.PrintErrf("Error(s) running tests:\n%v\n", err)
-				loadErr = errors.New("one or more test files failed to load")
+				// Record this as the final error message if no tests failed.
+				finalErr = errors.New("one or more test files failed to load")
 			}
 
-			if len(results) == 0 {
-				if outputFormat == "text" && loadErr == nil {
-					cmd.Printf("No tests found\n")
-				}
-				return loadErr
-			}
-
-			if outputFormat == "junit" {
+			switch outputFormat {
+			case "text":
+				formatFailuresHuman(cmd, results)
+			case "junit":
 				suites := ruletest.AsJUnit(results)
-				bytes, fmtErr := xml.MarshalIndent(suites, "", "  ")
-				if fmtErr != nil {
-					return fmtErr
+				_, err := fmt.Fprint(cmd.OutOrStdout(), xml.Header)
+				if err != nil {
+					return fmt.Errorf("failed to write XML header: %w", err)
 				}
-				cmd.Println(xml.Header + string(bytes))
-
-				for _, res := range results {
-					if len(res.Failures) > 0 {
-						return errors.New("one or more tests failed")
-					}
+				encoder := xml.NewEncoder(cmd.OutOrStdout())
+				encoder.Indent("", "  ")
+				if err := encoder.Encode(suites); err != nil {
+					return fmt.Errorf("failed to encode JUnit XML: %w", err)
 				}
-				return loadErr
+			default:
+				return fmt.Errorf("unsupported output format %q: must be \"text\" or \"junit\"", outputFormat)
 			}
 
-			hasFailures := false
 			for _, res := range results {
 				if len(res.Failures) > 0 {
-					hasFailures = true
-					cmd.Printf("FAIL: %s/%s\n", res.Filename, res.Name)
-					for _, f := range res.Failures {
-						cmd.Printf("  - %s\n", f)
-					}
-				} else {
-					cmd.Printf("PASS: %s/%s\n", res.Filename, res.Name)
+					finalErr = errors.New("one or more tests failed")
+					break
 				}
 			}
-
-			if hasFailures {
-				return errors.New("one or more tests failed")
-			}
-
-			return loadErr
+			return finalErr
 		},
 	}
 
 	cmd.Flags().StringVarP(&outputFormat, "output", "o", "text", "Output format (text, junit)")
 
 	return cmd
+}
+
+func formatFailuresHuman(cmd *cobra.Command, results []ruletest.TestResult) {
+	if len(results) == 0 {
+		cmd.Printf("No tests found\n")
+	}
+	for _, res := range results {
+		if len(res.Failures) > 0 {
+			cmd.Printf("FAIL: %s/%s\n", res.Filename, res.Name)
+			for _, f := range res.Failures {
+				cmd.Printf("  - %s\n", f)
+			}
+		} else {
+			cmd.Printf("PASS: %s/%s\n", res.Filename, res.Name)
+		}
+	}
 }

--- a/go.mod
+++ b/go.mod
@@ -453,7 +453,7 @@ require (
 	go.uber.org/multierr v1.11.0 // indirect
 	go.uber.org/zap v1.28.0 // indirect
 	golang.org/x/mod v0.38.0
-	golang.org/x/net v0.57.0
+	golang.org/x/net v0.57.0 // indirect
 	golang.org/x/sys v0.47.0 // indirect
 	golang.org/x/text v0.40.0 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260622175928-b703f567277d // indirect

--- a/internal/engine/actions/remediate/pull_request/pull_request_test.go
+++ b/internal/engine/actions/remediate/pull_request/pull_request_test.go
@@ -26,27 +26,18 @@ import (
 	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
-	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/reflect/protoreflect"
 	"google.golang.org/protobuf/types/known/structpb"
 
 	"github.com/mindersec/minder/internal/engine/interfaces"
-	"github.com/mindersec/minder/internal/providers/credentials"
-	"github.com/mindersec/minder/internal/providers/github/clients"
 	mockghclient "github.com/mindersec/minder/internal/providers/github/mock"
-	"github.com/mindersec/minder/internal/providers/github/properties"
-	"github.com/mindersec/minder/internal/providers/ratecache"
-	"github.com/mindersec/minder/internal/providers/telemetry"
 	pb "github.com/mindersec/minder/pkg/api/protobuf/go/minder/v1"
 	"github.com/mindersec/minder/pkg/engine/errors"
 	interfaces2 "github.com/mindersec/minder/pkg/engine/v1/interfaces"
 	"github.com/mindersec/minder/pkg/profiles/models"
-	provifv1 "github.com/mindersec/minder/pkg/providers/v1"
 )
 
 const (
-	ghApiUrl = "https://api.github.com"
-
 	repoOwner   = "stacklok"
 	repoName    = "minder"
 	dflBranchTo = "main"
@@ -86,21 +77,6 @@ jobs:
 )
 
 var TestActionTypeValid interfaces.ActionType = "remediate-test"
-
-func testGithubProvider() (provifv1.GitHub, error) {
-	return clients.NewRestClient(
-		&pb.GitHubProviderConfig{
-			Endpoint: proto.String(ghApiUrl + "/"),
-		},
-		nil,
-		nil,
-		&ratecache.NoopRestClientCache{},
-		credentials.NewGitHubTokenCredential("token"),
-		clients.NewGitHubClientFactory(telemetry.NewNoopMetrics()),
-		properties.NewPropertyFetcherFactory(),
-		"",
-	)
-}
 
 func dependabotPrRem() *pb.RuleType_Definition_Remediate_PullRequestRemediation {
 	return &pb.RuleType_Definition_Remediate_PullRequestRemediation{
@@ -253,8 +229,8 @@ func resolveActionMockSetup(t *testing.T, mockGitHub *mockghclient.MockGitHub, u
 			Body:       io.NopCloser(bytes.NewBuffer(jsonCheckoutRef)),
 			StatusCode: http.StatusOK,
 		}, nil)
-
 }
+
 func mockRepoSetup(t *testing.T, postSetupHooks ...hookFunc) (*git.Repository, error) {
 	t.Helper()
 
@@ -668,7 +644,6 @@ func TestPullRequestRemediate(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -742,7 +717,7 @@ func TestCheckoutToOriginallyFetchedBranch_CleansWorktree(t *testing.T) {
 	require.NoError(t, err)
 
 	// Create an initial commit on main so we have a valid HEAD.
-	require.NoError(t, billyutil.WriteFile(mfs, "README.md", []byte("initial"), 0644))
+	require.NoError(t, billyutil.WriteFile(mfs, "README.md", []byte("initial"), 0o644))
 
 	_, err = wt.Add("README.md")
 	require.NoError(t, err)
@@ -762,10 +737,10 @@ func TestCheckoutToOriginallyFetchedBranch_CleansWorktree(t *testing.T) {
 	require.NoError(t, err)
 
 	// Dirty a tracked file (simulates remediation writing a compliant version).
-	require.NoError(t, billyutil.WriteFile(mfs, "README.md", []byte("dirty content from failed remediation"), 0644))
+	require.NoError(t, billyutil.WriteFile(mfs, "README.md", []byte("dirty content from failed remediation"), 0o644))
 
 	// Create an untracked file (simulates remediation creating a new config).
-	require.NoError(t, billyutil.WriteFile(mfs, "leftover.txt", []byte("should be removed"), 0644))
+	require.NoError(t, billyutil.WriteFile(mfs, "leftover.txt", []byte("should be removed"), 0o644))
 
 	// Verify the worktree is actually dirty before we clean it.
 	status, err := wt.Status()

--- a/internal/engine/actions/remediate/remediate.go
+++ b/internal/engine/actions/remediate/remediate.go
@@ -25,6 +25,8 @@ import (
 const ActionType engif.ActionType = "remediate"
 
 // NewRuleRemediator creates a new rule remediator
+//
+//nolint:gocyclo // Just a big switch statment
 func NewRuleRemediator(
 	rt *pb.RuleType,
 	provider provinfv1.Provider,

--- a/internal/util/cli/credentials_test.go
+++ b/internal/util/cli/credentials_test.go
@@ -22,8 +22,6 @@ import (
 	_ "github.com/lib/pq"
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/require"
-	"golang.org/x/net/http2"
-	"golang.org/x/net/http2/h2c"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials/insecure"
@@ -88,12 +86,11 @@ func TestGetGrpcConnection(t *testing.T) {
 		}
 	})
 
-	h2cServer := http2.Server{}
-	h2cHandler := h2c.NewHandler(requestHandler, &h2cServer)
-
-	authServer := httptest.NewUnstartedServer(h2cHandler)
+	authServer := httptest.NewUnstartedServer(requestHandler)
 	authServer.EnableHTTP2 = true
-	require.NoError(t, http2.ConfigureServer(authServer.Config, &h2cServer))
+	authServer.Config.Protocols = new(http.Protocols)
+	authServer.Config.Protocols.SetHTTP1(true)
+	authServer.Config.Protocols.SetUnencryptedHTTP2(true)
 	authServer.Start()
 	fakeSvc.authUrl = authServer.URL + "/custom"
 	t.Cleanup(authServer.Close)
@@ -238,7 +235,6 @@ func TestSaveCredentials(t *testing.T) {
 	if string(content) != string(credsJSON) {
 		t.Errorf("expected file content %v, got %v", string(credsJSON), string(content))
 	}
-
 }
 
 // TestRemoveCredentials tests the RemoveCredentials function
@@ -253,13 +249,12 @@ func TestRemoveCredentials(t *testing.T) {
 	filePath := filepath.Join(xdgConfigHome, "minder", "localhost_8081.json")
 
 	// Create a dummy credentials file
-	err := os.MkdirAll(filepath.Dir(filePath), 0750)
-
+	err := os.MkdirAll(filepath.Dir(filePath), 0o750)
 	if err != nil {
 		t.Fatalf("error creating directory: %v", err)
 	}
 
-	err = os.WriteFile(filePath, []byte(`{"access_token":"test_access_token","refresh_token":"test_refresh_token","access_token_expires_at":1234567890}`), 0600)
+	err = os.WriteFile(filePath, []byte(`{"access_token":"test_access_token","refresh_token":"test_refresh_token","access_token_expires_at":1234567890}`), 0o600)
 	if err != nil {
 		t.Fatalf("error writing credentials to file: %v", err)
 	}
@@ -395,13 +390,12 @@ func TestLoadCredentials(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-
 		t.Run(tt.name, func(t *testing.T) {
 			testDir := t.TempDir()
 			setEnvVar(t, XdgConfigHomeEnvVar, testDir)
 			// Create the minder directory inside the temp directory
 			minderDir := filepath.Join(testDir, "minder")
-			err := os.MkdirAll(minderDir, 0750)
+			err := os.MkdirAll(minderDir, 0o750)
 			if err != nil {
 				t.Fatalf("failed to create minder directory: %v", err)
 			}
@@ -413,7 +407,7 @@ func TestLoadCredentials(t *testing.T) {
 
 			if tt.fileContent != "" {
 				// Create a temporary file with the specified content
-				require.NoError(t, os.WriteFile(filePath, []byte(tt.fileContent), 0600))
+				require.NoError(t, os.WriteFile(filePath, []byte(tt.fileContent), 0o600))
 				// Print the file path and content for debugging
 				t.Logf("Test %s: written file path %s with content: %s", tt.name, filePath, tt.fileContent)
 			} else {
@@ -434,9 +428,7 @@ func TestLoadCredentials(t *testing.T) {
 					t.Errorf("expected result %v, got %v", tt.expectedResult, result)
 				}
 			}
-
 		})
-
 	}
 }
 
@@ -488,7 +480,6 @@ func TestRevokeToken(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			var server *httptest.Server


### PR DESCRIPTION
# Summary

golangci-lint has become more strict, and it flags several things which were either merged with the lint check failing, or which were valid at the time but are flagged now (for example, `h2c` module deprecation).

Note that this more-substantially refactors the `mindev test` command that @krrish175-byte introduced, because it was flagged for cyclomatic complexity (and there were a lot of different execution paths).

# Testing

Unit testing (and a manual test of `mindev test`, which led me to add the `cmd.SilenceUsage` line)
