### PR TITLE
feat(ruletest): expose eval output to Starlark tests and fix CWD-sensitive path resolution

### DIFF
--- a/pkg/ruletest/eval.go
+++ b/pkg/ruletest/eval.go
@@ -103,16 +103,15 @@ func (tr *testCaseRunner) builtinEval(
 	}
 
 	res, err := rte.Eval(ctx, entityProto, profileMap, paramsMap, &stubResultSink{})
-	_ = res
 
-	return formatEvalResult(err), nil
+	return formatEvalResult(res, err), nil
 }
 
 type stubResultSink struct{}
 
 func (*stubResultSink) SetIngestResult(*interfaces.Ingested) {}
 
-func formatEvalResult(evalErr error) *starlark.Dict {
+func formatEvalResult(res *interfaces.EvaluationResult, evalErr error) *starlark.Dict {
 	result := starlark.NewDict(2)
 	status, msg := "", ""
 
@@ -136,7 +135,56 @@ func formatEvalResult(evalErr error) *starlark.Dict {
 
 	_ = result.SetKey(starlark.String("status"), starlark.String(status))
 	_ = result.SetKey(starlark.String("message"), starlark.String(msg))
+
+	if res != nil && res.Output != nil {
+		if slVal, err := goToStarlarkValue(res.Output); err == nil {
+			_ = result.SetKey(starlark.String("output"), slVal)
+		}
+	}
+
 	return result
+}
+
+func goToStarlarkValue(v any) (starlark.Value, error) {
+	if v == nil {
+		return starlark.None, nil
+	}
+	switch x := v.(type) {
+	case string:
+		return starlark.String(x), nil
+	case bool:
+		return starlark.Bool(x), nil
+	case int:
+		return starlark.MakeInt(x), nil
+	case int64:
+		return starlark.MakeInt64(x), nil
+	case float64:
+		return starlark.Float(x), nil
+	case map[string]any:
+		dict := starlark.NewDict(len(x))
+		for k, val := range x {
+			slVal, err := goToStarlarkValue(val)
+			if err != nil {
+				return nil, err
+			}
+			if err := dict.SetKey(starlark.String(k), slVal); err != nil {
+				return nil, err
+			}
+		}
+		return dict, nil
+	case []any:
+		var list []starlark.Value
+		for _, val := range x {
+			slVal, err := goToStarlarkValue(val)
+			if err != nil {
+				return nil, err
+			}
+			list = append(list, slVal)
+		}
+		return starlark.NewList(list), nil
+	default:
+		return starlark.String(fmt.Sprintf("%v", x)), nil
+	}
 }
 
 func parseMockFSDict(mockFSDict *starlark.Dict) (map[string]string, error) {

--- a/pkg/ruletest/eval.go
+++ b/pkg/ruletest/eval.go
@@ -162,7 +162,9 @@ func parseMockFSDict(mockFSDict *starlark.Dict) (map[string]string, error) {
 	return mockFSMap, nil
 }
 
-func buildDataSourceRegistry(datasourcesList *starlark.List, tk *tkv1.TestKit, baseDir string) (*v1datasources.DataSourceRegistry, error) {
+func buildDataSourceRegistry(
+	datasourcesList *starlark.List, tk *tkv1.TestKit, baseDir string,
+) (*v1datasources.DataSourceRegistry, error) {
 	registry := v1datasources.NewDataSourceRegistry()
 	if datasourcesList == nil {
 		return registry, nil

--- a/pkg/ruletest/eval.go
+++ b/pkg/ruletest/eval.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"path/filepath"
 
 	"go.starlark.net/starlark"
 	"google.golang.org/protobuf/encoding/protojson"
@@ -88,7 +89,7 @@ func (tr *testCaseRunner) builtinEval(
 	}
 	tk := tkv1.NewTestKit(tkOpts...)
 
-	dsRegistry, err := buildDataSourceRegistry(datasourcesList, tk)
+	dsRegistry, err := buildDataSourceRegistry(datasourcesList, tk, tr.baseDir)
 	if err != nil {
 		return nil, fmt.Errorf("invalid data_sources argument: %w", err)
 	}
@@ -161,7 +162,7 @@ func parseMockFSDict(mockFSDict *starlark.Dict) (map[string]string, error) {
 	return mockFSMap, nil
 }
 
-func buildDataSourceRegistry(datasourcesList *starlark.List, tk *tkv1.TestKit) (*v1datasources.DataSourceRegistry, error) {
+func buildDataSourceRegistry(datasourcesList *starlark.List, tk *tkv1.TestKit, baseDir string) (*v1datasources.DataSourceRegistry, error) {
 	registry := v1datasources.NewDataSourceRegistry()
 	if datasourcesList == nil {
 		return registry, nil
@@ -174,6 +175,9 @@ func buildDataSourceRegistry(datasourcesList *starlark.List, tk *tkv1.TestKit) (
 		}
 
 		path := string(pathStr)
+		if !filepath.IsAbs(path) {
+			path = filepath.Join(baseDir, path)
+		}
 
 		ds, err := loadDataSource(path)
 		if err != nil {

--- a/pkg/ruletest/eval.go
+++ b/pkg/ruletest/eval.go
@@ -145,48 +145,6 @@ func formatEvalResult(res *interfaces.EvaluationResult, evalErr error) *starlark
 	return result
 }
 
-func goToStarlarkValue(v any) (starlark.Value, error) {
-	if v == nil {
-		return starlark.None, nil
-	}
-	switch x := v.(type) {
-	case string:
-		return starlark.String(x), nil
-	case bool:
-		return starlark.Bool(x), nil
-	case int:
-		return starlark.MakeInt(x), nil
-	case int64:
-		return starlark.MakeInt64(x), nil
-	case float64:
-		return starlark.Float(x), nil
-	case map[string]any:
-		dict := starlark.NewDict(len(x))
-		for k, val := range x {
-			slVal, err := goToStarlarkValue(val)
-			if err != nil {
-				return nil, err
-			}
-			if err := dict.SetKey(starlark.String(k), slVal); err != nil {
-				return nil, err
-			}
-		}
-		return dict, nil
-	case []any:
-		var list []starlark.Value
-		for _, val := range x {
-			slVal, err := goToStarlarkValue(val)
-			if err != nil {
-				return nil, err
-			}
-			list = append(list, slVal)
-		}
-		return starlark.NewList(list), nil
-	default:
-		return starlark.String(fmt.Sprintf("%v", x)), nil
-	}
-}
-
 func parseMockFSDict(mockFSDict *starlark.Dict) (map[string]string, error) {
 	mockFSMap := make(map[string]string)
 	if mockFSDict != nil {

--- a/pkg/ruletest/eval_test.go
+++ b/pkg/ruletest/eval_test.go
@@ -19,12 +19,23 @@ func TestFormatEvalResult(t *testing.T) {
 
 	tests := []struct {
 		name    string
+		res     *interfaces.EvaluationResult
 		err     error
 		wantSt  string
 		wantMsg string
+		wantOut any
 	}{
 		{
+			name:    "pass on nil error with output",
+			res:     &interfaces.EvaluationResult{Output: map[string]any{"foo": "bar"}},
+			err:     nil,
+			wantSt:  "pass",
+			wantMsg: "",
+			wantOut: map[string]any{"foo": "bar"},
+		},
+		{
 			name:    "pass on nil error",
+			res:     nil,
 			err:     nil,
 			wantSt:  "pass",
 			wantMsg: "",
@@ -52,14 +63,19 @@ func TestFormatEvalResult(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			dict := formatEvalResult(tt.err)
+			dict := formatEvalResult(tt.res, tt.err)
 
 			result, err := dictToGoMap(dict)
 			if err != nil {
 				t.Fatalf("dictToGoMap failed: %v", err)
 			}
 
-			diff := cmp.Diff(result, map[string]any{"status": tt.wantSt, "message": tt.wantMsg})
+			want := map[string]any{"status": tt.wantSt, "message": tt.wantMsg}
+			if tt.wantOut != nil {
+				want["output"] = tt.wantOut
+			}
+
+			diff := cmp.Diff(result, want)
 			if diff != "" {
 				t.Errorf("unexpected result: %s", diff)
 			}

--- a/pkg/ruletest/runner.go
+++ b/pkg/ruletest/runner.go
@@ -31,17 +31,19 @@ import (
 type testCaseRunner struct {
 	thread      *starlark.Thread
 	fs          fs.FS
+	baseDir     string
 	predeclared starlark.StringDict
 	failures    []string
 	ruleTypes   map[string]*minderv1.RuleType
 }
 
-func (r *Runner) newTestCaseRunner(name string, fileSystem fs.FS, ruleTypes map[string]*minderv1.RuleType) *testCaseRunner {
+func (r *Runner) newTestCaseRunner(name string, fileSystem fs.FS, baseDir string, ruleTypes map[string]*minderv1.RuleType) *testCaseRunner {
 	if fileSystem == nil {
 		panic("fileSystem cannot be nil")
 	}
 	tr := &testCaseRunner{
 		fs:          fileSystem,
+		baseDir:     baseDir,
 		predeclared: starlark.StringDict{},
 		ruleTypes:   ruleTypes,
 	}
@@ -116,7 +118,7 @@ func (r *Runner) RunFile(filename string, src any, ruleTypes map[string]*minderv
 	fileSystem := os.DirFS(baseDir)
 
 	name := filepath.Base(filename)
-	tr := r.newTestCaseRunner(name, fileSystem, ruleTypes)
+	tr := r.newTestCaseRunner(name, fileSystem, baseDir, ruleTypes)
 
 	globals, err := tr.runFile(filename, src)
 	if err != nil {
@@ -144,7 +146,7 @@ func (r *Runner) RunFile(filename string, src any, ruleTypes map[string]*minderv
 	base := filepath.Base(filename)
 	var results []TestResult
 	for name, fn := range testFns {
-		result := r.runOneTest(name, fn, fileSystem, ruleTypes)
+		result := r.runOneTest(name, fn, fileSystem, baseDir, ruleTypes)
 		result.Filename = base
 		results = append(results, result)
 	}
@@ -156,9 +158,10 @@ func (r *Runner) runOneTest(
 	name string,
 	fn *starlark.Function,
 	fileSystem fs.FS,
+	baseDir string,
 	ruleTypes map[string]*minderv1.RuleType,
 ) TestResult {
-	tr := r.newTestCaseRunner(name, fileSystem, ruleTypes)
+	tr := r.newTestCaseRunner(name, fileSystem, baseDir, ruleTypes)
 	result := TestResult{Name: name}
 
 	_, err := starlark.Call(tr.thread, fn, nil, nil)

--- a/pkg/ruletest/runner.go
+++ b/pkg/ruletest/runner.go
@@ -37,7 +37,9 @@ type testCaseRunner struct {
 	ruleTypes   map[string]*minderv1.RuleType
 }
 
-func (r *Runner) newTestCaseRunner(name string, fileSystem fs.FS, baseDir string, ruleTypes map[string]*minderv1.RuleType) *testCaseRunner {
+func (r *Runner) newTestCaseRunner(
+	name string, fileSystem fs.FS, baseDir string, ruleTypes map[string]*minderv1.RuleType,
+) *testCaseRunner {
 	if fileSystem == nil {
 		panic("fileSystem cannot be nil")
 	}

--- a/pkg/ruletest/starlark_util.go
+++ b/pkg/ruletest/starlark_util.go
@@ -55,6 +55,50 @@ func starlarkValueToGo(val starlark.Value) (any, error) {
 	}
 }
 
+// goToStarlarkValue converts a Go value into its starlark.Value equivalent.
+// Unknown types are stringified as a fallback.
+func goToStarlarkValue(v any) (starlark.Value, error) {
+	if v == nil {
+		return starlark.None, nil
+	}
+	switch x := v.(type) {
+	case string:
+		return starlark.String(x), nil
+	case bool:
+		return starlark.Bool(x), nil
+	case int:
+		return starlark.MakeInt(x), nil
+	case int64:
+		return starlark.MakeInt64(x), nil
+	case float64:
+		return starlark.Float(x), nil
+	case map[string]any:
+		dict := starlark.NewDict(len(x))
+		for k, val := range x {
+			slVal, err := goToStarlarkValue(val)
+			if err != nil {
+				return nil, err
+			}
+			if err := dict.SetKey(starlark.String(k), slVal); err != nil {
+				return nil, err
+			}
+		}
+		return dict, nil
+	case []any:
+		var list []starlark.Value
+		for _, val := range x {
+			slVal, err := goToStarlarkValue(val)
+			if err != nil {
+				return nil, err
+			}
+			list = append(list, slVal)
+		}
+		return starlark.NewList(list), nil
+	default:
+		return starlark.String(fmt.Sprintf("%v", x)), nil
+	}
+}
+
 // dictToGoMap converts a starlark.Dict to map[string]any, defaulting to
 // an empty map when d is nil.
 func dictToGoMap(d *starlark.Dict) (map[string]any, error) {

--- a/pkg/ruletest/starlark_util_test.go
+++ b/pkg/ruletest/starlark_util_test.go
@@ -120,3 +120,52 @@ func TestStarlarkValueToGo(t *testing.T) {
 		})
 	}
 }
+
+func TestGoToStarlarkValue(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name     string
+		input    any
+		expected any // round-tripped back via starlarkValueToGo for comparison
+		wantErr  bool
+	}{
+		{name: "nil", input: nil, expected: nil},
+		{name: "string", input: "hello", expected: "hello"},
+		{name: "bool true", input: true, expected: true},
+		{name: "bool false", input: false, expected: false},
+		// int comes back as int64 after the Starlark round-trip
+		{name: "int", input: int(42), expected: int64(42)},
+		{name: "int64", input: int64(99), expected: int64(99)},
+		{name: "float64", input: float64(3.14), expected: float64(3.14)},
+		{
+			name:     "map",
+			input:    map[string]any{"key": "val", "num": int64(1)},
+			expected: map[string]any{"key": "val", "num": int64(1)},
+		},
+		{
+			name:     "slice",
+			input:    []any{"a", int64(2)},
+			expected: []any{"a", int64(2)},
+		},
+		{
+			name:  "unknown type falls back to string",
+			input: struct{ X int }{X: 7},
+			// default case: fmt.Sprintf("%v", ...) → "{7}"
+			expected: "{7}",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			slVal, err := goToStarlarkValue(tc.input)
+			require.NoError(t, err)
+
+			got, err := starlarkValueToGo(slVal)
+			require.NoError(t, err)
+			assert.Equal(t, tc.expected, got)
+		})
+	}
+}

--- a/pkg/ruletest/testdata/mock_datasources.star
+++ b/pkg/ruletest/testdata/mock_datasources.star
@@ -6,7 +6,7 @@ def test_mock_datasource_passing():
         rule="mock_datasource_rule",
         entity={"type": "repository", "name": "test"},
         profile={"required_value": "hello"},
-        data_sources=["testdata/mock_datasource_def.yaml"],
+        data_sources=["mock_datasource_def.yaml"],
         mock_http={
             "https://api.github.com/mock_endpoint": body('"hello"')
         }
@@ -20,7 +20,7 @@ def test_mock_datasource_failing():
         rule="mock_datasource_rule",
         entity={"type": "repository", "name": "test"},
         profile={"required_value": "hello"},
-        data_sources=["testdata/mock_datasource_def.yaml"],
+        data_sources=["mock_datasource_def.yaml"],
         mock_http={
             "https://api.github.com/mock_endpoint": body('"wrong_value"')
         }

--- a/pkg/ruletest/testdata/output.star
+++ b/pkg/ruletest/testdata/output.star
@@ -1,0 +1,31 @@
+# SPDX-FileCopyrightText: Copyright 2026 The Minder Authors
+# SPDX-License-Identifier: Apache-2.0
+
+# These tests demonstrate that res["output"] is populated from the rule's rego
+# `output` expression, allowing test authors to assert on structured evaluation
+# data rather than just status/message.
+
+def test_output_present_on_fail():
+    res = eval(
+        rule="check_required_setting",
+        entity={"owner": "test", "name": "repo"},
+        profile={"required_value": "enabled"},
+        mock_http={
+            "/repos/test/repo/settings": body('{"value": "disabled"}')
+        }
+    )
+    assert.eq(res["status"], "fail")
+    assert.eq(res["output"]["actual"], "disabled")
+    assert.eq(res["output"]["expected"], "enabled")
+
+def test_output_absent_on_pass():
+    res = eval(
+        rule="check_required_setting",
+        entity={"owner": "test", "name": "repo"},
+        profile={"required_value": "enabled"},
+        mock_http={
+            "/repos/test/repo/settings": body('{"value": "enabled"}')
+        }
+    )
+    assert.eq(res["status"], "pass")
+    assert.true("output" not in res)

--- a/pkg/ruletest/testdata/output_rule.yaml
+++ b/pkg/ruletest/testdata/output_rule.yaml
@@ -1,0 +1,39 @@
+# SPDX-FileCopyrightText: Copyright 2026 The Minder Authors
+# SPDX-License-Identifier: Apache-2.0
+
+version: v1
+type: rule-type
+name: check_required_setting
+context:
+  project: 00000000-0000-0000-0000-000000000000
+description: Checks whether a required setting matches the expected value.
+def:
+  in_entity: repository
+  rule_schema:
+    properties:
+      required_value:
+        type: string
+  ingest:
+    type: rest
+    rest:
+      endpoint: '/repos/{{.Entity.Owner}}/{{.Entity.Name}}/settings'
+      parse: 'json'
+  eval:
+    type: rego
+    rego:
+      type: 'deny-by-default'
+      def: |
+        package minder
+
+        import rego.v1
+
+        default allow := false
+
+        allow if {
+          input.ingested.value == input.profile.required_value
+        }
+
+        output := {
+          "actual": input.ingested.value,
+          "expected": input.profile.required_value,
+        }


### PR DESCRIPTION
## Description:

### Summary

This PR makes two improvements to the `mindev test` / `ruletest` framework:

**1. Expose rule evaluation output to Starlark tests** (`feat`)

The `eval()` builtin now returns an `output` key in its result dict, containing the structured output produced by the rule evaluator. This lets test authors assert on the data returned by rules, not just pass/fail status.

The `goToStarlarkValue` helper (which converts arbitrary Go values to Starlark values) has been extracted into `starlark_util.go` with its own unit tests.

**2. Fix CWD-sensitive datasource path resolution** (`fix`)

`mindev test pkg/ruletest/testdata` failed when run from the project root, while `(cd pkg/ruletest && mindev test testdata)` passed. Paths supplied via `data_sources=` are now resolved relative to the directory containing the `.star` test file rather than the process working directory.

Fixes #6672

### Testing:

- `go test ./pkg/ruletest/...` passes.
- New integration tests in `testdata/output.star` assert the `output` field
  is populated correctly for a passing and failing evaluation.
- `mock_datasources.star` updated to use bare filenames
  (`mock_datasource_def.yaml`) confirming relative-path resolution works.